### PR TITLE
8332328: [GHA] GitHub Actions build fails on Linux: unable to find gcc-13

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -63,7 +63,7 @@ jobs:
   linux_x64_build:
     name: Linux x64
     needs: validation
-    runs-on: "ubuntu-22.04"
+    runs-on: "ubuntu-24.04"
 
     env:
       # FIXME: read this information from a property file


### PR DESCRIPTION
It looks like the list of packages available in the Ubuntu 22.04 GitHub Actions test runner no longer includes `gcc-13` as of yesterday. I didn't find any documentation to indicate that this was intentional, but now that Ubuntu 24.04 is available we can fix the problem by updating to that version. We will need to do this at some point anyway, so we might as well do it now.

With this fix, the GHA test build now passes on all platforms. See the test results to verify this.

Given that GHA builds are currently broken on Linux, and that this fix doesn't affect the product at all (just our GHA tests), I will integrate this as soon as it is approved by 1 Reviewer, as an exception to the usual requirement to wait for 24 hours.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332328](https://bugs.openjdk.org/browse/JDK-8332328): [GHA] GitHub Actions build fails on Linux: unable to find gcc-13 (**Bug** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1457/head:pull/1457` \
`$ git checkout pull/1457`

Update a local copy of the PR: \
`$ git checkout pull/1457` \
`$ git pull https://git.openjdk.org/jfx.git pull/1457/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1457`

View PR using the GUI difftool: \
`$ git pr show -t 1457`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1457.diff">https://git.openjdk.org/jfx/pull/1457.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1457#issuecomment-2115599699)