### PR TITLE
8331214: Doc: update spec for SpinnerFactory classes

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/SpinnerValueFactory.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/SpinnerValueFactory.java
@@ -414,11 +414,11 @@ public abstract class SpinnerValueFactory<T> {
      * A {@link javafx.scene.control.SpinnerValueFactory} implementation designed to iterate through
      * integer values.
      * <p>
-     * If {@link #wrapAroundProperty wrapAround} is {@code true}, the {@code IntegerSpinnerValueFactory} will step from
-     * the minimum value to the maximum value (and vice versa). As a consequence of that, the number
-     * of steps required to wrap around to the same value is {@code N+1}, where {@code N} is the number of steps between
-     * {@link #minProperty min} (inclusive) and {@link #maxProperty max} (inclusive). The new value after a step is
-     * {@code val = (val + amountToStepBy) % (max - min + 1)}.
+     * If {@link SpinnerValueFactory#wrapAroundProperty wrapAround} is {@code true}, the
+     * {@code IntegerSpinnerValueFactory} will step from the minimum value to the maximum value (and vice versa).
+     * As a consequence of that, the number of steps required to wrap around to the same value is {@code N+1}, where
+     * {@code N} is the number of steps between {@link #minProperty min} (inclusive) and {@link #maxProperty max}
+     * (inclusive). The new value after a step is {@code val = (val + amountToStepBy) % (max - min + 1)}.
      * <p>
      * Note that the default {@link #converterProperty() converter} is implemented
      * as an {@link javafx.util.converter.IntegerStringConverter} instance.
@@ -617,10 +617,10 @@ public abstract class SpinnerValueFactory<T> {
      * A {@link javafx.scene.control.SpinnerValueFactory} implementation designed to iterate through
      * double values.
      * <p>
-     * If {@link #wrapAroundProperty wrapAround} is {@code true}, the {@code DoubleSpinnerValueFactory} will step
-     * through from the maximum value to the minimum value seamlessly; that is, any step up from the maximum value
-     * is equal to the same step up from the minimum value (and vice versa). The new value after a step is
-     * {@code val = (val + amountToStepBy) % (max - min)}.
+     * If {@link SpinnerValueFactory#wrapAroundProperty wrapAround} is {@code true}, the
+     * {@code DoubleSpinnerValueFactory} will step through from the maximum value to the minimum value seamlessly; that
+     * is, any step up from the maximum value is equal to the same step up from the minimum value (and vice versa).
+     * The new value after a step is {@code val = (val + amountToStepBy) % (max - min)}.
      * <p>
      * Note that the default {@link #converterProperty() converter} is implemented
      * simply as shown below, which may be adequate in many cases, but it is important

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/SpinnerValueFactory.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/SpinnerValueFactory.java
@@ -115,7 +115,7 @@ public abstract class SpinnerValueFactory<T> {
      *
      * @param steps The number of decrements that should be performed on the value.
      *              If the number is negative, the call is equivalent to calling
-     *              {@link #increment(int)} with the absolute number of steps.
+     *              {@link #increment(int)} with the absolute value of {@code steps}.
      */
     public abstract void decrement(int steps);
 
@@ -126,7 +126,7 @@ public abstract class SpinnerValueFactory<T> {
      *
      * @param steps The number of increments that should be performed on the value.
      *              If the number is negative, the call is equivalent to calling
-     *              {@link #decrement(int)} with the absolute number of steps.
+     *              {@link #decrement(int)} with the absolute number of {@code steps}.
      */
     public abstract void increment(int steps);
 
@@ -414,10 +414,11 @@ public abstract class SpinnerValueFactory<T> {
      * A {@link javafx.scene.control.SpinnerValueFactory} implementation designed to iterate through
      * integer values.
      * <p>
-     * If {@link #wrapAround} is {@code true}, the {@code IntegerSpinnerValueFactory} will step from
+     * If {@link #wrapAroundProperty wrapAround} is {@code true}, the {@code IntegerSpinnerValueFactory} will step from
      * the minimum value to the maximum value (and vice versa). As a consequence of that, the number
-     * of steps required to wrap around to the same value is N+1, where N is the number of steps between
-     * {@link #min} (inclusive) and {@link #max} (inclusive).
+     * of steps required to wrap around to the same value is {@code N+1}, where {@code N} is the number of steps between
+     * {@link #minProperty min} (inclusive) and {@link #maxProperty max} (inclusive). The new value after a step is
+     * {@code val = (val + amountToStepBy) % (max - min + 1)}.
      * <p>
      * Note that the default {@link #converterProperty() converter} is implemented
      * as an {@link javafx.util.converter.IntegerStringConverter} instance.
@@ -616,9 +617,10 @@ public abstract class SpinnerValueFactory<T> {
      * A {@link javafx.scene.control.SpinnerValueFactory} implementation designed to iterate through
      * double values.
      * <p>
-     * If {@link #wrapAround} is {@code true}, the {@code DoubleSpinnerValueFactory} will step through
-     * from the maximum value to the minimum value seamlessly; that is, any step up from the maximum value
-     * is equal to the same step up from the minimum value (and vice versa).
+     * If {@link #wrapAroundProperty wrapAround} is {@code true}, the {@code DoubleSpinnerValueFactory} will step
+     * through from the maximum value to the minimum value seamlessly; that is, any step up from the maximum value
+     * is equal to the same step up from the minimum value (and vice versa). The new value after a step is
+     * {@code val = (val + amountToStepBy) % (max - min)}.
      * <p>
      * Note that the default {@link #converterProperty() converter} is implemented
      * simply as shown below, which may be adequate in many cases, but it is important

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/SpinnerValueFactory.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/SpinnerValueFactory.java
@@ -114,15 +114,19 @@ public abstract class SpinnerValueFactory<T> {
      * number of steps.
      *
      * @param steps The number of decrements that should be performed on the value.
+     *              If the number is negative, the call is equivalent to calling
+     *              {@link #increment(int)} with the absolute number of steps.
      */
     public abstract void decrement(int steps);
 
 
     /**
-     * Attempts to omcrement the {@link #valueProperty() value} by the given
+     * Attempts to increment the {@link #valueProperty() value} by the given
      * number of steps.
      *
      * @param steps The number of increments that should be performed on the value.
+     *              If the number is negative, the call is equivalent to calling
+     *              {@link #decrement(int)} with the absolute number of steps.
      */
     public abstract void increment(int steps);
 
@@ -172,9 +176,9 @@ public abstract class SpinnerValueFactory<T> {
 
     // --- wrapAround
     /**
-     * The wrapAround property is used to specify whether the value factory should
-     * be circular. For example, should an integer-based value model increment
-     * from the maximum value back to the minimum value (and vice versa).
+     * Specifies whether this {@code SpinnerValueFactory} wraps around from the maximum value to
+     * the minimum value, and vice versa. The semantics of the wrap-around behavior are specified
+     * by implementations of this class.
      */
     private BooleanProperty wrapAround;
     public final void setWrapAround(boolean value) {
@@ -409,8 +413,13 @@ public abstract class SpinnerValueFactory<T> {
     /**
      * A {@link javafx.scene.control.SpinnerValueFactory} implementation designed to iterate through
      * integer values.
-     *
-     * <p>Note that the default {@link #converterProperty() converter} is implemented
+     * <p>
+     * If {@link #wrapAround} is {@code true}, the {@code IntegerSpinnerValueFactory} will step from
+     * the minimum value to the maximum value (and vice versa). As a consequence of that, the number
+     * of steps required to wrap around to the same value is N+1, where N is the number of steps between
+     * {@link #min} (inclusive) and {@link #max} (inclusive).
+     * <p>
+     * Note that the default {@link #converterProperty() converter} is implemented
      * as an {@link javafx.util.converter.IntegerStringConverter} instance.
      *
      * @since JavaFX 8u40
@@ -606,8 +615,12 @@ public abstract class SpinnerValueFactory<T> {
     /**
      * A {@link javafx.scene.control.SpinnerValueFactory} implementation designed to iterate through
      * double values.
-     *
-     * <p>Note that the default {@link #converterProperty() converter} is implemented
+     * <p>
+     * If {@link #wrapAround} is {@code true}, the {@code DoubleSpinnerValueFactory} will step through
+     * from the maximum value to the minimum value seamlessly; that is, any step up from the maximum value
+     * is equal to the same step up from the minimum value (and vice versa).
+     * <p>
+     * Note that the default {@link #converterProperty() converter} is implemented
      * simply as shown below, which may be adequate in many cases, but it is important
      * for users to ensure that this suits their needs (and adjust when necessary). The
      * main point to note is that this {@link javafx.util.StringConverter} embeds


### PR DESCRIPTION
This PR updates the javadoc for the SpinnerFactory wrap-around behavior introduced in #1431.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331214](https://bugs.openjdk.org/browse/JDK-8331214): Doc: update spec for SpinnerFactory classes (**Bug** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1450/head:pull/1450` \
`$ git checkout pull/1450`

Update a local copy of the PR: \
`$ git checkout pull/1450` \
`$ git pull https://git.openjdk.org/jfx.git pull/1450/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1450`

View PR using the GUI difftool: \
`$ git pr show -t 1450`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1450.diff">https://git.openjdk.org/jfx/pull/1450.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1450#issuecomment-2095446703)