### PR TITLE
8273657 : TextField: all text content must be selected initially

### DIFF
--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/TextFieldBehavior.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/TextFieldBehavior.java
@@ -105,6 +105,9 @@ public class TextFieldBehavior extends TextInputControlBehavior<TextField> {
         textField.sceneProperty().addListener(weakSceneListener);
         if (textField.getScene() != null) {
             textField.getScene().focusOwnerProperty().addListener(weakFocusOwnerListener);
+            if (textField.getScene().getFocusOwner() == textField) {
+                textField.selectRange(textField.getLength(), 0);
+            }
         }
 
         // Only add this if we're on an embedded platform that supports 5-button navigation

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TextFieldTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TextFieldTest.java
@@ -616,6 +616,28 @@ public class TextFieldTest {
         assertEquals("", txtField.getText());
     }
 
+    //Test for JDK-8273657
+    @Test
+    public void testTextSelectionOnAddingTextField() {
+        initStage();
+        txtField.setSkin(new TextFieldSkin(txtField));
+        txtField.setText("A short text");
+        stage.show();
+
+        root.getChildren().add(txtField);
+        txtField.requestFocus();
+
+        assertEquals(0, txtField.getSelection().getStart());
+        assertEquals(txtField.getText().length(), txtField.getSelection().getEnd());
+
+        root.getChildren().remove(txtField);
+        root.getChildren().add(txtField);
+        txtField.requestFocus();
+
+        assertEquals(0, txtField.getSelection().getStart());
+        assertEquals(txtField.getText().length(), txtField.getSelection().getEnd());
+    }
+
     private Change upperCase(Change change) {
         change.setText(change.getText().toUpperCase());
         return change;


### PR DESCRIPTION
The text was not getting selected on adding the `TextField` to the scene initially, subsequently removing and adding the `TextField` to the scene selects the entire text present in the `TextField`. 

Made changes in the `TextFieldBehavior` constructor to select the text on adding the `TextField`.

Added unit test to validate the fix

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8273657](https://bugs.openjdk.org/browse/JDK-8273657): TextField: all text content must be selected initially (**Bug** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1446/head:pull/1446` \
`$ git checkout pull/1446`

Update a local copy of the PR: \
`$ git checkout pull/1446` \
`$ git pull https://git.openjdk.org/jfx.git pull/1446/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1446`

View PR using the GUI difftool: \
`$ git pr show -t 1446`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1446.diff">https://git.openjdk.org/jfx/pull/1446.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1446#issuecomment-2077351422)