### PR TITLE
8322251: [Linux] JavaFX is not displaying CJK on Ubuntu 23.10 and later

### DIFF
--- a/modules/javafx.graphics/src/main/native-font/fontpath_linux.c
+++ b/modules/javafx.graphics/src/main/native-font/fontpath_linux.c
@@ -410,9 +410,13 @@ Java_com_sun_javafx_font_FontConfigManager_getFontConfig
 
             fontformat = NULL;
             (*FcPatternGetString)(fontPattern, FC_FONTFORMAT, 0, &fontformat);
-            /* We only want TrueType fonts for Java FX */
-            if (fontformat != NULL
-                && (strcmp((char*)fontformat, "TrueType") != 0)) {
+            /* We only want OpenType fonts for Java FX :
+             * ie TrueType and CFF format fonts.
+             */
+            if ((fontformat != NULL) &&
+                ((strcmp((char*)fontformat, "TrueType") != 0) &&
+                 (strcmp((char*)fontformat, "CFF") != 0)))
+            {
                 continue;
             }
             result = (*FcPatternGetCharSet)(fontPattern,


### PR DESCRIPTION
The Linux font lookup code is rejecting CFF OpenType fonts.
Since these are becoming common because of the Noto family this could soon be quite a problem.
I expect this fix is a candidate for backporting.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322251](https://bugs.openjdk.org/browse/JDK-8322251): [Linux] JavaFX is not displaying CJK on Ubuntu 23.10 and later (**Bug** - P4)


### Reviewers
 * [Ajit Ghaisas](https://openjdk.org/census#aghaisas) (@aghaisas - **Reviewer**)
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1439/head:pull/1439` \
`$ git checkout pull/1439`

Update a local copy of the PR: \
`$ git checkout pull/1439` \
`$ git pull https://git.openjdk.org/jfx.git pull/1439/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1439`

View PR using the GUI difftool: \
`$ git pr show -t 1439`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1439.diff">https://git.openjdk.org/jfx/pull/1439.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1439#issuecomment-2048254859)