### PR TITLE
8330701: Fix Eclipse project in tests/manual/text

### DIFF
--- a/tests/manual/text/.classpath
+++ b/tests/manual/text/.classpath
@@ -10,6 +10,11 @@
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry combineaccessrules="false" kind="src" path="/controls">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER">
 		<attributes>
 			<attribute name="module" value="true"/>


### PR DESCRIPTION
Came out of the work on [JDK-8319555](https://bugs.openjdk.org/browse/JDK-8319555): [TestBug] Utility for creating instruction window for manual tests.

This project generates errors if opened in Eclipse. Yes, I can close the project each time, but I would rather fix the setup. This fix is extracted from
https://github.com/openjdk/jfx/pull/1413

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330701](https://bugs.openjdk.org/browse/JDK-8330701): Fix Eclipse project in tests/manual/text (**Bug** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1443/head:pull/1443` \
`$ git checkout pull/1443`

Update a local copy of the PR: \
`$ git checkout pull/1443` \
`$ git pull https://git.openjdk.org/jfx.git pull/1443/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1443`

View PR using the GUI difftool: \
`$ git pr show -t 1443`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1443.diff">https://git.openjdk.org/jfx/pull/1443.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1443#issuecomment-2067073948)