### PR TITLE
8271865: SortedList::getViewIndex behaves not correctly for some index values

### DIFF
--- a/modules/javafx.base/src/main/java/javafx/collections/transformation/FilteredList.java
+++ b/modules/javafx.base/src/main/java/javafx/collections/transformation/FilteredList.java
@@ -32,6 +32,7 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.Objects;
 import java.util.function.Predicate;
 import javafx.beans.NamedArg;
 import javafx.beans.property.ObjectProperty;
@@ -173,14 +174,13 @@ public final class FilteredList<E> extends TransformationList<E, E>{
 
     @Override
     public int getSourceIndex(int index) {
-        if (index >= size) {
-            throw new IndexOutOfBoundsException();
-        }
+        Objects.checkIndex(index, size);
         return filtered[index];
     }
 
     @Override
     public int getViewIndex(int index) {
+        Objects.checkIndex(index, getSource().size());
         return Arrays.binarySearch(filtered, 0, size, index);
     }
 

--- a/modules/javafx.base/src/main/java/javafx/collections/transformation/SortedList.java
+++ b/modules/javafx.base/src/main/java/javafx/collections/transformation/SortedList.java
@@ -33,6 +33,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 
 import javafx.beans.NamedArg;
 import javafx.beans.property.ObjectProperty;
@@ -221,11 +222,13 @@ public final class SortedList<E> extends TransformationList<E, E>{
 
     @Override
     public int getSourceIndex(int index) {
+        Objects.checkIndex(index, size);
         return sorted[index].index;
     }
 
     @Override
     public int getViewIndex(int index) {
+        Objects.checkIndex(index, size);
         return perm[index];
     }
 

--- a/modules/javafx.base/src/main/java/javafx/collections/transformation/TransformationList.java
+++ b/modules/javafx.base/src/main/java/javafx/collections/transformation/TransformationList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -118,6 +118,7 @@ public abstract class TransformationList<E, F> extends ObservableListBase<E> {
      * Maps the index of this list's element to an index in the direct source list.
      * @param index the index in this list
      * @return the index of the element's origin in the source list
+     * @throws IndexOutOfBoundsException if the index is out of range (index &lt; 0 || index >= size())
      * @see #getSource()
      */
     public abstract int getSourceIndex(int index);
@@ -130,6 +131,7 @@ public abstract class TransformationList<E, F> extends ObservableListBase<E> {
      * @param list a list from the transformation chain
      * @param index the index of an element in this list
      * @return the index of the element's origin in the provided list
+     * @throws IndexOutOfBoundsException if the index is out of range (index &lt; 0 || index >= list.getSource().size())
      * @see #isInTransformationChain(javafx.collections.ObservableList)
      */
     public final int getSourceIndexFor(ObservableList<?> list, int index) {
@@ -151,6 +153,7 @@ public abstract class TransformationList<E, F> extends ObservableListBase<E> {
      * @param index the index in the source list
      * @return the index of the element in this list if it is contained
      * in this list or negative value otherwise
+     * @throws IndexOutOfBoundsException if the index is out of range (index &lt; 0 || index >= getSource().size())
      * @see #getSource()
      * @see #getSourceIndex(int)
      *

--- a/modules/javafx.base/src/test/java/test/javafx/collections/FilteredListTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/collections/FilteredListTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,9 +36,10 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.collections.ObservableListWrapperShim;
 import javafx.collections.transformation.FilteredList;
-import static org.junit.Assert.*;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class FilteredListTest {
 
@@ -46,7 +47,7 @@ public class FilteredListTest {
     private MockListObserver<String> mlo;
     private FilteredList<String> filteredList;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         list = FXCollections.observableArrayList();
         list.addAll("a", "c", "d", "c");
@@ -70,7 +71,7 @@ public class FilteredListTest {
     public void test_rt35857_retainFiltered() {
         ObservableList<String> copyFiltered = FXCollections.observableArrayList(filteredList);
         list.retainAll(filteredList);
-        assertEquals("sanity: filteredList unchanged", copyFiltered, filteredList);
+        assertEquals(copyFiltered, filteredList, "sanity: filteredList unchanged");
         assertEquals(filteredList, list);
     }
 
@@ -305,5 +306,19 @@ public class FilteredListTest {
         assertEquals(list.size(), filteredList.size());
         assertEquals(list, filteredList);
         compareIndices();
+    }
+
+    @Test
+    public void testGetSourceIndexOutOfBounds() {
+        assertThrows(IndexOutOfBoundsException.class, () -> filteredList.getSourceIndex(-1));
+        assertThrows(IndexOutOfBoundsException.class, () -> filteredList.getSourceIndex(filteredList.size()));
+        assertDoesNotThrow(() -> filteredList.getSourceIndex(filteredList.size() - 1));
+    }
+
+    @Test
+    public void testGetViewIndexOutOfBounds() {
+        assertThrows(IndexOutOfBoundsException.class, () -> filteredList.getViewIndex(-1));
+        assertThrows(IndexOutOfBoundsException.class, () -> filteredList.getViewIndex(list.size()));
+        assertDoesNotThrow(() -> filteredList.getViewIndex(filteredList.size()));
     }
 }

--- a/modules/javafx.base/src/test/java/test/javafx/collections/SortedListTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/collections/SortedListTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,10 +43,10 @@ import javafx.collections.ObservableList;
 import javafx.collections.ObservableListWrapperShim;
 import javafx.collections.transformation.FilteredList;
 import javafx.collections.transformation.SortedList;
-import org.junit.Before;
-import org.junit.Test;
-import static org.junit.Assert.* ;
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class SortedListTest {
 
@@ -54,7 +54,7 @@ public class SortedListTest {
     private MockListObserver<String> mockListObserver;
     private SortedList<String> sortedList;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         list = FXCollections.observableArrayList();
         list.addAll("a", "c", "d", "c");
@@ -594,5 +594,19 @@ public class SortedListTest {
         assertEquals(Arrays.asList("a", "e", "d", "c"), sortedList);
         mockListObserver.check1Permutation(sortedList, new int[] {0, 3, 2, 1});
         compareIndices();
+    }
+
+    @Test
+    public void testGetSourceIndexOutOfBounds() {
+        assertThrows(IndexOutOfBoundsException.class, () -> sortedList.getSourceIndex(-1));
+        assertThrows(IndexOutOfBoundsException.class, () -> sortedList.getSourceIndex(sortedList.size()));
+        assertDoesNotThrow(() -> sortedList.getSourceIndex(sortedList.size() - 1));
+    }
+
+    @Test
+    public void testGetViewIndexOutOfBounds() {
+        assertThrows(IndexOutOfBoundsException.class, () -> sortedList.getViewIndex(-1));
+        assertThrows(IndexOutOfBoundsException.class, () -> sortedList.getViewIndex(sortedList.size()));
+        assertDoesNotThrow(() -> sortedList.getViewIndex(sortedList.size() - 1));
     }
 }


### PR DESCRIPTION
This PR adds the missing checks, as well as code documentation that an IndexOutOfBoundsException may be thrown.