### PR TITLE
8332748: Grammatical errors in animation API docs

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/animation/FadeTransition.java
+++ b/modules/javafx.graphics/src/main/java/javafx/animation/FadeTransition.java
@@ -36,7 +36,7 @@ import javafx.util.Duration;
 /**
  * This {@code Transition} creates a fade effect animation that spans its
  * {@code duration}. This is done by updating the {@code opacity} variable of
- * the {@code node} at regular interval.
+ * the {@code node} at regular intervals.
  * <p>
  * It starts from the {@code fromValue} if provided else uses the {@code node}'s
  * {@code opacity} value.

--- a/modules/javafx.graphics/src/main/java/javafx/animation/PathTransition.java
+++ b/modules/javafx.graphics/src/main/java/javafx/animation/PathTransition.java
@@ -42,7 +42,7 @@ import java.util.ArrayList;
  * {@link #durationProperty() duration}. The translation along the path is done by updating the
  * {@code translateX} and {@code translateY} variables of the {@code node}, and
  * the {@code rotate} variable will get updated if {@code orientation} is set to
- * {@code OrientationType.ORTHOGONAL_TO_TANGENT}, at regular interval.
+ * {@code OrientationType.ORTHOGONAL_TO_TANGENT}, at regular intervals.
  * <p>
  * The animated path is defined by the outline of a shape.
  *

--- a/modules/javafx.graphics/src/main/java/javafx/animation/RotateTransition.java
+++ b/modules/javafx.graphics/src/main/java/javafx/animation/RotateTransition.java
@@ -37,7 +37,7 @@ import javafx.util.Duration;
 /**
  * This {@code Transition} creates a rotation animation that spans its
  * {@code duration}. This is done by updating the {@code rotate} variable of the
- * {@code node} at regular interval. The angle value is specified in degrees.
+ * {@code node} at regular intervals. The angle value is specified in degrees.
  * <p>
  * It starts from the {@code fromAngle} if provided else uses the {@code node}'s
  * {@code rotate} value.

--- a/modules/javafx.graphics/src/main/java/javafx/animation/TranslateTransition.java
+++ b/modules/javafx.graphics/src/main/java/javafx/animation/TranslateTransition.java
@@ -37,7 +37,7 @@ import javafx.util.Duration;
  * This {@code Transition} creates a move/translate animation that spans its
  * {@link #durationProperty() duration}. This is done by updating the {@code translateX},
  * {@code translateY} and {@code translateZ} variables of the {@code node} at
- * regular interval.
+ * regular intervals.
  * <p>
  * It starts from the ({@code fromX}, {@code fromY}, {@code fromZ}) value if
  * provided else uses the {@code node}'s ({@code translateX}, {@code translateY}, {@code translateZ}) value.


### PR DESCRIPTION
Checked code and fixed the gramatical error in Transition files: s/interval/intervals

Fill and Stroke Transition had correct grammatical form already, so those were untouched. I couldn't find any other instances of this error in our javadoc documentation.