### PR TITLE
8330559: Trailing space not rendering correctly in TextFlow in RTL mode

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/coretext/CTGlyphLayout.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/coretext/CTGlyphLayout.java
@@ -155,6 +155,20 @@ class CTGlyphLayout extends GlyphLayout {
             if (size > 0) {
                 positions[posStart] = (float)OS.CTLineGetTypographicBounds(lineRef);
             }
+            /* JDK-8330559 - Mac specific issue.
+             * When traling spces are present in the text containing LTR and RTL
+             * text together, negative position values are returned for spaces from
+             * the native side. Since TextRun expects positive value relative to the
+             * first glyph in the text run, shifting the position of each glyph by the
+             * absolute value of negative value of first character */
+            if (positions[0] < 0) {
+                float offsetVal = Math.abs(positions[0]);
+                int idx = 0;
+                while (idx < positions.length - 2) {
+                    positions[idx] += offsetVal;
+                    idx += 2;
+                }
+            }
             run.shape(glyphCount, glyphs, positions, indices);
         }
         OS.CFRelease(lineRef);

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/coretext/CTGlyphLayout.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/coretext/CTGlyphLayout.java
@@ -156,7 +156,7 @@ class CTGlyphLayout extends GlyphLayout {
                 positions[posStart] = (float)OS.CTLineGetTypographicBounds(lineRef);
             }
             /* JDK-8330559 - Mac specific issue.
-             * When traling spces are present in the text containing LTR and RTL
+             * When trailing spaces are present in the text containing LTR and RTL
              * text together, negative position values are returned for spaces from
              * the native side. Since TextRun expects positive value relative to the
              * first glyph in the text run, shifting the position of each glyph by the

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/text/TextRun.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/text/TextRun.java
@@ -329,8 +329,11 @@ public class TextRun implements GlyphList {
                 cacheWidth = x;
                 return x;
             }
-            int prevIdx = glyphIndex>>1;
-            if ((prevIdx) >= 0 && positions[prevIdx] < 0) {
+            int prevIdx = (glyphIndex - 1)<<1;
+            while (prevIdx > 0 && positions[prevIdx] < 0) {
+                prevIdx -= 2;
+            }
+            if (prevIdx >= 0 && positions[prevIdx] < 0) {
                 return Math.abs(positions[prevIdx]);
             }
             return positions[glyphIndex<<1];

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/text/TextRun.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/text/TextRun.java
@@ -329,6 +329,10 @@ public class TextRun implements GlyphList {
                 cacheWidth = x;
                 return x;
             }
+            int prevIdx = glyphIndex>>1;
+            if ((prevIdx) >= 0 && positions[prevIdx] < 0) {
+                return Math.abs(positions[prevIdx]);
+            }
             return positions[glyphIndex<<1];
         }
         return glyphIndex == 0 ? 0 : getWidth();

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/text/TextRun.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/text/TextRun.java
@@ -329,13 +329,6 @@ public class TextRun implements GlyphList {
                 cacheWidth = x;
                 return x;
             }
-            int prevIdx = (glyphIndex - 1)<<1;
-            while (prevIdx > 0 && positions[prevIdx] < 0) {
-                prevIdx -= 2;
-            }
-            if (prevIdx >= 0 && positions[prevIdx] < 0) {
-                return Math.abs(positions[prevIdx]);
-            }
             return positions[glyphIndex<<1];
         }
         return glyphIndex == 0 ? 0 : getWidth();


### PR DESCRIPTION
The issue is specific to Mac. The glyph positions returned from native side for complex text is not handled in the text render logic. This issue is observed only when trailing spaces are present along with LTR text mixed with RTL text (Example: "Arabic: العربية").

Made changes in `getPosX` of `TextRun` class to handle negative values.

Tested the changes manually with the sample code present in the bug and using the MonkeyTester.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330559](https://bugs.openjdk.org/browse/JDK-8330559): Trailing space not rendering correctly in TextFlow in RTL mode (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1468/head:pull/1468` \
`$ git checkout pull/1468`

Update a local copy of the PR: \
`$ git checkout pull/1468` \
`$ git pull https://git.openjdk.org/jfx.git pull/1468/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1468`

View PR using the GUI difftool: \
`$ git pr show -t 1468`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1468.diff">https://git.openjdk.org/jfx/pull/1468.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1468#issuecomment-2142416480)