### PR TITLE
8329821: [Linux] When using i3 WM, menus are incorrectly sized

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/gtk/glass_window.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/glass_window.cpp
@@ -961,7 +961,10 @@ void WindowContextTop::process_state(GdkEventWindowState* event) {
 
 void WindowContextTop::process_realize() {
     gdk_window = gtk_widget_get_window(gtk_widget);
-    request_frame_extents();
+    if (frame_type == TITLED) {
+        request_frame_extents();
+    }
+
     gdk_window_set_events(gdk_window, GDK_FILTERED_EVENTS_MASK);
     g_object_set_data_full(G_OBJECT(gdk_window), GDK_WINDOW_DATA_CONTEXT, this, NULL);
     gdk_window_register_dnd(gdk_window);


### PR DESCRIPTION
Simple fix to only request `_NET_FRAME_EXTENTS` if window has decoration.

It seems i3 replies with decorated sizes, even if window is not decorated.

Won't hurt other WMs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329821](https://bugs.openjdk.org/browse/JDK-8329821): [Linux] When using i3 WM, menus are incorrectly sized (**Bug** - P4)


### Reviewers
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1437/head:pull/1437` \
`$ git checkout pull/1437`

Update a local copy of the PR: \
`$ git checkout pull/1437` \
`$ git pull https://git.openjdk.org/jfx.git pull/1437/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1437`

View PR using the GUI difftool: \
`$ git pr show -t 1437`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1437.diff">https://git.openjdk.org/jfx/pull/1437.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1437#issuecomment-2041147568)