### PR TITLE
8334713: WebKit build failed on LoongArch64 because currentStackPointer is undefined

### DIFF
--- a/modules/javafx.web/src/main/native/Source/WTF/wtf/StackPointer.cpp
+++ b/modules/javafx.web/src/main/native/Source/WTF/wtf/StackPointer.cpp
@@ -136,6 +136,17 @@ asm (
      ".previous" "\n"
 );
 
+#elif CPU(LOONGARCH64) && COMPILER(GCC_COMPATIBLE)
+asm (
+    ".text" "\n"
+    ".globl " SYMBOL_STRING(currentStackPointer) "\n"
+    SYMBOL_STRING(currentStackPointer) ":" "\n"
+
+     "move $r4, $r3" "\n"
+     "jr   $r1" "\n"
+     ".previous" "\n"
+);
+
 #else
 #error "Unsupported platform: need implementation of currentStackPointer."
 #endif


### PR DESCRIPTION
This problem has been fixed [upstream](https://github.com/WebKit/WebKit/pull/23282). This patch merges the fix in advance.

Error log:

```
/some_dir/jfx/modules/javafx.web/src/main/native/Source/WTF/wtf/StackPointer.cpp:140:2: error: #error "Unsupported platform: need implementation of currentStackPointer."
  140 | #error "Unsupported platform: need implementation of currentStackPointer."
      | ^~~~~
make[2]: *** [Source/WTF/wtf/CMakeFiles/WTF.dir/build.make:1098: Source/WTF/wtf/CMakeFiles/WTF.dir/StackPointer.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [CMakeFiles/Makefile2:360: Source/WTF/wtf/CMakeFiles/WTF.dir/all] Error 2
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8334713](https://bugs.openjdk.org/browse/JDK-8334713): WebKit build failed on LoongArch64 because currentStackPointer is undefined (**Bug** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Hima Bindu Meda](https://openjdk.org/census#hmeda) (@HimaBinduMeda - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1482/head:pull/1482` \
`$ git checkout pull/1482`

Update a local copy of the PR: \
`$ git checkout pull/1482` \
`$ git pull https://git.openjdk.org/jfx.git pull/1482/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1482`

View PR using the GUI difftool: \
`$ git pr show -t 1482`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1482.diff">https://git.openjdk.org/jfx/pull/1482.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1482#issuecomment-2182340278)