### PR TITLE
8328818: Fix Decora JSL to remove missing @Override warnings

### DIFF
--- a/modules/javafx.graphics/src/main/jsl-decora/LinearConvolve.jsl
+++ b/modules/javafx.graphics/src/main/jsl-decora/LinearConvolve.jsl
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
  */
 
 <<
+@Override
 public Rectangle getResultBounds(com.sun.javafx.geom.transform.BaseTransform transform,
                                  com.sun.javafx.geom.Rectangle outputClip,
                                  com.sun.scenario.effect.ImageData... inputDatas)

--- a/modules/javafx.graphics/src/main/jsl-decora/LinearConvolveShadow.jsl
+++ b/modules/javafx.graphics/src/main/jsl-decora/LinearConvolveShadow.jsl
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
  */
 
 <<
+@Override
 public Rectangle getResultBounds(com.sun.javafx.geom.transform.BaseTransform transform,
                                  com.sun.javafx.geom.Rectangle outputClip,
                                  com.sun.scenario.effect.ImageData... inputDatas)


### PR DESCRIPTION
Updating the JSL files to remove the "missing @ override" warning.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328818](https://bugs.openjdk.org/browse/JDK-8328818): Fix Decora JSL to remove missing @<!---->Override warnings (**Bug** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1425/head:pull/1425` \
`$ git checkout pull/1425`

Update a local copy of the PR: \
`$ git checkout pull/1425` \
`$ git pull https://git.openjdk.org/jfx.git pull/1425/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1425`

View PR using the GUI difftool: \
`$ git pr show -t 1425`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1425.diff">https://git.openjdk.org/jfx/pull/1425.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1425#issuecomment-2015433253)