### PR TITLE
8314683: TextArea: scroll bar size and content padding

### DIFF
--- a/modules/javafx.controls/src/main/resources/com/sun/javafx/scene/control/skin/modena/modena.css
+++ b/modules/javafx.controls/src/main/resources/com/sun/javafx/scene/control/skin/modena/modena.css
@@ -1044,7 +1044,7 @@ is being used to size a border should also be in pixels.
 .scroll-bar > .decrement-button {
     -fx-background-color: -fx-outer-border, -fx-inner-border, -fx-body-color;
     -fx-color: transparent;
-    -fx-padding: 0.25em; /* 3px */
+    -fx-padding: 3px;
 }
 .scroll-bar:horizontal > .increment-button,
 .scroll-bar:horizontal > .decrement-button {
@@ -1067,25 +1067,25 @@ is being used to size a border should also be in pixels.
     -fx-background-color: -fx-mark-highlight-color,derive(-fx-base,-55%);
 }
 .scroll-bar:horizontal > .decrement-button > .decrement-arrow {
-    -fx-padding: 0.333em 0.167em 0.333em 0.167em; /* 4 2 4 2 */
+    -fx-padding: 4px 2px 4px 2px;
     -fx-shape: "M5.997,5.072L5.995,6.501l-2.998-4l2.998-4l0.002,1.43l-1.976,2.57L5.997,5.072z";
     -fx-effect: dropshadow(two-pass-box , -fx-shadow-highlight-color, 1, 0.0 , 0, 1.4);
     /*-fx-background-insets: 2 0 -2 0, 0;*/
 }
 .scroll-bar:horizontal > .increment-button > .increment-arrow {
-    -fx-padding: 0.333em 0.167em 0.333em 0.167em; /* 4 2 4 2 */
+    -fx-padding: 4px 2px 4px 2px
     -fx-shape: "M2.998-0.07L3-1.499l2.998,4L3,6.501l-0.002-1.43l1.976-2.57L2.998-0.07z";
     -fx-effect: dropshadow(two-pass-box , -fx-shadow-highlight-color, 1, 0.0 , 0, 1.4);
     /*-fx-background-insets: 2 0 -2 0, 0;*/
 }
 .scroll-bar:vertical > .decrement-button > .decrement-arrow {
-    -fx-padding: 0.167em 0.333em 0.167em 0.333em; /* 2 4 2 4 */
+    -fx-padding: 2px 4px 2px 4px;
     -fx-shape: "M1.929,4L0.5,3.998L4.5,1l4,2.998L7.07,4L4.5,2.024L1.929,4z";
     -fx-effect: dropshadow(two-pass-box , -fx-shadow-highlight-color, 1, 0.0 , 0, 1.4);
     /*-fx-background-insets: 2 0 -2 0, 0;*/
 }
 .scroll-bar:vertical > .increment-button > .increment-arrow {
-    -fx-padding: 0.167em 0.333em 0.167em 0.333em; /* 2 4 2 4 */
+    -fx-padding: 2px 4px 2px 4px;
     -fx-shape: "M7.071,1L8.5,1.002L4.5,4l-4-2.998L1.93,1L4.5,2.976L7.071,1z";
     -fx-effect: dropshadow(two-pass-box , -fx-shadow-highlight-color, 1, 0.0 , 0, 1.4);
     /*-fx-background-insets: 2 0 -2 0, 0;*/
@@ -1105,11 +1105,11 @@ is being used to size a border should also be in pixels.
 }
 .scroll-pane > .scroll-bar:horizontal > .increment-button,
 .scroll-pane > .scroll-bar:horizontal > .decrement-button {
-    -fx-padding: 0.166667em 0.25em 0.25em  0.25em; /* 2 3 3 3 */
+    -fx-padding: 2px 3px 3px 3px;
 }
 .scroll-pane > .scroll-bar:vertical > .increment-button,
 .scroll-pane > .scroll-bar:vertical > .decrement-button {
-    -fx-padding: 0.25em 0.25em 0.25em 0.166667em; /* 3 3 3 2 */
+    -fx-padding: 3px 3px 3px 2px;
 }
 .scroll-pane > .scroll-bar:vertical {
     -fx-background-insets: 1 1 1 0, 1;
@@ -1329,7 +1329,7 @@ is being used to size a border should also be in pixels.
 }
 .text-area .content {
     /*the is 1px less top and bottom than TextInput because of scrollpane border */
-    -fx-padding: 0.25em 0.583em 0.25em 0.583em; /* 3 7 3 7 */
+    -fx-padding: 3px 7px 3px 7px;
     -fx-cursor: text;
     -fx-background-color:
         linear-gradient(from 0px 0px to 0px 4px, derive(-fx-control-inner-background, -8%), -fx-control-inner-background);


### PR DESCRIPTION
Changing certain ScrollBar, ScrollPane, and TextArea sizes from `em` to `px` in modena.css to make them independent of the font size *in that control*.

After the change, the UI still looks good which can be tested by scaling default font size in a fairly wide range:

```
.root { -fx-font-size:100%; }
```

Using CSS Playground tool in the Monkey Tester at 50% and 200% font size:

![Screenshot 2024-05-31 at 14 48 41](https://github.com/openjdk/jfx/assets/107069028/c41e1500-ccfe-4aa6-b47a-42571f60b335)

![Screenshot 2024-05-31 at 14 49 34](https://github.com/openjdk/jfx/assets/107069028/78270097-4ce3-4c3e-8600-aba8d368495c)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 2 [Reviewers](https://openjdk.org/bylaws#reviewer))

### Issue
 * [JDK-8314683](https://bugs.openjdk.org/browse/JDK-8314683): TextArea: scroll bar size and content padding (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1469/head:pull/1469` \
`$ git checkout pull/1469`

Update a local copy of the PR: \
`$ git checkout pull/1469` \
`$ git pull https://git.openjdk.org/jfx.git pull/1469/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1469`

View PR using the GUI difftool: \
`$ git pr show -t 1469`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1469.diff">https://git.openjdk.org/jfx/pull/1469.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1469#issuecomment-2148552772)