### PR TITLE
8327255: javac lint warnings: removal, missing-explicit-ctor

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -546,12 +546,37 @@ ext.IS_RELEASE = !ext.IS_DEBUG_JAVA
 defineProperty("MAVEN_PUBLISH", "false")
 ext.IS_MAVEN_PUBLISH = Boolean.parseBoolean(MAVEN_PUBLISH)
 
-// Defines the compiler warning levels to use. If empty, then no warnings are generated. If
-// not empty, then the expected syntax is as a space or comma separated list of names, such
-// as defined in the javac documentation.
-defineProperty("LINT", "none")
-ext.IS_LINT = LINT != "none"
+// Define the compiler lint warnings to enable.
+//
+// We define a separate set of options for normal classes, test classes
+// (including shims), and tool classes (including JSLC).
+// A project (module) can add project-specific lint options for each
+// category if desired.
+// extraLintOptions
+// extraToolLintOptions
+// extraTestLintOptions
+//
+// The lint options can be overriden on the command line. If set to the
+// empty string, then no lint warnings are enabled; even project-specific
+// lint options are disabled. If not empty, then it is parsed as a space
+// or comma separated list of names. See the javac documentation for a list
+// of valid lint options.
 
+def defaultLintOptions =
+        "removal" + "," +
+        "missing-explicit-ctor"
+defineProperty("LINT", defaultLintOptions)
+ext.IS_LINT = LINT != ""
+
+def defaultToolLintOptions = ""
+defineProperty("TOOL_LINT", defaultToolLintOptions)
+ext.IS_TOOL_LINT = TOOL_LINT != ""
+
+def defaultTestLintOptions = ""
+defineProperty("TEST_LINT", defaultTestLintOptions)
+ext.IS_TEST_LINT = TEST_LINT != ""
+
+// Doclint options (all enabled by default)
 defineProperty("DOC_LINT", "all")
 ext.IS_DOC_LINT = DOC_LINT != ""
 
@@ -2158,6 +2183,11 @@ project(":base") {
     project.ext.includeSources = true
     project.ext.moduleRuntime = true
     project.ext.moduleName = "javafx.base"
+
+// TODO: the following is an example of enabling module-specific lint opts
+//    project.ext.extraLintOptions =
+//        "deprecation" + "," +
+//        "divzero"
 
     sourceSets {
         main
@@ -4043,6 +4073,20 @@ project(":systemTests") {
     addValidateSourceSets(project, nonModSrcSets, modSrcSets)
 }
 
+void setupLintOptions(Task compile, String lintOpts, String extraLintOpts) {
+    lintOpts.split("[, ]").each { s ->
+        compile.options.compilerArgs += "-Xlint:$s"
+    }
+
+    if (extraLintOpts != "") {
+        extraLintOpts.split("[, ]").each { s ->
+            compile.options.compilerArgs += "-Xlint:$s"
+        }
+    }
+
+    compile.options.compilerArgs += [ "-Xmaxwarns", "1000" ]
+}
+
 allprojects {
     // The following block is a workaround for the fact that presently Gradle
     // can't set the -XDignore.symbol.file flag, because it appears that the
@@ -4071,18 +4115,49 @@ allprojects {
 
         compile.options.forkOptions.executable = JAVAC
 
-        compile.options.warnings = IS_LINT
-
         compile.options.compilerArgs += ["-XDignore.symbol.file", "-encoding", "UTF-8"]
+        compile.options.compilerArgs += [ "-Xmaxerrs", "1000" ]
 
         // we use a custom javadoc command
         project.javadoc.enabled = false
 
-        // Add in the -Xlint options
-        if (IS_LINT) {
-            LINT.split("[, ]").each { s ->
-                compile.options.compilerArgs += "-Xlint:$s"
+        if (compile.name == "compileJava" ||
+            compile.name == "compileFullJava" ||
+            compile.name.startsWith("compileJavaDOMBinding")) {
+
+            // Add in the -Xlint options
+            compile.options.warnings = IS_LINT
+            if (IS_LINT) {
+                def extraLintOpts = project.hasProperty("extraLintOptions") ?
+                                    project.ext.extraLintOptions : ""
+                setupLintOptions(compile, LINT, extraLintOpts);
+
+                // TODO: enable the following once we are lint clean
+                //compile.options.compilerArgs += "-Werror"
             }
+        } else if (compile.name == "compileJslcJava" ||
+            compile.name == "compileToolJava") {
+
+            // Add in the -Xlint options
+            compile.options.warnings = IS_TOOL_LINT
+            if (IS_TOOL_LINT) {
+                def extraLintOpts = project.hasProperty("extraToolLintOptions") ?
+                                    project.ext.extraToolLintOptions : ""
+                setupLintOptions(compile, TOOL_LINT, extraLintOpts);
+            }
+        } else if (compile.name == "compileShimsJava" ||
+            compile.name.startsWith("compileTest")) {
+
+            // Add in the -Xlint options
+            compile.options.warnings = IS_TEST_LINT
+            if (IS_TEST_LINT) {
+                def extraLintOpts = project.hasProperty("extraTestLintOptions") ?
+                                    project.ext.extraTestLintOptions : ""
+                setupLintOptions(compile, TEST_LINT, extraLintOpts);
+            }
+        } else {
+            logger.warn("Unknown compilation task: ${compile.name}")
+            compile.options.warnings = false
         }
     } // tasks with javaCompile
 

--- a/build.gradle
+++ b/build.gradle
@@ -4136,7 +4136,9 @@ allprojects {
                 //compile.options.compilerArgs += "-Werror"
             }
         } else if (compile.name == "compileJslcJava" ||
-            compile.name == "compileToolJava") {
+            compile.name == "compileDecoraCompilers" ||
+            compile.name == "compilePrismCompilers" ||
+            compile.name == "compileToolsJava") {
 
             // Add in the -Xlint options
             compile.options.warnings = IS_TOOL_LINT
@@ -4156,7 +4158,7 @@ allprojects {
                 setupLintOptions(compile, TEST_LINT, extraLintOpts);
             }
         } else {
-            logger.warn("Unknown compilation task: ${compile.name}")
+            logger.info("Unknown compilation task: ${project}:${compile.name}")
             compile.options.warnings = false
         }
     } // tasks with javaCompile

--- a/modules/javafx.base/src/main/java/javafx/util/converter/CurrencyStringConverter.java
+++ b/modules/javafx.base/src/main/java/javafx/util/converter/CurrencyStringConverter.java
@@ -93,6 +93,7 @@ public class CurrencyStringConverter extends NumberStringConverter {
     * @deprecated This method was exposed erroneously and will be removed in a future version.
     */
     @Deprecated(forRemoval = true, since = "22")
+    @SuppressWarnings("removal")
     @Override
     protected NumberFormat getNumberFormat() {
         Locale _locale = locale == null ? Locale.getDefault() : locale;

--- a/modules/javafx.base/src/main/java/javafx/util/converter/PercentageStringConverter.java
+++ b/modules/javafx.base/src/main/java/javafx/util/converter/PercentageStringConverter.java
@@ -69,6 +69,7 @@ public class PercentageStringConverter extends NumberStringConverter {
      * @deprecated This method was exposed erroneously and will be removed in a future version.
      */
     @Deprecated(forRemoval = true, since = "22")
+    @SuppressWarnings("removal")
     @Override
     public NumberFormat getNumberFormat() {
         Locale _locale = locale == null ? Locale.getDefault() : locale;

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/css/SelectorPartitioning.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/css/SelectorPartitioning.java
@@ -228,6 +228,7 @@ public final class SelectorPartitioning {
     private static final PartitionKey WILDCARD = new PartitionKey<>("*");
 
     /* Place this selector into the partitioning map. Package accessible */
+    @SuppressWarnings("removal")
     public void partition(Selector selector) {
 
         SimpleSelector simpleSelector = null;

--- a/modules/javafx.graphics/src/main/java/com/sun/marlin/MaskMarlinAlphaConsumer.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/marlin/MaskMarlinAlphaConsumer.java
@@ -30,6 +30,9 @@ import java.nio.ByteBuffer;
 import java.util.Arrays;
 import sun.misc.Unsafe;
 
+// FIXME: We must replace the terminally deprecated sun.misc.Unsafe
+// memory access methods; see JDK-8334137
+@SuppressWarnings("removal")
 public final class MaskMarlinAlphaConsumer implements MarlinAlphaConsumer {
     int x, y, width, height;
     final byte alphas[];

--- a/modules/javafx.graphics/src/main/java/com/sun/marlin/OffHeapArray.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/marlin/OffHeapArray.java
@@ -34,6 +34,9 @@ import sun.misc.Unsafe;
 /**
  *
  */
+// FIXME: We must replace the terminally deprecated sun.misc.Unsafe
+// memory access methods; see JDK-8334137
+@SuppressWarnings("removal")
 final class OffHeapArray  {
 
     // unsafe reference

--- a/modules/javafx.graphics/src/main/java/com/sun/marlin/Renderer.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/marlin/Renderer.java
@@ -28,6 +28,9 @@ package com.sun.marlin;
 import static com.sun.marlin.OffHeapArray.SIZE_INT;
 import sun.misc.Unsafe;
 
+// FIXME: We must replace the terminally deprecated sun.misc.Unsafe
+// memory access methods; see JDK-8334137
+@SuppressWarnings("removal")
 public final class Renderer implements MarlinRenderer, MarlinConst {
 
     static final boolean DISABLE_RENDER = MarlinProperties.isSkipRenderer();

--- a/modules/javafx.graphics/src/main/java/com/sun/marlin/RendererNoAA.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/marlin/RendererNoAA.java
@@ -28,6 +28,9 @@ package com.sun.marlin;
 import static com.sun.marlin.OffHeapArray.SIZE_INT;
 import sun.misc.Unsafe;
 
+// FIXME: We must replace the terminally deprecated sun.misc.Unsafe
+// memory access methods; see JDK-8334137
+@SuppressWarnings("removal")
 public final class RendererNoAA implements MarlinRenderer, MarlinConst {
 
     static final boolean DISABLE_RENDER = false;

--- a/modules/javafx.graphics/src/main/java/javafx/css/CompoundSelector.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/CompoundSelector.java
@@ -65,6 +65,7 @@ import java.util.stream.Collectors;
  * @deprecated This class was exposed erroneously and will be removed in a future version
  */
 @Deprecated(since = "23", forRemoval = true)
+@SuppressWarnings("removal")
 final public class CompoundSelector extends Selector {
 
     private final List<SimpleSelector> selectors;

--- a/modules/javafx.graphics/src/main/java/javafx/css/CssParser.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/CssParser.java
@@ -4249,6 +4249,7 @@ final public class CssParser {
         return selectors;
     }
 
+    @SuppressWarnings("removal")
     private Selector selector(CssLexer lexer) {
 
         List<Combinator> combinators = null;
@@ -4292,6 +4293,7 @@ final public class CssParser {
 
     }
 
+    @SuppressWarnings("removal")
     private SimpleSelector simpleSelector(CssLexer lexer) {
 
         String esel = "*"; // element selector. default to universal

--- a/modules/javafx.graphics/src/main/java/javafx/css/Match.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/Match.java
@@ -52,6 +52,7 @@ public final class Match implements Comparable<Match> {
     // then pseudoclass count, and finally matching types (i.e., java name count)
     final int specificity;
 
+    @SuppressWarnings("removal")
     Match(final Selector selector, Set<PseudoClass> pseudoClasses, int idCount, int styleClassCount) {
         Objects.requireNonNull(selector);
         Objects.requireNonNull(pseudoClasses);

--- a/modules/javafx.graphics/src/main/java/javafx/css/Selector.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/Selector.java
@@ -49,6 +49,7 @@ abstract public class Selector {
     }
 
     private static class UniversalSelector {
+        @SuppressWarnings("removal")
         private static final Selector INSTANCE =
             new SimpleSelector("*", null, null, null);
     }
@@ -145,6 +146,7 @@ abstract public class Selector {
      * @param stringStore unused
      * @throws IOException if writing to {@code DataOutputStream} fails
      */
+    @SuppressWarnings("removal")
     protected void writeBinary(DataOutputStream os, StyleConverter.StringStore stringStore)
         throws IOException {
         if (this instanceof SimpleSelector) {
@@ -161,6 +163,7 @@ abstract public class Selector {
      * @param strings string array containing selector details
      * @throws IOException if reading from {@code DataInputStream} fails
      */
+    @SuppressWarnings("removal")
     static Selector readBinary(int bssVersion, DataInputStream is, String[] strings)
         throws IOException {
         final int type = is.readByte();
@@ -175,6 +178,7 @@ abstract public class Selector {
      * @param cssSelector CSS selector string
      * @return a {@code Selector}
      */
+    @SuppressWarnings("removal")
     public static Selector createSelector(final String cssSelector) {
         if (cssSelector == null || cssSelector.length() == 0) {
             return null; // actually return a default no-match selector

--- a/modules/javafx.graphics/src/main/java/javafx/css/SimpleSelector.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/SimpleSelector.java
@@ -54,6 +54,7 @@ import static javafx.geometry.NodeOrientation.RIGHT_TO_LEFT;
  * @deprecated This class was exposed erroneously and will be removed in a future version
  */
 @Deprecated(since = "23", forRemoval = true)
+@SuppressWarnings("removal")
 final public class SimpleSelector extends Selector {
 
     /**


### PR DESCRIPTION
This PR updates `build.gradle` to define javac lint options for three different types of java compilation tasks: sdk classes, test classes (including shims), and tool classes (including JSLC). The defaults for these three groups of lint options are specified in `build.gradle`.

We also define three gradle properties that can be used at build time to override the global lint options for each of the three categories of tasks as follows:

* `LINT` - used when compiling sdk tasks : default = "removal,missing-explicit-ctor"
* `TOOL_LINT` - used when compiling tool tasks : default = ""
* `TEST_LINT` - used when compiling test tasks : default = ""

Each property takes a string with a comma-separated list of lint options. For example:

```
gradle -PLINT="deprecation,removal" sdk
```

I provided a build mechanism to add extra per-module lint options in `build.gradle`. None are currently defined, but I tested the logic to show that it can be. I did not provide a way to override the per-module lint options via the command line. Once we start using them, we might consider adding that.

While testing this PR, I ran into a few places where we need to suppress removal warnings for use of our own internal classes that are terminally deprecated, so I filed [JDK-8334143](https://bugs.openjdk.org/browse/JDK-8334143) to track this, and added the missing annotations in this PR.

I also tested with JDK 23 to verify that we are now getting the expected warnings for the use of sun.misc.Unsafe, and filed two bugs --[JDK-8334138](https://bugs.openjdk.org/browse/JDK-8334138) to (temporarily) suppress those warnings in this PR and [JDK-8334137](https://bugs.openjdk.org/browse/JDK-8334137) to eventually fix them by replacing our use of sun.misc.Unsafe.

/issue add JDK-8334143
/issue add JDK-8334138

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issues
 * [JDK-8327255](https://bugs.openjdk.org/browse/JDK-8327255): javac lint warnings: removal, missing-explicit-ctor (**Bug** - P4)
 * [JDK-8334143](https://bugs.openjdk.org/browse/JDK-8334143): Suppress remaining removal warnings for internal methods and classes (**Bug** - P4)
 * [JDK-8334138](https://bugs.openjdk.org/browse/JDK-8334138): Suppress removal warnings for sun.misc.Unsafe memory access methods (**Bug** - P3)


### Reviewers
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)
 * [Lukasz Kostyra](https://openjdk.org/census#lkostyra) (@lukostyra - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1474/head:pull/1474` \
`$ git checkout pull/1474`

Update a local copy of the PR: \
`$ git checkout pull/1474` \
`$ git pull https://git.openjdk.org/jfx.git pull/1474/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1474`

View PR using the GUI difftool: \
`$ git pr show -t 1474`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1474.diff">https://git.openjdk.org/jfx/pull/1474.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1474#issuecomment-2163814836)