### PR TITLE
8332251: javadoc: incorrect method references in Region and PopupControl

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/PopupControl.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/PopupControl.java
@@ -362,11 +362,11 @@ public class PopupControl extends PopupWindow implements Skinnable, Styleable {
      * doesn't meet the application's layout needs.
      * <p>
      * Defaults to the <code>USE_COMPUTED_SIZE</code> flag, which means that
-     * <code>getMinWidth(forHeight)</code> will return the control's internally
+     * <code>minWidth(forHeight)</code> will return the control's internally
      * computed minimum width.
      * <p>
      * Setting this value to the <code>USE_PREF_SIZE</code> flag will cause
-     * <code>getMinWidth(forHeight)</code> to return the control's preferred width,
+     * <code>minWidth(forHeight)</code> to return the control's preferred width,
      * enabling applications to easily restrict the resizability of the control.
      */
     private DoubleProperty minWidth;
@@ -377,11 +377,11 @@ public class PopupControl extends PopupWindow implements Skinnable, Styleable {
      * doesn't meet the application's layout needs.
      * <p>
      * Defaults to the <code>USE_COMPUTED_SIZE</code> flag, which means that
-     * <code>getMinWidth(forHeight)</code> will return the control's internally
+     * <code>minWidth(forHeight)</code> will return the control's internally
      * computed minimum width.
      * <p>
      * Setting this value to the <code>USE_PREF_SIZE</code> flag will cause
-     * <code>getMinWidth(forHeight)</code> to return the control's preferred width,
+     * <code>minWidth(forHeight)</code> to return the control's preferred width,
      * enabling applications to easily restrict the resizability of the control.
      * @param value the minimum width
      */
@@ -393,11 +393,11 @@ public class PopupControl extends PopupWindow implements Skinnable, Styleable {
      * doesn't meet the application's layout needs.
      * <p>
      * Defaults to the <code>USE_COMPUTED_SIZE</code> flag, which means that
-     * <code>getMinWidth(forHeight)</code> will return the control's internally
+     * <code>minWidth(forHeight)</code> will return the control's internally
      * computed minimum width.
      * <p>
      * Setting this value to the <code>USE_PREF_SIZE</code> flag will cause
-     * <code>getMinWidth(forHeight)</code> to return the control's preferred width,
+     * <code>minWidth(forHeight)</code> to return the control's preferred width,
      * enabling applications to easily restrict the resizability of the control.
      * @return the minimum width
      */
@@ -430,11 +430,11 @@ public class PopupControl extends PopupWindow implements Skinnable, Styleable {
      * doesn't meet the application's layout needs.
      * <p>
      * Defaults to the <code>USE_COMPUTED_SIZE</code> flag, which means that
-     * <code>getMinHeight(forWidth)</code> will return the control's internally
+     * <code>minHeight(forWidth)</code> will return the control's internally
      * computed minimum height.
      * <p>
      * Setting this value to the <code>USE_PREF_SIZE</code> flag will cause
-     * <code>getMinHeight(forWidth)</code> to return the control's preferred height,
+     * <code>minHeight(forWidth)</code> to return the control's preferred height,
      * enabling applications to easily restrict the resizability of the control.
      *
      */
@@ -446,11 +446,11 @@ public class PopupControl extends PopupWindow implements Skinnable, Styleable {
      * doesn't meet the application's layout needs.
      * <p>
      * Defaults to the <code>USE_COMPUTED_SIZE</code> flag, which means that
-     * <code>getMinHeight(forWidth)</code> will return the control's internally
+     * <code>minHeight(forWidth)</code> will return the control's internally
      * computed minimum height.
      * <p>
      * Setting this value to the <code>USE_PREF_SIZE</code> flag will cause
-     * <code>getMinHeight(forWidth)</code> to return the control's preferred height,
+     * <code>minHeight(forWidth)</code> to return the control's preferred height,
      * enabling applications to easily restrict the resizability of the control.
      *
      * @param value the minimum height
@@ -463,11 +463,11 @@ public class PopupControl extends PopupWindow implements Skinnable, Styleable {
      * doesn't meet the application's layout needs.
      * <p>
      * Defaults to the <code>USE_COMPUTED_SIZE</code> flag, which means that
-     * <code>getMinHeight(forWidth)</code> will return the control's internally
+     * <code>minHeight(forWidth)</code> will return the control's internally
      * computed minimum height.
      * <p>
      * Setting this value to the <code>USE_PREF_SIZE</code> flag will cause
-     * <code>getMinHeight(forWidth)</code> to return the control's preferred height,
+     * <code>minHeight(forWidth)</code> to return the control's preferred height,
      * enabling applications to easily restrict the resizability of the control.
      *
      * @return the minimum height
@@ -515,7 +515,7 @@ public class PopupControl extends PopupWindow implements Skinnable, Styleable {
      * doesn't meet the application's layout needs.
      * <p>
      * Defaults to the <code>USE_COMPUTED_SIZE</code> flag, which means that
-     * <code>getPrefWidth(forHeight)</code> will return the control's internally
+     * <code>prefWidth(forHeight)</code> will return the control's internally
      * computed preferred width.
      */
     private DoubleProperty prefWidth;
@@ -526,7 +526,7 @@ public class PopupControl extends PopupWindow implements Skinnable, Styleable {
      * doesn't meet the application's layout needs.
      * <p>
      * Defaults to the <code>USE_COMPUTED_SIZE</code> flag, which means that
-     * <code>getPrefWidth(forHeight)</code> will return the control's internally
+     * <code>prefWidth(forHeight)</code> will return the control's internally
      * computed preferred width.
      * @param value the preferred width
      */
@@ -538,7 +538,7 @@ public class PopupControl extends PopupWindow implements Skinnable, Styleable {
      * doesn't meet the application's layout needs.
      * <p>
      * Defaults to the <code>USE_COMPUTED_SIZE</code> flag, which means that
-     * <code>getPrefWidth(forHeight)</code> will return the control's internally
+     * <code>prefWidth(forHeight)</code> will return the control's internally
      * computed preferred width.
      * @return the preferred width
      */
@@ -570,7 +570,7 @@ public class PopupControl extends PopupWindow implements Skinnable, Styleable {
      * doesn't meet the application's layout needs.
      * <p>
      * Defaults to the <code>USE_COMPUTED_SIZE</code> flag, which means that
-     * <code>getPrefHeight(forWidth)</code> will return the control's internally
+     * <code>prefHeight(forWidth)</code> will return the control's internally
      * computed preferred width.
      *
      */
@@ -582,7 +582,7 @@ public class PopupControl extends PopupWindow implements Skinnable, Styleable {
      * doesn't meet the application's layout needs.
      * <p>
      * Defaults to the <code>USE_COMPUTED_SIZE</code> flag, which means that
-     * <code>getPrefHeight(forWidth)</code> will return the control's internally
+     * <code>prefHeight(forWidth)</code> will return the control's internally
      * computed preferred width.
      *
      * @param value the preferred height
@@ -595,7 +595,7 @@ public class PopupControl extends PopupWindow implements Skinnable, Styleable {
      * doesn't meet the application's layout needs.
      * <p>
      * Defaults to the <code>USE_COMPUTED_SIZE</code> flag, which means that
-     * <code>getPrefHeight(forWidth)</code> will return the control's internally
+     * <code>prefHeight(forWidth)</code> will return the control's internally
      * computed preferred width.
      *
      * @return the preferred height
@@ -643,11 +643,11 @@ public class PopupControl extends PopupWindow implements Skinnable, Styleable {
      * doesn't meet the application's layout needs.
      * <p>
      * Defaults to the <code>USE_COMPUTED_SIZE</code> flag, which means that
-     * <code>getMaxWidth(forHeight)</code> will return the control's internally
+     * <code>maxWidth(forHeight)</code> will return the control's internally
      * computed maximum width.
      * <p>
      * Setting this value to the <code>USE_PREF_SIZE</code> flag will cause
-     * <code>getMaxWidth(forHeight)</code> to return the control's preferred width,
+     * <code>maxWidth(forHeight)</code> to return the control's preferred width,
      * enabling applications to easily restrict the resizability of the control.
      */
     private DoubleProperty maxWidth;
@@ -658,11 +658,11 @@ public class PopupControl extends PopupWindow implements Skinnable, Styleable {
      * doesn't meet the application's layout needs.
      * <p>
      * Defaults to the <code>USE_COMPUTED_SIZE</code> flag, which means that
-     * <code>getMaxWidth(forHeight)</code> will return the control's internally
+     * <code>maxWidth(forHeight)</code> will return the control's internally
      * computed maximum width.
      * <p>
      * Setting this value to the <code>USE_PREF_SIZE</code> flag will cause
-     * <code>getMaxWidth(forHeight)</code> to return the control's preferred width,
+     * <code>maxWidth(forHeight)</code> to return the control's preferred width,
      * enabling applications to easily restrict the resizability of the control.
      * @param value the maximum width
      */
@@ -674,11 +674,11 @@ public class PopupControl extends PopupWindow implements Skinnable, Styleable {
      * doesn't meet the application's layout needs.
      * <p>
      * Defaults to the <code>USE_COMPUTED_SIZE</code> flag, which means that
-     * <code>getMaxWidth(forHeight)</code> will return the control's internally
+     * <code>maxWidth(forHeight)</code> will return the control's internally
      * computed maximum width.
      * <p>
      * Setting this value to the <code>USE_PREF_SIZE</code> flag will cause
-     * <code>getMaxWidth(forHeight)</code> to return the control's preferred width,
+     * <code>maxWidth(forHeight)</code> to return the control's preferred width,
      * enabling applications to easily restrict the resizability of the control.
      * @return the maximum width
      */
@@ -710,11 +710,11 @@ public class PopupControl extends PopupWindow implements Skinnable, Styleable {
      * doesn't meet the application's layout needs.
      * <p>
      * Defaults to the <code>USE_COMPUTED_SIZE</code> flag, which means that
-     * <code>getMaxHeight(forWidth)</code> will return the control's internally
+     * <code>maxHeight(forWidth)</code> will return the control's internally
      * computed maximum height.
      * <p>
      * Setting this value to the <code>USE_PREF_SIZE</code> flag will cause
-     * <code>getMaxHeight(forWidth)</code> to return the control's preferred height,
+     * <code>maxHeight(forWidth)</code> to return the control's preferred height,
      * enabling applications to easily restrict the resizability of the control.
      *
      */
@@ -726,11 +726,11 @@ public class PopupControl extends PopupWindow implements Skinnable, Styleable {
      * doesn't meet the application's layout needs.
      * <p>
      * Defaults to the <code>USE_COMPUTED_SIZE</code> flag, which means that
-     * <code>getMaxHeight(forWidth)</code> will return the control's internally
+     * <code>maxHeight(forWidth)</code> will return the control's internally
      * computed maximum height.
      * <p>
      * Setting this value to the <code>USE_PREF_SIZE</code> flag will cause
-     * <code>getMaxHeight(forWidth)</code> to return the control's preferred height,
+     * <code>maxHeight(forWidth)</code> to return the control's preferred height,
      * enabling applications to easily restrict the resizability of the control.
      *
      * @param value the maximum height
@@ -743,11 +743,11 @@ public class PopupControl extends PopupWindow implements Skinnable, Styleable {
      * doesn't meet the application's layout needs.
      * <p>
      * Defaults to the <code>USE_COMPUTED_SIZE</code> flag, which means that
-     * <code>getMaxHeight(forWidth)</code> will return the control's internally
+     * <code>maxHeight(forWidth)</code> will return the control's internally
      * computed maximum height.
      * <p>
      * Setting this value to the <code>USE_PREF_SIZE</code> flag will cause
-     * <code>getMaxHeight(forWidth)</code> to return the control's preferred height,
+     * <code>maxHeight(forWidth)</code> to return the control's preferred height,
      * enabling applications to easily restrict the resizability of the control.
      *
      * @return the maximum height

--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/Region.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/Region.java
@@ -1184,7 +1184,7 @@ public class Region extends Parent {
      * doesn't meet the application's layout needs.
      * <p>
      * Defaults to the <code>USE_COMPUTED_SIZE</code> flag, which means that
-     * {@link #prefWidth(forHeight)} will return the region's internally
+     * <code>prefWidth(forHeight)</code> will return the region's internally
      * computed preferred width.
      */
     private DoubleProperty prefWidth;
@@ -1209,7 +1209,7 @@ public class Region extends Parent {
      * doesn't meet the application's layout needs.
      * <p>
      * Defaults to the <code>USE_COMPUTED_SIZE</code> flag, which means that
-     * {@link #prefHeight(forWidth)} will return the region's internally
+     * <code>prefHeight(forWidth)</code> will return the region's internally
      * computed preferred width.
      */
     private DoubleProperty prefHeight;
@@ -1249,11 +1249,11 @@ public class Region extends Parent {
      * doesn't meet the application's layout needs.
      * <p>
      * Defaults to the <code>USE_COMPUTED_SIZE</code> flag, which means that
-     * <code>getMaxWidth(forHeight)</code> will return the region's internally
+     * <code>maxWidth(forHeight)</code> will return the region's internally
      * computed maximum width.
      * <p>
      * Setting this value to the <code>USE_PREF_SIZE</code> flag will cause
-     * <code>getMaxWidth(forHeight)</code> to return the region's preferred width,
+     * <code>maxWidth(forHeight)</code> to return the region's preferred width,
      * enabling applications to easily restrict the resizability of the region.
      */
     private DoubleProperty maxWidth;
@@ -1278,11 +1278,11 @@ public class Region extends Parent {
      * doesn't meet the application's layout needs.
      * <p>
      * Defaults to the <code>USE_COMPUTED_SIZE</code> flag, which means that
-     * <code>getMaxHeight(forWidth)</code> will return the region's internally
+     * <code>maxHeight(forWidth)</code> will return the region's internally
      * computed maximum height.
      * <p>
      * Setting this value to the <code>USE_PREF_SIZE</code> flag will cause
-     * <code>getMaxHeight(forWidth)</code> to return the region's preferred height,
+     * <code>maxHeight(forWidth)</code> to return the region's preferred height,
      * enabling applications to easily restrict the resizability of the region.
      */
     private DoubleProperty maxHeight;

--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/Region.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/Region.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1184,7 +1184,7 @@ public class Region extends Parent {
      * doesn't meet the application's layout needs.
      * <p>
      * Defaults to the <code>USE_COMPUTED_SIZE</code> flag, which means that
-     * <code>getPrefWidth(forHeight)</code> will return the region's internally
+     * {@link #prefWidth(forHeight)} will return the region's internally
      * computed preferred width.
      */
     private DoubleProperty prefWidth;
@@ -1209,7 +1209,7 @@ public class Region extends Parent {
      * doesn't meet the application's layout needs.
      * <p>
      * Defaults to the <code>USE_COMPUTED_SIZE</code> flag, which means that
-     * <code>getPrefHeight(forWidth)</code> will return the region's internally
+     * {@link #prefHeight(forWidth)} will return the region's internally
      * computed preferred width.
      */
     private DoubleProperty prefHeight;


### PR DESCRIPTION
The javadoc for `Region.getPrefHeight() / getPrefWidth()` incorrectly refers to `getPrefHeight(forWidth) / getPrefWidth(forHeight)`

should be

`prefHeight(forWidth) / prefWidth(forHeight)`

- same issue is also fixed in `PopupControl`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332251](https://bugs.openjdk.org/browse/JDK-8332251): javadoc: incorrect method references in Region and PopupControl (**Bug** - P4)


### Reviewers
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1456/head:pull/1456` \
`$ git checkout pull/1456`

Update a local copy of the PR: \
`$ git checkout pull/1456` \
`$ git pull https://git.openjdk.org/jfx.git pull/1456/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1456`

View PR using the GUI difftool: \
`$ git pr show -t 1456`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1456.diff">https://git.openjdk.org/jfx/pull/1456.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1456#issuecomment-2113623650)