### PR TITLE
8088923: IOOBE when adding duplicate categories to the BarChart

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/chart/BarChart.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/chart/BarChart.java
@@ -60,7 +60,7 @@ import javafx.css.StyleableProperty;
 /**
  * A chart that plots bars indicating data values for a category. The bars can be vertical or horizontal depending on
  * which axis is a category axis.
- *
+ * <p>
  * Adding data with multiple occurences of a category to a series shows the last occurence.
  *
  * @param <X> the category axis value type

--- a/modules/javafx.controls/src/main/java/javafx/scene/chart/BarChart.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/chart/BarChart.java
@@ -221,6 +221,7 @@ public class BarChart<X,Y> extends XYChart<X,Y> {
             } else {
                 // There may be data items with duplicate categories. Find category insertion index on the axis
                 // by looking at the concatenation of the data of all series, skipping duplicate categories.
+                // The category insertion index is found when the new data's index is reached within its series.
                 categoryIndex = 0;
                 var uniqueCategories = new HashSet<String>();
                 for (var entry : seriesCategoryMap.entrySet()) {

--- a/modules/javafx.controls/src/main/java/javafx/scene/chart/BarChart.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/chart/BarChart.java
@@ -61,6 +61,8 @@ import javafx.css.StyleableProperty;
  * A chart that plots bars indicating data values for a category. The bars can be vertical or horizontal depending on
  * which axis is a category axis.
  *
+ * Adding data with multiple occurences of a category to a series shows the last occurence.
+ *
  * @param <X> the category axis value type
  * @param <Y> the data value type
  * @since JavaFX 2.0
@@ -209,8 +211,11 @@ public class BarChart<X,Y> extends XYChart<X,Y> {
         }
         // check if category is already present
         if (!categoryAxis.getCategories().contains(category)) {
+            // find category index in case data contains duplicate categories
+            int i = series.getData().size() != categoryAxis.getCategories().size() ? series.getItemIndex(item) :
+                    itemIndex;
             // note: cat axis categories can be updated only when autoranging is true.
-            categoryAxis.getCategories().add(itemIndex, category);
+            categoryAxis.getCategories().add(i, category);
         } else if (categoryMap.containsKey(category)){
             // RT-21162 : replacing the previous data, first remove the node from scenegraph.
             Data<X,Y> data = categoryMap.get(category);

--- a/modules/javafx.controls/src/main/java/javafx/scene/chart/BarChart.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/chart/BarChart.java
@@ -223,14 +223,18 @@ public class BarChart<X,Y> extends XYChart<X,Y> {
                 // by looking at the concatenation of the data of all series, skipping duplicate categories.
                 categoryIndex = 0;
                 var uniqueCategories = new HashSet<String>();
-                for (Map<String, Data<X,Y>> catMap : seriesCategoryMap.values()) {
+                for (var entry : seriesCategoryMap.entrySet()) {
+                    Series s = entry.getKey();
+                    Map<String, Data<X,Y>> catMap = entry.getValue();
+                    int i = 0;
                     for (String cat : catMap.keySet()) {
-                        if (cat == category) {
+                        if (s == series && i >= itemIndex) {
                             break;
                         }
                         if (uniqueCategories.add(cat)) {
                             categoryIndex++;
                         }
+                        i++;
                     }
                 }
             }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/chart/BarChartTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/chart/BarChartTest.java
@@ -26,6 +26,8 @@
 package test.javafx.scene.chart;
 
 import java.util.Arrays;
+import java.util.List;
+
 import javafx.collections.FXCollections;
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
@@ -180,6 +182,19 @@ public class BarChartTest extends XYChartTestBase {
     }
 
     @Test
+    public void testAddingNonEmptySeries() {
+        startApp();
+        ObservableList<XYChart.Data<String, Number>> list = FXCollections.observableArrayList();
+        list.add(new XYChart.Data<>("1", 1));
+        list.add(new XYChart.Data<>("2", 2));
+        list.add(new XYChart.Data<>("3", 3));
+        BarChart<String, Number> bc = new BarChart<>(new CategoryAxis(), new NumberAxis());
+        bc.getData().add(new Series<>());
+        bc.getData().getFirst().setData(list);
+        assertEquals(3, XYChartShim.Series_getDataSize(bc.getData().getFirst()));
+    }
+
+    @Test
     public void testAddingDuplicateCategory() {
         startApp();
         ObservableList<XYChart.Data<String, Number>> list = FXCollections.observableArrayList();
@@ -190,5 +205,38 @@ public class BarChartTest extends XYChartTestBase {
         bc.getData().add(new Series<>());
         bc.getData().getFirst().setData(list);
         assertEquals(2, XYChartShim.Series_getDataSize(bc.getData().getFirst()));
+    }
+
+    @Test
+    public void testAddingMultipleSeriesWithDuplicateCategories() {
+        startApp();
+        var series1 = new Series<String, Number>();
+        var series2 = new Series<String, Number>();
+        BarChart<String, Number> bc = new BarChart<>(new CategoryAxis(), new NumberAxis());
+        bc.getData().add(series1);
+        bc.getData().add(series2);
+
+        series1.getData().addAll(List.of(
+            new XYChart.Data<>("1", 1),
+            new XYChart.Data<>("1", 2), // duplicate category
+            new XYChart.Data<>("2", 3)
+        ));
+
+        series2.getData().addAll(List.of(
+            new XYChart.Data<>("3", 4),
+            new XYChart.Data<>("2", 5), // duplicate category with series1
+            new XYChart.Data<>("4", 6)
+        ));
+
+        assertEquals(2, XYChartShim.Series_getDataSize(series1));
+        assertEquals(3, XYChartShim.Series_getDataSize(series2));
+        assertEquals(5, XYChartShim.getPlotChildren(bc).size());
+
+        var categories = ((CategoryAxis)bc.getXAxis()).getCategories();
+        assertEquals(4, categories.size());
+        assertEquals("1", categories.get(0));
+        assertEquals("2", categories.get(1));
+        assertEquals("3", categories.get(2));
+        assertEquals("4", categories.get(3));
     }
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/chart/BarChartTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/chart/BarChartTest.java
@@ -178,4 +178,17 @@ public class BarChartTest extends XYChartTestBase {
         int nodesPerSeries = 3; // 3 bars
         checkSeriesRemoveAnimatedStyleClasses(bc, nodesPerSeries, 700);
     }
+
+    @Test
+    public void testAddingDuplicateCategory() {
+        startApp();
+        ObservableList<XYChart.Data<String, Number>> list = FXCollections.observableArrayList();
+        list.add(new XYChart.Data<>("1", 1));
+        list.add(new XYChart.Data<>("1", 2));
+        list.add(new XYChart.Data<>("2", 3));
+        BarChart<String, Number> bc = new BarChart<>(new CategoryAxis(), new NumberAxis());
+        bc.getData().add(new Series<>());
+        bc.getData().getFirst().setData(list);
+        assertEquals(2, XYChartShim.Series_getDataSize(bc.getData().getFirst()));
+    }
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/chart/BarChartTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/chart/BarChartTest.java
@@ -208,6 +208,29 @@ public class BarChartTest extends XYChartTestBase {
     }
 
     @Test
+    public void testAddingDataAtIndex() {
+        startApp();
+        ObservableList<XYChart.Data<String, Number>> list = FXCollections.observableArrayList();
+        list.add(new XYChart.Data<>("1", 1));
+        list.add(new XYChart.Data<>("2", 2));
+        list.add(new XYChart.Data<>("3", 3));
+        BarChart<String, Number> bc = new BarChart<>(new CategoryAxis(), new NumberAxis());
+        bc.getData().add(new Series<>());
+        bc.getData().getFirst().setData(list);
+        assertEquals(3, XYChartShim.Series_getDataSize(bc.getData().getFirst()));
+
+        // insert new data before data item "3":
+        bc.getData().getFirst().getData().add(2, new XYChart.Data<>("4", 4));
+
+        var categories = ((CategoryAxis)bc.getXAxis()).getCategories();
+        assertEquals(4, categories.size());
+        assertEquals("1", categories.get(0));
+        assertEquals("2", categories.get(1));
+        assertEquals("4", categories.get(2));
+        assertEquals("3", categories.get(3));
+    }
+
+    @Test
     public void testAddingMultipleSeriesWithDuplicateCategories() {
         startApp();
         var series1 = new Series<String, Number>();
@@ -238,5 +261,14 @@ public class BarChartTest extends XYChartTestBase {
         assertEquals("2", categories.get(1));
         assertEquals("3", categories.get(2));
         assertEquals("4", categories.get(3));
+
+        // insert new data before data item "4" in series2:
+        series2.getData().add(2, new XYChart.Data<>("5", 7));
+
+        assertEquals("1", categories.get(0));
+        assertEquals("2", categories.get(1));
+        assertEquals("3", categories.get(2));
+        assertEquals("5", categories.get(3));
+        assertEquals("4", categories.get(4));
     }
 }


### PR DESCRIPTION
This PR provides the test case given in the JBS issue, and a simple fix for the index calculation when inserting data after previous data with duplicate categories.

Also, I've added a comment to `BarChart`s javadoc, clarifying the behavior that was apparently assumed (but broken) previously.

The index lookup is skipped for performance reasons if there are no duplicates, corresponding to the previous implementation.
Further optimizations would be possible, but probably are not really helpful without more extensive changes. The previous code already loops over all categories to check if they are present, typically nested in a loop adding many data items, thus already scaling quadratically when adding lots of mostly unique data points.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8088923](https://bugs.openjdk.org/browse/JDK-8088923): IOOBE when adding duplicate categories to the BarChart (**Bug** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Michael Strauß](https://openjdk.org/census#mstrauss) (@mstr2 - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1476/head:pull/1476` \
`$ git checkout pull/1476`

Update a local copy of the PR: \
`$ git checkout pull/1476` \
`$ git pull https://git.openjdk.org/jfx.git pull/1476/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1476`

View PR using the GUI difftool: \
`$ git pr show -t 1476`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1476.diff">https://git.openjdk.org/jfx/pull/1476.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1476#issuecomment-2178328333)