### PR TITLE
8331319: IME Window breaks after popup menu

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassView3D.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassView3D.m
@@ -742,7 +742,12 @@
 {
     IMLOG("finishInputMethodComposition called");
     [self unmarkText];
-    [self.inputContext discardMarkedText];
+    // If we call discardMarkedText on an input context that is not
+    // the current one the IM will get into a persistent state where
+    // it will not call setMarkedText or firstRectForCharacterRange.
+    if (self.inputContext == NSTextInputContext.currentInputContext) {
+        [self.inputContext discardMarkedText];
+    }
 }
 
 /*


### PR DESCRIPTION
When focus moves away from a node JavaFX calls `finishInputMethodComposition` so glass can clean up any in-progress IME editing. On Mac we call `discardMarkedText` on the view's NSTextInputContext to dismiss the IME.

It appears that the OS can get confused if `discardMarkedText` is called on an NSTextInputContext that is not the current active context. JavaFX popups are displayed in windows that don't have OS focus and therefore do not have the active input context but the JavaFX scene associated with the popup doesn't know this and still makes calls to manipulate the IME. This seems to be triggering a bug in the OS that leads to bad behavior which persists until the user moves focus away from the main JavaFX stage altogether and then brings it back.
