### PR TITLE
8328577: Toolbar's overflow button overlaps the items

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ToolBarSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ToolBarSkin.java
@@ -41,6 +41,8 @@ import javafx.beans.property.DoubleProperty;
 import javafx.beans.value.WritableValue;
 import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
+import javafx.collections.SetChangeListener;
+import javafx.css.PseudoClass;
 import javafx.geometry.HPos;
 import javafx.geometry.Orientation;
 import javafx.geometry.Pos;
@@ -566,8 +568,18 @@ public class ToolBarSkin extends SkinBase<ToolBar> {
         box.getStyleClass().add("container");
         box.getChildren().addAll(getSkinnable().getItems());
         // The overflowBox must have the same style classes, otherwise the overflow items may get wrong values.
-        overflowBox.setId(box.getId());
-        overflowBox.getStyleClass().addAll(box.getStyleClass());
+        overflowBox.idProperty().bind(box.idProperty());
+        overflowBox.getStyleClass().setAll(box.getStyleClass());
+        box.getStyleClass().addListener((ListChangeListener<? super String>) change -> overflowBox.getStyleClass().setAll(change.getList()));
+        overflowBox.getStylesheets().setAll(box.getStylesheets());
+        box.getStylesheets().addListener((ListChangeListener<? super String>) change -> overflowBox.getStylesheets().setAll(change.getList()));
+        box.getPseudoClassStates().addListener((SetChangeListener<? super PseudoClass>) change -> {
+            if (change.wasAdded()) {
+                overflowBox.pseudoClassStateChanged(change.getElementAdded(), true);
+            } else if (change.wasRemoved()) {
+                overflowBox.pseudoClassStateChanged(change.getElementAdded(), false);
+            }
+        });
         overflowBox.setManaged(false);
         overflowBox.setVisible(false);
         overflowMenu = new ToolBarOverflowMenu(overflowBox.getChildren());

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ToolBarSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ToolBarSkin.java
@@ -792,7 +792,7 @@ public class ToolBarSkin extends SkinBase<ToolBar> {
                 } else {
                     CustomMenuItem customMenuItem = new CustomMenuItem(node);
 
-                    // RT-36455:
+                    // RT-36455 (JDK-8096292):
                     // We can't be totally certain of all nodes, but for the
                     // most common nodes we can check to see whether we should
                     // hide the menu when the node is clicked on. The common

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ToolBarSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ToolBarSkin.java
@@ -36,6 +36,7 @@ import com.sun.javafx.scene.traversal.Algorithm;
 import com.sun.javafx.scene.traversal.ParentTraversalEngine;
 import com.sun.javafx.scene.traversal.TraversalContext;
 
+import javafx.beans.binding.Bindings;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.value.WritableValue;
@@ -569,15 +570,13 @@ public class ToolBarSkin extends SkinBase<ToolBar> {
         box.getChildren().addAll(getSkinnable().getItems());
         // The overflowBox must have the same style classes, otherwise the overflow items may get wrong values.
         overflowBox.idProperty().bind(box.idProperty());
-        overflowBox.getStyleClass().setAll(box.getStyleClass());
-        box.getStyleClass().addListener((ListChangeListener<? super String>) change -> overflowBox.getStyleClass().setAll(change.getList()));
-        overflowBox.getStylesheets().setAll(box.getStylesheets());
-        box.getStylesheets().addListener((ListChangeListener<? super String>) change -> overflowBox.getStylesheets().setAll(change.getList()));
+        Bindings.bindContent(overflowBox.getStyleClass(), box.getStyleClass());
+        Bindings.bindContent(overflowBox.getStylesheets(), box.getStylesheets());
         box.getPseudoClassStates().addListener((SetChangeListener<? super PseudoClass>) change -> {
             if (change.wasAdded()) {
                 overflowBox.pseudoClassStateChanged(change.getElementAdded(), true);
             } else if (change.wasRemoved()) {
-                overflowBox.pseudoClassStateChanged(change.getElementAdded(), false);
+                overflowBox.pseudoClassStateChanged(change.getElementRemoved(), false);
             }
         });
         overflowBox.setManaged(false);

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ToolBarSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ToolBarSkin.java
@@ -576,7 +576,7 @@ public class ToolBarSkin extends SkinBase<ToolBar> {
     private void correctOverflow(double length) {
         boolean overflowed = isOverflowed(length);
         if (overflowed != overflow) {
-            organizeOverflow(length, overflow);
+            organizeOverflow(length, overflowed);
         }
     }
 
@@ -590,14 +590,15 @@ public class ToolBarSkin extends SkinBase<ToolBar> {
             length -= getSpacing();
         }
 
-        // Determine which node goes to the toolbar and which goes to the overflow.
+        ObservableList<Node> nodes = getSkinnable().getItems();
 
+        // Determine the index of the first node to be moved to the overflow menu
+        // IMPORTANT: As the width/height of the node may depend on whether the node has been added to the scene,
+        // do not move it between the toolbar and the overflow menu here.
+        int overflowIndex = nodes.size();
         double x = 0;
-        overflowMenuItems.clear();
-        box.getChildren().clear();
-        for (Node node : getSkinnable().getItems()) {
-            node.getStyleClass().remove("menu-item");
-            node.getStyleClass().remove("custom-menu-item");
+        for (int i = 0; i < nodes.size(); i++) {
+            Node node = nodes.get(i);
 
             if (node.isManaged()) {
                 if (getSkinnable().getOrientation() == Orientation.VERTICAL) {
@@ -607,7 +608,22 @@ public class ToolBarSkin extends SkinBase<ToolBar> {
                 }
             }
 
-            if (x <= length) {
+            if (x > length) {
+                overflowIndex = i;
+                break;
+            }
+        }
+
+        // Determine which node goes to the toolbar and which goes to the overflow.
+
+        overflowMenuItems.clear();
+        box.getChildren().clear();
+        for (int i = 0; i < nodes.size(); i++) {
+            Node node = nodes.get(i);
+            node.getStyleClass().remove("menu-item");
+            node.getStyleClass().remove("custom-menu-item");
+
+            if (i < overflowIndex) {
                 box.getChildren().add(node);
             } else {
                 if (node.isFocused()) {


### PR DESCRIPTION
This change fixes the calculation of which nodes go to the toolbar and which go to the overflow menu.
It is now determined before the nodes are removed from the scene graph.
This is important because the values returned by ``Node.prefWidth(..)``/``Node.prefHeight(..)`` may depend on whether the node is added to the scene graph.

Furthermore I corrected the ``hasOveflow`` value passed to the ``organizeOverflow(double, boolean)`` in ``correctOverflow(double)``.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8328577](https://bugs.openjdk.org/browse/JDK-8328577): Toolbar's overflow button overlaps the items (**Bug** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Karthik P K](https://openjdk.org/census#kpk) (@karthikpandelu - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1434/head:pull/1434` \
`$ git checkout pull/1434`

Update a local copy of the PR: \
`$ git checkout pull/1434` \
`$ git pull https://git.openjdk.org/jfx.git pull/1434/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1434`

View PR using the GUI difftool: \
`$ git pr show -t 1434`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1434.diff">https://git.openjdk.org/jfx/pull/1434.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1434#issuecomment-2024971783)