### PR TITLE
8289115: Touch events is not dispatched after upgrade to JAVAFX17+

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/win/ViewContainer.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/win/ViewContainer.cpp
@@ -1211,7 +1211,7 @@ void NotifyTouchInput(
 
     // Sets to 'true' if source device is a touch screen
     // and to 'false' if source device is a touch pad/pen.
-    const bool isDirect = IsTouchEvent();
+    const bool isDirect = (ti->dwFlags & TOUCHEVENTF_PEN) == 0;
 
     jint modifiers = GetModifiers();
     env->CallStaticObjectMethod(gestureSupportCls,


### PR DESCRIPTION
This PR fixes a bug ([JDK-8289115](https://bugs.openjdk.org/browse/JDK-8289115)) that was introduced with #394, which changed the following line in the `NotifyTouchInput` function (ViewContainer.cpp):
```
- const bool isDirect = true;
+ const bool isDirect = IsTouchEvent();
```

`IsTouchEvent` is a small utility function that uses the Windows SDK function `GetMessageExtraInfo` to distinguish between mouse events and pen events as described in this article: https://learn.microsoft.com/en-us/windows/win32/tablet/system-events-and-mouse-messages

I think that using this function to distinguish between touchscreen events and pen events is erroneous. The linked article states:
_"When your application receives a **mouse message** (such as WM_LBUTTONDOWN) [...]"_

But we are not receiving a mouse message in `NotifyTouchInput`, we are receiving a `WM_TOUCH` message.
I couldn't find any information on whether this API usage is also supported for `WM_TOUCH` messages, but my testing shows that that's probably not the case (I tested this with a XPS 15 touchscreen laptop, where `GetMessageExtraInfo` returns 0 for `WM_TOUCH` messages).

My suggestion is to check the `TOUCHEVENTF_PEN` flag of the `TOUCHINPUT` structure instead:
```
const bool isDirect = (ti->dwFlags & TOUCHEVENTF_PEN) == 0;
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8289115](https://bugs.openjdk.org/browse/JDK-8289115): Touch events is not dispatched after upgrade to JAVAFX17+ (**Bug** - P4)


### Reviewers
 * [Jose Pereda](https://openjdk.org/census#jpereda) (@jperedadnr - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1459/head:pull/1459` \
`$ git checkout pull/1459`

Update a local copy of the PR: \
`$ git checkout pull/1459` \
`$ git pull https://git.openjdk.org/jfx.git pull/1459/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1459`

View PR using the GUI difftool: \
`$ git pr show -t 1459`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1459.diff">https://git.openjdk.org/jfx/pull/1459.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1459#issuecomment-2122775164)