### PR TITLE
8334161: Enable -Werror for javac tasks to fail on any warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -576,6 +576,15 @@ def defaultTestLintOptions = ""
 defineProperty("TEST_LINT", defaultTestLintOptions)
 ext.IS_TEST_LINT = TEST_LINT != ""
 
+defineProperty("JAVAC_WERROR", "true")
+ext.IS_JAVAC_WERROR = Boolean.parseBoolean(JAVAC_WERROR)
+
+defineProperty("TOOL_JAVAC_WERROR", "false")
+ext.IS_TOOL_JAVAC_WERROR = Boolean.parseBoolean(TOOL_JAVAC_WERROR)
+
+defineProperty("TEST_JAVAC_WERROR", "false")
+ext.IS_TEST_JAVAC_WERROR = Boolean.parseBoolean(TEST_JAVAC_WERROR)
+
 // Doclint options (all enabled by default)
 defineProperty("DOC_LINT", "all")
 ext.IS_DOC_LINT = DOC_LINT != ""
@@ -2258,6 +2267,10 @@ project(":graphics") {
     project.ext.moduleRuntime = true
     project.ext.moduleName = "javafx.graphics"
 
+    // FIXME: Remove this setting when JDK-8334137 is fixed
+    // Disable javac -Werror until we stop using sun.misc.Unsafe
+    project.ext.disableJavacWerror = true
+
     getConfigurations().create("antlr");
 
     sourceSets {
@@ -2789,6 +2802,11 @@ project(":swing") {
     // excluded by "--release NN". This will fall back to using
     // "-source NN -target NN" for this module.
     project.ext.skipJavaCompilerOptionRelease = true
+
+    // We also need to disable the implicitly-enabled lint warning that
+    // results from the above
+    project.ext.extraLintOptions =
+        "-options"
 
     tasks.all {
         if (!COMPILE_SWING) it.enabled = false
@@ -4121,6 +4139,10 @@ allprojects {
         // we use a custom javadoc command
         project.javadoc.enabled = false
 
+        def disableJavacWerror =
+                project.hasProperty('disableJavacWerror') &&
+                project.ext.disableJavacWerror
+
         if (compile.name == "compileJava" ||
             compile.name == "compileFullJava" ||
             compile.name.startsWith("compileJavaDOMBinding")) {
@@ -4132,8 +4154,9 @@ allprojects {
                                     project.ext.extraLintOptions : ""
                 setupLintOptions(compile, LINT, extraLintOpts);
 
-                // TODO: enable the following once we are lint clean
-                //compile.options.compilerArgs += "-Werror"
+                if (IS_JAVAC_WERROR && !disableJavacWerror) {
+                    compile.options.compilerArgs += "-Werror"
+                }
             }
         } else if (compile.name == "compileJslcJava" ||
             compile.name == "compileDecoraCompilers" ||
@@ -4146,6 +4169,10 @@ allprojects {
                 def extraLintOpts = project.hasProperty("extraToolLintOptions") ?
                                     project.ext.extraToolLintOptions : ""
                 setupLintOptions(compile, TOOL_LINT, extraLintOpts);
+
+                if (IS_TOOL_JAVAC_WERROR && !disableJavacWerror) {
+                    compile.options.compilerArgs += "-Werror"
+                }
             }
         } else if (compile.name == "compileShimsJava" ||
             compile.name.startsWith("compileTest")) {
@@ -4156,6 +4183,10 @@ allprojects {
                 def extraLintOpts = project.hasProperty("extraTestLintOptions") ?
                                     project.ext.extraTestLintOptions : ""
                 setupLintOptions(compile, TEST_LINT, extraLintOpts);
+
+                if (IS_TEST_JAVAC_WERROR && !disableJavacWerror) {
+                    compile.options.compilerArgs += "-Werror"
+                }
             }
         } else {
             logger.info("Unknown compilation task: ${project}:${compile.name}")


### PR DESCRIPTION
This PR is a follow-on to #1474.

Enable `javac -Werror` so that javac warnings, including but not limited to javac lint warnings, will cause the build to fail. As with the fix for [JDK-8327255](https://bugs.openjdk.org/browse/JDK-8327255), we define three new properties to enable `-Werror`, one for each type of java compilation task: sdk classes, test classes (including shims), and tool classes (including JSLC). The defaults for `-Werror` for these three groups are:

* `JAVAC_WERROR` : `true`
* `TOOL_JAVAC_WERROR` : `false`
* `TEST_JAVAC_WERROR` : `false`

They can be overridden on the command line.

I had to do the following two things for the build to pass:

1. Disable `-Werror` for the `javafx.graphics` module until [JDK-8334137](https://bugs.openjdk.org/browse/JDK-8334137) is fixed. The warning generated when using `sun.misc.Unsafe` in JDK 22 or later cannot be suppressed, so we must not use `-Werror` when compiling the graphics module.
2. Define module-specific `extraLintOptions` in the swing module to disable the "options" lint warning, which is enabled by default. That warning is generated because we (necessarily) use `--source 21` instead of `--release 21` for the Swing module, and don't set the location of the system modules.

I tested this, both locally and via GHA, in the following two branches, each of which introduces an error, the first tests that a removal warning will fail the build and the second tests that a missing explicit constructor will fail the build:

* [test-Werror-removal](https://github.com/kevinrushforth/jfx/tree/test-Werror-removal) : [GHA workflow](https://github.com/kevinrushforth/jfx/actions/runs/9664971290)
* [test-Werror-implicit-ctor](https://github.com/kevinrushforth/jfx/tree/test-Werror-implicit-ctor) : [GHA workflow](https://github.com/kevinrushforth/jfx/actions/runs/9664924813)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8334161](https://bugs.openjdk.org/browse/JDK-8334161): Enable -Werror for javac tasks to fail on any warnings (**Bug** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1475/head:pull/1475` \
`$ git checkout pull/1475`

Update a local copy of the PR: \
`$ git checkout pull/1475` \
`$ git pull https://git.openjdk.org/jfx.git pull/1475/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1475`

View PR using the GUI difftool: \
`$ git pr show -t 1475`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1475.diff">https://git.openjdk.org/jfx/pull/1475.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1475#issuecomment-2189245281)