### PR TITLE
8328752: Fix missing @Overrides in javafx.web

### DIFF
--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/AttrImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/AttrImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,31 +41,37 @@ public class AttrImpl extends NodeImpl implements Attr {
 
 
 // Attributes
+    @Override
     public String getName() {
         return getNameImpl(getPeer());
     }
     native static String getNameImpl(long peer);
 
+    @Override
     public boolean getSpecified() {
         return getSpecifiedImpl(getPeer());
     }
     native static boolean getSpecifiedImpl(long peer);
 
+    @Override
     public String getValue() {
         return getValueImpl(getPeer());
     }
     native static String getValueImpl(long peer);
 
+    @Override
     public void setValue(String value) throws DOMException {
         setValueImpl(getPeer(), value);
     }
     native static void setValueImpl(long peer, String value);
 
+    @Override
     public Element getOwnerElement() {
         return ElementImpl.getImpl(getOwnerElementImpl(getPeer()));
     }
     native static long getOwnerElementImpl(long peer);
 
+    @Override
     public boolean isId() {
         return isIdImpl(getPeer());
     }
@@ -73,6 +79,7 @@ public class AttrImpl extends NodeImpl implements Attr {
 
 
 //stubs
+    @Override
     public TypeInfo getSchemaTypeInfo() {
         throw new UnsupportedOperationException("Not supported yet.");
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/CSSCharsetRuleImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/CSSCharsetRuleImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,11 +39,13 @@ public class CSSCharsetRuleImpl extends CSSRuleImpl implements CSSCharsetRule {
 
 
 // Attributes
+    @Override
     public String getEncoding() {
         return getEncodingImpl(getPeer());
     }
     native static String getEncodingImpl(long peer);
 
+    @Override
     public void setEncoding(String value) throws DOMException {
         setEncodingImpl(getPeer(), value);
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/CSSFontFaceRuleImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/CSSFontFaceRuleImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,6 +39,7 @@ public class CSSFontFaceRuleImpl extends CSSRuleImpl implements CSSFontFaceRule 
 
 
 // Attributes
+    @Override
     public CSSStyleDeclaration getStyle() {
         return CSSStyleDeclarationImpl.getImpl(getStyleImpl(getPeer()));
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/CSSImportRuleImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/CSSImportRuleImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,16 +40,19 @@ public class CSSImportRuleImpl extends CSSRuleImpl implements CSSImportRule {
 
 
 // Attributes
+    @Override
     public String getHref() {
         return getHrefImpl(getPeer());
     }
     native static String getHrefImpl(long peer);
 
+    @Override
     public MediaList getMedia() {
         return MediaListImpl.getImpl(getMediaImpl(getPeer()));
     }
     native static long getMediaImpl(long peer);
 
+    @Override
     public CSSStyleSheet getStyleSheet() {
         return CSSStyleSheetImpl.getImpl(getStyleSheetImpl(getPeer()));
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/CSSMediaRuleImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/CSSMediaRuleImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,11 +41,13 @@ public class CSSMediaRuleImpl extends CSSRuleImpl implements CSSMediaRule {
 
 
 // Attributes
+    @Override
     public MediaList getMedia() {
         return MediaListImpl.getImpl(getMediaImpl(getPeer()));
     }
     native static long getMediaImpl(long peer);
 
+    @Override
     public CSSRuleList getCssRules() {
         return CSSRuleListImpl.getImpl(getCssRulesImpl(getPeer()));
     }
@@ -53,6 +55,7 @@ public class CSSMediaRuleImpl extends CSSRuleImpl implements CSSMediaRule {
 
 
 // Functions
+    @Override
     public int insertRule(String rule
         , int index) throws DOMException
     {
@@ -65,6 +68,7 @@ public class CSSMediaRuleImpl extends CSSRuleImpl implements CSSMediaRule {
         , int index);
 
 
+    @Override
     public void deleteRule(int index) throws DOMException
     {
         deleteRuleImpl(getPeer()

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/CSSPageRuleImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/CSSPageRuleImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,16 +39,19 @@ public class CSSPageRuleImpl extends CSSRuleImpl implements CSSPageRule {
 
 
 // Attributes
+    @Override
     public String getSelectorText() {
         return getSelectorTextImpl(getPeer());
     }
     native static String getSelectorTextImpl(long peer);
 
+    @Override
     public void setSelectorText(String value) {
         setSelectorTextImpl(getPeer(), value);
     }
     native static void setSelectorTextImpl(long peer, String value);
 
+    @Override
     public CSSStyleDeclaration getStyle() {
         return CSSStyleDeclarationImpl.getImpl(getStyleImpl(getPeer()));
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/CSSPrimitiveValueImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/CSSPrimitiveValueImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -74,6 +74,7 @@ public class CSSPrimitiveValueImpl extends CSSValueImpl implements CSSPrimitiveV
     public static final int CSS_VMAX = 29;
 
 // Attributes
+    @Override
     public short getPrimitiveType() {
         return getPrimitiveTypeImpl(getPeer());
     }
@@ -81,6 +82,7 @@ public class CSSPrimitiveValueImpl extends CSSValueImpl implements CSSPrimitiveV
 
 
 // Functions
+    @Override
     public void setFloatValue(short unitType
         , float floatValue) throws DOMException
     {
@@ -93,6 +95,7 @@ public class CSSPrimitiveValueImpl extends CSSValueImpl implements CSSPrimitiveV
         , float floatValue);
 
 
+    @Override
     public float getFloatValue(short unitType) throws DOMException
     {
         return getFloatValueImpl(getPeer()
@@ -102,6 +105,7 @@ public class CSSPrimitiveValueImpl extends CSSValueImpl implements CSSPrimitiveV
         , short unitType);
 
 
+    @Override
     public void setStringValue(short stringType
         , String stringValue) throws DOMException
     {
@@ -114,6 +118,7 @@ public class CSSPrimitiveValueImpl extends CSSValueImpl implements CSSPrimitiveV
         , String stringValue);
 
 
+    @Override
     public String getStringValue() throws DOMException
     {
         return getStringValueImpl(getPeer());
@@ -121,6 +126,7 @@ public class CSSPrimitiveValueImpl extends CSSValueImpl implements CSSPrimitiveV
     native static String getStringValueImpl(long peer);
 
 
+    @Override
     public Counter getCounterValue() throws DOMException
     {
         return CounterImpl.getImpl(getCounterValueImpl(getPeer()));
@@ -128,6 +134,7 @@ public class CSSPrimitiveValueImpl extends CSSValueImpl implements CSSPrimitiveV
     native static long getCounterValueImpl(long peer);
 
 
+    @Override
     public Rect getRectValue() throws DOMException
     {
         return RectImpl.getImpl(getRectValueImpl(getPeer()));
@@ -135,6 +142,7 @@ public class CSSPrimitiveValueImpl extends CSSValueImpl implements CSSPrimitiveV
     native static long getRectValueImpl(long peer);
 
 
+    @Override
     public RGBColor getRGBColorValue() throws DOMException
     {
         return RGBColorImpl.getImpl(getRGBColorValueImpl(getPeer()));

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/CSSRuleImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/CSSRuleImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,6 +37,8 @@ public class CSSRuleImpl implements CSSRule {
         SelfDisposer(final long peer) {
             this.peer = peer;
         }
+
+        @Override
         public void dispose() {
             CSSRuleImpl.dispose(peer);
         }
@@ -102,26 +104,31 @@ public class CSSRuleImpl implements CSSRule {
     public static final int WEBKIT_KEYFRAME_RULE = 8;
 
 // Attributes
+    @Override
     public short getType() {
         return getTypeImpl(getPeer());
     }
     native static short getTypeImpl(long peer);
 
+    @Override
     public String getCssText() {
         return getCssTextImpl(getPeer());
     }
     native static String getCssTextImpl(long peer);
 
+    @Override
     public void setCssText(String value) throws DOMException {
         setCssTextImpl(getPeer(), value);
     }
     native static void setCssTextImpl(long peer, String value);
 
+    @Override
     public CSSStyleSheet getParentStyleSheet() {
         return CSSStyleSheetImpl.getImpl(getParentStyleSheetImpl(getPeer()));
     }
     native static long getParentStyleSheetImpl(long peer);
 
+    @Override
     public CSSRule getParentRule() {
         return CSSRuleImpl.getImpl(getParentRuleImpl(getPeer()));
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/CSSRuleListImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/CSSRuleListImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,6 +36,8 @@ public class CSSRuleListImpl implements CSSRuleList {
         SelfDisposer(final long peer) {
             this.peer = peer;
         }
+
+        @Override
         public void dispose() {
             CSSRuleListImpl.dispose(peer);
         }
@@ -78,6 +80,7 @@ public class CSSRuleListImpl implements CSSRuleList {
 
 
 // Attributes
+    @Override
     public int getLength() {
         return getLengthImpl(getPeer());
     }
@@ -85,6 +88,7 @@ public class CSSRuleListImpl implements CSSRuleList {
 
 
 // Functions
+    @Override
     public CSSRule item(int index)
     {
         return CSSRuleImpl.getImpl(itemImpl(getPeer()

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/CSSStyleDeclarationImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/CSSStyleDeclarationImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,6 +38,8 @@ public class CSSStyleDeclarationImpl implements CSSStyleDeclaration {
         SelfDisposer(final long peer) {
             this.peer = peer;
         }
+
+        @Override
         public void dispose() {
             CSSStyleDeclarationImpl.dispose(peer);
         }
@@ -80,21 +82,25 @@ public class CSSStyleDeclarationImpl implements CSSStyleDeclaration {
 
 
 // Attributes
+    @Override
     public String getCssText() {
         return getCssTextImpl(getPeer());
     }
     native static String getCssTextImpl(long peer);
 
+    @Override
     public void setCssText(String value) throws DOMException {
         setCssTextImpl(getPeer(), value);
     }
     native static void setCssTextImpl(long peer, String value);
 
+    @Override
     public int getLength() {
         return getLengthImpl(getPeer());
     }
     native static int getLengthImpl(long peer);
 
+    @Override
     public CSSRule getParentRule() {
         return CSSRuleImpl.getImpl(getParentRuleImpl(getPeer()));
     }
@@ -102,6 +108,7 @@ public class CSSStyleDeclarationImpl implements CSSStyleDeclaration {
 
 
 // Functions
+    @Override
     public String getPropertyValue(String propertyName)
     {
         return getPropertyValueImpl(getPeer()
@@ -111,6 +118,7 @@ public class CSSStyleDeclarationImpl implements CSSStyleDeclaration {
         , String propertyName);
 
 
+    @Override
     public CSSValue getPropertyCSSValue(String propertyName)
     {
         return CSSValueImpl.getImpl(getPropertyCSSValueImpl(getPeer()
@@ -120,6 +128,7 @@ public class CSSStyleDeclarationImpl implements CSSStyleDeclaration {
         , String propertyName);
 
 
+    @Override
     public String removeProperty(String propertyName) throws DOMException
     {
         return removePropertyImpl(getPeer()
@@ -129,6 +138,7 @@ public class CSSStyleDeclarationImpl implements CSSStyleDeclaration {
         , String propertyName);
 
 
+    @Override
     public String getPropertyPriority(String propertyName)
     {
         return getPropertyPriorityImpl(getPeer()
@@ -138,6 +148,7 @@ public class CSSStyleDeclarationImpl implements CSSStyleDeclaration {
         , String propertyName);
 
 
+    @Override
     public void setProperty(String propertyName
         , String value
         , String priority) throws DOMException
@@ -153,6 +164,7 @@ public class CSSStyleDeclarationImpl implements CSSStyleDeclaration {
         , String priority);
 
 
+    @Override
     public String item(int index)
     {
         return itemImpl(getPeer()

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/CSSStyleRuleImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/CSSStyleRuleImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,16 +39,19 @@ public class CSSStyleRuleImpl extends CSSRuleImpl implements CSSStyleRule {
 
 
 // Attributes
+    @Override
     public String getSelectorText() {
         return getSelectorTextImpl(getPeer());
     }
     native static String getSelectorTextImpl(long peer);
 
+    @Override
     public void setSelectorText(String value) {
         setSelectorTextImpl(getPeer(), value);
     }
     native static void setSelectorTextImpl(long peer, String value);
 
+    @Override
     public CSSStyleDeclaration getStyle() {
         return CSSStyleDeclarationImpl.getImpl(getStyleImpl(getPeer()));
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/CSSStyleSheetImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/CSSStyleSheetImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,11 +41,13 @@ public class CSSStyleSheetImpl extends StyleSheetImpl implements CSSStyleSheet {
 
 
 // Attributes
+    @Override
     public CSSRule getOwnerRule() {
         return CSSRuleImpl.getImpl(getOwnerRuleImpl(getPeer()));
     }
     native static long getOwnerRuleImpl(long peer);
 
+    @Override
     public CSSRuleList getCssRules() {
         return CSSRuleListImpl.getImpl(getCssRulesImpl(getPeer()));
     }
@@ -58,6 +60,7 @@ public class CSSStyleSheetImpl extends StyleSheetImpl implements CSSStyleSheet {
 
 
 // Functions
+    @Override
     public int insertRule(String rule
         , int index) throws DOMException
     {
@@ -70,6 +73,7 @@ public class CSSStyleSheetImpl extends StyleSheetImpl implements CSSStyleSheet {
         , int index);
 
 
+    @Override
     public void deleteRule(int index) throws DOMException
     {
         deleteRuleImpl(getPeer()

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/CSSValueImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/CSSValueImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,6 +36,8 @@ public class CSSValueImpl implements CSSValue {
         SelfDisposer(final long peer) {
             this.peer = peer;
         }
+
+        @Override
         public void dispose() {
             CSSValueImpl.dispose(peer);
         }
@@ -88,16 +90,19 @@ public class CSSValueImpl implements CSSValue {
     public static final int CSS_CUSTOM = 3;
 
 // Attributes
+    @Override
     public String getCssText() {
         return getCssTextImpl(getPeer());
     }
     native static String getCssTextImpl(long peer);
 
+    @Override
     public void setCssText(String value) throws DOMException {
         setCssTextImpl(getPeer(), value);
     }
     native static void setCssTextImpl(long peer, String value);
 
+    @Override
     public short getCssValueType() {
         return getCssValueTypeImpl(getPeer());
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/CSSValueListImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/CSSValueListImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,6 +39,7 @@ public class CSSValueListImpl extends CSSValueImpl implements CSSValueList {
 
 
 // Attributes
+    @Override
     public int getLength() {
         return getLengthImpl(getPeer());
     }
@@ -46,6 +47,7 @@ public class CSSValueListImpl extends CSSValueImpl implements CSSValueList {
 
 
 // Functions
+    @Override
     public CSSValue item(int index)
     {
         return CSSValueImpl.getImpl(itemImpl(getPeer()

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/CharacterDataImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/CharacterDataImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -99,16 +99,19 @@ public class CharacterDataImpl extends NodeImpl implements CharacterData {
 
 
 // Attributes
+    @Override
     public String getData() {
         return getDataImpl(getPeer());
     }
     native static String getDataImpl(long peer);
 
+    @Override
     public void setData(String value) {
         setDataImpl(getPeer(), value);
     }
     native static void setDataImpl(long peer, String value);
 
+    @Override
     public int getLength() {
         return getLengthImpl(getPeer());
     }
@@ -126,6 +129,7 @@ public class CharacterDataImpl extends NodeImpl implements CharacterData {
 
 
 // Functions
+    @Override
     public String substringData(int offset
         , int length) throws DOMException
     {
@@ -138,6 +142,7 @@ public class CharacterDataImpl extends NodeImpl implements CharacterData {
         , int length);
 
 
+    @Override
     public void appendData(String data)
     {
         appendDataImpl(getPeer()
@@ -147,6 +152,7 @@ public class CharacterDataImpl extends NodeImpl implements CharacterData {
         , String data);
 
 
+    @Override
     public void insertData(int offset
         , String data) throws DOMException
     {
@@ -159,6 +165,7 @@ public class CharacterDataImpl extends NodeImpl implements CharacterData {
         , String data);
 
 
+    @Override
     public void deleteData(int offset
         , int length) throws DOMException
     {
@@ -171,6 +178,7 @@ public class CharacterDataImpl extends NodeImpl implements CharacterData {
         , int length);
 
 
+    @Override
     public void replaceData(int offset
         , int length
         , String data) throws DOMException

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/CounterImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/CounterImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,8 @@ public class CounterImpl implements Counter {
         SelfDisposer(final long peer) {
             this.peer = peer;
         }
+
+        @Override
         public void dispose() {
             CounterImpl.dispose(peer);
         }
@@ -77,16 +79,19 @@ public class CounterImpl implements Counter {
 
 
 // Attributes
+    @Override
     public String getIdentifier() {
         return getIdentifierImpl(getPeer());
     }
     native static String getIdentifierImpl(long peer);
 
+    @Override
     public String getListStyle() {
         return getListStyleImpl(getPeer());
     }
     native static String getListStyleImpl(long peer);
 
+    @Override
     public String getSeparator() {
         return getSeparatorImpl(getPeer());
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/DOMImplementationImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/DOMImplementationImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,6 +40,8 @@ public class DOMImplementationImpl implements DOMImplementation {
         SelfDisposer(final long peer) {
             this.peer = peer;
         }
+
+        @Override
         public void dispose() {
             DOMImplementationImpl.dispose(peer);
         }
@@ -82,6 +84,7 @@ public class DOMImplementationImpl implements DOMImplementation {
 
 
 // Functions
+    @Override
     public boolean hasFeature(String feature
         , String version)
     {
@@ -94,6 +97,7 @@ public class DOMImplementationImpl implements DOMImplementation {
         , String version);
 
 
+    @Override
     public DocumentType createDocumentType(String qualifiedName
         , String publicId
         , String systemId) throws DOMException
@@ -109,6 +113,7 @@ public class DOMImplementationImpl implements DOMImplementation {
         , String systemId);
 
 
+    @Override
     public Document createDocument(String namespaceURI
         , String qualifiedName
         , DocumentType doctype) throws DOMException
@@ -147,6 +152,7 @@ public class DOMImplementationImpl implements DOMImplementation {
 
 
 //stubs
+    @Override
     public Object getFeature(String feature, String version) {
         throw new UnsupportedOperationException("Not supported yet.");
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/DOMSelectionImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/DOMSelectionImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,6 +37,8 @@ public class DOMSelectionImpl {
         SelfDisposer(final long peer) {
             this.peer = peer;
         }
+
+        @Override
         public void dispose() {
             DOMSelectionImpl.dispose(peer);
         }

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/DOMStringListImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/DOMStringListImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,8 @@ public class DOMStringListImpl implements DOMStringList {
         SelfDisposer(final long peer) {
             this.peer = peer;
         }
+
+        @Override
         public void dispose() {
             DOMStringListImpl.dispose(peer);
         }
@@ -77,6 +79,7 @@ public class DOMStringListImpl implements DOMStringList {
 
 
 // Attributes
+    @Override
     public int getLength() {
         return getLengthImpl(getPeer());
     }
@@ -84,6 +87,7 @@ public class DOMStringListImpl implements DOMStringList {
 
 
 // Functions
+    @Override
     public String item(int index)
     {
         return itemImpl(getPeer()
@@ -93,6 +97,7 @@ public class DOMStringListImpl implements DOMStringList {
         , int index);
 
 
+    @Override
     public boolean contains(String string)
     {
         return containsImpl(getPeer()

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/DOMWindowImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/DOMWindowImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -114,6 +114,7 @@ public class DOMWindowImpl extends JSObject implements AbstractView, EventTarget
             peer = _peer;
         }
 
+        @Override
         public void dispose() {
             int hash = hashPeer(peer);
             SelfDisposer head = hashTable[hash];
@@ -1262,6 +1263,7 @@ public class DOMWindowImpl extends JSObject implements AbstractView, EventTarget
     native static void releaseEventsImpl(long peer);
 
 
+    @Override
     public void addEventListener(String type
         , EventListener listener
         , boolean useCapture)
@@ -1277,6 +1279,7 @@ public class DOMWindowImpl extends JSObject implements AbstractView, EventTarget
         , boolean useCapture);
 
 
+    @Override
     public void removeEventListener(String type
         , EventListener listener
         , boolean useCapture)
@@ -1292,6 +1295,7 @@ public class DOMWindowImpl extends JSObject implements AbstractView, EventTarget
         , boolean useCapture);
 
 
+    @Override
     public boolean dispatchEvent(Event event) throws DOMException
     {
         return dispatchEventImpl(getPeer()
@@ -1339,6 +1343,7 @@ public class DOMWindowImpl extends JSObject implements AbstractView, EventTarget
 
 
 //stubs
+    @Override
     public DocumentView getDocument() {
         throw new UnsupportedOperationException("Not supported yet.");
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/DocumentImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/DocumentImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -77,61 +77,73 @@ public class DocumentImpl extends NodeImpl implements Document, XPathEvaluator, 
 
 
 // Attributes
+    @Override
     public DocumentType getDoctype() {
         return DocumentTypeImpl.getImpl(getDoctypeImpl(getPeer()));
     }
     native static long getDoctypeImpl(long peer);
 
+    @Override
     public DOMImplementation getImplementation() {
         return DOMImplementationImpl.getImpl(getImplementationImpl(getPeer()));
     }
     native static long getImplementationImpl(long peer);
 
+    @Override
     public Element getDocumentElement() {
         return ElementImpl.getImpl(getDocumentElementImpl(getPeer()));
     }
     native static long getDocumentElementImpl(long peer);
 
+    @Override
     public String getInputEncoding() {
         return getInputEncodingImpl(getPeer());
     }
     native static String getInputEncodingImpl(long peer);
 
+    @Override
     public String getXmlEncoding() {
         return getXmlEncodingImpl(getPeer());
     }
     native static String getXmlEncodingImpl(long peer);
 
+    @Override
     public String getXmlVersion() {
         return getXmlVersionImpl(getPeer());
     }
     native static String getXmlVersionImpl(long peer);
 
+    @Override
     public void setXmlVersion(String value) throws DOMException {
         setXmlVersionImpl(getPeer(), value);
     }
     native static void setXmlVersionImpl(long peer, String value);
 
+    @Override
     public boolean getXmlStandalone() {
         return getXmlStandaloneImpl(getPeer());
     }
     native static boolean getXmlStandaloneImpl(long peer);
 
+    @Override
     public void setXmlStandalone(boolean value) throws DOMException {
         setXmlStandaloneImpl(getPeer(), value);
     }
     native static void setXmlStandaloneImpl(long peer, boolean value);
 
+    @Override
     public String getDocumentURI() {
         return getDocumentURIImpl(getPeer());
     }
     native static String getDocumentURIImpl(long peer);
 
+    @Override
     public void setDocumentURI(String value) {
         setDocumentURIImpl(getPeer(), value);
     }
     native static void setDocumentURIImpl(long peer, String value);
 
+    @Override
     public AbstractView getDefaultView() {
         return DOMWindowImpl.getImpl(getDefaultViewImpl(getPeer()));
     }
@@ -994,6 +1006,7 @@ public class DocumentImpl extends NodeImpl implements Document, XPathEvaluator, 
 
 
 // Functions
+    @Override
     public Element createElement(String tagName) throws DOMException
     {
         return ElementImpl.getImpl(createElementImpl(getPeer()
@@ -1003,6 +1016,7 @@ public class DocumentImpl extends NodeImpl implements Document, XPathEvaluator, 
         , String tagName);
 
 
+    @Override
     public DocumentFragment createDocumentFragment()
     {
         return DocumentFragmentImpl.getImpl(createDocumentFragmentImpl(getPeer()));
@@ -1010,6 +1024,7 @@ public class DocumentImpl extends NodeImpl implements Document, XPathEvaluator, 
     native static long createDocumentFragmentImpl(long peer);
 
 
+    @Override
     public Text createTextNode(String data)
     {
         return TextImpl.getImpl(createTextNodeImpl(getPeer()
@@ -1019,6 +1034,7 @@ public class DocumentImpl extends NodeImpl implements Document, XPathEvaluator, 
         , String data);
 
 
+    @Override
     public Comment createComment(String data)
     {
         return CommentImpl.getImpl(createCommentImpl(getPeer()
@@ -1028,6 +1044,7 @@ public class DocumentImpl extends NodeImpl implements Document, XPathEvaluator, 
         , String data);
 
 
+    @Override
     public CDATASection createCDATASection(String data) throws DOMException
     {
         return CDATASectionImpl.getImpl(createCDATASectionImpl(getPeer()
@@ -1037,6 +1054,7 @@ public class DocumentImpl extends NodeImpl implements Document, XPathEvaluator, 
         , String data);
 
 
+    @Override
     public ProcessingInstruction createProcessingInstruction(String target
         , String data) throws DOMException
     {
@@ -1049,6 +1067,7 @@ public class DocumentImpl extends NodeImpl implements Document, XPathEvaluator, 
         , String data);
 
 
+    @Override
     public Attr createAttribute(String name) throws DOMException
     {
         return AttrImpl.getImpl(createAttributeImpl(getPeer()
@@ -1058,6 +1077,7 @@ public class DocumentImpl extends NodeImpl implements Document, XPathEvaluator, 
         , String name);
 
 
+    @Override
     public EntityReference createEntityReference(String name) throws DOMException
     {
         return EntityReferenceImpl.getImpl(createEntityReferenceImpl(getPeer()
@@ -1067,6 +1087,7 @@ public class DocumentImpl extends NodeImpl implements Document, XPathEvaluator, 
         , String name);
 
 
+    @Override
     public NodeList getElementsByTagName(String tagname)
     {
         return NodeListImpl.getImpl(getElementsByTagNameImpl(getPeer()
@@ -1076,6 +1097,7 @@ public class DocumentImpl extends NodeImpl implements Document, XPathEvaluator, 
         , String tagname);
 
 
+    @Override
     public Node importNode(Node importedNode
         , boolean deep) throws DOMException
     {
@@ -1088,6 +1110,7 @@ public class DocumentImpl extends NodeImpl implements Document, XPathEvaluator, 
         , boolean deep);
 
 
+    @Override
     public Element createElementNS(String namespaceURI
         , String qualifiedName) throws DOMException
     {
@@ -1100,6 +1123,7 @@ public class DocumentImpl extends NodeImpl implements Document, XPathEvaluator, 
         , String qualifiedName);
 
 
+    @Override
     public Attr createAttributeNS(String namespaceURI
         , String qualifiedName) throws DOMException
     {
@@ -1112,6 +1136,7 @@ public class DocumentImpl extends NodeImpl implements Document, XPathEvaluator, 
         , String qualifiedName);
 
 
+    @Override
     public NodeList getElementsByTagNameNS(String namespaceURI
         , String localName)
     {
@@ -1124,6 +1149,7 @@ public class DocumentImpl extends NodeImpl implements Document, XPathEvaluator, 
         , String localName);
 
 
+    @Override
     public Node adoptNode(Node source) throws DOMException
     {
         return NodeImpl.getImpl(adoptNodeImpl(getPeer()
@@ -1133,6 +1159,7 @@ public class DocumentImpl extends NodeImpl implements Document, XPathEvaluator, 
         , long source);
 
 
+    @Override
     public Event createEvent(String eventType) throws DOMException
     {
         return EventImpl.getImpl(createEventImpl(getPeer()
@@ -1197,6 +1224,7 @@ public class DocumentImpl extends NodeImpl implements Document, XPathEvaluator, 
         , String pseudoElement);
 
 
+    @Override
     public XPathExpression createExpression(String expression
         , XPathNSResolver resolver) throws DOMException
     {
@@ -1209,6 +1237,7 @@ public class DocumentImpl extends NodeImpl implements Document, XPathEvaluator, 
         , long resolver);
 
 
+    @Override
     public XPathNSResolver createNSResolver(Node nodeResolver)
     {
         return XPathNSResolverImpl.getImpl(createNSResolverImpl(getPeer()
@@ -1369,6 +1398,7 @@ public class DocumentImpl extends NodeImpl implements Document, XPathEvaluator, 
     native static void webkitExitFullscreenImpl(long peer);
 
 
+    @Override
     public Element getElementById(String elementId)
     {
         return ElementImpl.getImpl(getElementByIdImpl(getPeer()
@@ -1398,18 +1428,27 @@ public class DocumentImpl extends NodeImpl implements Document, XPathEvaluator, 
 
 
 //stubs
+    @Override
     public boolean getStrictErrorChecking() {
         throw new UnsupportedOperationException("Not supported yet.");
     }
+
+    @Override
     public void setStrictErrorChecking(boolean strictErrorChecking) {
         throw new UnsupportedOperationException("Not supported yet.");
     }
+
+    @Override
     public Node renameNode(Node n, String namespaceURI, String qualifiedName) throws DOMException {
         throw new UnsupportedOperationException("Not supported yet.");
     }
+
+    @Override
     public DOMConfiguration getDomConfig() {
         throw new UnsupportedOperationException("Not supported yet.");
     }
+
+    @Override
     public void normalizeDocument() {
         throw new UnsupportedOperationException("Not supported yet.");
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/DocumentTypeImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/DocumentTypeImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,31 +40,37 @@ public class DocumentTypeImpl extends NodeImpl implements DocumentType {
 
 
 // Attributes
+    @Override
     public String getName() {
         return getNameImpl(getPeer());
     }
     native static String getNameImpl(long peer);
 
+    @Override
     public NamedNodeMap getEntities() {
         return NamedNodeMapImpl.getImpl(getEntitiesImpl(getPeer()));
     }
     native static long getEntitiesImpl(long peer);
 
+    @Override
     public NamedNodeMap getNotations() {
         return NamedNodeMapImpl.getImpl(getNotationsImpl(getPeer()));
     }
     native static long getNotationsImpl(long peer);
 
+    @Override
     public String getPublicId() {
         return getPublicIdImpl(getPeer());
     }
     native static String getPublicIdImpl(long peer);
 
+    @Override
     public String getSystemId() {
         return getSystemIdImpl(getPeer());
     }
     native static String getSystemIdImpl(long peer);
 
+    @Override
     public String getInternalSubset() {
         return getInternalSubsetImpl(getPeer());
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/ElementImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/ElementImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,11 +51,13 @@ public class ElementImpl extends NodeImpl implements Element {
     public static final int ALLOW_KEYBOARD_INPUT = 1;
 
 // Attributes
+    @Override
     public String getTagName() {
         return getTagNameImpl(getPeer());
     }
     native static String getTagNameImpl(long peer);
 
+    @Override
     public NamedNodeMap getAttributes() {
         return NamedNodeMapImpl.getImpl(getAttributesImpl(getPeer()));
     }
@@ -953,6 +955,7 @@ public class ElementImpl extends NodeImpl implements Element {
 
 
 // Functions
+    @Override
     public String getAttribute(String name)
     {
         return getAttributeImpl(getPeer()
@@ -962,6 +965,7 @@ public class ElementImpl extends NodeImpl implements Element {
         , String name);
 
 
+    @Override
     public void setAttribute(String name
         , String value) throws DOMException
     {
@@ -974,6 +978,7 @@ public class ElementImpl extends NodeImpl implements Element {
         , String value);
 
 
+    @Override
     public void removeAttribute(String name)
     {
         removeAttributeImpl(getPeer()
@@ -983,6 +988,7 @@ public class ElementImpl extends NodeImpl implements Element {
         , String name);
 
 
+    @Override
     public Attr getAttributeNode(String name)
     {
         return AttrImpl.getImpl(getAttributeNodeImpl(getPeer()
@@ -992,6 +998,7 @@ public class ElementImpl extends NodeImpl implements Element {
         , String name);
 
 
+    @Override
     public Attr setAttributeNode(Attr newAttr) throws DOMException
     {
         return AttrImpl.getImpl(setAttributeNodeImpl(getPeer()
@@ -1001,6 +1008,7 @@ public class ElementImpl extends NodeImpl implements Element {
         , long newAttr);
 
 
+    @Override
     public Attr removeAttributeNode(Attr oldAttr) throws DOMException
     {
         return AttrImpl.getImpl(removeAttributeNodeImpl(getPeer()
@@ -1010,6 +1018,7 @@ public class ElementImpl extends NodeImpl implements Element {
         , long oldAttr);
 
 
+    @Override
     public NodeList getElementsByTagName(String name)
     {
         return NodeListImpl.getImpl(getElementsByTagNameImpl(getPeer()
@@ -1019,6 +1028,7 @@ public class ElementImpl extends NodeImpl implements Element {
         , String name);
 
 
+    @Override
     public boolean hasAttributes()
     {
         return hasAttributesImpl(getPeer());
@@ -1026,6 +1036,7 @@ public class ElementImpl extends NodeImpl implements Element {
     native static boolean hasAttributesImpl(long peer);
 
 
+    @Override
     public String getAttributeNS(String namespaceURI
         , String localName)
     {
@@ -1038,6 +1049,7 @@ public class ElementImpl extends NodeImpl implements Element {
         , String localName);
 
 
+    @Override
     public void setAttributeNS(String namespaceURI
         , String qualifiedName
         , String value) throws DOMException
@@ -1053,6 +1065,7 @@ public class ElementImpl extends NodeImpl implements Element {
         , String value);
 
 
+    @Override
     public void removeAttributeNS(String namespaceURI
         , String localName)
     {
@@ -1065,6 +1078,7 @@ public class ElementImpl extends NodeImpl implements Element {
         , String localName);
 
 
+    @Override
     public NodeList getElementsByTagNameNS(String namespaceURI
         , String localName)
     {
@@ -1077,6 +1091,7 @@ public class ElementImpl extends NodeImpl implements Element {
         , String localName);
 
 
+    @Override
     public Attr getAttributeNodeNS(String namespaceURI
         , String localName)
     {
@@ -1089,6 +1104,7 @@ public class ElementImpl extends NodeImpl implements Element {
         , String localName);
 
 
+    @Override
     public Attr setAttributeNodeNS(Attr newAttr) throws DOMException
     {
         return AttrImpl.getImpl(setAttributeNodeNSImpl(getPeer()
@@ -1098,6 +1114,7 @@ public class ElementImpl extends NodeImpl implements Element {
         , long newAttr);
 
 
+    @Override
     public boolean hasAttribute(String name)
     {
         return hasAttributeImpl(getPeer()
@@ -1107,6 +1124,7 @@ public class ElementImpl extends NodeImpl implements Element {
         , String name);
 
 
+    @Override
     public boolean hasAttributeNS(String namespaceURI
         , String localName)
     {
@@ -1248,15 +1266,22 @@ public class ElementImpl extends NodeImpl implements Element {
 
 
 //stubs
+    @Override
     public void setIdAttribute(String name, boolean isId) throws DOMException {
         throw new UnsupportedOperationException("Not supported yet.");
     }
+
+    @Override
     public void setIdAttributeNode(Attr idAttr, boolean isId) throws DOMException {
         throw new UnsupportedOperationException("Not supported yet.");
     }
+
+    @Override
     public TypeInfo getSchemaTypeInfo() {
         throw new UnsupportedOperationException("Not supported yet.");
     }
+
+    @Override
     public void setIdAttributeNS(String namespaceURI, String localName, boolean isId) throws DOMException {
         throw new UnsupportedOperationException("Not supported yet.");
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/EntityImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/EntityImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,16 +38,19 @@ public class EntityImpl extends NodeImpl implements Entity {
 
 
 // Attributes
+    @Override
     public String getPublicId() {
         return getPublicIdImpl(getPeer());
     }
     native static String getPublicIdImpl(long peer);
 
+    @Override
     public String getSystemId() {
         return getSystemIdImpl(getPeer());
     }
     native static String getSystemIdImpl(long peer);
 
+    @Override
     public String getNotationName() {
         return getNotationNameImpl(getPeer());
     }
@@ -55,12 +58,17 @@ public class EntityImpl extends NodeImpl implements Entity {
 
 
 //stubs
+    @Override
     public String getInputEncoding() {
         throw new UnsupportedOperationException("Not supported yet.");
     }
+
+    @Override
     public String getXmlVersion() {
         throw new UnsupportedOperationException("Not supported yet.");
     }
+
+    @Override
     public String getXmlEncoding() {
         throw new UnsupportedOperationException("Not supported yet.");
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/EventImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/EventImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,6 +36,8 @@ public class EventImpl implements Event {
         SelfDisposer(final long peer) {
             this.peer = peer;
         }
+
+        @Override
         public void dispose() {
             EventImpl.dispose(peer);
         }
@@ -114,36 +116,43 @@ public class EventImpl implements Event {
     public static final int CHANGE = 32768;
 
 // Attributes
+    @Override
     public String getType() {
         return getTypeImpl(getPeer());
     }
     native static String getTypeImpl(long peer);
 
+    @Override
     public EventTarget getTarget() {
         return (EventTarget)NodeImpl.getImpl(getTargetImpl(getPeer()));
     }
     native static long getTargetImpl(long peer);
 
+    @Override
     public EventTarget getCurrentTarget() {
         return (EventTarget)NodeImpl.getImpl(getCurrentTargetImpl(getPeer()));
     }
     native static long getCurrentTargetImpl(long peer);
 
+    @Override
     public short getEventPhase() {
         return getEventPhaseImpl(getPeer());
     }
     native static short getEventPhaseImpl(long peer);
 
+    @Override
     public boolean getBubbles() {
         return getBubblesImpl(getPeer());
     }
     native static boolean getBubblesImpl(long peer);
 
+    @Override
     public boolean getCancelable() {
         return getCancelableImpl(getPeer());
     }
     native static boolean getCancelableImpl(long peer);
 
+    @Override
     public long getTimeStamp() {
         return getTimeStampImpl(getPeer());
     }
@@ -186,6 +195,7 @@ public class EventImpl implements Event {
 
 
 // Functions
+    @Override
     public void stopPropagation()
     {
         stopPropagationImpl(getPeer());
@@ -193,6 +203,7 @@ public class EventImpl implements Event {
     native static void stopPropagationImpl(long peer);
 
 
+    @Override
     public void preventDefault()
     {
         preventDefaultImpl(getPeer());
@@ -200,6 +211,7 @@ public class EventImpl implements Event {
     native static void preventDefaultImpl(long peer);
 
 
+    @Override
     public void initEvent(String eventTypeArg
         , boolean canBubbleArg
         , boolean cancelableArg)

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/EventListenerImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/EventListenerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,6 +47,8 @@ final class EventListenerImpl implements EventListener {
         private SelfDisposer(final long peer) {
             this.peer = peer;
         }
+
+        @Override
         public void dispose() {
             //dispose JavaEL <-> JSstab connection (JavaEL die)
             EventListenerImpl.dispose(peer);
@@ -102,6 +104,7 @@ final class EventListenerImpl implements EventListener {
         return el;
     }
 
+    @Override
     public void handleEvent(Event evt) {
         //call to JS peer if any
         if (jsPeer != 0L && (evt instanceof EventImpl)) {

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/EventTargetImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/EventTargetImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,6 +38,8 @@ public class EventTargetImpl implements EventTarget {
         SelfDisposer(final long peer) {
             this.peer = peer;
         }
+
+        @Override
         public void dispose() {
             EventTargetImpl.dispose(peer);
         }
@@ -80,6 +82,7 @@ public class EventTargetImpl implements EventTarget {
 
 
 // Functions
+    @Override
     public void addEventListener(String type
         , EventListener listener
         , boolean useCapture)
@@ -95,6 +98,7 @@ public class EventTargetImpl implements EventTarget {
         , boolean useCapture);
 
 
+    @Override
     public void removeEventListener(String type
         , EventListener listener
         , boolean useCapture)
@@ -110,6 +114,7 @@ public class EventTargetImpl implements EventTarget {
         , boolean useCapture);
 
 
+    @Override
     public boolean dispatchEvent(Event event) throws DOMException
     {
         return dispatchEventImpl(getPeer()

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLAnchorElementImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLAnchorElementImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,41 +39,49 @@ public class HTMLAnchorElementImpl extends HTMLElementImpl implements HTMLAnchor
 
 
 // Attributes
+    @Override
     public String getCharset() {
         return getCharsetImpl(getPeer());
     }
     native static String getCharsetImpl(long peer);
 
+    @Override
     public void setCharset(String value) {
         setCharsetImpl(getPeer(), value);
     }
     native static void setCharsetImpl(long peer, String value);
 
+    @Override
     public String getCoords() {
         return getCoordsImpl(getPeer());
     }
     native static String getCoordsImpl(long peer);
 
+    @Override
     public void setCoords(String value) {
         setCoordsImpl(getPeer(), value);
     }
     native static void setCoordsImpl(long peer, String value);
 
+    @Override
     public String getHreflang() {
         return getHreflangImpl(getPeer());
     }
     native static String getHreflangImpl(long peer);
 
+    @Override
     public void setHreflang(String value) {
         setHreflangImpl(getPeer(), value);
     }
     native static void setHreflangImpl(long peer, String value);
 
+    @Override
     public String getName() {
         return getNameImpl(getPeer());
     }
     native static String getNameImpl(long peer);
 
+    @Override
     public void setName(String value) {
         setNameImpl(getPeer(), value);
     }
@@ -89,51 +97,61 @@ public class HTMLAnchorElementImpl extends HTMLElementImpl implements HTMLAnchor
     }
     native static void setPingImpl(long peer, String value);
 
+    @Override
     public String getRel() {
         return getRelImpl(getPeer());
     }
     native static String getRelImpl(long peer);
 
+    @Override
     public void setRel(String value) {
         setRelImpl(getPeer(), value);
     }
     native static void setRelImpl(long peer, String value);
 
+    @Override
     public String getRev() {
         return getRevImpl(getPeer());
     }
     native static String getRevImpl(long peer);
 
+    @Override
     public void setRev(String value) {
         setRevImpl(getPeer(), value);
     }
     native static void setRevImpl(long peer, String value);
 
+    @Override
     public String getShape() {
         return getShapeImpl(getPeer());
     }
     native static String getShapeImpl(long peer);
 
+    @Override
     public void setShape(String value) {
         setShapeImpl(getPeer(), value);
     }
     native static void setShapeImpl(long peer, String value);
 
+    @Override
     public String getTarget() {
         return getTargetImpl(getPeer());
     }
     native static String getTargetImpl(long peer);
 
+    @Override
     public void setTarget(String value) {
         setTargetImpl(getPeer(), value);
     }
     native static void setTargetImpl(long peer, String value);
 
+    @Override
     public String getType() {
         return getTypeImpl(getPeer());
     }
     native static String getTypeImpl(long peer);
 
+    @Override
     public void setType(String value) {
         setTypeImpl(getPeer(), value);
     }
@@ -149,11 +167,13 @@ public class HTMLAnchorElementImpl extends HTMLElementImpl implements HTMLAnchor
     }
     native static void setTextImpl(long peer, String value);
 
+    @Override
     public String getHref() {
         return getHrefImpl(getPeer());
     }
     native static String getHrefImpl(long peer);
 
+    @Override
     public void setHref(String value) {
         setHrefImpl(getPeer(), value);
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLAppletElementImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLAppletElementImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,111 +38,133 @@ public class HTMLAppletElementImpl extends HTMLElementImpl implements HTMLApplet
 
 
 // Attributes
+    @Override
     public String getAlign() {
         return getAlignImpl(getPeer());
     }
     native static String getAlignImpl(long peer);
 
+    @Override
     public void setAlign(String value) {
         setAlignImpl(getPeer(), value);
     }
     native static void setAlignImpl(long peer, String value);
 
+    @Override
     public String getAlt() {
         return getAltImpl(getPeer());
     }
     native static String getAltImpl(long peer);
 
+    @Override
     public void setAlt(String value) {
         setAltImpl(getPeer(), value);
     }
     native static void setAltImpl(long peer, String value);
 
+    @Override
     public String getArchive() {
         return getArchiveImpl(getPeer());
     }
     native static String getArchiveImpl(long peer);
 
+    @Override
     public void setArchive(String value) {
         setArchiveImpl(getPeer(), value);
     }
     native static void setArchiveImpl(long peer, String value);
 
+    @Override
     public String getCode() {
         return getCodeImpl(getPeer());
     }
     native static String getCodeImpl(long peer);
 
+    @Override
     public void setCode(String value) {
         setCodeImpl(getPeer(), value);
     }
     native static void setCodeImpl(long peer, String value);
 
+    @Override
     public String getCodeBase() {
         return getCodeBaseImpl(getPeer());
     }
     native static String getCodeBaseImpl(long peer);
 
+    @Override
     public void setCodeBase(String value) {
         setCodeBaseImpl(getPeer(), value);
     }
     native static void setCodeBaseImpl(long peer, String value);
 
+    @Override
     public String getHeight() {
         return getHeightImpl(getPeer());
     }
     native static String getHeightImpl(long peer);
 
+    @Override
     public void setHeight(String value) {
         setHeightImpl(getPeer(), value);
     }
     native static void setHeightImpl(long peer, String value);
 
+    @Override
     public String getHspace() {
         return getHspaceImpl(getPeer())+"";
     }
     native static int getHspaceImpl(long peer);
 
+    @Override
     public void setHspace(String value) {
         setHspaceImpl(getPeer(), Integer.parseInt(value));
     }
     native static void setHspaceImpl(long peer, int value);
 
+    @Override
     public String getName() {
         return getNameImpl(getPeer());
     }
     native static String getNameImpl(long peer);
 
+    @Override
     public void setName(String value) {
         setNameImpl(getPeer(), value);
     }
     native static void setNameImpl(long peer, String value);
 
+    @Override
     public String getObject() {
         return getObjectImpl(getPeer());
     }
     native static String getObjectImpl(long peer);
 
+    @Override
     public void setObject(String value) {
         setObjectImpl(getPeer(), value);
     }
     native static void setObjectImpl(long peer, String value);
 
+    @Override
     public String getVspace() {
         return getVspaceImpl(getPeer())+"";
     }
     native static int getVspaceImpl(long peer);
 
+    @Override
     public void setVspace(String value) {
         setVspaceImpl(getPeer(), Integer.parseInt(value));
     }
     native static void setVspaceImpl(long peer, int value);
 
+    @Override
     public String getWidth() {
         return getWidthImpl(getPeer());
     }
     native static String getWidthImpl(long peer);
 
+    @Override
     public void setWidth(String value) {
         setWidthImpl(getPeer(), value);
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLAreaElementImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLAreaElementImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,31 +38,37 @@ public class HTMLAreaElementImpl extends HTMLElementImpl implements HTMLAreaElem
 
 
 // Attributes
+    @Override
     public String getAlt() {
         return getAltImpl(getPeer());
     }
     native static String getAltImpl(long peer);
 
+    @Override
     public void setAlt(String value) {
         setAltImpl(getPeer(), value);
     }
     native static void setAltImpl(long peer, String value);
 
+    @Override
     public String getCoords() {
         return getCoordsImpl(getPeer());
     }
     native static String getCoordsImpl(long peer);
 
+    @Override
     public void setCoords(String value) {
         setCoordsImpl(getPeer(), value);
     }
     native static void setCoordsImpl(long peer, String value);
 
+    @Override
     public boolean getNoHref() {
         return getNoHrefImpl(getPeer());
     }
     native static boolean getNoHrefImpl(long peer);
 
+    @Override
     public void setNoHref(boolean value) {
         setNoHrefImpl(getPeer(), value);
     }
@@ -88,41 +94,49 @@ public class HTMLAreaElementImpl extends HTMLElementImpl implements HTMLAreaElem
     }
     native static void setRelImpl(long peer, String value);
 
+    @Override
     public String getShape() {
         return getShapeImpl(getPeer());
     }
     native static String getShapeImpl(long peer);
 
+    @Override
     public void setShape(String value) {
         setShapeImpl(getPeer(), value);
     }
     native static void setShapeImpl(long peer, String value);
 
+    @Override
     public String getTarget() {
         return getTargetImpl(getPeer());
     }
     native static String getTargetImpl(long peer);
 
+    @Override
     public void setTarget(String value) {
         setTargetImpl(getPeer(), value);
     }
     native static void setTargetImpl(long peer, String value);
 
+    @Override
     public String getAccessKey() {
         return getAccessKeyImpl(getPeer());
     }
     native static String getAccessKeyImpl(long peer);
 
+    @Override
     public void setAccessKey(String value) {
         setAccessKeyImpl(getPeer(), value);
     }
     native static void setAccessKeyImpl(long peer, String value);
 
+    @Override
     public String getHref() {
         return getHrefImpl(getPeer());
     }
     native static String getHrefImpl(long peer);
 
+    @Override
     public void setHref(String value) {
         setHrefImpl(getPeer(), value);
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLBRElementImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLBRElementImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,11 +38,13 @@ public class HTMLBRElementImpl extends HTMLElementImpl implements HTMLBRElement 
 
 
 // Attributes
+    @Override
     public String getClear() {
         return getClearImpl(getPeer());
     }
     native static String getClearImpl(long peer);
 
+    @Override
     public void setClear(String value) {
         setClearImpl(getPeer(), value);
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLBaseElementImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLBaseElementImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,21 +38,25 @@ public class HTMLBaseElementImpl extends HTMLElementImpl implements HTMLBaseElem
 
 
 // Attributes
+    @Override
     public String getHref() {
         return getHrefImpl(getPeer());
     }
     native static String getHrefImpl(long peer);
 
+    @Override
     public void setHref(String value) {
         setHrefImpl(getPeer(), value);
     }
     native static void setHrefImpl(long peer, String value);
 
+    @Override
     public String getTarget() {
         return getTargetImpl(getPeer());
     }
     native static String getTargetImpl(long peer);
 
+    @Override
     public void setTarget(String value) {
         setTargetImpl(getPeer(), value);
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLBaseFontElementImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLBaseFontElementImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,31 +38,37 @@ public class HTMLBaseFontElementImpl extends HTMLElementImpl implements HTMLBase
 
 
 // Attributes
+    @Override
     public String getColor() {
         return getColorImpl(getPeer());
     }
     native static String getColorImpl(long peer);
 
+    @Override
     public void setColor(String value) {
         setColorImpl(getPeer(), value);
     }
     native static void setColorImpl(long peer, String value);
 
+    @Override
     public String getFace() {
         return getFaceImpl(getPeer());
     }
     native static String getFaceImpl(long peer);
 
+    @Override
     public void setFace(String value) {
         setFaceImpl(getPeer(), value);
     }
     native static void setFaceImpl(long peer, String value);
 
+    @Override
     public String getSize() {
         return getSizeImpl(getPeer())+"";
     }
     native static String getSizeImpl(long peer);
 
+    @Override
     public void setSize(String value) {
         setSizeImpl(getPeer(), value);
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLBodyElementImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLBodyElementImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,141 +39,169 @@ public class HTMLBodyElementImpl extends HTMLElementImpl implements HTMLBodyElem
 
 
 // Attributes
+    @Override
     public String getALink() {
         return getALinkImpl(getPeer());
     }
     native static String getALinkImpl(long peer);
 
+    @Override
     public void setALink(String value) {
         setALinkImpl(getPeer(), value);
     }
     native static void setALinkImpl(long peer, String value);
 
+    @Override
     public String getBackground() {
         return getBackgroundImpl(getPeer());
     }
     native static String getBackgroundImpl(long peer);
 
+    @Override
     public void setBackground(String value) {
         setBackgroundImpl(getPeer(), value);
     }
     native static void setBackgroundImpl(long peer, String value);
 
+    @Override
     public String getBgColor() {
         return getBgColorImpl(getPeer());
     }
     native static String getBgColorImpl(long peer);
 
+    @Override
     public void setBgColor(String value) {
         setBgColorImpl(getPeer(), value);
     }
     native static void setBgColorImpl(long peer, String value);
 
+    @Override
     public String getLink() {
         return getLinkImpl(getPeer());
     }
     native static String getLinkImpl(long peer);
 
+    @Override
     public void setLink(String value) {
         setLinkImpl(getPeer(), value);
     }
     native static void setLinkImpl(long peer, String value);
 
+    @Override
     public String getText() {
         return getTextImpl(getPeer());
     }
     native static String getTextImpl(long peer);
 
+    @Override
     public void setText(String value) {
         setTextImpl(getPeer(), value);
     }
     native static void setTextImpl(long peer, String value);
 
+    @Override
     public String getVLink() {
         return getVLinkImpl(getPeer());
     }
     native static String getVLinkImpl(long peer);
 
+    @Override
     public void setVLink(String value) {
         setVLinkImpl(getPeer(), value);
     }
     native static void setVLinkImpl(long peer, String value);
 
+    @Override
     public EventListener getOnblur() {
         return EventListenerImpl.getImpl(getOnblurImpl(getPeer()));
     }
     native static long getOnblurImpl(long peer);
 
+    @Override
     public void setOnblur(EventListener value) {
         setOnblurImpl(getPeer(), EventListenerImpl.getPeer(value));
     }
     native static void setOnblurImpl(long peer, long value);
 
+    @Override
     public EventListener getOnerror() {
         return EventListenerImpl.getImpl(getOnerrorImpl(getPeer()));
     }
     native static long getOnerrorImpl(long peer);
 
+    @Override
     public void setOnerror(EventListener value) {
         setOnerrorImpl(getPeer(), EventListenerImpl.getPeer(value));
     }
     native static void setOnerrorImpl(long peer, long value);
 
+    @Override
     public EventListener getOnfocus() {
         return EventListenerImpl.getImpl(getOnfocusImpl(getPeer()));
     }
     native static long getOnfocusImpl(long peer);
 
+    @Override
     public void setOnfocus(EventListener value) {
         setOnfocusImpl(getPeer(), EventListenerImpl.getPeer(value));
     }
     native static void setOnfocusImpl(long peer, long value);
 
+    @Override
     public EventListener getOnfocusin() {
         return EventListenerImpl.getImpl(getOnfocusinImpl(getPeer()));
     }
     native static long getOnfocusinImpl(long peer);
 
+    @Override
     public void setOnfocusin(EventListener value) {
         setOnfocusinImpl(getPeer(), EventListenerImpl.getPeer(value));
     }
     native static void setOnfocusinImpl(long peer, long value);
 
+    @Override
     public EventListener getOnfocusout() {
         return EventListenerImpl.getImpl(getOnfocusoutImpl(getPeer()));
     }
     native static long getOnfocusoutImpl(long peer);
 
+    @Override
     public void setOnfocusout(EventListener value) {
         setOnfocusoutImpl(getPeer(), EventListenerImpl.getPeer(value));
     }
     native static void setOnfocusoutImpl(long peer, long value);
 
+    @Override
     public EventListener getOnload() {
         return EventListenerImpl.getImpl(getOnloadImpl(getPeer()));
     }
     native static long getOnloadImpl(long peer);
 
+    @Override
     public void setOnload(EventListener value) {
         setOnloadImpl(getPeer(), EventListenerImpl.getPeer(value));
     }
     native static void setOnloadImpl(long peer, long value);
 
+    @Override
     public EventListener getOnresize() {
         return EventListenerImpl.getImpl(getOnresizeImpl(getPeer()));
     }
     native static long getOnresizeImpl(long peer);
 
+    @Override
     public void setOnresize(EventListener value) {
         setOnresizeImpl(getPeer(), EventListenerImpl.getPeer(value));
     }
     native static void setOnresizeImpl(long peer, long value);
 
+    @Override
     public EventListener getOnscroll() {
         return EventListenerImpl.getImpl(getOnscrollImpl(getPeer()));
     }
     native static long getOnscrollImpl(long peer);
 
+    @Override
     public void setOnscroll(EventListener value) {
         setOnscrollImpl(getPeer(), EventListenerImpl.getPeer(value));
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLButtonElementImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLButtonElementImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,16 +50,19 @@ public class HTMLButtonElementImpl extends HTMLElementImpl implements HTMLButton
     }
     native static void setAutofocusImpl(long peer, boolean value);
 
+    @Override
     public boolean getDisabled() {
         return getDisabledImpl(getPeer());
     }
     native static boolean getDisabledImpl(long peer);
 
+    @Override
     public void setDisabled(boolean value) {
         setDisabledImpl(getPeer(), value);
     }
     native static void setDisabledImpl(long peer, boolean value);
 
+    @Override
     public HTMLFormElement getForm() {
         return HTMLFormElementImpl.getImpl(getFormImpl(getPeer()));
     }
@@ -95,6 +98,7 @@ public class HTMLButtonElementImpl extends HTMLElementImpl implements HTMLButton
     }
     native static void setFormMethodImpl(long peer, String value);
 
+    @Override
     public String getType() {
         return getTypeImpl(getPeer());
     }
@@ -125,21 +129,25 @@ public class HTMLButtonElementImpl extends HTMLElementImpl implements HTMLButton
     }
     native static void setFormTargetImpl(long peer, String value);
 
+    @Override
     public String getName() {
         return getNameImpl(getPeer());
     }
     native static String getNameImpl(long peer);
 
+    @Override
     public void setName(String value) {
         setNameImpl(getPeer(), value);
     }
     native static void setNameImpl(long peer, String value);
 
+    @Override
     public String getValue() {
         return getValueImpl(getPeer());
     }
     native static String getValueImpl(long peer);
 
+    @Override
     public void setValue(String value) {
         setValueImpl(getPeer(), value);
     }
@@ -160,11 +168,13 @@ public class HTMLButtonElementImpl extends HTMLElementImpl implements HTMLButton
     }
     native static long getLabelsImpl(long peer);
 
+    @Override
     public String getAccessKey() {
         return getAccessKeyImpl(getPeer());
     }
     native static String getAccessKeyImpl(long peer);
 
+    @Override
     public void setAccessKey(String value) {
         setAccessKeyImpl(getPeer(), value);
     }
@@ -188,6 +198,7 @@ public class HTMLButtonElementImpl extends HTMLElementImpl implements HTMLButton
         , String error);
 
 
+    @Override
     public void click()
     {
         clickImpl(getPeer());

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLCollectionImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLCollectionImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,6 +36,8 @@ public class HTMLCollectionImpl implements HTMLCollection {
         SelfDisposer(final long peer) {
             this.peer = peer;
         }
+
+        @Override
         public void dispose() {
             HTMLCollectionImpl.dispose(peer);
         }
@@ -84,6 +86,7 @@ public class HTMLCollectionImpl implements HTMLCollection {
 
 
 // Attributes
+    @Override
     public int getLength() {
         return getLengthImpl(getPeer());
     }
@@ -91,7 +94,8 @@ public class HTMLCollectionImpl implements HTMLCollection {
 
 
 // Functions
-    public Node item(int index)
+    @Override
+   public Node item(int index)
     {
         return NodeImpl.getImpl(itemImpl(getPeer()
             , index));
@@ -100,6 +104,7 @@ public class HTMLCollectionImpl implements HTMLCollection {
         , int index);
 
 
+    @Override
     public Node namedItem(String name)
     {
         return NodeImpl.getImpl(namedItemImpl(getPeer()

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLDListElementImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLDListElementImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,11 +38,13 @@ public class HTMLDListElementImpl extends HTMLElementImpl implements HTMLDListEl
 
 
 // Attributes
+    @Override
     public boolean getCompact() {
         return getCompactImpl(getPeer());
     }
     native static boolean getCompactImpl(long peer);
 
+    @Override
     public void setCompact(boolean value) {
         setCompactImpl(getPeer(), value);
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLDirectoryElementImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLDirectoryElementImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,11 +38,13 @@ public class HTMLDirectoryElementImpl extends HTMLElementImpl implements HTMLDir
 
 
 // Attributes
+    @Override
     public boolean getCompact() {
         return getCompactImpl(getPeer());
     }
     native static boolean getCompactImpl(long peer);
 
+    @Override
     public void setCompact(boolean value) {
         setCompactImpl(getPeer(), value);
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLDivElementImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLDivElementImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,11 +38,13 @@ public class HTMLDivElementImpl extends HTMLElementImpl implements HTMLDivElemen
 
 
 // Attributes
+    @Override
     public String getAlign() {
         return getAlignImpl(getPeer());
     }
     native static String getAlignImpl(long peer);
 
+    @Override
     public void setAlign(String value) {
         setAlignImpl(getPeer(), value);
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLDocumentImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLDocumentImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -84,6 +84,7 @@ public class HTMLDocumentImpl extends DocumentImpl implements HTMLDocument {
     }
     native static void setDesignModeImpl(long peer, String value);
 
+    @Override
     public String getCompatMode() {
         return getCompatModeImpl(getPeer());
     }
@@ -141,6 +142,7 @@ public class HTMLDocumentImpl extends DocumentImpl implements HTMLDocument {
 
 
 // Functions
+    @Override
     public void open()
     {
         openImpl(getPeer());
@@ -148,6 +150,7 @@ public class HTMLDocumentImpl extends DocumentImpl implements HTMLDocument {
     native static void openImpl(long peer);
 
 
+    @Override
     public void close()
     {
         closeImpl(getPeer());
@@ -155,6 +158,7 @@ public class HTMLDocumentImpl extends DocumentImpl implements HTMLDocument {
     native static void closeImpl(long peer);
 
 
+    @Override
     public void write(String text)
     {
         writeImpl(getPeer()
@@ -164,6 +168,7 @@ public class HTMLDocumentImpl extends DocumentImpl implements HTMLDocument {
         , String text);
 
 
+    @Override
     public void writeln(String text)
     {
         writelnImpl(getPeer()

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLElementImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLElementImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,31 +41,37 @@ public class HTMLElementImpl extends ElementImpl implements HTMLElement {
 
 
 // Attributes
+    @Override
     public String getId() {
         return getIdImpl(getPeer());
     }
     native static String getIdImpl(long peer);
 
+    @Override
     public void setId(String value) {
         setIdImpl(getPeer(), value);
     }
     native static void setIdImpl(long peer, String value);
 
+    @Override
     public String getTitle() {
         return getTitleImpl(getPeer());
     }
     native static String getTitleImpl(long peer);
 
+    @Override
     public void setTitle(String value) {
         setTitleImpl(getPeer(), value);
     }
     native static void setTitleImpl(long peer, String value);
 
+    @Override
     public String getLang() {
         return getLangImpl(getPeer());
     }
     native static String getLangImpl(long peer);
 
+    @Override
     public void setLang(String value) {
         setLangImpl(getPeer(), value);
     }
@@ -81,11 +87,13 @@ public class HTMLElementImpl extends ElementImpl implements HTMLElement {
     }
     native static void setTranslateImpl(long peer, boolean value);
 
+    @Override
     public String getDir() {
         return getDirImpl(getPeer());
     }
     native static String getDirImpl(long peer);
 
+    @Override
     public void setDir(String value) {
         setDirImpl(getPeer(), value);
     }
@@ -161,6 +169,7 @@ public class HTMLElementImpl extends ElementImpl implements HTMLElement {
     }
     native static void setOuterTextImpl(long peer, String value);
 
+    @Override
     public HTMLCollection getChildren() {
         return HTMLCollectionImpl.getImpl(getChildrenImpl(getPeer()));
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLFieldSetElementImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLFieldSetElementImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,6 +49,7 @@ public class HTMLFieldSetElementImpl extends HTMLElementImpl implements HTMLFiel
     }
     native static void setDisabledImpl(long peer, boolean value);
 
+    @Override
     public HTMLFormElement getForm() {
         return HTMLFormElementImpl.getImpl(getFormImpl(getPeer()));
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLFontElementImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLFontElementImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,31 +38,37 @@ public class HTMLFontElementImpl extends HTMLElementImpl implements HTMLFontElem
 
 
 // Attributes
+    @Override
     public String getColor() {
         return getColorImpl(getPeer());
     }
     native static String getColorImpl(long peer);
 
+    @Override
     public void setColor(String value) {
         setColorImpl(getPeer(), value);
     }
     native static void setColorImpl(long peer, String value);
 
+    @Override
     public String getFace() {
         return getFaceImpl(getPeer());
     }
     native static String getFaceImpl(long peer);
 
+    @Override
     public void setFace(String value) {
         setFaceImpl(getPeer(), value);
     }
     native static void setFaceImpl(long peer, String value);
 
+    @Override
     public String getSize() {
         return getSizeImpl(getPeer());
     }
     native static String getSizeImpl(long peer);
 
+    @Override
     public void setSize(String value) {
         setSizeImpl(getPeer(), value);
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLFormElementImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLFormElementImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,21 +39,25 @@ public class HTMLFormElementImpl extends HTMLElementImpl implements HTMLFormElem
 
 
 // Attributes
+    @Override
     public String getAcceptCharset() {
         return getAcceptCharsetImpl(getPeer());
     }
     native static String getAcceptCharsetImpl(long peer);
 
+    @Override
     public void setAcceptCharset(String value) {
         setAcceptCharsetImpl(getPeer(), value);
     }
     native static void setAcceptCharsetImpl(long peer, String value);
 
+    @Override
     public String getAction() {
         return getActionImpl(getPeer());
     }
     native static String getActionImpl(long peer);
 
+    @Override
     public void setAction(String value) {
         setActionImpl(getPeer(), value);
     }
@@ -69,11 +73,13 @@ public class HTMLFormElementImpl extends HTMLElementImpl implements HTMLFormElem
     }
     native static void setAutocompleteImpl(long peer, String value);
 
+    @Override
     public String getEnctype() {
         return getEnctypeImpl(getPeer());
     }
     native static String getEnctypeImpl(long peer);
 
+    @Override
     public void setEnctype(String value) {
         setEnctypeImpl(getPeer(), value);
     }
@@ -89,21 +95,25 @@ public class HTMLFormElementImpl extends HTMLElementImpl implements HTMLFormElem
     }
     native static void setEncodingImpl(long peer, String value);
 
+    @Override
     public String getMethod() {
         return getMethodImpl(getPeer());
     }
     native static String getMethodImpl(long peer);
 
+    @Override
     public void setMethod(String value) {
         setMethodImpl(getPeer(), value);
     }
     native static void setMethodImpl(long peer, String value);
 
+    @Override
     public String getName() {
         return getNameImpl(getPeer());
     }
     native static String getNameImpl(long peer);
 
+    @Override
     public void setName(String value) {
         setNameImpl(getPeer(), value);
     }
@@ -119,21 +129,25 @@ public class HTMLFormElementImpl extends HTMLElementImpl implements HTMLFormElem
     }
     native static void setNoValidateImpl(long peer, boolean value);
 
+    @Override
     public String getTarget() {
         return getTargetImpl(getPeer());
     }
     native static String getTargetImpl(long peer);
 
+    @Override
     public void setTarget(String value) {
         setTargetImpl(getPeer(), value);
     }
     native static void setTargetImpl(long peer, String value);
 
+    @Override
     public HTMLCollection getElements() {
         return HTMLCollectionImpl.getImpl(getElementsImpl(getPeer()));
     }
     native static long getElementsImpl(long peer);
 
+    @Override
     public int getLength() {
         return getLengthImpl(getPeer());
     }
@@ -141,6 +155,7 @@ public class HTMLFormElementImpl extends HTMLElementImpl implements HTMLFormElem
 
 
 // Functions
+    @Override
     public void submit()
     {
         submitImpl(getPeer());
@@ -148,6 +163,7 @@ public class HTMLFormElementImpl extends HTMLElementImpl implements HTMLFormElem
     native static void submitImpl(long peer);
 
 
+    @Override
     public void reset()
     {
         resetImpl(getPeer());

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLFrameElementImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLFrameElementImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,86 +40,103 @@ public class HTMLFrameElementImpl extends HTMLElementImpl implements HTMLFrameEl
 
 
 // Attributes
+    @Override
     public String getFrameBorder() {
         return getFrameBorderImpl(getPeer());
     }
     native static String getFrameBorderImpl(long peer);
 
+    @Override
     public void setFrameBorder(String value) {
         setFrameBorderImpl(getPeer(), value);
     }
     native static void setFrameBorderImpl(long peer, String value);
 
+    @Override
     public String getLongDesc() {
         return getLongDescImpl(getPeer());
     }
     native static String getLongDescImpl(long peer);
 
+    @Override
     public void setLongDesc(String value) {
         setLongDescImpl(getPeer(), value);
     }
     native static void setLongDescImpl(long peer, String value);
 
+    @Override
     public String getMarginHeight() {
         return getMarginHeightImpl(getPeer());
     }
     native static String getMarginHeightImpl(long peer);
 
+    @Override
     public void setMarginHeight(String value) {
         setMarginHeightImpl(getPeer(), value);
     }
     native static void setMarginHeightImpl(long peer, String value);
 
+    @Override
     public String getMarginWidth() {
         return getMarginWidthImpl(getPeer());
     }
     native static String getMarginWidthImpl(long peer);
 
+    @Override
     public void setMarginWidth(String value) {
         setMarginWidthImpl(getPeer(), value);
     }
     native static void setMarginWidthImpl(long peer, String value);
 
+    @Override
     public String getName() {
         return getNameImpl(getPeer());
     }
     native static String getNameImpl(long peer);
 
+    @Override
     public void setName(String value) {
         setNameImpl(getPeer(), value);
     }
     native static void setNameImpl(long peer, String value);
 
+    @Override
     public boolean getNoResize() {
         return getNoResizeImpl(getPeer());
     }
     native static boolean getNoResizeImpl(long peer);
 
+    @Override
     public void setNoResize(boolean value) {
         setNoResizeImpl(getPeer(), value);
     }
     native static void setNoResizeImpl(long peer, boolean value);
 
+    @Override
     public String getScrolling() {
         return getScrollingImpl(getPeer());
     }
     native static String getScrollingImpl(long peer);
 
+    @Override
     public void setScrolling(String value) {
         setScrollingImpl(getPeer(), value);
     }
     native static void setScrollingImpl(long peer, String value);
 
+    @Override
     public String getSrc() {
         return getSrcImpl(getPeer());
     }
     native static String getSrcImpl(long peer);
 
+    @Override
     public void setSrc(String value) {
         setSrcImpl(getPeer(), value);
     }
     native static void setSrcImpl(long peer, String value);
 
+    @Override
     public Document getContentDocument() {
         return DocumentImpl.getImpl(getContentDocumentImpl(getPeer()));
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLFrameSetElementImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLFrameSetElementImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,101 +39,121 @@ public class HTMLFrameSetElementImpl extends HTMLElementImpl implements HTMLFram
 
 
 // Attributes
+    @Override
     public String getCols() {
         return getColsImpl(getPeer());
     }
     native static String getColsImpl(long peer);
 
+    @Override
     public void setCols(String value) {
         setColsImpl(getPeer(), value);
     }
     native static void setColsImpl(long peer, String value);
 
+    @Override
     public String getRows() {
         return getRowsImpl(getPeer());
     }
     native static String getRowsImpl(long peer);
 
+    @Override
     public void setRows(String value) {
         setRowsImpl(getPeer(), value);
     }
     native static void setRowsImpl(long peer, String value);
 
+    @Override
     public EventListener getOnblur() {
         return EventListenerImpl.getImpl(getOnblurImpl(getPeer()));
     }
     native static long getOnblurImpl(long peer);
 
+    @Override
     public void setOnblur(EventListener value) {
         setOnblurImpl(getPeer(), EventListenerImpl.getPeer(value));
     }
     native static void setOnblurImpl(long peer, long value);
 
+    @Override
     public EventListener getOnerror() {
         return EventListenerImpl.getImpl(getOnerrorImpl(getPeer()));
     }
     native static long getOnerrorImpl(long peer);
 
+    @Override
     public void setOnerror(EventListener value) {
         setOnerrorImpl(getPeer(), EventListenerImpl.getPeer(value));
     }
     native static void setOnerrorImpl(long peer, long value);
 
+    @Override
     public EventListener getOnfocus() {
         return EventListenerImpl.getImpl(getOnfocusImpl(getPeer()));
     }
     native static long getOnfocusImpl(long peer);
 
+    @Override
     public void setOnfocus(EventListener value) {
         setOnfocusImpl(getPeer(), EventListenerImpl.getPeer(value));
     }
     native static void setOnfocusImpl(long peer, long value);
 
+    @Override
     public EventListener getOnfocusin() {
         return EventListenerImpl.getImpl(getOnfocusinImpl(getPeer()));
     }
     native static long getOnfocusinImpl(long peer);
 
+    @Override
     public void setOnfocusin(EventListener value) {
         setOnfocusinImpl(getPeer(), EventListenerImpl.getPeer(value));
     }
     native static void setOnfocusinImpl(long peer, long value);
 
+    @Override
     public EventListener getOnfocusout() {
         return EventListenerImpl.getImpl(getOnfocusoutImpl(getPeer()));
     }
     native static long getOnfocusoutImpl(long peer);
 
+    @Override
     public void setOnfocusout(EventListener value) {
         setOnfocusoutImpl(getPeer(), EventListenerImpl.getPeer(value));
     }
     native static void setOnfocusoutImpl(long peer, long value);
 
+    @Override
     public EventListener getOnload() {
         return EventListenerImpl.getImpl(getOnloadImpl(getPeer()));
     }
     native static long getOnloadImpl(long peer);
 
+    @Override
     public void setOnload(EventListener value) {
         setOnloadImpl(getPeer(), EventListenerImpl.getPeer(value));
     }
     native static void setOnloadImpl(long peer, long value);
 
+    @Override
     public EventListener getOnresize() {
         return EventListenerImpl.getImpl(getOnresizeImpl(getPeer()));
     }
     native static long getOnresizeImpl(long peer);
 
+    @Override
     public void setOnresize(EventListener value) {
         setOnresizeImpl(getPeer(), EventListenerImpl.getPeer(value));
     }
     native static void setOnresizeImpl(long peer, long value);
 
+    @Override
     public EventListener getOnscroll() {
         return EventListenerImpl.getImpl(getOnscrollImpl(getPeer()));
     }
     native static long getOnscrollImpl(long peer);
 
+    @Override
     public void setOnscroll(EventListener value) {
         setOnscrollImpl(getPeer(), EventListenerImpl.getPeer(value));
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLHRElementImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLHRElementImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,41 +38,49 @@ public class HTMLHRElementImpl extends HTMLElementImpl implements HTMLHRElement 
 
 
 // Attributes
+    @Override
     public String getAlign() {
         return getAlignImpl(getPeer());
     }
     native static String getAlignImpl(long peer);
 
+    @Override
     public void setAlign(String value) {
         setAlignImpl(getPeer(), value);
     }
     native static void setAlignImpl(long peer, String value);
 
+    @Override
     public boolean getNoShade() {
         return getNoShadeImpl(getPeer());
     }
     native static boolean getNoShadeImpl(long peer);
 
+    @Override
     public void setNoShade(boolean value) {
         setNoShadeImpl(getPeer(), value);
     }
     native static void setNoShadeImpl(long peer, boolean value);
 
+    @Override
     public String getSize() {
         return getSizeImpl(getPeer());
     }
     native static String getSizeImpl(long peer);
 
+    @Override
     public void setSize(String value) {
         setSizeImpl(getPeer(), value);
     }
     native static void setSizeImpl(long peer, String value);
 
+    @Override
     public String getWidth() {
         return getWidthImpl(getPeer());
     }
     native static String getWidthImpl(long peer);
 
+    @Override
     public void setWidth(String value) {
         setWidthImpl(getPeer(), value);
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLHeadElementImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLHeadElementImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,11 +38,13 @@ public class HTMLHeadElementImpl extends HTMLElementImpl implements HTMLHeadElem
 
 
 // Attributes
+    @Override
     public String getProfile() {
         return getProfileImpl(getPeer());
     }
     native static String getProfileImpl(long peer);
 
+    @Override
     public void setProfile(String value) {
         setProfileImpl(getPeer(), value);
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLHeadingElementImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLHeadingElementImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,11 +38,13 @@ public class HTMLHeadingElementImpl extends HTMLElementImpl implements HTMLHeadi
 
 
 // Attributes
+    @Override
     public String getAlign() {
         return getAlignImpl(getPeer());
     }
     native static String getAlignImpl(long peer);
 
+    @Override
     public void setAlign(String value) {
         setAlignImpl(getPeer(), value);
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLHtmlElementImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLHtmlElementImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,11 +38,13 @@ public class HTMLHtmlElementImpl extends HTMLElementImpl implements HTMLHtmlElem
 
 
 // Attributes
+    @Override
     public String getVersion() {
         return getVersionImpl(getPeer());
     }
     native static String getVersionImpl(long peer);
 
+    @Override
     public void setVersion(String value) {
         setVersionImpl(getPeer(), value);
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLIFrameElementImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLIFrameElementImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,91 +40,109 @@ public class HTMLIFrameElementImpl extends HTMLElementImpl implements HTMLIFrame
 
 
 // Attributes
+    @Override
     public String getAlign() {
         return getAlignImpl(getPeer());
     }
     native static String getAlignImpl(long peer);
 
+    @Override
     public void setAlign(String value) {
         setAlignImpl(getPeer(), value);
     }
     native static void setAlignImpl(long peer, String value);
 
+    @Override
     public String getFrameBorder() {
         return getFrameBorderImpl(getPeer());
     }
     native static String getFrameBorderImpl(long peer);
 
+    @Override
     public void setFrameBorder(String value) {
         setFrameBorderImpl(getPeer(), value);
     }
     native static void setFrameBorderImpl(long peer, String value);
 
+    @Override
     public String getHeight() {
         return getHeightImpl(getPeer());
     }
     native static String getHeightImpl(long peer);
 
+    @Override
     public void setHeight(String value) {
         setHeightImpl(getPeer(), value);
     }
     native static void setHeightImpl(long peer, String value);
 
+    @Override
     public String getLongDesc() {
         return getLongDescImpl(getPeer());
     }
     native static String getLongDescImpl(long peer);
 
+    @Override
     public void setLongDesc(String value) {
         setLongDescImpl(getPeer(), value);
     }
     native static void setLongDescImpl(long peer, String value);
 
+    @Override
     public String getMarginHeight() {
         return getMarginHeightImpl(getPeer());
     }
     native static String getMarginHeightImpl(long peer);
 
+    @Override
     public void setMarginHeight(String value) {
         setMarginHeightImpl(getPeer(), value);
     }
     native static void setMarginHeightImpl(long peer, String value);
 
+    @Override
     public String getMarginWidth() {
         return getMarginWidthImpl(getPeer());
     }
     native static String getMarginWidthImpl(long peer);
 
+    @Override
     public void setMarginWidth(String value) {
         setMarginWidthImpl(getPeer(), value);
     }
     native static void setMarginWidthImpl(long peer, String value);
 
+    @Override
     public String getName() {
         return getNameImpl(getPeer());
     }
     native static String getNameImpl(long peer);
 
+    @Override
     public void setName(String value) {
         setNameImpl(getPeer(), value);
     }
     native static void setNameImpl(long peer, String value);
 
+    @Override
     public String getScrolling() {
         return getScrollingImpl(getPeer());
     }
     native static String getScrollingImpl(long peer);
 
+    @Override
     public void setScrolling(String value) {
         setScrollingImpl(getPeer(), value);
     }
     native static void setScrollingImpl(long peer, String value);
 
+    @Override
     public String getSrc() {
         return getSrcImpl(getPeer());
     }
     native static String getSrcImpl(long peer);
 
+    @Override
     public void setSrc(String value) {
         setSrcImpl(getPeer(), value);
     }
@@ -140,16 +158,19 @@ public class HTMLIFrameElementImpl extends HTMLElementImpl implements HTMLIFrame
     }
     native static void setSrcdocImpl(long peer, String value);
 
+    @Override
     public String getWidth() {
         return getWidthImpl(getPeer());
     }
     native static String getWidthImpl(long peer);
 
+    @Override
     public void setWidth(String value) {
         setWidthImpl(getPeer(), value);
     }
     native static void setWidthImpl(long peer, String value);
 
+    @Override
     public Document getContentDocument() {
         return DocumentImpl.getImpl(getContentDocumentImpl(getPeer()));
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLImageElementImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLImageElementImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,41 +38,49 @@ public class HTMLImageElementImpl extends HTMLElementImpl implements HTMLImageEl
 
 
 // Attributes
+    @Override
     public String getName() {
         return getNameImpl(getPeer());
     }
     native static String getNameImpl(long peer);
 
+    @Override
     public void setName(String value) {
         setNameImpl(getPeer(), value);
     }
     native static void setNameImpl(long peer, String value);
 
+    @Override
     public String getAlign() {
         return getAlignImpl(getPeer());
     }
     native static String getAlignImpl(long peer);
 
+    @Override
     public void setAlign(String value) {
         setAlignImpl(getPeer(), value);
     }
     native static void setAlignImpl(long peer, String value);
 
+    @Override
     public String getAlt() {
         return getAltImpl(getPeer());
     }
     native static String getAltImpl(long peer);
 
+    @Override
     public void setAlt(String value) {
         setAltImpl(getPeer(), value);
     }
     native static void setAltImpl(long peer, String value);
 
+    @Override
     public String getBorder() {
         return getBorderImpl(getPeer());
     }
     native static String getBorderImpl(long peer);
 
+    @Override
     public void setBorder(String value) {
         setBorderImpl(getPeer(), value);
     }
@@ -88,51 +96,61 @@ public class HTMLImageElementImpl extends HTMLElementImpl implements HTMLImageEl
     }
     native static void setCrossOriginImpl(long peer, String value);
 
+    @Override
     public String getHeight() {
         return getHeightImpl(getPeer())+"";
     }
     native static int getHeightImpl(long peer);
 
+    @Override
     public void setHeight(String value) {
         setHeightImpl(getPeer(), Integer.parseInt(value));
     }
     native static void setHeightImpl(long peer, int value);
 
+    @Override
     public String getHspace() {
         return getHspaceImpl(getPeer())+"";
     }
     native static int getHspaceImpl(long peer);
 
+    @Override
     public void setHspace(String value) {
         setHspaceImpl(getPeer(), Integer.parseInt(value));
     }
     native static void setHspaceImpl(long peer, int value);
 
+    @Override
     public boolean getIsMap() {
         return getIsMapImpl(getPeer());
     }
     native static boolean getIsMapImpl(long peer);
 
+    @Override
     public void setIsMap(boolean value) {
         setIsMapImpl(getPeer(), value);
     }
     native static void setIsMapImpl(long peer, boolean value);
 
+    @Override
     public String getLongDesc() {
         return getLongDescImpl(getPeer());
     }
     native static String getLongDescImpl(long peer);
 
+    @Override
     public void setLongDesc(String value) {
         setLongDescImpl(getPeer(), value);
     }
     native static void setLongDescImpl(long peer, String value);
 
+    @Override
     public String getSrc() {
         return getSrcImpl(getPeer());
     }
     native static String getSrcImpl(long peer);
 
+    @Override
     public void setSrc(String value) {
         setSrcImpl(getPeer(), value);
     }
@@ -163,31 +181,37 @@ public class HTMLImageElementImpl extends HTMLElementImpl implements HTMLImageEl
     }
     native static String getCurrentSrcImpl(long peer);
 
+    @Override
     public String getUseMap() {
         return getUseMapImpl(getPeer());
     }
     native static String getUseMapImpl(long peer);
 
+    @Override
     public void setUseMap(String value) {
         setUseMapImpl(getPeer(), value);
     }
     native static void setUseMapImpl(long peer, String value);
 
+    @Override
     public String getVspace() {
         return getVspaceImpl(getPeer())+"";
     }
     native static int getVspaceImpl(long peer);
 
+    @Override
     public void setVspace(String value) {
         setVspaceImpl(getPeer(), Integer.parseInt(value));
     }
     native static void setVspaceImpl(long peer, int value);
 
+    @Override
     public String getWidth() {
         return getWidthImpl(getPeer())+"";
     }
     native static int getWidthImpl(long peer);
 
+    @Override
     public void setWidth(String value) {
         setWidthImpl(getPeer(), Integer.parseInt(value));
     }
@@ -230,9 +254,11 @@ public class HTMLImageElementImpl extends HTMLElementImpl implements HTMLImageEl
 
 
 //stubs
+    @Override
     public void setLowSrc(String lowSrc) {
         throw new UnsupportedOperationException("Not supported yet.");
     }
+    @Override
     public String getLowSrc() {
         throw new UnsupportedOperationException("Not supported yet.");
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLInputElementImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLInputElementImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,21 +41,25 @@ public class HTMLInputElementImpl extends HTMLElementImpl implements HTMLInputEl
 
 
 // Attributes
+    @Override
     public String getAccept() {
         return getAcceptImpl(getPeer());
     }
     native static String getAcceptImpl(long peer);
 
+    @Override
     public void setAccept(String value) {
         setAcceptImpl(getPeer(), value);
     }
     native static void setAcceptImpl(long peer, String value);
 
+    @Override
     public String getAlt() {
         return getAltImpl(getPeer());
     }
     native static String getAltImpl(long peer);
 
+    @Override
     public void setAlt(String value) {
         setAltImpl(getPeer(), value);
     }
@@ -81,21 +85,25 @@ public class HTMLInputElementImpl extends HTMLElementImpl implements HTMLInputEl
     }
     native static void setAutofocusImpl(long peer, boolean value);
 
+    @Override
     public boolean getDefaultChecked() {
         return getDefaultCheckedImpl(getPeer());
     }
     native static boolean getDefaultCheckedImpl(long peer);
 
+    @Override
     public void setDefaultChecked(boolean value) {
         setDefaultCheckedImpl(getPeer(), value);
     }
     native static void setDefaultCheckedImpl(long peer, boolean value);
 
+    @Override
     public boolean getChecked() {
         return getCheckedImpl(getPeer());
     }
     native static boolean getCheckedImpl(long peer);
 
+    @Override
     public void setChecked(boolean value) {
         setCheckedImpl(getPeer(), value);
     }
@@ -111,16 +119,19 @@ public class HTMLInputElementImpl extends HTMLElementImpl implements HTMLInputEl
     }
     native static void setDirNameImpl(long peer, String value);
 
+    @Override
     public boolean getDisabled() {
         return getDisabledImpl(getPeer());
     }
     native static boolean getDisabledImpl(long peer);
 
+    @Override
     public void setDisabled(boolean value) {
         setDisabledImpl(getPeer(), value);
     }
     native static void setDisabledImpl(long peer, boolean value);
 
+    @Override
     public HTMLFormElement getForm() {
         return HTMLFormElementImpl.getImpl(getFormImpl(getPeer()));
     }
@@ -206,11 +217,13 @@ public class HTMLInputElementImpl extends HTMLElementImpl implements HTMLInputEl
     }
     native static void setMaxImpl(long peer, String value);
 
+    @Override
     public int getMaxLength() {
         return getMaxLengthImpl(getPeer());
     }
     native static int getMaxLengthImpl(long peer);
 
+    @Override
     public void setMaxLength(int value) throws DOMException {
         setMaxLengthImpl(getPeer(), value);
     }
@@ -236,11 +249,13 @@ public class HTMLInputElementImpl extends HTMLElementImpl implements HTMLInputEl
     }
     native static void setMultipleImpl(long peer, boolean value);
 
+    @Override
     public String getName() {
         return getNameImpl(getPeer());
     }
     native static String getNameImpl(long peer);
 
+    @Override
     public void setName(String value) {
         setNameImpl(getPeer(), value);
     }
@@ -266,11 +281,13 @@ public class HTMLInputElementImpl extends HTMLElementImpl implements HTMLInputEl
     }
     native static void setPlaceholderImpl(long peer, String value);
 
+    @Override
     public boolean getReadOnly() {
         return getReadOnlyImpl(getPeer());
     }
     native static boolean getReadOnlyImpl(long peer);
 
+    @Override
     public void setReadOnly(boolean value) {
         setReadOnlyImpl(getPeer(), value);
     }
@@ -286,21 +303,25 @@ public class HTMLInputElementImpl extends HTMLElementImpl implements HTMLInputEl
     }
     native static void setRequiredImpl(long peer, boolean value);
 
+    @Override
     public String getSize() {
         return getSizeImpl(getPeer())+"";
     }
     native static String getSizeImpl(long peer);
 
+    @Override
     public void setSize(String value) {
         setSizeImpl(getPeer(), value);
     }
     native static void setSizeImpl(long peer, String value);
 
+    @Override
     public String getSrc() {
         return getSrcImpl(getPeer());
     }
     native static String getSrcImpl(long peer);
 
+    @Override
     public void setSrc(String value) {
         setSrcImpl(getPeer(), value);
     }
@@ -316,6 +337,7 @@ public class HTMLInputElementImpl extends HTMLElementImpl implements HTMLInputEl
     }
     native static void setStepImpl(long peer, String value);
 
+    @Override
     public String getType() {
         return getTypeImpl(getPeer());
     }
@@ -326,21 +348,25 @@ public class HTMLInputElementImpl extends HTMLElementImpl implements HTMLInputEl
     }
     native static void setTypeImpl(long peer, String value);
 
+    @Override
     public String getDefaultValue() {
         return getDefaultValueImpl(getPeer());
     }
     native static String getDefaultValueImpl(long peer);
 
+    @Override
     public void setDefaultValue(String value) {
         setDefaultValueImpl(getPeer(), value);
     }
     native static void setDefaultValueImpl(long peer, String value);
 
+    @Override
     public String getValue() {
         return getValueImpl(getPeer());
     }
     native static String getValueImpl(long peer);
 
+    @Override
     public void setValue(String value) {
         setValueImpl(getPeer(), value);
     }
@@ -391,21 +417,25 @@ public class HTMLInputElementImpl extends HTMLElementImpl implements HTMLInputEl
     }
     native static long getLabelsImpl(long peer);
 
+    @Override
     public String getAlign() {
         return getAlignImpl(getPeer());
     }
     native static String getAlignImpl(long peer);
 
+    @Override
     public void setAlign(String value) {
         setAlignImpl(getPeer(), value);
     }
     native static void setAlignImpl(long peer, String value);
 
+    @Override
     public String getUseMap() {
         return getUseMapImpl(getPeer());
     }
     native static String getUseMapImpl(long peer);
 
+    @Override
     public void setUseMap(String value) {
         setUseMapImpl(getPeer(), value);
     }
@@ -421,11 +451,13 @@ public class HTMLInputElementImpl extends HTMLElementImpl implements HTMLInputEl
     }
     native static void setIncrementalImpl(long peer, boolean value);
 
+    @Override
     public String getAccessKey() {
         return getAccessKeyImpl(getPeer());
     }
     native static String getAccessKeyImpl(long peer);
 
+    @Override
     public void setAccessKey(String value) {
         setAccessKeyImpl(getPeer(), value);
     }
@@ -467,6 +499,7 @@ public class HTMLInputElementImpl extends HTMLElementImpl implements HTMLInputEl
         , String error);
 
 
+    @Override
     public void select()
     {
         selectImpl(getPeer());
@@ -501,6 +534,7 @@ public class HTMLInputElementImpl extends HTMLElementImpl implements HTMLInputEl
         , String selectionMode);
 
 
+    @Override
     public void click()
     {
         clickImpl(getPeer());

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLLIElementImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLLIElementImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,21 +38,25 @@ public class HTMLLIElementImpl extends HTMLElementImpl implements HTMLLIElement 
 
 
 // Attributes
+    @Override
     public String getType() {
         return getTypeImpl(getPeer());
     }
     native static String getTypeImpl(long peer);
 
+    @Override
     public void setType(String value) {
         setTypeImpl(getPeer(), value);
     }
     native static void setTypeImpl(long peer, String value);
 
+    @Override
     public int getValue() {
         return getValueImpl(getPeer());
     }
     native static int getValueImpl(long peer);
 
+    @Override
     public void setValue(int value) {
         setValueImpl(getPeer(), value);
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLLabelElementImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLLabelElementImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,16 +40,19 @@ public class HTMLLabelElementImpl extends HTMLElementImpl implements HTMLLabelEl
 
 
 // Attributes
+    @Override
     public HTMLFormElement getForm() {
         return HTMLFormElementImpl.getImpl(getFormImpl(getPeer()));
     }
     native static long getFormImpl(long peer);
 
+    @Override
     public String getHtmlFor() {
         return getHtmlForImpl(getPeer());
     }
     native static String getHtmlForImpl(long peer);
 
+    @Override
     public void setHtmlFor(String value) {
         setHtmlForImpl(getPeer(), value);
     }
@@ -60,11 +63,13 @@ public class HTMLLabelElementImpl extends HTMLElementImpl implements HTMLLabelEl
     }
     native static long getControlImpl(long peer);
 
+    @Override
     public String getAccessKey() {
         return getAccessKeyImpl(getPeer());
     }
     native static String getAccessKeyImpl(long peer);
 
+    @Override
     public void setAccessKey(String value) {
         setAccessKeyImpl(getPeer(), value);
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLLegendElementImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLLegendElementImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,26 +39,31 @@ public class HTMLLegendElementImpl extends HTMLElementImpl implements HTMLLegend
 
 
 // Attributes
+    @Override
     public HTMLFormElement getForm() {
         return HTMLFormElementImpl.getImpl(getFormImpl(getPeer()));
     }
     native static long getFormImpl(long peer);
 
+    @Override
     public String getAlign() {
         return getAlignImpl(getPeer());
     }
     native static String getAlignImpl(long peer);
 
+    @Override
     public void setAlign(String value) {
         setAlignImpl(getPeer(), value);
     }
     native static void setAlignImpl(long peer, String value);
 
+    @Override
     public String getAccessKey() {
         return getAccessKeyImpl(getPeer());
     }
     native static String getAccessKeyImpl(long peer);
 
+    @Override
     public void setAccessKey(String value) {
         setAccessKeyImpl(getPeer(), value);
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLLinkElementImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLLinkElementImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,91 +39,109 @@ public class HTMLLinkElementImpl extends HTMLElementImpl implements HTMLLinkElem
 
 
 // Attributes
+    @Override
     public boolean getDisabled() {
         return getDisabledImpl(getPeer());
     }
     native static boolean getDisabledImpl(long peer);
 
+    @Override
     public void setDisabled(boolean value) {
         setDisabledImpl(getPeer(), value);
     }
     native static void setDisabledImpl(long peer, boolean value);
 
+    @Override
     public String getCharset() {
         return getCharsetImpl(getPeer());
     }
     native static String getCharsetImpl(long peer);
 
+    @Override
     public void setCharset(String value) {
         setCharsetImpl(getPeer(), value);
     }
     native static void setCharsetImpl(long peer, String value);
 
+    @Override
     public String getHref() {
         return getHrefImpl(getPeer());
     }
     native static String getHrefImpl(long peer);
 
+    @Override
     public void setHref(String value) {
         setHrefImpl(getPeer(), value);
     }
     native static void setHrefImpl(long peer, String value);
 
+    @Override
     public String getHreflang() {
         return getHreflangImpl(getPeer());
     }
     native static String getHreflangImpl(long peer);
 
+    @Override
     public void setHreflang(String value) {
         setHreflangImpl(getPeer(), value);
     }
     native static void setHreflangImpl(long peer, String value);
 
+    @Override
     public String getMedia() {
         return getMediaImpl(getPeer());
     }
     native static String getMediaImpl(long peer);
 
+    @Override
     public void setMedia(String value) {
         setMediaImpl(getPeer(), value);
     }
     native static void setMediaImpl(long peer, String value);
 
+    @Override
     public String getRel() {
         return getRelImpl(getPeer());
     }
     native static String getRelImpl(long peer);
 
+    @Override
     public void setRel(String value) {
         setRelImpl(getPeer(), value);
     }
     native static void setRelImpl(long peer, String value);
 
+    @Override
     public String getRev() {
         return getRevImpl(getPeer());
     }
     native static String getRevImpl(long peer);
 
+    @Override
     public void setRev(String value) {
         setRevImpl(getPeer(), value);
     }
     native static void setRevImpl(long peer, String value);
 
+    @Override
     public String getTarget() {
         return getTargetImpl(getPeer());
     }
     native static String getTargetImpl(long peer);
 
+    @Override
     public void setTarget(String value) {
         setTargetImpl(getPeer(), value);
     }
     native static void setTargetImpl(long peer, String value);
 
+    @Override
     public String getType() {
         return getTypeImpl(getPeer());
     }
     native static String getTypeImpl(long peer);
 
+    @Override
     public void setType(String value) {
         setTypeImpl(getPeer(), value);
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLMapElementImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLMapElementImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,16 +39,19 @@ public class HTMLMapElementImpl extends HTMLElementImpl implements HTMLMapElemen
 
 
 // Attributes
+    @Override
     public HTMLCollection getAreas() {
         return HTMLCollectionImpl.getImpl(getAreasImpl(getPeer()));
     }
     native static long getAreasImpl(long peer);
 
+    @Override
     public String getName() {
         return getNameImpl(getPeer());
     }
     native static String getNameImpl(long peer);
 
+    @Override
     public void setName(String value) {
         setNameImpl(getPeer(), value);
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLMenuElementImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLMenuElementImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,11 +38,13 @@ public class HTMLMenuElementImpl extends HTMLElementImpl implements HTMLMenuElem
 
 
 // Attributes
+    @Override
     public boolean getCompact() {
         return getCompactImpl(getPeer());
     }
     native static boolean getCompactImpl(long peer);
 
+    @Override
     public void setCompact(boolean value) {
         setCompactImpl(getPeer(), value);
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLMetaElementImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLMetaElementImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,41 +38,49 @@ public class HTMLMetaElementImpl extends HTMLElementImpl implements HTMLMetaElem
 
 
 // Attributes
+    @Override
     public String getContent() {
         return getContentImpl(getPeer());
     }
     native static String getContentImpl(long peer);
 
+    @Override
     public void setContent(String value) {
         setContentImpl(getPeer(), value);
     }
     native static void setContentImpl(long peer, String value);
 
+    @Override
     public String getHttpEquiv() {
         return getHttpEquivImpl(getPeer());
     }
     native static String getHttpEquivImpl(long peer);
 
+    @Override
     public void setHttpEquiv(String value) {
         setHttpEquivImpl(getPeer(), value);
     }
     native static void setHttpEquivImpl(long peer, String value);
 
+    @Override
     public String getName() {
         return getNameImpl(getPeer());
     }
     native static String getNameImpl(long peer);
 
+    @Override
     public void setName(String value) {
         setNameImpl(getPeer(), value);
     }
     native static void setNameImpl(long peer, String value);
 
+    @Override
     public String getScheme() {
         return getSchemeImpl(getPeer());
     }
     native static String getSchemeImpl(long peer);
 
+    @Override
     public void setScheme(String value) {
         setSchemeImpl(getPeer(), value);
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLModElementImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLModElementImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,21 +38,25 @@ public class HTMLModElementImpl extends HTMLElementImpl implements HTMLModElemen
 
 
 // Attributes
+    @Override
     public String getCite() {
         return getCiteImpl(getPeer());
     }
     native static String getCiteImpl(long peer);
 
+    @Override
     public void setCite(String value) {
         setCiteImpl(getPeer(), value);
     }
     native static void setCiteImpl(long peer, String value);
 
+    @Override
     public String getDateTime() {
         return getDateTimeImpl(getPeer());
     }
     native static String getDateTimeImpl(long peer);
 
+    @Override
     public void setDateTime(String value) {
         setDateTimeImpl(getPeer(), value);
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLOListElementImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLOListElementImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,21 +38,25 @@ public class HTMLOListElementImpl extends HTMLElementImpl implements HTMLOListEl
 
 
 // Attributes
+    @Override
     public boolean getCompact() {
         return getCompactImpl(getPeer());
     }
     native static boolean getCompactImpl(long peer);
 
+    @Override
     public void setCompact(boolean value) {
         setCompactImpl(getPeer(), value);
     }
     native static void setCompactImpl(long peer, boolean value);
 
+    @Override
     public int getStart() {
         return getStartImpl(getPeer());
     }
     native static int getStartImpl(long peer);
 
+    @Override
     public void setStart(int value) {
         setStartImpl(getPeer(), value);
     }
@@ -68,11 +72,13 @@ public class HTMLOListElementImpl extends HTMLElementImpl implements HTMLOListEl
     }
     native static void setReversedImpl(long peer, boolean value);
 
+    @Override
     public String getType() {
         return getTypeImpl(getPeer());
     }
     native static String getTypeImpl(long peer);
 
+    @Override
     public void setType(String value) {
         setTypeImpl(getPeer(), value);
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLObjectElementImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLObjectElementImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,166 +40,199 @@ public class HTMLObjectElementImpl extends HTMLElementImpl implements HTMLObject
 
 
 // Attributes
+    @Override
     public HTMLFormElement getForm() {
         return HTMLFormElementImpl.getImpl(getFormImpl(getPeer()));
     }
     native static long getFormImpl(long peer);
 
+    @Override
     public String getCode() {
         return getCodeImpl(getPeer());
     }
     native static String getCodeImpl(long peer);
 
+    @Override
     public void setCode(String value) {
         setCodeImpl(getPeer(), value);
     }
     native static void setCodeImpl(long peer, String value);
 
+    @Override
     public String getAlign() {
         return getAlignImpl(getPeer());
     }
     native static String getAlignImpl(long peer);
 
+    @Override
     public void setAlign(String value) {
         setAlignImpl(getPeer(), value);
     }
     native static void setAlignImpl(long peer, String value);
 
+    @Override
     public String getArchive() {
         return getArchiveImpl(getPeer());
     }
     native static String getArchiveImpl(long peer);
 
+    @Override
     public void setArchive(String value) {
         setArchiveImpl(getPeer(), value);
     }
     native static void setArchiveImpl(long peer, String value);
 
+    @Override
     public String getBorder() {
         return getBorderImpl(getPeer());
     }
     native static String getBorderImpl(long peer);
 
+    @Override
     public void setBorder(String value) {
         setBorderImpl(getPeer(), value);
     }
     native static void setBorderImpl(long peer, String value);
 
+    @Override
     public String getCodeBase() {
         return getCodeBaseImpl(getPeer());
     }
     native static String getCodeBaseImpl(long peer);
 
+    @Override
     public void setCodeBase(String value) {
         setCodeBaseImpl(getPeer(), value);
     }
     native static void setCodeBaseImpl(long peer, String value);
 
+    @Override
     public String getCodeType() {
         return getCodeTypeImpl(getPeer());
     }
     native static String getCodeTypeImpl(long peer);
 
+    @Override
     public void setCodeType(String value) {
         setCodeTypeImpl(getPeer(), value);
     }
     native static void setCodeTypeImpl(long peer, String value);
 
+    @Override
     public String getData() {
         return getDataImpl(getPeer());
     }
     native static String getDataImpl(long peer);
 
+    @Override
     public void setData(String value) {
         setDataImpl(getPeer(), value);
     }
     native static void setDataImpl(long peer, String value);
 
+    @Override
     public boolean getDeclare() {
         return getDeclareImpl(getPeer());
     }
     native static boolean getDeclareImpl(long peer);
 
+    @Override
     public void setDeclare(boolean value) {
         setDeclareImpl(getPeer(), value);
     }
     native static void setDeclareImpl(long peer, boolean value);
 
+    @Override
     public String getHeight() {
         return getHeightImpl(getPeer());
     }
     native static String getHeightImpl(long peer);
 
+    @Override
     public void setHeight(String value) {
         setHeightImpl(getPeer(), value);
     }
     native static void setHeightImpl(long peer, String value);
 
+    @Override
     public String getHspace() {
         return getHspaceImpl(getPeer())+"";
     }
     native static int getHspaceImpl(long peer);
 
+    @Override
     public void setHspace(String value) {
         setHspaceImpl(getPeer(), Integer.parseInt(value));
     }
     native static void setHspaceImpl(long peer, int value);
 
+    @Override
     public String getName() {
         return getNameImpl(getPeer());
     }
     native static String getNameImpl(long peer);
 
+    @Override
     public void setName(String value) {
         setNameImpl(getPeer(), value);
     }
     native static void setNameImpl(long peer, String value);
 
+    @Override
     public String getStandby() {
         return getStandbyImpl(getPeer());
     }
     native static String getStandbyImpl(long peer);
 
+    @Override
     public void setStandby(String value) {
         setStandbyImpl(getPeer(), value);
     }
     native static void setStandbyImpl(long peer, String value);
 
+    @Override
     public String getType() {
         return getTypeImpl(getPeer());
     }
     native static String getTypeImpl(long peer);
 
+    @Override
     public void setType(String value) {
         setTypeImpl(getPeer(), value);
     }
     native static void setTypeImpl(long peer, String value);
 
+    @Override
     public String getUseMap() {
         return getUseMapImpl(getPeer());
     }
     native static String getUseMapImpl(long peer);
 
+    @Override
     public void setUseMap(String value) {
         setUseMapImpl(getPeer(), value);
     }
     native static void setUseMapImpl(long peer, String value);
 
+    @Override
     public String getVspace() {
         return getVspaceImpl(getPeer())+"";
     }
     native static int getVspaceImpl(long peer);
 
+    @Override
     public void setVspace(String value) {
         setVspaceImpl(getPeer(), Integer.parseInt(value));
     }
     native static void setVspaceImpl(long peer, int value);
 
+    @Override
     public String getWidth() {
         return getWidthImpl(getPeer());
     }
     native static String getWidthImpl(long peer);
 
+    @Override
     public void setWidth(String value) {
         setWidthImpl(getPeer(), value);
     }
@@ -215,6 +248,7 @@ public class HTMLObjectElementImpl extends HTMLElementImpl implements HTMLObject
     }
     native static String getValidationMessageImpl(long peer);
 
+    @Override
     public Document getContentDocument() {
         return DocumentImpl.getImpl(getContentDocumentImpl(getPeer()));
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLOptGroupElementImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLOptGroupElementImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,21 +38,25 @@ public class HTMLOptGroupElementImpl extends HTMLElementImpl implements HTMLOptG
 
 
 // Attributes
+    @Override
     public boolean getDisabled() {
         return getDisabledImpl(getPeer());
     }
     native static boolean getDisabledImpl(long peer);
 
+    @Override
     public void setDisabled(boolean value) {
         setDisabledImpl(getPeer(), value);
     }
     native static void setDisabledImpl(long peer, boolean value);
 
+    @Override
     public String getLabel() {
         return getLabelImpl(getPeer());
     }
     native static String getLabelImpl(long peer);
 
+    @Override
     public void setLabel(String value) {
         setLabelImpl(getPeer(), value);
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLOptionElementImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLOptionElementImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,66 +39,79 @@ public class HTMLOptionElementImpl extends HTMLElementImpl implements HTMLOption
 
 
 // Attributes
+    @Override
     public boolean getDisabled() {
         return getDisabledImpl(getPeer());
     }
     native static boolean getDisabledImpl(long peer);
 
+    @Override
     public void setDisabled(boolean value) {
         setDisabledImpl(getPeer(), value);
     }
     native static void setDisabledImpl(long peer, boolean value);
 
+    @Override
     public HTMLFormElement getForm() {
         return HTMLFormElementImpl.getImpl(getFormImpl(getPeer()));
     }
     native static long getFormImpl(long peer);
 
+    @Override
     public String getLabel() {
         return getLabelImpl(getPeer());
     }
     native static String getLabelImpl(long peer);
 
+    @Override
     public void setLabel(String value) {
         setLabelImpl(getPeer(), value);
     }
     native static void setLabelImpl(long peer, String value);
 
+    @Override
     public boolean getDefaultSelected() {
         return getDefaultSelectedImpl(getPeer());
     }
     native static boolean getDefaultSelectedImpl(long peer);
 
+    @Override
     public void setDefaultSelected(boolean value) {
         setDefaultSelectedImpl(getPeer(), value);
     }
     native static void setDefaultSelectedImpl(long peer, boolean value);
 
+    @Override
     public boolean getSelected() {
         return getSelectedImpl(getPeer());
     }
     native static boolean getSelectedImpl(long peer);
 
+    @Override
     public void setSelected(boolean value) {
         setSelectedImpl(getPeer(), value);
     }
     native static void setSelectedImpl(long peer, boolean value);
 
+    @Override
     public String getValue() {
         return getValueImpl(getPeer());
     }
     native static String getValueImpl(long peer);
 
+    @Override
     public void setValue(String value) {
         setValueImpl(getPeer(), value);
     }
     native static void setValueImpl(long peer, String value);
 
+    @Override
     public String getText() {
         return getTextImpl(getPeer());
     }
     native static String getTextImpl(long peer);
 
+    @Override
     public int getIndex() {
         return getIndexImpl(getPeer());
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLOptionsCollectionImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLOptionsCollectionImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,6 +50,7 @@ public class HTMLOptionsCollectionImpl extends HTMLCollectionImpl {
     }
     native static void setSelectedIndexImpl(long peer, int value);
 
+    @Override
     public int getLength() {
         return getLengthImpl(getPeer());
     }
@@ -62,6 +63,7 @@ public class HTMLOptionsCollectionImpl extends HTMLCollectionImpl {
 
 
 // Functions
+    @Override
     public Node namedItem(String name)
     {
         return NodeImpl.getImpl(namedItemImpl(getPeer()
@@ -83,6 +85,7 @@ public class HTMLOptionsCollectionImpl extends HTMLCollectionImpl {
         , int index);
 
 
+    @Override
     public Node item(int index)
     {
         return NodeImpl.getImpl(itemImpl(getPeer()

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLParagraphElementImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLParagraphElementImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,11 +38,13 @@ public class HTMLParagraphElementImpl extends HTMLElementImpl implements HTMLPar
 
 
 // Attributes
+    @Override
     public String getAlign() {
         return getAlignImpl(getPeer());
     }
     native static String getAlignImpl(long peer);
 
+    @Override
     public void setAlign(String value) {
         setAlignImpl(getPeer(), value);
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLParamElementImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLParamElementImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,41 +38,49 @@ public class HTMLParamElementImpl extends HTMLElementImpl implements HTMLParamEl
 
 
 // Attributes
+    @Override
     public String getName() {
         return getNameImpl(getPeer());
     }
     native static String getNameImpl(long peer);
 
+    @Override
     public void setName(String value) {
         setNameImpl(getPeer(), value);
     }
     native static void setNameImpl(long peer, String value);
 
+    @Override
     public String getType() {
         return getTypeImpl(getPeer());
     }
     native static String getTypeImpl(long peer);
 
+    @Override
     public void setType(String value) {
         setTypeImpl(getPeer(), value);
     }
     native static void setTypeImpl(long peer, String value);
 
+    @Override
     public String getValue() {
         return getValueImpl(getPeer());
     }
     native static String getValueImpl(long peer);
 
+    @Override
     public void setValue(String value) {
         setValueImpl(getPeer(), value);
     }
     native static void setValueImpl(long peer, String value);
 
+    @Override
     public String getValueType() {
         return getValueTypeImpl(getPeer());
     }
     native static String getValueTypeImpl(long peer);
 
+    @Override
     public void setValueType(String value) {
         setValueTypeImpl(getPeer(), value);
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLPreElementImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLPreElementImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,11 +38,13 @@ public class HTMLPreElementImpl extends HTMLElementImpl implements HTMLPreElemen
 
 
 // Attributes
+    @Override
     public int getWidth() {
         return getWidthImpl(getPeer());
     }
     native static int getWidthImpl(long peer);
 
+    @Override
     public void setWidth(int value) {
         setWidthImpl(getPeer(), value);
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLQuoteElementImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLQuoteElementImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,11 +38,13 @@ public class HTMLQuoteElementImpl extends HTMLElementImpl implements HTMLQuoteEl
 
 
 // Attributes
+    @Override
     public String getCite() {
         return getCiteImpl(getPeer());
     }
     native static String getCiteImpl(long peer);
 
+    @Override
     public void setCite(String value) {
         setCiteImpl(getPeer(), value);
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLScriptElementImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLScriptElementImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,41 +38,49 @@ public class HTMLScriptElementImpl extends HTMLElementImpl implements HTMLScript
 
 
 // Attributes
+    @Override
     public String getText() {
         return getTextImpl(getPeer());
     }
     native static String getTextImpl(long peer);
 
+    @Override
     public void setText(String value) {
         setTextImpl(getPeer(), value);
     }
     native static void setTextImpl(long peer, String value);
 
+    @Override
     public String getHtmlFor() {
         return getHtmlForImpl(getPeer());
     }
     native static String getHtmlForImpl(long peer);
 
+    @Override
     public void setHtmlFor(String value) {
         setHtmlForImpl(getPeer(), value);
     }
     native static void setHtmlForImpl(long peer, String value);
 
+    @Override
     public String getEvent() {
         return getEventImpl(getPeer());
     }
     native static String getEventImpl(long peer);
 
+    @Override
     public void setEvent(String value) {
         setEventImpl(getPeer(), value);
     }
     native static void setEventImpl(long peer, String value);
 
+    @Override
     public String getCharset() {
         return getCharsetImpl(getPeer());
     }
     native static String getCharsetImpl(long peer);
 
+    @Override
     public void setCharset(String value) {
         setCharsetImpl(getPeer(), value);
     }
@@ -88,31 +96,37 @@ public class HTMLScriptElementImpl extends HTMLElementImpl implements HTMLScript
     }
     native static void setAsyncImpl(long peer, boolean value);
 
+    @Override
     public boolean getDefer() {
         return getDeferImpl(getPeer());
     }
     native static boolean getDeferImpl(long peer);
 
+    @Override
     public void setDefer(boolean value) {
         setDeferImpl(getPeer(), value);
     }
     native static void setDeferImpl(long peer, boolean value);
 
+    @Override
     public String getSrc() {
         return getSrcImpl(getPeer());
     }
     native static String getSrcImpl(long peer);
 
+    @Override
     public void setSrc(String value) {
         setSrcImpl(getPeer(), value);
     }
     native static void setSrcImpl(long peer, String value);
 
+    @Override
     public String getType() {
         return getTypeImpl(getPeer());
     }
     native static String getTypeImpl(long peer);
 
+    @Override
     public void setType(String value) {
         setTypeImpl(getPeer(), value);
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLSelectElementImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLSelectElementImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,36 +54,43 @@ public class HTMLSelectElementImpl extends HTMLElementImpl implements HTMLSelect
     }
     native static void setAutofocusImpl(long peer, boolean value);
 
+    @Override
     public boolean getDisabled() {
         return getDisabledImpl(getPeer());
     }
     native static boolean getDisabledImpl(long peer);
 
+    @Override
     public void setDisabled(boolean value) {
         setDisabledImpl(getPeer(), value);
     }
     native static void setDisabledImpl(long peer, boolean value);
 
+    @Override
     public HTMLFormElement getForm() {
         return HTMLFormElementImpl.getImpl(getFormImpl(getPeer()));
     }
     native static long getFormImpl(long peer);
 
+    @Override
     public boolean getMultiple() {
         return getMultipleImpl(getPeer());
     }
     native static boolean getMultipleImpl(long peer);
 
+    @Override
     public void setMultiple(boolean value) {
         setMultipleImpl(getPeer(), value);
     }
     native static void setMultipleImpl(long peer, boolean value);
 
+    @Override
     public String getName() {
         return getNameImpl(getPeer());
     }
     native static String getNameImpl(long peer);
 
+    @Override
     public void setName(String value) {
         setNameImpl(getPeer(), value);
     }
@@ -99,26 +106,31 @@ public class HTMLSelectElementImpl extends HTMLElementImpl implements HTMLSelect
     }
     native static void setRequiredImpl(long peer, boolean value);
 
+    @Override
     public int getSize() {
         return getSizeImpl(getPeer());
     }
     native static int getSizeImpl(long peer);
 
+    @Override
     public void setSize(int value) {
         setSizeImpl(getPeer(), value);
     }
     native static void setSizeImpl(long peer, int value);
 
+    @Override
     public String getType() {
         return getTypeImpl(getPeer());
     }
     native static String getTypeImpl(long peer);
 
+    @Override
     public HTMLOptionsCollectionImpl getOptions() {
         return HTMLOptionsCollectionImpl.getImpl(getOptionsImpl(getPeer()));
     }
     native static long getOptionsImpl(long peer);
 
+    @Override
     public int getLength() {
         return getLengthImpl(getPeer());
     }
@@ -129,21 +141,25 @@ public class HTMLSelectElementImpl extends HTMLElementImpl implements HTMLSelect
     }
     native static long getSelectedOptionsImpl(long peer);
 
+    @Override
     public int getSelectedIndex() {
         return getSelectedIndexImpl(getPeer());
     }
     native static int getSelectedIndexImpl(long peer);
 
+    @Override
     public void setSelectedIndex(int value) {
         setSelectedIndexImpl(getPeer(), value);
     }
     native static void setSelectedIndexImpl(long peer, int value);
 
+    @Override
     public String getValue() {
         return getValueImpl(getPeer());
     }
     native static String getValueImpl(long peer);
 
+    @Override
     public void setValue(String value) {
         setValueImpl(getPeer(), value);
     }
@@ -194,6 +210,7 @@ public class HTMLSelectElementImpl extends HTMLElementImpl implements HTMLSelect
         , String name);
 
 
+    @Override
     public void add(HTMLElement element
         , HTMLElement before) throws DOMException
     {
@@ -206,6 +223,7 @@ public class HTMLSelectElementImpl extends HTMLElementImpl implements HTMLSelect
         , long before);
 
 
+    @Override
     public void remove(int index)
     {
         removeImpl(getPeer()

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLStyleElementImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLStyleElementImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,31 +39,37 @@ public class HTMLStyleElementImpl extends HTMLElementImpl implements HTMLStyleEl
 
 
 // Attributes
+    @Override
     public boolean getDisabled() {
         return getDisabledImpl(getPeer());
     }
     native static boolean getDisabledImpl(long peer);
 
+    @Override
     public void setDisabled(boolean value) {
         setDisabledImpl(getPeer(), value);
     }
     native static void setDisabledImpl(long peer, boolean value);
 
+    @Override
     public String getMedia() {
         return getMediaImpl(getPeer());
     }
     native static String getMediaImpl(long peer);
 
+    @Override
     public void setMedia(String value) {
         setMediaImpl(getPeer(), value);
     }
     native static void setMediaImpl(long peer, String value);
 
+    @Override
     public String getType() {
         return getTypeImpl(getPeer());
     }
     native static String getTypeImpl(long peer);
 
+    @Override
     public void setType(String value) {
         setTypeImpl(getPeer(), value);
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLTableCaptionElementImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLTableCaptionElementImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,11 +38,13 @@ public class HTMLTableCaptionElementImpl extends HTMLElementImpl implements HTML
 
 
 // Attributes
+    @Override
     public String getAlign() {
         return getAlignImpl(getPeer());
     }
     native static String getAlignImpl(long peer);
 
+    @Override
     public void setAlign(String value) {
         setAlignImpl(getPeer(), value);
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLTableCellElementImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLTableCellElementImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,146 +38,175 @@ public class HTMLTableCellElementImpl extends HTMLElementImpl implements HTMLTab
 
 
 // Attributes
+    @Override
     public int getCellIndex() {
         return getCellIndexImpl(getPeer());
     }
     native static int getCellIndexImpl(long peer);
 
+    @Override
     public String getAlign() {
         return getAlignImpl(getPeer());
     }
     native static String getAlignImpl(long peer);
 
+    @Override
     public void setAlign(String value) {
         setAlignImpl(getPeer(), value);
     }
     native static void setAlignImpl(long peer, String value);
 
+    @Override
     public String getAxis() {
         return getAxisImpl(getPeer());
     }
     native static String getAxisImpl(long peer);
 
+    @Override
     public void setAxis(String value) {
         setAxisImpl(getPeer(), value);
     }
     native static void setAxisImpl(long peer, String value);
 
+    @Override
     public String getBgColor() {
         return getBgColorImpl(getPeer());
     }
     native static String getBgColorImpl(long peer);
 
+    @Override
     public void setBgColor(String value) {
         setBgColorImpl(getPeer(), value);
     }
     native static void setBgColorImpl(long peer, String value);
 
+    @Override
     public String getCh() {
         return getChImpl(getPeer());
     }
     native static String getChImpl(long peer);
 
+    @Override
     public void setCh(String value) {
         setChImpl(getPeer(), value);
     }
     native static void setChImpl(long peer, String value);
 
+    @Override
     public String getChOff() {
         return getChOffImpl(getPeer());
     }
     native static String getChOffImpl(long peer);
 
+    @Override
     public void setChOff(String value) {
         setChOffImpl(getPeer(), value);
     }
     native static void setChOffImpl(long peer, String value);
 
+    @Override
     public int getColSpan() {
         return getColSpanImpl(getPeer());
     }
     native static int getColSpanImpl(long peer);
 
+    @Override
     public void setColSpan(int value) {
         setColSpanImpl(getPeer(), value);
     }
     native static void setColSpanImpl(long peer, int value);
 
+    @Override
     public int getRowSpan() {
         return getRowSpanImpl(getPeer());
     }
     native static int getRowSpanImpl(long peer);
 
+    @Override
     public void setRowSpan(int value) {
         setRowSpanImpl(getPeer(), value);
     }
     native static void setRowSpanImpl(long peer, int value);
 
+    @Override
     public String getHeaders() {
         return getHeadersImpl(getPeer());
     }
     native static String getHeadersImpl(long peer);
 
+    @Override
     public void setHeaders(String value) {
         setHeadersImpl(getPeer(), value);
     }
     native static void setHeadersImpl(long peer, String value);
 
+    @Override
     public String getHeight() {
         return getHeightImpl(getPeer());
     }
     native static String getHeightImpl(long peer);
 
+    @Override
     public void setHeight(String value) {
         setHeightImpl(getPeer(), value);
     }
     native static void setHeightImpl(long peer, String value);
 
+    @Override
     public boolean getNoWrap() {
         return getNoWrapImpl(getPeer());
     }
     native static boolean getNoWrapImpl(long peer);
 
+    @Override
     public void setNoWrap(boolean value) {
         setNoWrapImpl(getPeer(), value);
     }
     native static void setNoWrapImpl(long peer, boolean value);
 
+    @Override
     public String getVAlign() {
         return getVAlignImpl(getPeer());
     }
     native static String getVAlignImpl(long peer);
 
+    @Override
     public void setVAlign(String value) {
         setVAlignImpl(getPeer(), value);
     }
     native static void setVAlignImpl(long peer, String value);
 
+    @Override
     public String getWidth() {
         return getWidthImpl(getPeer());
     }
     native static String getWidthImpl(long peer);
 
+    @Override
     public void setWidth(String value) {
         setWidthImpl(getPeer(), value);
     }
     native static void setWidthImpl(long peer, String value);
 
+    @Override
     public String getAbbr() {
         return getAbbrImpl(getPeer());
     }
     native static String getAbbrImpl(long peer);
 
+    @Override
     public void setAbbr(String value) {
         setAbbrImpl(getPeer(), value);
     }
     native static void setAbbrImpl(long peer, String value);
 
+    @Override
     public String getScope() {
         return getScopeImpl(getPeer());
     }
     native static String getScopeImpl(long peer);
 
+    @Override
     public void setScope(String value) {
         setScopeImpl(getPeer(), value);
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLTableColElementImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLTableColElementImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,61 +38,73 @@ public class HTMLTableColElementImpl extends HTMLElementImpl implements HTMLTabl
 
 
 // Attributes
+    @Override
     public String getAlign() {
         return getAlignImpl(getPeer());
     }
     native static String getAlignImpl(long peer);
 
+    @Override
     public void setAlign(String value) {
         setAlignImpl(getPeer(), value);
     }
     native static void setAlignImpl(long peer, String value);
 
+    @Override
     public String getCh() {
         return getChImpl(getPeer());
     }
     native static String getChImpl(long peer);
 
+    @Override
     public void setCh(String value) {
         setChImpl(getPeer(), value);
     }
     native static void setChImpl(long peer, String value);
 
+    @Override
     public String getChOff() {
         return getChOffImpl(getPeer());
     }
     native static String getChOffImpl(long peer);
 
+    @Override
     public void setChOff(String value) {
         setChOffImpl(getPeer(), value);
     }
     native static void setChOffImpl(long peer, String value);
 
+    @Override
     public int getSpan() {
         return getSpanImpl(getPeer());
     }
     native static int getSpanImpl(long peer);
 
+    @Override
     public void setSpan(int value) {
         setSpanImpl(getPeer(), value);
     }
     native static void setSpanImpl(long peer, int value);
 
+    @Override
     public String getVAlign() {
         return getVAlignImpl(getPeer());
     }
     native static String getVAlignImpl(long peer);
 
+    @Override
     public void setVAlign(String value) {
         setVAlignImpl(getPeer(), value);
     }
     native static void setVAlignImpl(long peer, String value);
 
+    @Override
     public String getWidth() {
         return getWidthImpl(getPeer());
     }
     native static String getWidthImpl(long peer);
 
+    @Override
     public void setWidth(String value) {
         setWidthImpl(getPeer(), value);
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLTableElementImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLTableElementImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,131 +43,157 @@ public class HTMLTableElementImpl extends HTMLElementImpl implements HTMLTableEl
 
 
 // Attributes
+    @Override
     public HTMLTableCaptionElement getCaption() {
         return HTMLTableCaptionElementImpl.getImpl(getCaptionImpl(getPeer()));
     }
     native static long getCaptionImpl(long peer);
 
+    @Override
     public void setCaption(HTMLTableCaptionElement value) throws DOMException {
         setCaptionImpl(getPeer(), HTMLTableCaptionElementImpl.getPeer(value));
     }
     native static void setCaptionImpl(long peer, long value);
 
+    @Override
     public HTMLTableSectionElement getTHead() {
         return HTMLTableSectionElementImpl.getImpl(getTHeadImpl(getPeer()));
     }
     native static long getTHeadImpl(long peer);
 
+    @Override
     public void setTHead(HTMLTableSectionElement value) throws DOMException {
         setTHeadImpl(getPeer(), HTMLTableSectionElementImpl.getPeer(value));
     }
     native static void setTHeadImpl(long peer, long value);
 
+    @Override
     public HTMLTableSectionElement getTFoot() {
         return HTMLTableSectionElementImpl.getImpl(getTFootImpl(getPeer()));
     }
     native static long getTFootImpl(long peer);
 
+    @Override
     public void setTFoot(HTMLTableSectionElement value) throws DOMException {
         setTFootImpl(getPeer(), HTMLTableSectionElementImpl.getPeer(value));
     }
     native static void setTFootImpl(long peer, long value);
 
+    @Override
     public HTMLCollection getRows() {
         return HTMLCollectionImpl.getImpl(getRowsImpl(getPeer()));
     }
     native static long getRowsImpl(long peer);
 
+    @Override
     public HTMLCollection getTBodies() {
         return HTMLCollectionImpl.getImpl(getTBodiesImpl(getPeer()));
     }
     native static long getTBodiesImpl(long peer);
 
+    @Override
     public String getAlign() {
         return getAlignImpl(getPeer());
     }
     native static String getAlignImpl(long peer);
 
+    @Override
     public void setAlign(String value) {
         setAlignImpl(getPeer(), value);
     }
     native static void setAlignImpl(long peer, String value);
 
+    @Override
     public String getBgColor() {
         return getBgColorImpl(getPeer());
     }
     native static String getBgColorImpl(long peer);
 
+    @Override
     public void setBgColor(String value) {
         setBgColorImpl(getPeer(), value);
     }
     native static void setBgColorImpl(long peer, String value);
 
+    @Override
     public String getBorder() {
         return getBorderImpl(getPeer());
     }
     native static String getBorderImpl(long peer);
 
+    @Override
     public void setBorder(String value) {
         setBorderImpl(getPeer(), value);
     }
     native static void setBorderImpl(long peer, String value);
 
+    @Override
     public String getCellPadding() {
         return getCellPaddingImpl(getPeer());
     }
     native static String getCellPaddingImpl(long peer);
 
+    @Override
     public void setCellPadding(String value) {
         setCellPaddingImpl(getPeer(), value);
     }
     native static void setCellPaddingImpl(long peer, String value);
 
+    @Override
     public String getCellSpacing() {
         return getCellSpacingImpl(getPeer());
     }
     native static String getCellSpacingImpl(long peer);
 
+    @Override
     public void setCellSpacing(String value) {
         setCellSpacingImpl(getPeer(), value);
     }
     native static void setCellSpacingImpl(long peer, String value);
 
+    @Override
     public String getFrame() {
         return getFrameImpl(getPeer());
     }
     native static String getFrameImpl(long peer);
 
+    @Override
     public void setFrame(String value) {
         setFrameImpl(getPeer(), value);
     }
     native static void setFrameImpl(long peer, String value);
 
+    @Override
     public String getRules() {
         return getRulesImpl(getPeer());
     }
     native static String getRulesImpl(long peer);
 
+    @Override
     public void setRules(String value) {
         setRulesImpl(getPeer(), value);
     }
     native static void setRulesImpl(long peer, String value);
 
+    @Override
     public String getSummary() {
         return getSummaryImpl(getPeer());
     }
     native static String getSummaryImpl(long peer);
 
+    @Override
     public void setSummary(String value) {
         setSummaryImpl(getPeer(), value);
     }
     native static void setSummaryImpl(long peer, String value);
 
+    @Override
     public String getWidth() {
         return getWidthImpl(getPeer());
     }
     native static String getWidthImpl(long peer);
 
+    @Override
     public void setWidth(String value) {
         setWidthImpl(getPeer(), value);
     }
@@ -175,6 +201,7 @@ public class HTMLTableElementImpl extends HTMLElementImpl implements HTMLTableEl
 
 
 // Functions
+    @Override
     public HTMLElement createTHead()
     {
         return HTMLElementImpl.getImpl(createTHeadImpl(getPeer()));
@@ -182,6 +209,7 @@ public class HTMLTableElementImpl extends HTMLElementImpl implements HTMLTableEl
     native static long createTHeadImpl(long peer);
 
 
+    @Override
     public void deleteTHead()
     {
         deleteTHeadImpl(getPeer());
@@ -189,6 +217,7 @@ public class HTMLTableElementImpl extends HTMLElementImpl implements HTMLTableEl
     native static void deleteTHeadImpl(long peer);
 
 
+    @Override
     public HTMLElement createTFoot()
     {
         return HTMLElementImpl.getImpl(createTFootImpl(getPeer()));
@@ -196,6 +225,7 @@ public class HTMLTableElementImpl extends HTMLElementImpl implements HTMLTableEl
     native static long createTFootImpl(long peer);
 
 
+    @Override
     public void deleteTFoot()
     {
         deleteTFootImpl(getPeer());
@@ -210,6 +240,7 @@ public class HTMLTableElementImpl extends HTMLElementImpl implements HTMLTableEl
     native static long createTBodyImpl(long peer);
 
 
+    @Override
     public HTMLElement createCaption()
     {
         return HTMLElementImpl.getImpl(createCaptionImpl(getPeer()));
@@ -217,6 +248,7 @@ public class HTMLTableElementImpl extends HTMLElementImpl implements HTMLTableEl
     native static long createCaptionImpl(long peer);
 
 
+    @Override
     public void deleteCaption()
     {
         deleteCaptionImpl(getPeer());
@@ -224,6 +256,7 @@ public class HTMLTableElementImpl extends HTMLElementImpl implements HTMLTableEl
     native static void deleteCaptionImpl(long peer);
 
 
+    @Override
     public HTMLElement insertRow(int index) throws DOMException
     {
         return HTMLElementImpl.getImpl(insertRowImpl(getPeer()
@@ -233,6 +266,7 @@ public class HTMLTableElementImpl extends HTMLElementImpl implements HTMLTableEl
         , int index);
 
 
+    @Override
     public void deleteRow(int index) throws DOMException
     {
         deleteRowImpl(getPeer()

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLTableRowElementImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLTableRowElementImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,66 +41,79 @@ public class HTMLTableRowElementImpl extends HTMLElementImpl implements HTMLTabl
 
 
 // Attributes
+    @Override
     public int getRowIndex() {
         return getRowIndexImpl(getPeer());
     }
     native static int getRowIndexImpl(long peer);
 
+    @Override
     public int getSectionRowIndex() {
         return getSectionRowIndexImpl(getPeer());
     }
     native static int getSectionRowIndexImpl(long peer);
 
+    @Override
     public HTMLCollection getCells() {
         return HTMLCollectionImpl.getImpl(getCellsImpl(getPeer()));
     }
     native static long getCellsImpl(long peer);
 
+    @Override
     public String getAlign() {
         return getAlignImpl(getPeer());
     }
     native static String getAlignImpl(long peer);
 
+    @Override
     public void setAlign(String value) {
         setAlignImpl(getPeer(), value);
     }
     native static void setAlignImpl(long peer, String value);
 
+    @Override
     public String getBgColor() {
         return getBgColorImpl(getPeer());
     }
     native static String getBgColorImpl(long peer);
 
+    @Override
     public void setBgColor(String value) {
         setBgColorImpl(getPeer(), value);
     }
     native static void setBgColorImpl(long peer, String value);
 
+    @Override
     public String getCh() {
         return getChImpl(getPeer());
     }
     native static String getChImpl(long peer);
 
+    @Override
     public void setCh(String value) {
         setChImpl(getPeer(), value);
     }
     native static void setChImpl(long peer, String value);
 
+    @Override
     public String getChOff() {
         return getChOffImpl(getPeer());
     }
     native static String getChOffImpl(long peer);
 
+    @Override
     public void setChOff(String value) {
         setChOffImpl(getPeer(), value);
     }
     native static void setChOffImpl(long peer, String value);
 
+    @Override
     public String getVAlign() {
         return getVAlignImpl(getPeer());
     }
     native static String getVAlignImpl(long peer);
 
+    @Override
     public void setVAlign(String value) {
         setVAlignImpl(getPeer(), value);
     }
@@ -108,6 +121,7 @@ public class HTMLTableRowElementImpl extends HTMLElementImpl implements HTMLTabl
 
 
 // Functions
+    @Override
     public HTMLElement insertCell(int index) throws DOMException
     {
         return HTMLElementImpl.getImpl(insertCellImpl(getPeer()
@@ -117,6 +131,7 @@ public class HTMLTableRowElementImpl extends HTMLElementImpl implements HTMLTabl
         , int index);
 
 
+    @Override
     public void deleteCell(int index) throws DOMException
     {
         deleteCellImpl(getPeer()

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLTableSectionElementImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLTableSectionElementImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,46 +41,55 @@ public class HTMLTableSectionElementImpl extends HTMLElementImpl implements HTML
 
 
 // Attributes
+    @Override
     public String getAlign() {
         return getAlignImpl(getPeer());
     }
     native static String getAlignImpl(long peer);
 
+    @Override
     public void setAlign(String value) {
         setAlignImpl(getPeer(), value);
     }
     native static void setAlignImpl(long peer, String value);
 
+    @Override
     public String getCh() {
         return getChImpl(getPeer());
     }
     native static String getChImpl(long peer);
 
+    @Override
     public void setCh(String value) {
         setChImpl(getPeer(), value);
     }
     native static void setChImpl(long peer, String value);
 
+    @Override
     public String getChOff() {
         return getChOffImpl(getPeer());
     }
     native static String getChOffImpl(long peer);
 
+    @Override
     public void setChOff(String value) {
         setChOffImpl(getPeer(), value);
     }
     native static void setChOffImpl(long peer, String value);
 
+    @Override
     public String getVAlign() {
         return getVAlignImpl(getPeer());
     }
     native static String getVAlignImpl(long peer);
 
+    @Override
     public void setVAlign(String value) {
         setVAlignImpl(getPeer(), value);
     }
     native static void setVAlignImpl(long peer, String value);
 
+    @Override
     public HTMLCollection getRows() {
         return HTMLCollectionImpl.getImpl(getRowsImpl(getPeer()));
     }
@@ -88,6 +97,7 @@ public class HTMLTableSectionElementImpl extends HTMLElementImpl implements HTML
 
 
 // Functions
+    @Override
     public HTMLElement insertRow(int index) throws DOMException
     {
         return HTMLElementImpl.getImpl(insertRowImpl(getPeer()
@@ -97,6 +107,7 @@ public class HTMLTableSectionElementImpl extends HTMLElementImpl implements HTML
         , int index);
 
 
+    @Override
     public void deleteRow(int index) throws DOMException
     {
         deleteRowImpl(getPeer()

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLTextAreaElementImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLTextAreaElementImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,16 +61,19 @@ public class HTMLTextAreaElementImpl extends HTMLElementImpl implements HTMLText
     }
     native static void setDirNameImpl(long peer, String value);
 
+    @Override
     public boolean getDisabled() {
         return getDisabledImpl(getPeer());
     }
     native static boolean getDisabledImpl(long peer);
 
+    @Override
     public void setDisabled(boolean value) {
         setDisabledImpl(getPeer(), value);
     }
     native static void setDisabledImpl(long peer, boolean value);
 
+    @Override
     public HTMLFormElement getForm() {
         return HTMLFormElementImpl.getImpl(getFormImpl(getPeer()));
     }
@@ -86,11 +89,13 @@ public class HTMLTextAreaElementImpl extends HTMLElementImpl implements HTMLText
     }
     native static void setMaxLengthImpl(long peer, int value);
 
+    @Override
     public String getName() {
         return getNameImpl(getPeer());
     }
     native static String getNameImpl(long peer);
 
+    @Override
     public void setName(String value) {
         setNameImpl(getPeer(), value);
     }
@@ -106,11 +111,13 @@ public class HTMLTextAreaElementImpl extends HTMLElementImpl implements HTMLText
     }
     native static void setPlaceholderImpl(long peer, String value);
 
+    @Override
     public boolean getReadOnly() {
         return getReadOnlyImpl(getPeer());
     }
     native static boolean getReadOnlyImpl(long peer);
 
+    @Override
     public void setReadOnly(boolean value) {
         setReadOnlyImpl(getPeer(), value);
     }
@@ -126,21 +133,25 @@ public class HTMLTextAreaElementImpl extends HTMLElementImpl implements HTMLText
     }
     native static void setRequiredImpl(long peer, boolean value);
 
+    @Override
     public int getRows() {
         return getRowsImpl(getPeer());
     }
     native static int getRowsImpl(long peer);
 
+    @Override
     public void setRows(int value) {
         setRowsImpl(getPeer(), value);
     }
     native static void setRowsImpl(long peer, int value);
 
+    @Override
     public int getCols() {
         return getColsImpl(getPeer());
     }
     native static int getColsImpl(long peer);
 
+    @Override
     public void setCols(int value) {
         setColsImpl(getPeer(), value);
     }
@@ -156,26 +167,31 @@ public class HTMLTextAreaElementImpl extends HTMLElementImpl implements HTMLText
     }
     native static void setWrapImpl(long peer, String value);
 
+    @Override
     public String getType() {
         return getTypeImpl(getPeer());
     }
     native static String getTypeImpl(long peer);
 
+    @Override
     public String getDefaultValue() {
         return getDefaultValueImpl(getPeer());
     }
     native static String getDefaultValueImpl(long peer);
 
+    @Override
     public void setDefaultValue(String value) {
         setDefaultValueImpl(getPeer(), value);
     }
     native static void setDefaultValueImpl(long peer, String value);
 
+    @Override
     public String getValue() {
         return getValueImpl(getPeer());
     }
     native static String getValueImpl(long peer);
 
+    @Override
     public void setValue(String value) {
         setValueImpl(getPeer(), value);
     }
@@ -231,11 +247,13 @@ public class HTMLTextAreaElementImpl extends HTMLElementImpl implements HTMLText
     }
     native static void setSelectionDirectionImpl(long peer, String value);
 
+    @Override
     public String getAccessKey() {
         return getAccessKeyImpl(getPeer());
     }
     native static String getAccessKeyImpl(long peer);
 
+    @Override
     public void setAccessKey(String value) {
         setAccessKeyImpl(getPeer(), value);
     }
@@ -269,6 +287,7 @@ public class HTMLTextAreaElementImpl extends HTMLElementImpl implements HTMLText
         , String error);
 
 
+    @Override
     public void select()
     {
         selectImpl(getPeer());

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLTitleElementImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLTitleElementImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,11 +38,13 @@ public class HTMLTitleElementImpl extends HTMLElementImpl implements HTMLTitleEl
 
 
 // Attributes
+    @Override
     public String getText() {
         return getTextImpl(getPeer());
     }
     native static String getTextImpl(long peer);
 
+    @Override
     public void setText(String value) {
         setTextImpl(getPeer(), value);
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLUListElementImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/HTMLUListElementImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,21 +38,25 @@ public class HTMLUListElementImpl extends HTMLElementImpl implements HTMLUListEl
 
 
 // Attributes
+    @Override
     public boolean getCompact() {
         return getCompactImpl(getPeer());
     }
     native static boolean getCompactImpl(long peer);
 
+    @Override
     public void setCompact(boolean value) {
         setCompactImpl(getPeer(), value);
     }
     native static void setCompactImpl(long peer, boolean value);
 
+    @Override
     public String getType() {
         return getTypeImpl(getPeer());
     }
     native static String getTypeImpl(long peer);
 
+    @Override
     public void setType(String value) {
         setTypeImpl(getPeer(), value);
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/KeyboardEventImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/KeyboardEventImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -84,11 +84,13 @@ public class KeyboardEventImpl extends UIEventImpl {
     }
     native static boolean getAltGraphKeyImpl(long peer);
 
+    @Override
     public int getKeyCode() {
         return getKeyCodeImpl(getPeer());
     }
     native static int getKeyCodeImpl(long peer);
 
+    @Override
     public int getCharCode() {
         return getCharCodeImpl(getPeer());
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/MediaListImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/MediaListImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,6 +36,8 @@ public class MediaListImpl implements MediaList {
         SelfDisposer(final long peer) {
             this.peer = peer;
         }
+
+        @Override
         public void dispose() {
             MediaListImpl.dispose(peer);
         }
@@ -78,16 +80,19 @@ public class MediaListImpl implements MediaList {
 
 
 // Attributes
+    @Override
     public String getMediaText() {
         return getMediaTextImpl(getPeer());
     }
     native static String getMediaTextImpl(long peer);
 
+    @Override
     public void setMediaText(String value) throws DOMException {
         setMediaTextImpl(getPeer(), value);
     }
     native static void setMediaTextImpl(long peer, String value);
 
+    @Override
     public int getLength() {
         return getLengthImpl(getPeer());
     }
@@ -95,6 +100,7 @@ public class MediaListImpl implements MediaList {
 
 
 // Functions
+    @Override
     public String item(int index)
     {
         return itemImpl(getPeer()
@@ -104,6 +110,7 @@ public class MediaListImpl implements MediaList {
         , int index);
 
 
+    @Override
     public void deleteMedium(String oldMedium) throws DOMException
     {
         deleteMediumImpl(getPeer()
@@ -113,6 +120,7 @@ public class MediaListImpl implements MediaList {
         , String oldMedium);
 
 
+    @Override
     public void appendMedium(String newMedium) throws DOMException
     {
         appendMediumImpl(getPeer()

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/MouseEventImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/MouseEventImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,51 +41,61 @@ public class MouseEventImpl extends UIEventImpl implements MouseEvent {
 
 
 // Attributes
+    @Override
     public int getScreenX() {
         return getScreenXImpl(getPeer());
     }
     native static int getScreenXImpl(long peer);
 
+    @Override
     public int getScreenY() {
         return getScreenYImpl(getPeer());
     }
     native static int getScreenYImpl(long peer);
 
+    @Override
     public int getClientX() {
         return getClientXImpl(getPeer());
     }
     native static int getClientXImpl(long peer);
 
+    @Override
     public int getClientY() {
         return getClientYImpl(getPeer());
     }
     native static int getClientYImpl(long peer);
 
+    @Override
     public boolean getCtrlKey() {
         return getCtrlKeyImpl(getPeer());
     }
     native static boolean getCtrlKeyImpl(long peer);
 
+    @Override
     public boolean getShiftKey() {
         return getShiftKeyImpl(getPeer());
     }
     native static boolean getShiftKeyImpl(long peer);
 
+    @Override
     public boolean getAltKey() {
         return getAltKeyImpl(getPeer());
     }
     native static boolean getAltKeyImpl(long peer);
 
+    @Override
     public boolean getMetaKey() {
         return getMetaKeyImpl(getPeer());
     }
     native static boolean getMetaKeyImpl(long peer);
 
+    @Override
     public short getButton() {
         return getButtonImpl(getPeer());
     }
     native static short getButtonImpl(long peer);
 
+    @Override
     public EventTarget getRelatedTarget() {
         return (EventTarget)NodeImpl.getImpl(getRelatedTargetImpl(getPeer()));
     }
@@ -123,6 +133,7 @@ public class MouseEventImpl extends UIEventImpl implements MouseEvent {
 
 
 // Functions
+    @Override
     public void initMouseEvent(String type
         , boolean canBubble
         , boolean cancelable

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/MutationEventImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/MutationEventImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,26 +44,31 @@ public class MutationEventImpl extends EventImpl implements MutationEvent {
     public static final int REMOVAL = 3;
 
 // Attributes
+    @Override
     public Node getRelatedNode() {
         return NodeImpl.getImpl(getRelatedNodeImpl(getPeer()));
     }
     native static long getRelatedNodeImpl(long peer);
 
+    @Override
     public String getPrevValue() {
         return getPrevValueImpl(getPeer());
     }
     native static String getPrevValueImpl(long peer);
 
+    @Override
     public String getNewValue() {
         return getNewValueImpl(getPeer());
     }
     native static String getNewValueImpl(long peer);
 
+    @Override
     public String getAttrName() {
         return getAttrNameImpl(getPeer());
     }
     native static String getAttrNameImpl(long peer);
 
+    @Override
     public short getAttrChange() {
         return getAttrChangeImpl(getPeer());
     }
@@ -71,6 +76,7 @@ public class MutationEventImpl extends EventImpl implements MutationEvent {
 
 
 // Functions
+    @Override
     public void initMutationEvent(String type
         , boolean canBubble
         , boolean cancelable

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/NamedNodeMapImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/NamedNodeMapImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,6 +37,8 @@ public class NamedNodeMapImpl implements NamedNodeMap {
         SelfDisposer(final long peer) {
             this.peer = peer;
         }
+
+        @Override
         public void dispose() {
             NamedNodeMapImpl.dispose(peer);
         }
@@ -79,6 +81,7 @@ public class NamedNodeMapImpl implements NamedNodeMap {
 
 
 // Attributes
+    @Override
     public int getLength() {
         return getLengthImpl(getPeer());
     }
@@ -86,6 +89,7 @@ public class NamedNodeMapImpl implements NamedNodeMap {
 
 
 // Functions
+    @Override
     public Node getNamedItem(String name)
     {
         return NodeImpl.getImpl(getNamedItemImpl(getPeer()
@@ -95,6 +99,7 @@ public class NamedNodeMapImpl implements NamedNodeMap {
         , String name);
 
 
+    @Override
     public Node setNamedItem(Node node) throws DOMException
     {
         return NodeImpl.getImpl(setNamedItemImpl(getPeer()
@@ -104,6 +109,7 @@ public class NamedNodeMapImpl implements NamedNodeMap {
         , long node);
 
 
+    @Override
     public Node removeNamedItem(String name) throws DOMException
     {
         return NodeImpl.getImpl(removeNamedItemImpl(getPeer()
@@ -113,6 +119,7 @@ public class NamedNodeMapImpl implements NamedNodeMap {
         , String name);
 
 
+    @Override
     public Node item(int index)
     {
         return NodeImpl.getImpl(itemImpl(getPeer()
@@ -122,6 +129,7 @@ public class NamedNodeMapImpl implements NamedNodeMap {
         , int index);
 
 
+    @Override
     public Node getNamedItemNS(String namespaceURI
         , String localName)
     {
@@ -134,6 +142,7 @@ public class NamedNodeMapImpl implements NamedNodeMap {
         , String localName);
 
 
+    @Override
     public Node setNamedItemNS(Node node) throws DOMException
     {
         return NodeImpl.getImpl(setNamedItemNSImpl(getPeer()
@@ -143,6 +152,7 @@ public class NamedNodeMapImpl implements NamedNodeMap {
         , long node);
 
 
+    @Override
     public Node removeNamedItemNS(String namespaceURI
         , String localName) throws DOMException
     {

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/NodeFilterImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/NodeFilterImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,6 +36,8 @@ public class NodeFilterImpl implements NodeFilter {
         SelfDisposer(final long peer) {
             this.peer = peer;
         }
+
+        @Override
         public void dispose() {
             NodeFilterImpl.dispose(peer);
         }
@@ -96,6 +98,7 @@ public class NodeFilterImpl implements NodeFilter {
     public static final int SHOW_NOTATION = 0x00000800;
 
 // Functions
+    @Override
     public short acceptNode(Node n)
     {
         return acceptNodeImpl(getPeer()

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/NodeImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/NodeImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -115,6 +115,7 @@ public class NodeImpl extends JSObject implements Node, EventTarget {
             peer = _peer;
         }
 
+        @Override
         public void dispose() {
             int hash = hashPeer(peer);
             SelfDisposer head = hashTable[hash];
@@ -254,96 +255,115 @@ public class NodeImpl extends JSObject implements Node, EventTarget {
     public static final int DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC = 0x20;
 
 // Attributes
+    @Override
     public String getNodeName() {
         return getNodeNameImpl(getPeer());
     }
     native static String getNodeNameImpl(long peer);
 
+    @Override
     public String getNodeValue() {
         return getNodeValueImpl(getPeer());
     }
     native static String getNodeValueImpl(long peer);
 
+    @Override
     public void setNodeValue(String value) throws DOMException {
         setNodeValueImpl(getPeer(), value);
     }
     native static void setNodeValueImpl(long peer, String value);
 
+    @Override
     public short getNodeType() {
         return getNodeTypeImpl(getPeer());
     }
     native static short getNodeTypeImpl(long peer);
 
+    @Override
     public Node getParentNode() {
         return NodeImpl.getImpl(getParentNodeImpl(getPeer()));
     }
     native static long getParentNodeImpl(long peer);
 
+    @Override
     public NodeList getChildNodes() {
         return NodeListImpl.getImpl(getChildNodesImpl(getPeer()));
     }
     native static long getChildNodesImpl(long peer);
 
+    @Override
     public Node getFirstChild() {
         return NodeImpl.getImpl(getFirstChildImpl(getPeer()));
     }
     native static long getFirstChildImpl(long peer);
 
+    @Override
     public Node getLastChild() {
         return NodeImpl.getImpl(getLastChildImpl(getPeer()));
     }
     native static long getLastChildImpl(long peer);
 
+    @Override
     public Node getPreviousSibling() {
         return NodeImpl.getImpl(getPreviousSiblingImpl(getPeer()));
     }
     native static long getPreviousSiblingImpl(long peer);
 
+    @Override
     public Node getNextSibling() {
         return NodeImpl.getImpl(getNextSiblingImpl(getPeer()));
     }
     native static long getNextSiblingImpl(long peer);
 
+    @Override
     public Document getOwnerDocument() {
         return DocumentImpl.getImpl(getOwnerDocumentImpl(getPeer()));
     }
     native static long getOwnerDocumentImpl(long peer);
 
+    @Override
     public String getNamespaceURI() {
         return getNamespaceURIImpl(getPeer());
     }
     native static String getNamespaceURIImpl(long peer);
 
+    @Override
     public String getPrefix() {
         return getPrefixImpl(getPeer());
     }
     native static String getPrefixImpl(long peer);
 
+    @Override
     public void setPrefix(String value) throws DOMException {
         setPrefixImpl(getPeer(), value);
     }
     native static void setPrefixImpl(long peer, String value);
 
+    @Override
     public String getLocalName() {
         return getLocalNameImpl(getPeer());
     }
     native static String getLocalNameImpl(long peer);
 
+    @Override
     public NamedNodeMap getAttributes() {
         return NamedNodeMapImpl.getImpl(getAttributesImpl(getPeer()));
     }
     native static long getAttributesImpl(long peer);
 
+    @Override
     public String getBaseURI() {
         return getBaseURIImpl(getPeer());
     }
     native static String getBaseURIImpl(long peer);
 
+    @Override
     public String getTextContent() {
         return getTextContentImpl(getPeer());
     }
     native static String getTextContentImpl(long peer);
 
+    @Override
     public void setTextContent(String value) throws DOMException {
         setTextContentImpl(getPeer(), value);
     }
@@ -356,6 +376,7 @@ public class NodeImpl extends JSObject implements Node, EventTarget {
 
 
 // Functions
+    @Override
     public Node insertBefore(Node newChild
         , Node refChild) throws DOMException
     {
@@ -368,6 +389,7 @@ public class NodeImpl extends JSObject implements Node, EventTarget {
         , long refChild);
 
 
+    @Override
     public Node replaceChild(Node newChild
         , Node oldChild) throws DOMException
     {
@@ -380,6 +402,7 @@ public class NodeImpl extends JSObject implements Node, EventTarget {
         , long oldChild);
 
 
+    @Override
     public Node removeChild(Node oldChild) throws DOMException
     {
         return NodeImpl.getImpl(removeChildImpl(getPeer()
@@ -389,6 +412,7 @@ public class NodeImpl extends JSObject implements Node, EventTarget {
         , long oldChild);
 
 
+    @Override
     public Node appendChild(Node newChild) throws DOMException
     {
         return NodeImpl.getImpl(appendChildImpl(getPeer()
@@ -398,6 +422,7 @@ public class NodeImpl extends JSObject implements Node, EventTarget {
         , long newChild);
 
 
+    @Override
     public boolean hasChildNodes()
     {
         return hasChildNodesImpl(getPeer());
@@ -405,6 +430,7 @@ public class NodeImpl extends JSObject implements Node, EventTarget {
     native static boolean hasChildNodesImpl(long peer);
 
 
+    @Override
     public Node cloneNode(boolean deep) throws DOMException
     {
         return NodeImpl.getImpl(cloneNodeImpl(getPeer()
@@ -414,6 +440,7 @@ public class NodeImpl extends JSObject implements Node, EventTarget {
         , boolean deep);
 
 
+    @Override
     public void normalize()
     {
         normalizeImpl(getPeer());
@@ -421,6 +448,7 @@ public class NodeImpl extends JSObject implements Node, EventTarget {
     native static void normalizeImpl(long peer);
 
 
+    @Override
     public boolean isSupported(String feature
         , String version)
     {
@@ -433,6 +461,7 @@ public class NodeImpl extends JSObject implements Node, EventTarget {
         , String version);
 
 
+    @Override
     public boolean hasAttributes()
     {
         return hasAttributesImpl(getPeer());
@@ -440,6 +469,7 @@ public class NodeImpl extends JSObject implements Node, EventTarget {
     native static boolean hasAttributesImpl(long peer);
 
 
+    @Override
     public boolean isSameNode(Node other)
     {
         return isSameNodeImpl(getPeer()
@@ -449,6 +479,7 @@ public class NodeImpl extends JSObject implements Node, EventTarget {
         , long other);
 
 
+    @Override
     public boolean isEqualNode(Node other)
     {
         return isEqualNodeImpl(getPeer()
@@ -458,6 +489,7 @@ public class NodeImpl extends JSObject implements Node, EventTarget {
         , long other);
 
 
+    @Override
     public String lookupPrefix(String namespaceURI)
     {
         return lookupPrefixImpl(getPeer()
@@ -467,6 +499,7 @@ public class NodeImpl extends JSObject implements Node, EventTarget {
         , String namespaceURI);
 
 
+    @Override
     public boolean isDefaultNamespace(String namespaceURI)
     {
         return isDefaultNamespaceImpl(getPeer()
@@ -476,6 +509,7 @@ public class NodeImpl extends JSObject implements Node, EventTarget {
         , String namespaceURI);
 
 
+    @Override
     public String lookupNamespaceURI(String prefix)
     {
         return lookupNamespaceURIImpl(getPeer()
@@ -485,6 +519,7 @@ public class NodeImpl extends JSObject implements Node, EventTarget {
         , String prefix);
 
 
+    @Override
     public short compareDocumentPosition(Node other)
     {
         return compareDocumentPositionImpl(getPeer()
@@ -503,6 +538,7 @@ public class NodeImpl extends JSObject implements Node, EventTarget {
         , long other);
 
 
+    @Override
     public void addEventListener(String type
         , EventListener listener
         , boolean useCapture)
@@ -518,6 +554,7 @@ public class NodeImpl extends JSObject implements Node, EventTarget {
         , boolean useCapture);
 
 
+    @Override
     public void removeEventListener(String type
         , EventListener listener
         , boolean useCapture)
@@ -533,6 +570,7 @@ public class NodeImpl extends JSObject implements Node, EventTarget {
         , boolean useCapture);
 
 
+    @Override
     public boolean dispatchEvent(Event event) throws DOMException
     {
         return dispatchEventImpl(getPeer()
@@ -544,12 +582,17 @@ public class NodeImpl extends JSObject implements Node, EventTarget {
 
 
 //stubs
+    @Override
     public Object getUserData(String key) {
         throw new UnsupportedOperationException("Not supported yet.");
     }
+
+    @Override
     public Object setUserData(String key, Object data, UserDataHandler handler) {
         throw new UnsupportedOperationException("Not supported yet.");
     }
+
+    @Override
     public Object getFeature(String feature, String version) {
         throw new UnsupportedOperationException("Not supported yet.");
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/NodeIteratorImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/NodeIteratorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,6 +37,8 @@ public class NodeIteratorImpl implements NodeIterator {
         SelfDisposer(final long peer) {
             this.peer = peer;
         }
+
+        @Override
         public void dispose() {
             NodeIteratorImpl.dispose(peer);
         }
@@ -79,21 +81,25 @@ public class NodeIteratorImpl implements NodeIterator {
 
 
 // Attributes
+    @Override
     public Node getRoot() {
         return NodeImpl.getImpl(getRootImpl(getPeer()));
     }
     native static long getRootImpl(long peer);
 
+    @Override
     public int getWhatToShow() {
         return getWhatToShowImpl(getPeer());
     }
     native static int getWhatToShowImpl(long peer);
 
+    @Override
     public NodeFilter getFilter() {
         return NodeFilterImpl.getImpl(getFilterImpl(getPeer()));
     }
     native static long getFilterImpl(long peer);
 
+    @Override
     public boolean getExpandEntityReferences() {
         return getExpandEntityReferencesImpl(getPeer());
     }
@@ -111,6 +117,7 @@ public class NodeIteratorImpl implements NodeIterator {
 
 
 // Functions
+    @Override
     public Node nextNode()
     {
         return NodeImpl.getImpl(nextNodeImpl(getPeer()));
@@ -118,6 +125,7 @@ public class NodeIteratorImpl implements NodeIterator {
     native static long nextNodeImpl(long peer);
 
 
+    @Override
     public Node previousNode()
     {
         return NodeImpl.getImpl(previousNodeImpl(getPeer()));
@@ -125,6 +133,7 @@ public class NodeIteratorImpl implements NodeIterator {
     native static long previousNodeImpl(long peer);
 
 
+    @Override
     public void detach()
     {
         detachImpl(getPeer());

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/NodeListImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/NodeListImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,6 +36,8 @@ public class NodeListImpl implements NodeList {
         SelfDisposer(final long peer) {
             this.peer = peer;
         }
+
+        @Override
         public void dispose() {
             NodeListImpl.dispose(peer);
         }
@@ -78,6 +80,7 @@ public class NodeListImpl implements NodeList {
 
 
 // Attributes
+    @Override
     public int getLength() {
         return getLengthImpl(getPeer());
     }
@@ -85,6 +88,7 @@ public class NodeListImpl implements NodeList {
 
 
 // Functions
+    @Override
     public Node item(int index)
     {
         return NodeImpl.getImpl(itemImpl(getPeer()

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/ProcessingInstructionImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/ProcessingInstructionImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,6 +40,7 @@ public class ProcessingInstructionImpl extends CharacterDataImpl implements Proc
 
 
 // Attributes
+    @Override
     public String getTarget() {
         return getTargetImpl(getPeer());
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/RGBColorImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/RGBColorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,6 +36,8 @@ public class RGBColorImpl implements RGBColor {
         SelfDisposer(final long peer) {
             this.peer = peer;
         }
+
+        @Override
         public void dispose() {
             RGBColorImpl.dispose(peer);
         }
@@ -78,16 +80,19 @@ public class RGBColorImpl implements RGBColor {
 
 
 // Attributes
+    @Override
     public CSSPrimitiveValue getRed() {
         return CSSPrimitiveValueImpl.getImpl(getRedImpl(getPeer()));
     }
     native static long getRedImpl(long peer);
 
+    @Override
     public CSSPrimitiveValue getGreen() {
         return CSSPrimitiveValueImpl.getImpl(getGreenImpl(getPeer()));
     }
     native static long getGreenImpl(long peer);
 
+    @Override
     public CSSPrimitiveValue getBlue() {
         return CSSPrimitiveValueImpl.getImpl(getBlueImpl(getPeer()));
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/RangeImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/RangeImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,6 +38,8 @@ public class RangeImpl implements Range {
         SelfDisposer(final long peer) {
             this.peer = peer;
         }
+
+        @Override
         public void dispose() {
             RangeImpl.dispose(peer);
         }
@@ -90,31 +92,37 @@ public class RangeImpl implements Range {
     public static final int NODE_INSIDE = 3;
 
 // Attributes
+    @Override
     public Node getStartContainer() {
         return NodeImpl.getImpl(getStartContainerImpl(getPeer()));
     }
     native static long getStartContainerImpl(long peer);
 
+    @Override
     public int getStartOffset() {
         return getStartOffsetImpl(getPeer());
     }
     native static int getStartOffsetImpl(long peer);
 
+    @Override
     public Node getEndContainer() {
         return NodeImpl.getImpl(getEndContainerImpl(getPeer()));
     }
     native static long getEndContainerImpl(long peer);
 
+    @Override
     public int getEndOffset() {
         return getEndOffsetImpl(getPeer());
     }
     native static int getEndOffsetImpl(long peer);
 
+    @Override
     public boolean getCollapsed() {
         return getCollapsedImpl(getPeer());
     }
     native static boolean getCollapsedImpl(long peer);
 
+    @Override
     public Node getCommonAncestorContainer() {
         return NodeImpl.getImpl(getCommonAncestorContainerImpl(getPeer()));
     }
@@ -127,6 +135,7 @@ public class RangeImpl implements Range {
 
 
 // Functions
+    @Override
     public void setStart(Node refNode
         , int offset) throws DOMException
     {
@@ -139,6 +148,7 @@ public class RangeImpl implements Range {
         , int offset);
 
 
+    @Override
     public void setEnd(Node refNode
         , int offset) throws DOMException
     {
@@ -151,6 +161,7 @@ public class RangeImpl implements Range {
         , int offset);
 
 
+    @Override
     public void setStartBefore(Node refNode) throws DOMException
     {
         setStartBeforeImpl(getPeer()
@@ -160,6 +171,7 @@ public class RangeImpl implements Range {
         , long refNode);
 
 
+    @Override
     public void setStartAfter(Node refNode) throws DOMException
     {
         setStartAfterImpl(getPeer()
@@ -169,6 +181,7 @@ public class RangeImpl implements Range {
         , long refNode);
 
 
+    @Override
     public void setEndBefore(Node refNode) throws DOMException
     {
         setEndBeforeImpl(getPeer()
@@ -178,6 +191,7 @@ public class RangeImpl implements Range {
         , long refNode);
 
 
+    @Override
     public void setEndAfter(Node refNode) throws DOMException
     {
         setEndAfterImpl(getPeer()
@@ -187,6 +201,7 @@ public class RangeImpl implements Range {
         , long refNode);
 
 
+    @Override
     public void collapse(boolean toStart)
     {
         collapseImpl(getPeer()
@@ -196,6 +211,7 @@ public class RangeImpl implements Range {
         , boolean toStart);
 
 
+    @Override
     public void selectNode(Node refNode) throws DOMException
     {
         selectNodeImpl(getPeer()
@@ -205,6 +221,7 @@ public class RangeImpl implements Range {
         , long refNode);
 
 
+    @Override
     public void selectNodeContents(Node refNode) throws DOMException
     {
         selectNodeContentsImpl(getPeer()
@@ -214,6 +231,7 @@ public class RangeImpl implements Range {
         , long refNode);
 
 
+    @Override
     public short compareBoundaryPoints(short how
         , Range sourceRange) throws DOMException
     {
@@ -226,6 +244,7 @@ public class RangeImpl implements Range {
         , long sourceRange);
 
 
+    @Override
     public void deleteContents() throws DOMException
     {
         deleteContentsImpl(getPeer());
@@ -233,6 +252,7 @@ public class RangeImpl implements Range {
     native static void deleteContentsImpl(long peer);
 
 
+    @Override
     public DocumentFragment extractContents() throws DOMException
     {
         return DocumentFragmentImpl.getImpl(extractContentsImpl(getPeer()));
@@ -240,6 +260,7 @@ public class RangeImpl implements Range {
     native static long extractContentsImpl(long peer);
 
 
+    @Override
     public DocumentFragment cloneContents() throws DOMException
     {
         return DocumentFragmentImpl.getImpl(cloneContentsImpl(getPeer()));
@@ -247,6 +268,7 @@ public class RangeImpl implements Range {
     native static long cloneContentsImpl(long peer);
 
 
+    @Override
     public void insertNode(Node newNode) throws DOMException
     {
         insertNodeImpl(getPeer()
@@ -256,6 +278,7 @@ public class RangeImpl implements Range {
         , long newNode);
 
 
+    @Override
     public void surroundContents(Node newParent) throws DOMException
     {
         surroundContentsImpl(getPeer()
@@ -265,6 +288,7 @@ public class RangeImpl implements Range {
         , long newParent);
 
 
+    @Override
     public Range cloneRange()
     {
         return RangeImpl.getImpl(cloneRangeImpl(getPeer()));
@@ -272,6 +296,7 @@ public class RangeImpl implements Range {
     native static long cloneRangeImpl(long peer);
 
 
+    @Override
     public String toString()
     {
         return toStringImpl(getPeer());
@@ -279,6 +304,7 @@ public class RangeImpl implements Range {
     native static String toStringImpl(long peer);
 
 
+    @Override
     public void detach()
     {
         detachImpl(getPeer());

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/RectImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/RectImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,6 +36,8 @@ public class RectImpl implements Rect {
         SelfDisposer(final long peer) {
             this.peer = peer;
         }
+
+        @Override
         public void dispose() {
             RectImpl.dispose(peer);
         }
@@ -78,21 +80,25 @@ public class RectImpl implements Rect {
 
 
 // Attributes
+    @Override
     public CSSPrimitiveValue getTop() {
         return CSSPrimitiveValueImpl.getImpl(getTopImpl(getPeer()));
     }
     native static long getTopImpl(long peer);
 
+    @Override
     public CSSPrimitiveValue getRight() {
         return CSSPrimitiveValueImpl.getImpl(getRightImpl(getPeer()));
     }
     native static long getRightImpl(long peer);
 
+    @Override
     public CSSPrimitiveValue getBottom() {
         return CSSPrimitiveValueImpl.getImpl(getBottomImpl(getPeer()));
     }
     native static long getBottomImpl(long peer);
 
+    @Override
     public CSSPrimitiveValue getLeft() {
         return CSSPrimitiveValueImpl.getImpl(getLeftImpl(getPeer()));
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/StyleSheetImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/StyleSheetImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,6 +37,8 @@ public class StyleSheetImpl implements StyleSheet {
         SelfDisposer(final long peer) {
             this.peer = peer;
         }
+
+        @Override
         public void dispose() {
             StyleSheetImpl.dispose(peer);
         }
@@ -85,41 +87,49 @@ public class StyleSheetImpl implements StyleSheet {
 
 
 // Attributes
+    @Override
     public String getType() {
         return getTypeImpl(getPeer());
     }
     native static String getTypeImpl(long peer);
 
+    @Override
     public boolean getDisabled() {
         return getDisabledImpl(getPeer());
     }
     native static boolean getDisabledImpl(long peer);
 
+    @Override
     public void setDisabled(boolean value) {
         setDisabledImpl(getPeer(), value);
     }
     native static void setDisabledImpl(long peer, boolean value);
 
+    @Override
     public Node getOwnerNode() {
         return NodeImpl.getImpl(getOwnerNodeImpl(getPeer()));
     }
     native static long getOwnerNodeImpl(long peer);
 
+    @Override
     public StyleSheet getParentStyleSheet() {
         return StyleSheetImpl.getImpl(getParentStyleSheetImpl(getPeer()));
     }
     native static long getParentStyleSheetImpl(long peer);
 
+    @Override
     public String getHref() {
         return getHrefImpl(getPeer());
     }
     native static String getHrefImpl(long peer);
 
+    @Override
     public String getTitle() {
         return getTitleImpl(getPeer());
     }
     native static String getTitleImpl(long peer);
 
+    @Override
     public MediaList getMedia() {
         return MediaListImpl.getImpl(getMediaImpl(getPeer()));
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/StyleSheetListImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/StyleSheetListImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,6 +36,8 @@ public class StyleSheetListImpl implements StyleSheetList {
         SelfDisposer(final long peer) {
             this.peer = peer;
         }
+
+        @Override
         public void dispose() {
             StyleSheetListImpl.dispose(peer);
         }
@@ -78,6 +80,7 @@ public class StyleSheetListImpl implements StyleSheetList {
 
 
 // Attributes
+    @Override
     public int getLength() {
         return getLengthImpl(getPeer());
     }
@@ -85,6 +88,7 @@ public class StyleSheetListImpl implements StyleSheetList {
 
 
 // Functions
+    @Override
     public StyleSheet item(int index)
     {
         return StyleSheetImpl.getImpl(itemImpl(getPeer()

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/TextImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/TextImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,6 +39,7 @@ public class TextImpl extends CharacterDataImpl implements Text {
 
 
 // Attributes
+    @Override
     public String getWholeText() {
         return getWholeTextImpl(getPeer());
     }
@@ -46,6 +47,7 @@ public class TextImpl extends CharacterDataImpl implements Text {
 
 
 // Functions
+    @Override
     public Text splitText(int offset) throws DOMException
     {
         return TextImpl.getImpl(splitTextImpl(getPeer()
@@ -55,6 +57,7 @@ public class TextImpl extends CharacterDataImpl implements Text {
         , int offset);
 
 
+    @Override
     public Text replaceWholeText(String content) throws DOMException
     {
         return TextImpl.getImpl(replaceWholeTextImpl(getPeer()
@@ -66,6 +69,7 @@ public class TextImpl extends CharacterDataImpl implements Text {
 
 
 //stubs
+    @Override
     public boolean isElementContentWhitespace() {
         throw new UnsupportedOperationException("Not supported yet.");
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/TreeWalkerImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/TreeWalkerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,6 +38,8 @@ public class TreeWalkerImpl implements TreeWalker {
         SelfDisposer(final long peer) {
             this.peer = peer;
         }
+
+        @Override
         public void dispose() {
             TreeWalkerImpl.dispose(peer);
         }
@@ -80,31 +82,37 @@ public class TreeWalkerImpl implements TreeWalker {
 
 
 // Attributes
+    @Override
     public Node getRoot() {
         return NodeImpl.getImpl(getRootImpl(getPeer()));
     }
     native static long getRootImpl(long peer);
 
+    @Override
     public int getWhatToShow() {
         return getWhatToShowImpl(getPeer());
     }
     native static int getWhatToShowImpl(long peer);
 
+    @Override
     public NodeFilter getFilter() {
         return NodeFilterImpl.getImpl(getFilterImpl(getPeer()));
     }
     native static long getFilterImpl(long peer);
 
+    @Override
     public boolean getExpandEntityReferences() {
         return getExpandEntityReferencesImpl(getPeer());
     }
     native static boolean getExpandEntityReferencesImpl(long peer);
 
+    @Override
     public Node getCurrentNode() {
         return NodeImpl.getImpl(getCurrentNodeImpl(getPeer()));
     }
     native static long getCurrentNodeImpl(long peer);
 
+    @Override
     public void setCurrentNode(Node value) throws DOMException {
         setCurrentNodeImpl(getPeer(), NodeImpl.getPeer(value));
     }
@@ -112,6 +120,7 @@ public class TreeWalkerImpl implements TreeWalker {
 
 
 // Functions
+    @Override
     public Node parentNode()
     {
         return NodeImpl.getImpl(parentNodeImpl(getPeer()));
@@ -119,6 +128,7 @@ public class TreeWalkerImpl implements TreeWalker {
     native static long parentNodeImpl(long peer);
 
 
+    @Override
     public Node firstChild()
     {
         return NodeImpl.getImpl(firstChildImpl(getPeer()));
@@ -126,6 +136,7 @@ public class TreeWalkerImpl implements TreeWalker {
     native static long firstChildImpl(long peer);
 
 
+    @Override
     public Node lastChild()
     {
         return NodeImpl.getImpl(lastChildImpl(getPeer()));
@@ -133,6 +144,7 @@ public class TreeWalkerImpl implements TreeWalker {
     native static long lastChildImpl(long peer);
 
 
+    @Override
     public Node previousSibling()
     {
         return NodeImpl.getImpl(previousSiblingImpl(getPeer()));
@@ -140,6 +152,7 @@ public class TreeWalkerImpl implements TreeWalker {
     native static long previousSiblingImpl(long peer);
 
 
+    @Override
     public Node nextSibling()
     {
         return NodeImpl.getImpl(nextSiblingImpl(getPeer()));
@@ -147,6 +160,7 @@ public class TreeWalkerImpl implements TreeWalker {
     native static long nextSiblingImpl(long peer);
 
 
+    @Override
     public Node previousNode()
     {
         return NodeImpl.getImpl(previousNodeImpl(getPeer()));
@@ -154,6 +168,7 @@ public class TreeWalkerImpl implements TreeWalker {
     native static long previousNodeImpl(long peer);
 
 
+    @Override
     public Node nextNode()
     {
         return NodeImpl.getImpl(nextNodeImpl(getPeer()));

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/UIEventImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/UIEventImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,11 +39,13 @@ public class UIEventImpl extends EventImpl implements UIEvent {
 
 
 // Attributes
+    @Override
     public AbstractView getView() {
         return DOMWindowImpl.getImpl(getViewImpl(getPeer()));
     }
     native static long getViewImpl(long peer);
 
+    @Override
     public int getDetail() {
         return getDetailImpl(getPeer());
     }
@@ -86,6 +88,7 @@ public class UIEventImpl extends EventImpl implements UIEvent {
 
 
 // Functions
+    @Override
     public void initUIEvent(String type
         , boolean canBubble
         , boolean cancelable

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/XPathExpressionImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/XPathExpressionImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,6 +38,8 @@ public class XPathExpressionImpl implements XPathExpression {
         SelfDisposer(final long peer) {
             this.peer = peer;
         }
+
+        @Override
         public void dispose() {
             XPathExpressionImpl.dispose(peer);
         }

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/XPathNSResolverImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/XPathNSResolverImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,8 @@ public class XPathNSResolverImpl implements XPathNSResolver {
         SelfDisposer(final long peer) {
             this.peer = peer;
         }
+
+        @Override
         public void dispose() {
             XPathNSResolverImpl.dispose(peer);
         }
@@ -77,6 +79,7 @@ public class XPathNSResolverImpl implements XPathNSResolver {
 
 
 // Functions
+    @Override
     public String lookupNamespaceURI(String prefix)
     {
         return lookupNamespaceURIImpl(getPeer()

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/XPathResultImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/XPathResultImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,6 +37,8 @@ public class XPathResultImpl implements XPathResult {
         SelfDisposer(final long peer) {
             this.peer = peer;
         }
+
+        @Override
         public void dispose() {
             XPathResultImpl.dispose(peer);
         }
@@ -91,36 +93,43 @@ public class XPathResultImpl implements XPathResult {
     public static final int FIRST_ORDERED_NODE_TYPE = 9;
 
 // Attributes
+    @Override
     public short getResultType() {
         return getResultTypeImpl(getPeer());
     }
     native static short getResultTypeImpl(long peer);
 
+    @Override
     public double getNumberValue() throws DOMException {
         return getNumberValueImpl(getPeer());
     }
     native static double getNumberValueImpl(long peer);
 
+    @Override
     public String getStringValue() throws DOMException {
         return getStringValueImpl(getPeer());
     }
     native static String getStringValueImpl(long peer);
 
+    @Override
     public boolean getBooleanValue() throws DOMException {
         return getBooleanValueImpl(getPeer());
     }
     native static boolean getBooleanValueImpl(long peer);
 
+    @Override
     public Node getSingleNodeValue() throws DOMException {
         return NodeImpl.getImpl(getSingleNodeValueImpl(getPeer()));
     }
     native static long getSingleNodeValueImpl(long peer);
 
+    @Override
     public boolean getInvalidIteratorState() {
         return getInvalidIteratorStateImpl(getPeer());
     }
     native static boolean getInvalidIteratorStateImpl(long peer);
 
+    @Override
     public int getSnapshotLength() throws DOMException {
         return getSnapshotLengthImpl(getPeer());
     }
@@ -128,6 +137,7 @@ public class XPathResultImpl implements XPathResult {
 
 
 // Functions
+    @Override
     public Node iterateNext() throws DOMException
     {
         return NodeImpl.getImpl(iterateNextImpl(getPeer()));
@@ -135,6 +145,7 @@ public class XPathResultImpl implements XPathResult {
     native static long iterateNextImpl(long peer);
 
 
+    @Override
     public Node snapshotItem(int index) throws DOMException
     {
         return NodeImpl.getImpl(snapshotItemImpl(getPeer()


### PR DESCRIPTION
Fix missing @Overrides in **javafx.web**.

This is still a trivial change since all the spots are identified by the IDE.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8328752](https://bugs.openjdk.org/browse/JDK-8328752): Fix missing @<!---->Overrides in javafx.web (**Bug** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Hima Bindu Meda](https://openjdk.org/census#hmeda) (@HimaBinduMeda - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1424/head:pull/1424` \
`$ git checkout pull/1424`

Update a local copy of the PR: \
`$ git checkout pull/1424` \
`$ git pull https://git.openjdk.org/jfx.git pull/1424/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1424`

View PR using the GUI difftool: \
`$ git pr show -t 1424`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1424.diff">https://git.openjdk.org/jfx/pull/1424.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1424#issuecomment-2015237509)