### PR TITLE
8087444: CornerRadii with different horizontal and vertical values treated as uniform

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/CornerRadii.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/CornerRadii.java
@@ -312,18 +312,20 @@ public class CornerRadii {
                 topRightVerticalRadiusAsPercent || topRightHorizontalRadiusAsPercent ||
                 bottomRightHorizontalRadiusAsPercent || bottomRightVerticalRadiusAsPercent ||
                 bottomLeftVerticalRadiusAsPercent || bottomLeftHorizontalRadiusAsPercent;
-        uniform = topLeftHorizontalRadius == topRightHorizontalRadius &&
-                topLeftVerticalRadius == topRightVerticalRadius &&
+        uniform = topLeftHorizontalRadius == topLeftVerticalRadius &&
+                topLeftHorizontalRadius == topRightVerticalRadius &&
+                topLeftHorizontalRadius == topRightHorizontalRadius &&
                 topLeftHorizontalRadius == bottomRightHorizontalRadius &&
-                topLeftVerticalRadius == bottomRightVerticalRadius &&
+                topLeftHorizontalRadius == bottomRightVerticalRadius &&
+                topLeftHorizontalRadius == bottomLeftVerticalRadius &&
                 topLeftHorizontalRadius == bottomLeftHorizontalRadius &&
-                topLeftVerticalRadius == bottomLeftVerticalRadius &&
+                topLeftHorizontalRadiusAsPercent == topLeftVerticalRadiusAsPercent &&
+                topLeftHorizontalRadiusAsPercent == topRightVerticalRadiusAsPercent &&
                 topLeftHorizontalRadiusAsPercent == topRightHorizontalRadiusAsPercent &&
-                topLeftVerticalRadiusAsPercent == topRightVerticalRadiusAsPercent &&
                 topLeftHorizontalRadiusAsPercent == bottomRightHorizontalRadiusAsPercent &&
-                topLeftVerticalRadiusAsPercent == bottomRightVerticalRadiusAsPercent &&
-                topLeftHorizontalRadiusAsPercent == bottomLeftHorizontalRadiusAsPercent &&
-                topLeftVerticalRadiusAsPercent == bottomLeftVerticalRadiusAsPercent;
+                topLeftHorizontalRadiusAsPercent == bottomRightVerticalRadiusAsPercent &&
+                topLeftHorizontalRadiusAsPercent == bottomLeftVerticalRadiusAsPercent &&
+                topLeftHorizontalRadiusAsPercent == bottomLeftHorizontalRadiusAsPercent;
     }
 
     private int preComputeHash() {

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/CornerRadiiTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/CornerRadiiTest.java
@@ -26,14 +26,17 @@
 package test.javafx.scene.layout;
 
 import javafx.scene.layout.CornerRadii;
-import org.junit.Test;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import java.util.stream.DoubleStream;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  */
 public class CornerRadiiTest {
-    @Test public void instanceCreation_singleConstructor() {
+    @Test
+    public void instanceCreation_singleConstructor() {
         CornerRadii r = new CornerRadii(1);
         assertEquals(1, r.getTopLeftHorizontalRadius(), 0);
         assertEquals(1, r.getTopLeftVerticalRadius(), 0);
@@ -53,8 +56,71 @@ public class CornerRadiiTest {
         assertFalse(r.isBottomLeftHorizontalRadiusAsPercentage());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void negativeRadiusNotAllowed_singleConstructor() {
-        new CornerRadii(-1);
+        assertThrows(IllegalArgumentException.class, () -> new CornerRadii(-1));
+    }
+
+    @Nested
+    class IsUniformTests {
+        @Test
+        public void isUniform_1ArgConstructor() {
+            assertTrue(new CornerRadii(1).isUniform());
+        }
+
+        @Test
+        public void isUniform_2ArgConstructor() {
+            assertTrue(new CornerRadii(1, false).isUniform());
+            assertTrue(new CornerRadii(1, true).isUniform());
+        }
+
+        @Test
+        public void isUniform_5ArgConstructor() {
+            for (boolean percent : new boolean[] { true, false }) {
+                assertTrue(new CornerRadii(0, 0, 0, 0, percent).isUniform());
+                assertTrue(new CornerRadii(1, 1, 1, 1, percent).isUniform());
+                assertFalse(new CornerRadii(1, 0, 0, 0, percent).isUniform());
+                assertFalse(new CornerRadii(0, 1, 0, 0, percent).isUniform());
+                assertFalse(new CornerRadii(0, 0, 1, 0, percent).isUniform());
+                assertFalse(new CornerRadii(0, 0, 0, 1, percent).isUniform());
+                assertFalse(new CornerRadii(1, 1, 0, 0, percent).isUniform());
+                assertFalse(new CornerRadii(0, 1, 1, 0, percent).isUniform());
+                assertFalse(new CornerRadii(0, 0, 1, 1, percent).isUniform());
+                assertFalse(new CornerRadii(1, 0, 0, 1, percent).isUniform());
+                assertFalse(new CornerRadii(1, 0, 1, 0, percent).isUniform());
+                assertFalse(new CornerRadii(0, 1, 0, 1, percent).isUniform());
+                assertFalse(new CornerRadii(1, 1, 1, 0, percent).isUniform());
+                assertFalse(new CornerRadii(0, 1, 1, 1, percent).isUniform());
+                assertFalse(new CornerRadii(1, 0, 1, 1, percent).isUniform());
+                assertFalse(new CornerRadii(1, 1, 0, 1, percent).isUniform());
+            }
+        }
+
+        @Test
+        public void isUniform_16ArgConstructor() {
+            final int max = 1 << 16;
+            double[] arg = new double[16];
+
+            // Test all combinations of constructor arguments with a radius of either 0 or 1.
+            for (int i = 0; i < max; ++i) {
+                boolean uniform = true;
+
+                for (int j = 0; j < 16; ++j) {
+                    arg[j] = (i >> j) & 1;
+                    uniform &= arg[j] == arg[j < 8 ? 0 : 8]; // args 0-8 must be equal, and args 8-16 must be equal
+                }
+
+                var cornerRadii = new CornerRadii(
+                    arg[0], arg[1], arg[2], arg[3], arg[4], arg[5], arg[6], arg[7],
+                    arg[8] > 0, arg[9] > 0, arg[10] > 0, arg[11] > 0, arg[12] > 0, arg[13] > 0, arg[14] > 0, arg[15] > 0);
+
+                final boolean expectUniform = uniform;
+
+                assertEquals(expectUniform, cornerRadii.isUniform(), () ->
+                    "Expected " + (expectUniform ? "" : "not ") + "isUniform for constructor: " +
+                    String.join(", ", DoubleStream.of(arg).limit(8).mapToObj(Double::toString).toList()) + ", " +
+                    String.join(", ", DoubleStream.of(arg).skip(8).mapToObj(d -> Boolean.toString(d > 0)).toList()));
+            }
+        }
     }
 }


### PR DESCRIPTION
This PR fixes the incorrect computation of the `CornerRadii.uniform` flag for the 16-argument constructor.

I've also added tests for all other constructors.