### PR TITLE
8324327: ColorPicker shows a white rectangle on clicking on picker

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ColorPalette.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ColorPalette.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -163,12 +163,12 @@ class ColorPalette extends Region {
     }
 
     private void setFocusedSquare(ColorSquare square) {
+        hoverSquare.setVisible(square != null);
         if (square == focusedSquare) {
             return;
         }
         focusedSquare = square;
 
-        hoverSquare.setVisible(focusedSquare != null);
         if (focusedSquare == null) {
             return;
         }


### PR DESCRIPTION
Root cause: premature 'return' from initialization code leaves the hover square visible, even when it should be hidden, as the case is when the color value is not present in the palette.

- added unit tests

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324327](https://bugs.openjdk.org/browse/JDK-8324327): ColorPicker shows a white rectangle on clicking on picker (**Bug** - P4)


### Reviewers
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1458/head:pull/1458` \
`$ git checkout pull/1458`

Update a local copy of the PR: \
`$ git checkout pull/1458` \
`$ git pull https://git.openjdk.org/jfx.git pull/1458/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1458`

View PR using the GUI difftool: \
`$ git pr show -t 1458`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1458.diff">https://git.openjdk.org/jfx/pull/1458.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1458#issuecomment-2115943666)