### PR TITLE
8279140: ComboBox can lose selected value on item change via setAll

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ComboBox.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ComboBox.java
@@ -618,17 +618,11 @@ public class ComboBox<T> extends ComboBoxBase<T> {
                     T selectedItem = getSelectedItem();
                     for (int i = 0; i < comboBox.getItems().size(); i++) {
                         if (selectedItem.equals(comboBox.getItems().get(i))) {
-                            comboBox.setValue(null);
-                            setSelectedItem(null);
-
-                            //Restore the previous selection
-                            comboBox.setValue(selectedItem);
-                            setSelectedIndex(i);
+                            clearAndSelect(i);
                             break;
                         }
                     }
                 }
-
                 comboBox.previousItemCount = getItemCount();
             }
         };

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ComboBox.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ComboBox.java
@@ -620,6 +620,9 @@ public class ComboBox<T> extends ComboBoxBase<T> {
                         if (selectedItem.equals(comboBox.getItems().get(i))) {
                             comboBox.setValue(null);
                             setSelectedItem(null);
+
+                            //Restore the previous selection
+                            comboBox.setValue(selectedItem);
                             setSelectedIndex(i);
                             break;
                         }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
@@ -2321,7 +2321,7 @@ public class ComboBoxTest {
 
     //JDK-8279140
     @Test
-    public void testSelectionOnItemChange() {
+    public void testSelectionOnItemChangeUsingSetAllThroughPropertyBinding() {
         ObservableList<String> comboBoxItemsList = FXCollections.observableArrayList();
         ObjectProperty<String> selectedValue = new SimpleObjectProperty<>();
 
@@ -2347,5 +2347,38 @@ public class ComboBoxTest {
         selectedValue.set("D");
         assertEquals("D", comboBox.getSelectionModel().getSelectedItem());
         assertEquals("D", selectedValue.get());
+    }
+
+    //JDK-8279139
+    @Test
+    public void testSelectionOnItemChangeUsingSetAllOnButtonPress() {
+        ObservableList<String> comboBoxItemsList = FXCollections.observableArrayList();
+
+        List<String> strings1 = List.of("A", "B", "C");
+        List<String> strings2 = List.of("D", "B", "F");
+
+        comboBox = new ComboBox<>();
+        comboBox.setItems(comboBoxItemsList);
+        comboBox.setValue("B");
+
+        comboBoxItemsList.setAll(strings2);
+        assertEquals("B", comboBox.getSelectionModel().getSelectedItem());
+        comboBoxItemsList.setAll(strings1);
+        assertEquals("B", comboBox.getSelectionModel().getSelectedItem());
+
+        Button button = new Button("Change content");
+        button.setOnAction(e -> {
+            if (comboBoxItemsList.equals(strings1)) {
+                comboBoxItemsList.setAll(strings2);
+            } else {
+                comboBoxItemsList.setAll(strings1);
+            }
+        });
+
+        MouseEventFirer mouse = new MouseEventFirer(button);
+        mouse.fireMousePressAndRelease();
+        assertEquals("B", comboBox.getSelectionModel().getSelectedItem());
+        mouse.fireMousePressAndRelease();
+        assertEquals("B", comboBox.getSelectionModel().getSelectedItem());
     }
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
@@ -2318,4 +2318,34 @@ public class ComboBoxTest {
 
         assertEquals("ComboBox skinProperty changed more than once, which is not expected.", 1, skinChangedCount);
     }
+
+    //JDK-8279140
+    @Test
+    public void testSelectionOnItemChange() {
+        ObservableList<String> comboBoxItemsList = FXCollections.observableArrayList();
+        ObjectProperty<String> selectedValue = new SimpleObjectProperty<>();
+
+        List<String> strings1 = List.of("A", "B", "C");
+        List<String> strings2 = List.of("D", "E", "F");
+
+        comboBox = new ComboBox<>();
+        comboBox.setItems(comboBoxItemsList);
+
+        selectedValue.addListener((obs, oldValue, newValue) -> {
+            if ("D".equals(newValue) || "A".equals(newValue)) {
+                List<String> newContent = "A".equals(newValue) ? strings1 : strings2;
+                comboBoxItemsList.setAll(newContent);
+            }
+        });
+
+        comboBox.valueProperty().bindBidirectional(selectedValue);
+
+        selectedValue.set("A");
+        assertEquals("A", comboBox.getSelectionModel().getSelectedItem());
+        assertEquals("A", selectedValue.get());
+
+        selectedValue.set("D");
+        assertEquals("D", comboBox.getSelectionModel().getSelectedItem());
+        assertEquals("D", selectedValue.get());
+    }
 }


### PR DESCRIPTION
The `ComboBox` value was not set to previously selected value in the item list change listener when `setAll` method is used to change the items. Fixed the issue by restoring the selection in this case.

Added a unit test to validate the fix.
[JDK-8279139](https://bugs.openjdk.org/browse/JDK-8279139) is also fixed with this change and added a unit test for the same.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8279140](https://bugs.openjdk.org/browse/JDK-8279140): ComboBox can lose selected value on item change via setAll (**Bug** - P3)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1452/head:pull/1452` \
`$ git checkout pull/1452`

Update a local copy of the PR: \
`$ git checkout pull/1452` \
`$ git pull https://git.openjdk.org/jfx.git pull/1452/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1452`

View PR using the GUI difftool: \
`$ git pr show -t 1452`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1452.diff">https://git.openjdk.org/jfx/pull/1452.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1452#issuecomment-2097951529)