### PR TITLE
8328603: HLS video stream fails to render consistently

### DIFF
--- a/modules/javafx.media/src/main/native/jfxmedia/platform/osx/avf/AVFMediaPlayer.mm
+++ b/modules/javafx.media/src/main/native/jfxmedia/platform/osx/avf/AVFMediaPlayer.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,12 +48,28 @@ static void *AVFMediaPlayerItemStatusContext = &AVFMediaPlayerItemStatusContext;
 static void *AVFMediaPlayerItemDurationContext = &AVFMediaPlayerItemDurationContext;
 static void *AVFMediaPlayerItemTracksContext = &AVFMediaPlayerItemTracksContext;
 
+// See JDK-8328603. For some streams if we let AVFoundation to decide
+// the format and decided format is not supported video will not be outputed
+// after we force AVFoundation to supported format (FALLBACK_VO_FORMAT).
+// Not sure why it happens, but if we provide supported by JavaFX Media format
+// list to AVFoundation will use one of them and no video issue is no longer
+// reproducible. We will still have fallback to FALLBACK_VO_FORMAT even if it
+// is in the list of prefered formats.
+// Uncomment to force list of supported formats by JavaFX.
+// Note: This array should match CVVideoFrame::IsFormatSupported().
+#define VO_FORMATS @{(id)kCVPixelBufferPixelFormatTypeKey: @[@(kCVPixelFormatType_422YpCbCr8),\
+                                                           @(kCVPixelFormatType_420YpCbCr8Planar),\
+                                                           @(kCVPixelFormatType_32BGRA)]}
+// Uncomment to let AVFoundation decide the format...
+//#define VO_FORMATS @{}
+
 #define FORCE_VO_FORMAT 0
 #if FORCE_VO_FORMAT
 // #define FORCED_VO_FORMAT kCVPixelFormatType_32BGRA
 // #define FORCED_VO_FORMAT kCVPixelFormatType_422YpCbCr8
 // #define FORCED_VO_FORMAT kCVPixelFormatType_420YpCbCr8Planar
  #define FORCED_VO_FORMAT kCVPixelFormatType_422YpCbCr8_yuvs // Unsupported, use to test fallback
+// #define FORCED_VO_FORMAT kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange // Unsupported, use to test fallback
 #endif
 
 // Apple really likes to output '2vuy', this should be the least expensive conversion
@@ -268,7 +284,7 @@ static CVReturn displayLinkCallback(CVDisplayLinkRef displayLink,
 #if FORCE_VO_FORMAT
                              @{(id)kCVPixelBufferPixelFormatTypeKey: @(FORCED_VO_FORMAT)}];
 #else
-                             @{}]; // let AVFoundation decide the format...
+                             VO_FORMATS];
 #endif
             if (!_playerOutput) {
                 return;
@@ -751,7 +767,6 @@ static CVReturn displayLinkCallback(CVDisplayLinkRef displayLink,
         (AVAssetResourceLoadingRequest *)loadingRequest {
     AVAssetResourceLoadingContentInformationRequest* contentRequest = loadingRequest.contentInformationRequest;
     AVAssetResourceLoadingDataRequest* dataRequest = loadingRequest.dataRequest;
-    NSURLResponse *response = loadingRequest.response;
 
     if (locatorStream == NULL) {
         return NO;


### PR DESCRIPTION
- When video fails to render AVFoundation outputs frame in `kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange` format which is not supported. We do force format change after that to `kCVPixelFormatType_422YpCbCr8`, but AVFoundation does not provides any video frames after format change. Not sure why it happens.
- When video worked for stream in this issue, then AVFoundation was using `kCVPixelFormatType_422YpCbCr8` for some reason instead of `kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange`.
- I tested format fallback from `kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange` to `kCVPixelFormatType_422YpCbCr8` manually and many streams I tried works fine, except one reported in this bug.
- If AVFoundation is initialized with list of formats JavaFX Media rendering supports, then this issue is no longer reproducible.
- Fixed by providing list of supported formats to AVFoundation.
- Removed unused variable `response`.
- Tested with all streams I have and no issues found.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8328603](https://bugs.openjdk.org/browse/JDK-8328603): HLS video stream fails to render consistently (**Bug** - P3)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1440/head:pull/1440` \
`$ git checkout pull/1440`

Update a local copy of the PR: \
`$ git checkout pull/1440` \
`$ git pull https://git.openjdk.org/jfx.git pull/1440/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1440`

View PR using the GUI difftool: \
`$ git pr show -t 1440`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1440.diff">https://git.openjdk.org/jfx/pull/1440.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1440#issuecomment-2052919695)