### PR TITLE
8306322: JDK8130122Test fails intermittently

### DIFF
--- a/tests/system/src/test/java/test/robot/scenegraph/JDK8130122Test.java
+++ b/tests/system/src/test/java/test/robot/scenegraph/JDK8130122Test.java
@@ -84,7 +84,6 @@ public class JDK8130122Test extends VisualTestBase {
             testScene.setCamera(new PerspectiveCamera());
             testScene.setFill(Color.WHITE);
             testStage.setScene(testScene);
-            testStage.setAlwaysOnTop(true);
             testStage.show();
         });
         waitFirstFrame();
@@ -99,8 +98,8 @@ public class JDK8130122Test extends VisualTestBase {
             assertColorEquals(Color.WHITE, color, TOLERANCE);
             horizontalListView.setVisible(true);
         });
-        sleep(1000);
-        waitNextFrame();
+        // Give more time after setVisible(true) is called for frame update
+        waitFirstFrame();
         runAndWait(() -> {
             Color color = getColor(testScene, 200, 200);
             assertColorEquals(Color.GREEN, color, TOLERANCE);

--- a/tests/system/src/test/java/test/robot/scenegraph/JDK8130122Test.java
+++ b/tests/system/src/test/java/test/robot/scenegraph/JDK8130122Test.java
@@ -50,7 +50,7 @@ public class JDK8130122Test extends VisualTestBase {
 
     private static final double TOLERANCE = 0.07;
 
-    @Test(timeout = 15000)
+    @Test(timeout = 20000)
     public void testEmptyShapes() {
         final int WIDTH = 800;
         final int HEIGHT = 400;
@@ -84,6 +84,7 @@ public class JDK8130122Test extends VisualTestBase {
             testScene.setCamera(new PerspectiveCamera());
             testScene.setFill(Color.WHITE);
             testStage.setScene(testScene);
+            testStage.setAlwaysOnTop(true);
             testStage.show();
         });
         waitFirstFrame();
@@ -98,9 +99,10 @@ public class JDK8130122Test extends VisualTestBase {
             assertColorEquals(Color.WHITE, color, TOLERANCE);
             horizontalListView.setVisible(true);
         });
+        sleep(1000);
         waitNextFrame();
         runAndWait(() -> {
-            Color color = getColor(testScene, 200, 250);
+            Color color = getColor(testScene, 200, 200);
             assertColorEquals(Color.GREEN, color, TOLERANCE);
         });
 


### PR DESCRIPTION
This test has failed once and we are not seeing its failure after that instance in our test systems.

This test verifies whether bounds of GridPane gets updated properly on adding an invisible node.
Initial test has 8 nodes in GridPane and then we update it with another node with larger bounds without making it visible. After adding additional node we make the scenegraph visible and check for colors of the newly added node.

We are making this test robust to make sure we don't see any of these single instance failures.
Test is updated to:
1) To always show on top, so that we pick proper color.
2) Add additional sleep so that we give more time for test to be visible.
3) Pick color exactly at mid point in y axis, so that we pick the green color properly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306322](https://bugs.openjdk.org/browse/JDK-8306322): JDK8130122Test fails intermittently (**Bug** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1433/head:pull/1433` \
`$ git checkout pull/1433`

Update a local copy of the PR: \
`$ git checkout pull/1433` \
`$ git pull https://git.openjdk.org/jfx.git pull/1433/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1433`

View PR using the GUI difftool: \
`$ git pr show -t 1433`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1433.diff">https://git.openjdk.org/jfx/pull/1433.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1433#issuecomment-2017893789)