### PR TITLE
8273349: Check uses of Stream::peek in controls and replace as needed

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ControlUtils.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ControlUtils.java
@@ -38,7 +38,6 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.function.IntPredicate;
-import java.util.stream.Collectors;
 
 class ControlUtils {
     private ControlUtils() { }

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ControlUtils.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ControlUtils.java
@@ -162,10 +162,6 @@ class ControlUtils {
         sm.selectedIndices._beginChange();
 
         while (c.next()) {
-            // it may look like all we are doing here is collecting the removed elements (and
-            // counting the added elements), but the call to 'peek' is also crucial - it is
-            // ensuring that the selectedIndices bitset is correctly updated.
-
             sm.startAtomic();
 
             final List<Integer> removed = new ArrayList<>(c.getRemovedSize());

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/MultipleSelectionModelBase.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/MultipleSelectionModelBase.java
@@ -761,16 +761,18 @@ abstract class MultipleSelectionModelBase<T> extends MultipleSelectionModel<T> {
                 // by finding all contiguous indices, of all indices that are
                 // not already selected, and which are in the valid range
                 startAtomic();
-                List<Integer> sortedNewIndices =
-                        IntStream.concat(IntStream.of(index), IntStream.of(indices))
+
+                List<Integer> sortedNewIndices = new ArrayList<>(indices.length + 1);
+                IntStream.concat(IntStream.of(index), IntStream.of(indices))
                         .distinct()
                         .filter(this::isValidIndex)
                         .filter(this::isNotSelected)
                         .sorted()
-                        .boxed()
-                        .collect(Collectors.toList());
+                        .forEach(i -> {
+                            sortedNewIndices.add(i);
+                            set(i);
+                        });
 
-                sortedNewIndices.forEach(this::set);
                 stopAtomic();
 
                 final int size = sortedNewIndices.size();

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/MultipleSelectionModelBase.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/MultipleSelectionModelBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -768,8 +768,9 @@ abstract class MultipleSelectionModelBase<T> extends MultipleSelectionModel<T> {
                         .filter(this::isNotSelected)
                         .sorted()
                         .boxed()
-                        .peek(this::set) // we also set here, but it's atomic!
                         .collect(Collectors.toList());
+
+                sortedNewIndices.forEach(this::set);
                 stopAtomic();
 
                 final int size = sortedNewIndices.size();


### PR DESCRIPTION
This PR removes potentially incorrect usages of Stream.peek().
The changed code should be covered by the tests that are already present.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8273349](https://bugs.openjdk.org/browse/JDK-8273349): Check uses of Stream::peek in controls and replace as needed (**Bug** - P3)


### Reviewers
 * [Karthik P K](https://openjdk.org/census#kpk) (@karthikpandelu - Committer)
 * [Marius Hanl](https://openjdk.org/census#mhanl) (@Maran23 - Committer)
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1430/head:pull/1430` \
`$ git checkout pull/1430`

Update a local copy of the PR: \
`$ git checkout pull/1430` \
`$ git pull https://git.openjdk.org/jfx.git pull/1430/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1430`

View PR using the GUI difftool: \
`$ git pr show -t 1430`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1430.diff">https://git.openjdk.org/jfx/pull/1430.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1430#issuecomment-2016841067)