### PR TITLE
8330304: MenuBar: Invisible Menu works incorrectly with keyboard arrows

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/MenuBarSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/MenuBarSkin.java
@@ -121,16 +121,14 @@ public class MenuBarSkin extends SkinBase<MenuBar> {
      *                                                                         *
      **************************************************************************/
 
+    /** contains MenuBarButton's children only */
     private final HBox container;
+    /** index of *focused* MenuBarButton */
+    private int focusedMenuIndex = -1;
 
     // represents the currently _open_ menu
     private Menu openMenu;
     private MenuBarButton openMenuButton;
-
-    // represents the currently _focused_ menu. If openMenu is non-null, this should equal
-    // openMenu. If openMenu is null, this can be any menu in the menu bar.
-    private Menu focusedMenu;
-    private int focusedMenuIndex = -1;
 
     private static WeakHashMap<Stage, Reference<MenuBarSkin>> systemMenuMap;
     private static List<MenuBase> wrappedDefaultMenus = new ArrayList<>();
@@ -295,7 +293,7 @@ public class MenuBarSkin extends SkinBase<MenuBar> {
                 // Key navigation
                 sceneListenerHelper.addEventFilter(scene, KeyEvent.KEY_PRESSED, (ev) -> {
                     // process right left and may be tab key events
-                    if (focusedMenu != null) {
+                    if (focusedMenuIndex >= 0) {
                         switch (ev.getCode()) {
                         case LEFT: {
                             boolean isRTL = control.getEffectiveNodeOrientation() == NodeOrientation.RIGHT_TO_LEFT;
@@ -429,7 +427,7 @@ public class MenuBarSkin extends SkinBase<MenuBar> {
         if (!menu.isShowing() && !isMenuEmpty(menu)) {
             if (selectFirstItem) {
                 // put selection / focus on first item in menu
-                MenuButton menuButton = getNodeForMenu(focusedMenuIndex);
+                MenuButton menuButton = menuBarButtonAt(focusedMenuIndex);
                 Skin<?> skin = menuButton.getSkin();
                 if (skin instanceof MenuButtonSkinBase) {
                     ((MenuButtonSkinBase)skin).requestFocusOnFirstMenuItem();
@@ -445,7 +443,6 @@ public class MenuBarSkin extends SkinBase<MenuBar> {
      */
     void setFocusedMenuIndex(int index) {
         focusedMenuIndex = (index >= -1 && index < getSkinnable().getMenus().size()) ? index : -1;
-        focusedMenu = (focusedMenuIndex != -1) ? getSkinnable().getMenus().get(index) : null;
 
         if (focusedMenuIndex != -1) {
             openMenuButton = (MenuBarButton)container.getChildren().get(focusedMenuIndex);
@@ -733,8 +730,8 @@ public class MenuBarSkin extends SkinBase<MenuBar> {
      *                                                                         *
      **************************************************************************/
 
-    // For testing purpose only.
-    MenuButton getNodeForMenu(int i) {
+    // package protected for testing purposes
+    MenuBarButton menuBarButtonAt(int i) {
         if (i < container.getChildren().size()) {
             return (MenuBarButton)container.getChildren().get(i);
         }
@@ -1083,6 +1080,7 @@ public class MenuBarSkin extends SkinBase<MenuBar> {
     }
 
     private void moveToMenu(Direction dir, boolean doShow) {
+        Menu focusedMenu = menuBarButtonAt(focusedMenuIndex).menu;
         boolean showNextMenu = doShow && focusedMenu.isShowing();
         findSibling(dir, focusedMenuIndex).ifPresent(p -> {
             setFocusedMenuIndex(p.getValue());

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/MenuBarSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/MenuBarSkin.java
@@ -732,10 +732,7 @@ public class MenuBarSkin extends SkinBase<MenuBar> {
 
     // package protected for testing purposes
     MenuBarButton menuBarButtonAt(int i) {
-        if (i < container.getChildren().size()) {
-            return (MenuBarButton)container.getChildren().get(i);
-        }
-        return null;
+        return (MenuBarButton)container.getChildren().get(i);
     }
 
     int getFocusedMenuIndex() {

--- a/modules/javafx.controls/src/shims/java/javafx/scene/control/skin/MenuBarSkinShim.java
+++ b/modules/javafx.controls/src/shims/java/javafx/scene/control/skin/MenuBarSkinShim.java
@@ -37,7 +37,7 @@ public class MenuBarSkinShim {
 
     // can only access the getNodeForMenu method in MenuBarSkin from this package.
     public static MenuButton getNodeForMenu(MenuBarSkin skin, int i) {
-        return skin.getNodeForMenu(i);
+        return skin.menuBarButtonAt(i);
     }
 
     public static Skin getPopupSkin(MenuButton mb) {


### PR DESCRIPTION
The root cause is that the skin used two fields to store one entity (`focusedMenu` and `focusedMenuIndex`), causing mismatch when invisible menu(s) are present.

The fix involves using a single index variable.

Also wanted to note that in theory, `openMenu` and `openMenuButton` can also be replaced with a single boolean, but I decided not to change these in order to keep the amount of diffs to a minimum.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330304](https://bugs.openjdk.org/browse/JDK-8330304): MenuBar: Invisible Menu works incorrectly with keyboard arrows (**Bug** - P3)


### Reviewers
 * [Michael Strauß](https://openjdk.org/census#mstrauss) (@mstr2 - Committer)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1467/head:pull/1467` \
`$ git checkout pull/1467`

Update a local copy of the PR: \
`$ git checkout pull/1467` \
`$ git pull https://git.openjdk.org/jfx.git pull/1467/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1467`

View PR using the GUI difftool: \
`$ git pr show -t 1467`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1467.diff">https://git.openjdk.org/jfx/pull/1467.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1467#issuecomment-2140989050)