### PR TITLE
8320563: Remove D3D9 code paths in favor of D3D9Ex

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DContext.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DContext.java
@@ -498,14 +498,6 @@ class D3DContext extends BaseShaderContext {
     private static native boolean nGetFrameStats(long pContext,
             D3DFrameStats returnValue, boolean bReset);
 
-    private static native boolean nIsRTTVolatile(long contextHandle);
-
-    public boolean isRTTVolatile() {
-        if (checkDisposed()) return false;
-
-        return nIsRTTVolatile(pContext);
-    }
-
     public static String hResultToString(long hResult) {
         switch ((int)hResult) {
             case D3DERR_DEVICELOST:

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DRTTexture.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DRTTexture.java
@@ -172,7 +172,7 @@ class D3DRTTexture extends D3DTexture
 
     @Override
     public boolean isVolatile() {
-        return getContext().isRTTVolatile();
+        return false;
     }
 
     @Override

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/impl/PrismSettings.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/impl/PrismSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -68,7 +68,6 @@ public final class PrismSettings {
     public static final boolean disableRegionCaching;
     public static final boolean forcePow2;
     public static final boolean noClampToZero;
-    public static final boolean disableD3D9Ex;
     public static final boolean allowHiDPIScaling;
     public static final long maxVram;
     public static final long targetVram;
@@ -325,8 +324,6 @@ public final class PrismSettings {
         disableRegionCaching = getBoolean(systemProperties,
                                           "prism.disableRegionCaching",
                                           false);
-
-        disableD3D9Ex = getBoolean(systemProperties, "prism.disableD3D9Ex", false);
 
         disableEffects = getBoolean(systemProperties, "prism.disableEffects", false);
 

--- a/modules/javafx.graphics/src/main/native-prism-d3d/D3DContext.cc
+++ b/modules/javafx.graphics/src/main/native-prism-d3d/D3DContext.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -69,10 +69,10 @@ inline void D3DUtils_SetIdentityMatrix(D3DMATRIX *m) {
 
 // static
 HRESULT
-D3DContext::CreateInstance(IDirect3D9 *pd3d9, IDirect3D9Ex *pd3d9Ex, UINT adapter, bool isVsyncEnabled, D3DContext **ppCtx)
+D3DContext::CreateInstance(IDirect3D9Ex *pd3d9Ex, UINT adapter, bool isVsyncEnabled, D3DContext **ppCtx)
 {
     HRESULT res;
-    *ppCtx = new D3DContext(pd3d9, pd3d9Ex, adapter);
+    *ppCtx = new D3DContext(pd3d9Ex, adapter);
     if (FAILED(res = (*ppCtx)->InitContext(isVsyncEnabled))) {
         delete *ppCtx;
         *ppCtx = NULL;
@@ -80,14 +80,12 @@ D3DContext::CreateInstance(IDirect3D9 *pd3d9, IDirect3D9Ex *pd3d9Ex, UINT adapte
     return res;
 }
 
-D3DContext::D3DContext(IDirect3D9 *pd3d, IDirect3D9Ex *pd3dEx, UINT adapter)
+D3DContext::D3DContext(IDirect3D9Ex *pd3dEx, UINT adapter)
 {
     TraceLn(NWT_TRACE_INFO, "D3DContext::D3DContext");
-    TraceLn1(NWT_TRACE_VERBOSE, "  pd3d=0x%x", pd3d);
-    pd3dObject = pd3d;
-    pd3dObjectEx = pd3dEx;
+    TraceLn1(NWT_TRACE_VERBOSE, "  pd3dEx=0x%x", pd3dEx);
+    pd3dObject = pd3dEx;
     pd3dDevice = NULL;
-    pd3dDeviceEx = NULL;
     adapterOrdinal = adapter;
     defaulResourcePool = D3DPOOL_SYSTEMMEM;
 
@@ -163,7 +161,6 @@ int D3DContext::release() {
         SAFE_RELEASE(textureCache[i].texture);
     }
     SAFE_RELEASE(pd3dDevice);
-    SAFE_RELEASE(pd3dDeviceEx);
 
     if (phongShader) {
         delete phongShader;
@@ -654,7 +651,7 @@ HRESULT D3DContext::createIndexBuffer() {
     return hr;
 }
 
-HRESULT D3DContext::InitDevice(IDirect3DDevice9 *pd3dDevice)
+HRESULT D3DContext::InitDevice(IDirect3DDevice9Ex *pd3dDevice)
 {
 #if defined PERF_COUNTERS
     stats.clear();
@@ -735,16 +732,14 @@ HRESULT D3DContext::InitDevice(IDirect3DDevice9 *pd3dDevice)
 HRESULT
 D3DContext::TestCooperativeLevel()
 {
-    TraceLn2(NWT_TRACE_INFO,
-             "D3DContext::testCooperativeLevel pd3dDevice = 0x%x, pd3dDeviceEx = 0x%x",
-             pd3dDevice, pd3dDeviceEx);
+    TraceLn1(NWT_TRACE_INFO,
+             "D3DContext::CheckDeviceState pd3dDevice = 0x%x",
+             pd3dDevice);
 
     RETURN_STATUS_IF_NULL(pd3dDevice, E_FAIL);
 
     //TODO: call CheckDeviceState only if Present fails
-    HRESULT res = pd3dDeviceEx ?
-        pd3dDeviceEx->CheckDeviceState(NULL) :
-        pd3dDevice->TestCooperativeLevel();
+    HRESULT res = pd3dDevice->CheckDeviceState(NULL);
 
     switch (res) {
     case S_OK: break;
@@ -1280,7 +1275,7 @@ HRESULT D3DContext::InitContextCaps() {
     return S_OK;
 }
 
-IDirect3DTexture9 *createTexture(D3DFORMAT format, int w, int h, IDirect3DSurface9 **pSurface, IDirect3DDevice9 *dev) {
+IDirect3DTexture9 *createTexture(D3DFORMAT format, int w, int h, IDirect3DSurface9 **pSurface, IDirect3DDevice9Ex *dev) {
     IDirect3DTexture9 *texture;
     HRESULT hr = dev->CreateTexture(w, h, 1, D3DUSAGE_DYNAMIC, format, D3DPOOL_SYSTEMMEM, &texture, 0);
     if (FAILED(hr)) {
@@ -1300,7 +1295,7 @@ IDirect3DTexture9 *createTexture(D3DFORMAT format, int w, int h, IDirect3DSurfac
 }
 
 IDirect3DTexture9 *D3DContext::TextureUpdateCache::getTexture(
-    D3DFORMAT format, int w, int h, IDirect3DSurface9 **pSurface, IDirect3DDevice9 *dev)
+    D3DFORMAT format, int w, int h, IDirect3DSurface9 **pSurface, IDirect3DDevice9Ex *dev)
 {
     if (w <= width && h <= height && texture != NULL) {
         if (pSurface) *pSurface = surface;

--- a/modules/javafx.graphics/src/main/native-prism-d3d/D3DContext.cc
+++ b/modules/javafx.graphics/src/main/native-prism-d3d/D3DContext.cc
@@ -69,10 +69,10 @@ inline void D3DUtils_SetIdentityMatrix(D3DMATRIX *m) {
 
 // static
 HRESULT
-D3DContext::CreateInstance(IDirect3D9Ex *pd3d9Ex, UINT adapter, bool isVsyncEnabled, D3DContext **ppCtx)
+D3DContext::CreateInstance(IDirect3D9Ex *pd3d9, UINT adapter, bool isVsyncEnabled, D3DContext **ppCtx)
 {
     HRESULT res;
-    *ppCtx = new D3DContext(pd3d9Ex, adapter);
+    *ppCtx = new D3DContext(pd3d9, adapter);
     if (FAILED(res = (*ppCtx)->InitContext(isVsyncEnabled))) {
         delete *ppCtx;
         *ppCtx = NULL;

--- a/modules/javafx.graphics/src/main/native-prism-d3d/D3DContext.cc
+++ b/modules/javafx.graphics/src/main/native-prism-d3d/D3DContext.cc
@@ -80,11 +80,11 @@ D3DContext::CreateInstance(IDirect3D9Ex *pd3d9, UINT adapter, bool isVsyncEnable
     return res;
 }
 
-D3DContext::D3DContext(IDirect3D9Ex *pd3dEx, UINT adapter)
+D3DContext::D3DContext(IDirect3D9Ex *pd3d9, UINT adapter)
 {
     TraceLn(NWT_TRACE_INFO, "D3DContext::D3DContext");
-    TraceLn1(NWT_TRACE_VERBOSE, "  pd3dEx=0x%x", pd3dEx);
-    pd3dObject = pd3dEx;
+    TraceLn1(NWT_TRACE_VERBOSE, "  pd3d9=0x%x", pd3d9);
+    pd3dObject = pd3d9;
     pd3dDevice = NULL;
     adapterOrdinal = adapter;
     defaulResourcePool = D3DPOOL_SYSTEMMEM;

--- a/modules/javafx.graphics/src/main/native-prism-d3d/D3DContext.h
+++ b/modules/javafx.graphics/src/main/native-prism-d3d/D3DContext.h
@@ -105,7 +105,7 @@ public:
      * to initialize and test the device last time, it doesn't attempt
      * to create/init/test the device.
      */
-    static HRESULT CreateInstance(IDirect3D9Ex *pd3d9Ex, UINT adapter, bool isVsyncEnabled, D3DContext **ppCtx);
+    static HRESULT CreateInstance(IDirect3D9Ex *pd3d9, UINT adapter, bool isVsyncEnabled, D3DContext **ppCtx);
 
     // desrtoys this instance
     /* virtual */ int release();

--- a/modules/javafx.graphics/src/main/native-prism-d3d/D3DContext.h
+++ b/modules/javafx.graphics/src/main/native-prism-d3d/D3DContext.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -75,7 +75,7 @@ class D3DResourceManager;
  * This class provides the following functionality:
  *  - holds the state of D3DContext java class (current pixel color,
  *    alpha compositing mode, extra alpha)
- *  - provides access to IDirect3DDevice9 interface (creation,
+ *  - provides access to IDirect3DDevice9Ex interface (creation,
  *    disposal, exclusive access)
  *  - handles state changes of the direct3d device (transform,
  *    compositing mode, current texture)
@@ -105,7 +105,7 @@ public:
      * to initialize and test the device last time, it doesn't attempt
      * to create/init/test the device.
      */
-    static HRESULT CreateInstance(IDirect3D9 *pd3d9, IDirect3D9Ex *pd3d9Ex, UINT adapter, bool isVsyncEnabled, D3DContext **ppCtx);
+    static HRESULT CreateInstance(IDirect3D9Ex *pd3d9Ex, UINT adapter, bool isVsyncEnabled, D3DContext **ppCtx);
 
     // desrtoys this instance
     /* virtual */ int release();
@@ -130,10 +130,9 @@ public:
 
     D3DPRESENT_PARAMETERS *GetPresentationParams() { return &curParams; }
 
-    IDirect3DDevice9 *Get3DDevice() { return pd3dDevice; }
-    IDirect3DDevice9Ex *Get3DExDevice() { return pd3dDeviceEx; }
+    IDirect3DDevice9Ex *Get3DDevice() { return pd3dDevice; }
 
-    IDirect3D9 *Get3DObject() { return pd3dObject; }
+    IDirect3D9Ex *Get3DObject() { return pd3dObject; }
 
     D3DMATRIX *GetViewProjTx() { return &projection; }
 
@@ -259,15 +258,13 @@ private:
 
     HRESULT UpdateVertexShaderTX();
 
-    D3DContext(IDirect3D9 *pd3d, IDirect3D9Ex *pd3dEx, UINT adapter);
-    HRESULT InitDevice(IDirect3DDevice9 *d3dDevice);
+    D3DContext(IDirect3D9Ex *pd3dEx, UINT adapter);
+    HRESULT InitDevice(IDirect3DDevice9Ex *d3dDevice);
     HRESULT createIndexBuffer();
     HRESULT InitContextCaps();
-    IDirect3DDevice9        *pd3dDevice;
-    IDirect3DDevice9Ex      *pd3dDeviceEx;
+    IDirect3DDevice9Ex      *pd3dDevice;
     IDirect3DSurface9       *currentSurface;
-    IDirect3D9              *pd3dObject;
-    IDirect3D9Ex            *pd3dObjectEx;
+    IDirect3D9Ex            *pd3dObject;
 
     D3DPOOL defaulResourcePool;
 
@@ -294,7 +291,7 @@ private:
         IDirect3DTexture9 *texture;
         IDirect3DSurface9 *surface;
         int width, height;
-        IDirect3DTexture9 *getTexture(D3DFORMAT format, int width, int height, IDirect3DSurface9 **pSurface, IDirect3DDevice9 *dev);
+        IDirect3DTexture9 *getTexture(D3DFORMAT format, int width, int height, IDirect3DSurface9 **pSurface, IDirect3DDevice9Ex *dev);
     } textureCache[NUM_TEXTURE_CACHE];
 
 public:

--- a/modules/javafx.graphics/src/main/native-prism-d3d/D3DContext.h
+++ b/modules/javafx.graphics/src/main/native-prism-d3d/D3DContext.h
@@ -258,7 +258,7 @@ private:
 
     HRESULT UpdateVertexShaderTX();
 
-    D3DContext(IDirect3D9Ex *pd3dEx, UINT adapter);
+    D3DContext(IDirect3D9Ex *pd3d9, UINT adapter);
     HRESULT InitDevice(IDirect3DDevice9Ex *d3dDevice);
     HRESULT createIndexBuffer();
     HRESULT InitContextCaps();

--- a/modules/javafx.graphics/src/main/native-prism-d3d/D3DContextInit.cc
+++ b/modules/javafx.graphics/src/main/native-prism-d3d/D3DContextInit.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,16 +58,8 @@ HRESULT D3DContext::InitContext(bool isVsyncEnabled) {
 
     RlsTraceLn(NWT_TRACE_VERBOSE, (hwVertexProcessing ? "\tHARDWARE_VERTEXPROCESSING": "\tSOFTWARE_VERTEXPROCESSING"));
 
-    if (pd3dObjectEx) {
-        hr = pd3dObjectEx->CreateDeviceEx(adapterOrdinal, devType, 0,
-            dwBehaviorFlags, &params, 0, &pd3dDeviceEx);
-        if (SUCCEEDED(hr)) {
-            pd3dDevice = addRef<IDirect3DDevice9>(pd3dDeviceEx);
-        }
-    } else {
-        hr = pd3dObject->CreateDevice(adapterOrdinal, devType, 0,
-            dwBehaviorFlags, &params, &pd3dDevice);
-    }
+    hr = pd3dObject->CreateDeviceEx(adapterOrdinal, devType, 0,
+        dwBehaviorFlags, &params, 0, &pd3dDevice);
 
     if (FAILED(hr)) {
         DebugPrintD3DError(hr, "D3DContext::InitContext: error creating d3d device");
@@ -75,7 +67,7 @@ HRESULT D3DContext::InitContext(bool isVsyncEnabled) {
     }
 
     // we do not care about D3DPOOL_SYSTEMMEM if pCtx->IsHWRasterizer()
-    defaulResourcePool = pd3dObjectEx ? D3DPOOL_DEFAULT : D3DPOOL_MANAGED;
+    defaulResourcePool = D3DPOOL_DEFAULT;
 
     RlsTraceLn1(NWT_TRACE_INFO, "D3DContext::InitContext: successfully created device: %d", adapterOrdinal);
     bIsHWRasterizer = (devType == D3DDEVTYPE_HAL);

--- a/modules/javafx.graphics/src/main/native-prism-d3d/D3DGraphics.cc
+++ b/modules/javafx.graphics/src/main/native-prism-d3d/D3DGraphics.cc
@@ -494,16 +494,3 @@ JNIEXPORT jint JNICALL Java_com_sun_prism_d3d_D3DContext_nResetClipRect
 
     return pCtx->ResetClip();
 }
-
-/*
- * Class:     com_sun_prism_d3d_D3DContext
- * Method:    nIsRTTVolatile
- */
-JNIEXPORT jboolean JNICALL Java_com_sun_prism_d3d_D3DContext_nIsRTTVolatile
-  (JNIEnv *, jclass, jlong ctx)
-{
-    D3DContext *pCtx = (D3DContext*)jlong_to_ptr(ctx);
-    RETURN_STATUS_IF_NULL(pCtx, false);
-
-    return false;
-}

--- a/modules/javafx.graphics/src/main/native-prism-d3d/D3DGraphics.cc
+++ b/modules/javafx.graphics/src/main/native-prism-d3d/D3DGraphics.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -265,7 +265,7 @@ JNIEXPORT jint JNICALL Java_com_sun_prism_d3d_D3DContext_nSetBlendEnabled
     D3DContext *pCtx = (D3DContext*)jlong_to_ptr(ctx);
     RETURN_STATUS_IF_NULL(pCtx, E_FAIL);
 
-    IDirect3DDevice9 *pd3dDevice = pCtx->Get3DDevice();
+    IDirect3DDevice9Ex *pd3dDevice = pCtx->Get3DDevice();
     RETURN_STATUS_IF_NULL(pd3dDevice, E_FAIL);
 
     HRESULT res;
@@ -345,7 +345,7 @@ JNIEXPORT jint JNICALL Java_com_sun_prism_d3d_D3DContext_nSetTexture
     HRESULT res = pCtx->BeginScene();
     RETURN_STATUS_IF_FAILED(res);
 
-    IDirect3DDevice9 *pd3dDevice = pCtx->Get3DDevice();
+    IDirect3DDevice9Ex *pd3dDevice = pCtx->Get3DDevice();
     RETURN_STATUS_IF_NULL(pd3dDevice, E_FAIL);
 
     IDirect3DTexture9 *pTex = pRes == NULL ? NULL : pRes->GetTexture();
@@ -505,5 +505,5 @@ JNIEXPORT jboolean JNICALL Java_com_sun_prism_d3d_D3DContext_nIsRTTVolatile
     D3DContext *pCtx = (D3DContext*)jlong_to_ptr(ctx);
     RETURN_STATUS_IF_NULL(pCtx, false);
 
-    return pCtx->Get3DExDevice() ? false : true;
+    return false;
 }

--- a/modules/javafx.graphics/src/main/native-prism-d3d/D3DMesh.cc
+++ b/modules/javafx.graphics/src/main/native-prism-d3d/D3DMesh.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -104,7 +104,7 @@ boolean D3DMesh::buildBuffers(float *vb, UINT vbSize, USHORT *ib, UINT ibSize) {
 //    cout << "D3DMesh::buildBuffers: vertexBufferSize = " << vbSize
 //            << ", indexBufferSize = " << ibSize << endl;
 
-    IDirect3DDevice9 *device = context->Get3DDevice();
+    IDirect3DDevice9Ex *device = context->Get3DDevice();
     D3DPOOL pool = context->getResourcePool();
     UINT size = vbSize * sizeof (float); // in bytes
     UINT vbCount = size / PRIMITIVE_VERTEX_SIZE; // in vertices
@@ -152,7 +152,7 @@ boolean D3DMesh::buildBuffers(float *vb, UINT vbSize, UINT *ib, UINT ibSize) {
 //    cout << "D3DMesh::buildBuffers: vertexBufferSize = " << vbSize
 //            << ", indexBufferSize = " << ibSize << endl;
 
-    IDirect3DDevice9 *device = context->Get3DDevice();
+    IDirect3DDevice9Ex *device = context->Get3DDevice();
     D3DPOOL pool = context->getResourcePool();
     UINT size = vbSize * sizeof (float); // in bytes
     UINT vbCount = size / PRIMITIVE_VERTEX_SIZE; // in vertices

--- a/modules/javafx.graphics/src/main/native-prism-d3d/D3DMeshView.cc
+++ b/modules/javafx.graphics/src/main/native-prism-d3d/D3DMeshView.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -118,7 +118,7 @@ void D3DMeshView::render() {
     RETURN_IF_NULL(material);
     RETURN_IF_NULL(mesh);
 
-    IDirect3DDevice9 *device = context->Get3DDevice();
+    IDirect3DDevice9Ex *device = context->Get3DDevice();
     RETURN_IF_NULL(device);
 
     HRESULT status = SUCCEEDED(device->SetFVF(mesh->getVertexFVF()));

--- a/modules/javafx.graphics/src/main/native-prism-d3d/D3DPhongShader.cc
+++ b/modules/javafx.graphics/src/main/native-prism-d3d/D3DPhongShader.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,12 +31,12 @@ using std::cout;
 using std::cerr;
 using std::endl;
 
-IDirect3DVertexShader9 *createVertexShader(IDirect3DDevice9 *d, ShaderFunction pFun()) {
+IDirect3DVertexShader9 *createVertexShader(IDirect3DDevice9Ex *d, ShaderFunction pFun()) {
     IDirect3DVertexShader9 * s;
     return SUCCEEDED(d->CreateVertexShader(pFun(), &s)) ? s : 0;
 }
 
-IDirect3DPixelShader9 *createPixelShader(IDirect3DDevice9 *d, ShaderFunction pFun()) {
+IDirect3DPixelShader9 *createPixelShader(IDirect3DDevice9Ex *d, ShaderFunction pFun()) {
     IDirect3DPixelShader9 * s;
     return SUCCEEDED(d->CreatePixelShader(pFun(), &s)) ? s : 0;
 }
@@ -59,7 +59,7 @@ D3DPhongShader::~D3DPhongShader() {
     device = NULL;
 }
 
-D3DPhongShader::D3DPhongShader(IDirect3DDevice9 *dev) {
+D3DPhongShader::D3DPhongShader(IDirect3DDevice9Ex *dev) {
     device = dev;
 
     static ShaderFunction(* const sFuncArr[SelfIlllumTotal][BumpTotal][SpecTotal][maxLights])() = {

--- a/modules/javafx.graphics/src/main/native-prism-d3d/D3DPhongShader.h
+++ b/modules/javafx.graphics/src/main/native-prism-d3d/D3DPhongShader.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -110,7 +110,7 @@ psMtl1_b1mi(), psMtl1_b2mi(), psMtl1_b3mi();
 
 class D3DPhongShader {
 public:
-    D3DPhongShader(IDirect3DDevice9 *dev);
+    D3DPhongShader(IDirect3DDevice9Ex *dev);
     virtual ~D3DPhongShader();
     IDirect3DVertexShader9 *getVertexShader();
     int getBumpMode(bool isBumpMap);
@@ -121,7 +121,7 @@ static const int SelfIlllumTotal = 2;
 static const int maxLights = 3;
 
 private:
-    IDirect3DDevice9 *device;
+    IDirect3DDevice9Ex *device;
     IDirect3DVertexShader9 *vertexShader;
     IDirect3DPixelShader9 *pixelShader0, *pixelShader0_si;
     IDirect3DPixelShader9 *pixelShaders[SelfIlllumTotal][BumpTotal][SpecTotal][maxLights];

--- a/modules/javafx.graphics/src/main/native-prism-d3d/D3DPipeline.cc
+++ b/modules/javafx.graphics/src/main/native-prism-d3d/D3DPipeline.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,10 +30,8 @@
 
 // d3d9.dll library dynamic load
 HMODULE hLibD3D9 = 0;
-typedef IDirect3D9 * WINAPI FnDirect3DCreate9(UINT SDKVersion);
 typedef HRESULT WINAPI FnDirect3DCreate9Ex(UINT SDKVersion, IDirect3D9Ex**);
 
-FnDirect3DCreate9 * pD3D9FactoryFunction = 0;
 FnDirect3DCreate9Ex * pD3D9FactoryExFunction = 0;
 
 static jboolean checkAndClearException(JNIEnv *env) {
@@ -51,7 +49,6 @@ void loadD3DLibrary() {
         hLibD3D9 = ::LoadLibrary(path);
     }
     if (hLibD3D9) {
-        pD3D9FactoryFunction = (FnDirect3DCreate9*)GetProcAddress(hLibD3D9, "Direct3DCreate9");
         pD3D9FactoryExFunction = (FnDirect3DCreate9Ex*)GetProcAddress(hLibD3D9, "Direct3DCreate9Ex");
     }
 }
@@ -60,13 +57,8 @@ void freeD3DLibrary() {
     if (hLibD3D9) {
         ::FreeLibrary(hLibD3D9);
         hLibD3D9 = 0;
-        pD3D9FactoryFunction = 0;
         pD3D9FactoryExFunction = 0;
     }
-}
-
-IDirect3D9 * Direct3DCreate9() {
-    return pD3D9FactoryFunction ? pD3D9FactoryFunction(D3D_SDK_VERSION) : 0;
 }
 
 IDirect3D9Ex * Direct3DCreate9Ex() {
@@ -237,12 +229,12 @@ void fillOsVersionInformation(JNIEnv *env, jobject object, jclass clazz) {
     }
 }
 
-inline IDirect3D9* addRef(IDirect3D9* i) {
+inline IDirect3D9Ex* addRef(IDirect3D9Ex* i) {
     i->AddRef();
     return i;
 }
 
-int getMaxSampleSupport(IDirect3D9 *d3d9, UINT adapter) {
+int getMaxSampleSupport(IDirect3D9Ex *d3d9, UINT adapter) {
     int maxSamples = 0;
     if (SUCCEEDED(d3d9->CheckDeviceMultiSampleType(adapter,
                     D3DDEVTYPE_HAL , D3DFMT_X8R8G8B8, FALSE,
@@ -272,8 +264,8 @@ JNIEXPORT jobject JNICALL Java_com_sun_prism_d3d_D3DPipeline_nGetDriverInformati
     }
 
     // if there is D3DPipelineManager take ready D3D9 object, otherwise create new
-    IDirect3D9 * d3d9 = D3DPipelineManager::GetInstance() ?
-        addRef(D3DPipelineManager::GetInstance()->GetD3DObject()) : Direct3DCreate9();
+    IDirect3D9Ex * d3d9 = D3DPipelineManager::GetInstance() ?
+        addRef(D3DPipelineManager::GetInstance()->GetD3DObject()) : Direct3DCreate9Ex();
 
     if (!d3d9) {
         return 0;
@@ -307,8 +299,8 @@ JNIEXPORT jobject JNICALL Java_com_sun_prism_d3d_D3DPipeline_nGetDriverInformati
 JNIEXPORT jint JNICALL Java_com_sun_prism_d3d_D3DPipeline_nGetMaxSampleSupport(JNIEnv *env, jclass, jint adapter) {
 
     // if there is D3DPipelineManager take ready D3D9 object, otherwise create new
-    IDirect3D9 * d3d9 = D3DPipelineManager::GetInstance() ?
-        addRef(D3DPipelineManager::GetInstance()->GetD3DObject()) : Direct3DCreate9();
+    IDirect3D9Ex * d3d9 = D3DPipelineManager::GetInstance() ?
+        addRef(D3DPipelineManager::GetInstance()->GetD3DObject()) : Direct3DCreate9Ex();
 
     if (!d3d9) {
         return 0;

--- a/modules/javafx.graphics/src/main/native-prism-d3d/D3DPipeline.h
+++ b/modules/javafx.graphics/src/main/native-prism-d3d/D3DPipeline.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2014, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -123,7 +123,7 @@ do {                      \
     } else do { } while (0)
 
 // d3d9 must be valid and tested
-int getMaxSampleSupport(IDirect3D9 *d3d9, UINT adapter);
+int getMaxSampleSupport(IDirect3D9Ex *d3d9, UINT adapter);
 
 inline void logD3DSurfaceDesc(D3DSURFACE_DESC const & dsk) {
     RlsTrace5(NWT_TRACE_INFO, "w=%d, h=%d, Format = %d, Pool=%d, Usage=%d\n",
@@ -136,7 +136,7 @@ inline void logSurfaceDesk(IDirect3DSurface9 *surf) {
         logD3DSurfaceDesc(dsk) : TraceImpl(NWT_TRACE_INFO, JNI_FALSE, "Error reading surface desk\n");
 }
 
-inline void logDeviceTargets(IDirect3DDevice9 *pd3dDevice) {
+inline void logDeviceTargets(IDirect3DDevice9Ex *pd3dDevice) {
     IDirect3DSurface9 * pSurf=0, *pZB=0;
     HRESULT hr1 = pd3dDevice->GetRenderTarget(0, &pSurf);
     HRESULT hr2 = pd3dDevice->GetDepthStencilSurface(&pZB);

--- a/modules/javafx.graphics/src/main/native-prism-d3d/D3DPipelineManager.h
+++ b/modules/javafx.graphics/src/main/native-prism-d3d/D3DPipelineManager.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,7 +41,6 @@ interface IConfig {
     virtual bool getBool(cstr name)=0;
 };
 
-IDirect3D9 * Direct3DCreate9();
 IDirect3D9Ex * Direct3DCreate9Ex();
 
 template <class T> inline T * addRef(T *t) {
@@ -80,7 +79,7 @@ public:
                                             D3DFORMAT adapterFormat,
                                             D3DFORMAT renderTargetFormat);
 
-    LPDIRECT3D9 GetD3DObject() { return pd3d9; }
+    LPDIRECT3D9EX GetD3DObject() { return pd3d9; }
     D3DDEVTYPE GetDeviceType() { return devType; }
 
     // returns adapterOrdinal given a HMONITOR handle
@@ -135,8 +134,7 @@ private:
     // current adapter count
     UINT adapterCount;
     // Pointer to Direct3D9 Object mainained by the pipeline manager
-    LPDIRECT3D9 pd3d9;
-    IDirect3D9Ex * pd3d9Ex;
+    IDirect3D9Ex * pd3d9;
 
     D3DDEVTYPE devType;
 

--- a/modules/javafx.graphics/src/main/native-prism-d3d/D3DResourceFactory.cc
+++ b/modules/javafx.graphics/src/main/native-prism-d3d/D3DResourceFactory.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -254,9 +254,7 @@ inline HRESULT updateTexture(
     updater.setTarget(pTexResource->GetTexture(), pTexResource->GetSurface(), desc, dstx, dsty);
     updater.setSource(pixels, size, PFormat(format), srcx, srcy, srcw, srch, srcscan);
 
-    int nBytes = pCtx->Get3DExDevice()
-        ? updater.updateD3D9ExTexture(pCtx)
-        : updater.updateLockableTexture();
+    int nBytes = updater.updateD3D9ExTexture(pCtx);
 
 #if defined PERF_COUNTERS
     D3DContext::FrameStats &stats = pCtx->getStats();
@@ -401,7 +399,7 @@ static HRESULT D3DResourceFactory_nReadPixels(D3DContext *pCtx, D3DResource *pRe
 
     TraceLn(NWT_TRACE_INFO, "D3DResourceFactory_nReadPixels");
 
-    IDirect3DDevice9 *pd3dDevice = pCtx->Get3DDevice();
+    IDirect3DDevice9Ex *pd3dDevice = pCtx->Get3DDevice();
     RETURN_STATUS_IF_NULL(pd3dDevice, E_FAIL);
 
     IDirect3DSurface9 *pSrc = pResource->GetSurface();

--- a/modules/javafx.graphics/src/main/native-prism-d3d/D3DResourceManager.cc
+++ b/modules/javafx.graphics/src/main/native-prism-d3d/D3DResourceManager.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -272,7 +272,7 @@ D3DResourceManager::CreatePixelShader(DWORD *buf,
 
     TraceLn(NWT_TRACE_INFO, "D3DRM::CreatePixelShader");
 
-    IDirect3DDevice9 *pd3dDevice = pCtx->Get3DDevice();
+    IDirect3DDevice9Ex *pd3dDevice = pCtx->Get3DDevice();
     if (pd3dDevice == NULL) {
         return E_FAIL;
     }
@@ -297,7 +297,7 @@ D3DResourceManager::CreateVertexBuffer(D3DVertexBufferResource** ppVBRes)
 
     TraceLn(NWT_TRACE_INFO, "D3DRM::CreateVertexBuffer");
 
-    IDirect3DDevice9 *pd3dDevice = pCtx->Get3DDevice();
+    IDirect3DDevice9Ex *pd3dDevice = pCtx->Get3DDevice();
     if (pd3dDevice == NULL) {
         return E_FAIL;
     }
@@ -330,7 +330,7 @@ D3DResourceManager::CreateTexture(UINT width, UINT height,
     TraceLn4(NWT_TRACE_VERBOSE, "  w=%d h=%d isRTT=%d isOpaque=%d",
                 width, height, isRTT, isOpaque);
 
-    IDirect3DDevice9 *pd3dDevice = pCtx->Get3DDevice();
+    IDirect3DDevice9Ex *pd3dDevice = pCtx->Get3DDevice();
 
     if (pd3dDevice == NULL) {
         return E_FAIL;
@@ -411,7 +411,7 @@ HRESULT D3DResourceManager::CreateRenderTarget(UINT width, UINT height,
 {
     TraceLn(NWT_TRACE_INFO, "D3DRM::CreateRenderTarget");
 
-    IDirect3DDevice9 *pd3dDevice = pCtx->Get3DDevice();
+    IDirect3DDevice9Ex *pd3dDevice = pCtx->Get3DDevice();
 
     if (pd3dDevice == NULL) {
         return E_FAIL;
@@ -429,7 +429,7 @@ HRESULT D3DResourceManager::CreateRenderTarget(UINT width, UINT height,
     }
 
     DWORD totalSamples = 0;
-    IDirect3D9 *pd3dObject = pCtx->Get3DObject();
+    IDirect3D9Ex *pd3dObject = pCtx->Get3DObject();
     HRESULT res;
     if(FAILED(res = pd3dObject->CheckDeviceMultiSampleType(D3DADAPTER_DEFAULT,
                                     D3DDEVTYPE_HAL, format, false,
@@ -501,7 +501,7 @@ HRESULT D3DResourceManager::CreateOSPSurface(UINT width, UINT height,
     TraceLn(NWT_TRACE_INFO, "D3DRM::CreateOSPSurface");
     TraceLn2(NWT_TRACE_VERBOSE, "  w=%d h=%d", width, height);
 
-    IDirect3DDevice9 *pd3dDevice = pCtx->Get3DDevice();
+    IDirect3DDevice9Ex *pd3dDevice = pCtx->Get3DDevice();
     if (pd3dDevice == NULL) {
         return E_FAIL;
     }
@@ -544,7 +544,7 @@ D3DResourceManager::CreateSwapChain(HWND hWnd, UINT numBuffers,
     TraceLn4(NWT_TRACE_VERBOSE, "  w=%d h=%d hwnd=%x numBuffers=%d",
                 width, height, hWnd, numBuffers);
 
-    IDirect3DDevice9 *pd3dDevice = pCtx->Get3DDevice();
+    IDirect3DDevice9Ex *pd3dDevice = pCtx->Get3DDevice();
     if (pd3dDevice == NULL) {
         return E_FAIL;
     }

--- a/modules/javafx.graphics/src/main/native-prism-d3d/D3DShader.cc
+++ b/modules/javafx.graphics/src/main/native-prism-d3d/D3DShader.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -73,7 +73,7 @@ Java_com_sun_prism_d3d_D3DShader_enable
     pCtx->getStats().numSetPixelShader++;
 #endif
 
-    IDirect3DDevice9 *pd3dDevice = pCtx->Get3DDevice();
+    IDirect3DDevice9Ex *pd3dDevice = pCtx->Get3DDevice();
     RETURN_STATUS_IF_NULL(pd3dDevice, E_FAIL);
 
     IDirect3DPixelShader9 *pShader = pPSResource->GetPixelShader();
@@ -99,7 +99,7 @@ Java_com_sun_prism_d3d_D3DShader_disable
     D3DContext *pCtx = (D3DContext*)jlong_to_ptr(ctx);
     RETURN_STATUS_IF_NULL(pCtx, E_FAIL);
 
-    IDirect3DDevice9 *pd3dDevice = pCtx->Get3DDevice();
+    IDirect3DDevice9Ex *pd3dDevice = pCtx->Get3DDevice();
     RETURN_STATUS_IF_NULL(pd3dDevice, E_FAIL);
 
     HRESULT res = pd3dDevice->SetPixelShader(NULL);
@@ -139,7 +139,7 @@ Java_com_sun_prism_d3d_D3DShader_setConstantsI
 
     buf += off * sizeof(jint);
 
-    IDirect3DDevice9 *pd3dDevice = pCtx->Get3DDevice();
+    IDirect3DDevice9Ex *pd3dDevice = pCtx->Get3DDevice();
     RETURN_STATUS_IF_NULL(pd3dDevice, E_FAIL);
 
     HRESULT res = pd3dDevice->SetPixelShaderConstantI(reg, (const int *)buf, count);
@@ -179,7 +179,7 @@ Java_com_sun_prism_d3d_D3DShader_setConstantsF
 
     TraceLn4(NWT_TRACE_VERBOSE, "  vals: %f %f %f %f", buf[0], buf[1], buf[2], buf[3]);
 
-    IDirect3DDevice9 *pd3dDevice = pCtx->Get3DDevice();
+    IDirect3DDevice9Ex *pd3dDevice = pCtx->Get3DDevice();
     RETURN_STATUS_IF_NULL(pd3dDevice, E_FAIL);
 
     HRESULT res = pd3dDevice->SetPixelShaderConstantF(reg, (const float *)buf, count);

--- a/modules/javafx.graphics/src/main/native-prism-d3d/TextureUploader.cc
+++ b/modules/javafx.graphics/src/main/native-prism-d3d/TextureUploader.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -164,7 +164,7 @@ int TextureUpdater::updateD3D9ExTexture(D3DContext *pCtx) {
 
         RECT sRect = { 0, 0, srcW, srcH };
         POINT dPos = { dstX, dstY };
-        HRESULT hr = pCtx->Get3DExDevice()->UpdateSurface(tempSurface, &sRect, pSurface, &dPos);
+        HRESULT hr = pCtx->Get3DDevice()->UpdateSurface(tempSurface, &sRect, pSurface, &dPos);
         if (FAILED(hr)) {
             RlsTraceLn1(NWT_TRACE_ERROR, "Failed to update surface: %08X", hr);
             size = 0;


### PR DESCRIPTION
JFX minimum requirements guarantee 9Ex availability, so old non-Ex paths are no longer needed.

In multiple parts (ex. Mesh, Graphics, etc.) where the Device is acquired I changed the type to explicitly use `IDirect3DDevice9Ex`. Technically it doesn't matter much (`IDirect3DDevice9Ex` inherits `IDirect3DDevice` - it was leveraged to transparently use the Ex device in the backend) but now we don't have the non-Ex device, so that keeps it a bit more consistent and clear IMO.

Verified by running tests on Windows 11, did not notice any regressions. Unfortunately I have no way to test this on older systems.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8320563](https://bugs.openjdk.org/browse/JDK-8320563): Remove D3D9 code paths in favor of D3D9Ex (**Enhancement** - P4)


### Reviewers
 * [Nir Lisker](https://openjdk.org/census#nlisker) (@nlisker - **Reviewer**)
 * [Michael Strauß](https://openjdk.org/census#mstrauss) (@mstr2 - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1445/head:pull/1445` \
`$ git checkout pull/1445`

Update a local copy of the PR: \
`$ git checkout pull/1445` \
`$ git pull https://git.openjdk.org/jfx.git pull/1445/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1445`

View PR using the GUI difftool: \
`$ git pr show -t 1445`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1445.diff">https://git.openjdk.org/jfx/pull/1445.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1445#issuecomment-2071974710)