### PR TITLE
8328820: Remove unused imports in javafx.swing

### DIFF
--- a/modules/javafx.swing/src/main/java/javafx/embed/swing/InputMethodSupport.java
+++ b/modules/javafx.swing/src/main/java/javafx/embed/swing/InputMethodSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,15 +25,6 @@
 
 package javafx.embed.swing;
 
-import com.sun.javafx.application.PlatformImpl;
-import com.sun.javafx.collections.ObservableListWrapper;
-import com.sun.javafx.scene.input.ExtendedInputMethodRequests;
-import javafx.application.Platform;
-import javafx.collections.ObservableList;
-import javafx.geometry.Point2D;
-import javafx.scene.input.InputMethodHighlight;
-import javafx.scene.input.InputMethodTextRun;
-
 import java.awt.Rectangle;
 import java.awt.event.InputMethodEvent;
 import java.awt.font.TextHitInfo;
@@ -45,6 +36,13 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import javafx.collections.ObservableList;
+import javafx.geometry.Point2D;
+import javafx.scene.input.InputMethodHighlight;
+import javafx.scene.input.InputMethodTextRun;
+import com.sun.javafx.application.PlatformImpl;
+import com.sun.javafx.collections.ObservableListWrapper;
+import com.sun.javafx.scene.input.ExtendedInputMethodRequests;
 
 /**
  * A utility class containing the functions to support Input Methods


### PR DESCRIPTION
Removed unused imports in javafx.swing (1 change) module.

See the discussion in [JDK-8289379](https://bugs.openjdk.org/browse/JDK-8289379)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328820](https://bugs.openjdk.org/browse/JDK-8328820): Remove unused imports in javafx.swing (**Bug** - P4)


### Reviewers
 * [Ajit Ghaisas](https://openjdk.org/census#aghaisas) (@aghaisas - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1428/head:pull/1428` \
`$ git checkout pull/1428`

Update a local copy of the PR: \
`$ git checkout pull/1428` \
`$ git pull https://git.openjdk.org/jfx.git pull/1428/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1428`

View PR using the GUI difftool: \
`$ git pr show -t 1428`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1428.diff">https://git.openjdk.org/jfx/pull/1428.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1428#issuecomment-2015469913)