### PR TITLE
8333147: update maven classifier syntax to recent gradle version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1731,7 +1731,7 @@ void addMavenPublication(Project project, List<String> projectDependencies) {
                     afterEvaluate {
                         artifact project.tasks."moduleEmptyPublicationJar$t.capital"
                         artifact project.tasks."modularPublicationJar$t.capital" {
-                            classifier "$t.name"
+                            archiveClassifier.set("$t.name")
                         }
                     }
 


### PR DESCRIPTION
Replaces the deprecated `classifier` property with `archiveClassifier`. The property was removed with the release of Gradle 8.0: https://docs.gradle.org/8.0/userguide/upgrading_version_7.html#abstractarchivetask_api_cleanup