### PR TITLE
8334657: Enable binary check

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -31,6 +31,7 @@ tags=(jdk-){0,1}([1-9]([0-9]*)(\.(0|[1-9][0-9]*)){0,3})(\+(([0-9]+))|(-ga))|[1-9
 
 [checks]
 error=author,reviewers,merge,message,issues,whitespace,executable
+warning=issuestitle,binary
 
 [census]
 version=0


### PR DESCRIPTION
This PR enables two warnings that are now (or soon will be) enabled in the [jdk](https://github.com/openjdk/jdk) repo:

1. Binary file check -- this will alert the reviewers of a PR that the patch being reviewed includes one or more binary files.
2. Issue title check -- this will check for two common (minor) formatting issues with the JBS title and matching PR title, a trailing period or a leading lower-case word.

Both are informational warnings that will not block integration.

To see how the warnings look, refer to the following Draft PRs:

1. PR with binary file: #1478
2. PR for bug with trailing period: #1479

/issue add 8334656
/reviewers 2

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issues
 * [JDK-8334657](https://bugs.openjdk.org/browse/JDK-8334657): Enable binary check (**Bug** - P3)
 * [JDK-8334656](https://bugs.openjdk.org/browse/JDK-8334656): Enable issuestitle check (**Bug** - P4)


### Reviewers
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1483/head:pull/1483` \
`$ git checkout pull/1483`

Update a local copy of the PR: \
`$ git checkout pull/1483` \
`$ git pull https://git.openjdk.org/jfx.git pull/1483/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1483`

View PR using the GUI difftool: \
`$ git pr show -t 1483`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1483.diff">https://git.openjdk.org/jfx/pull/1483.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1483#issuecomment-2182707153)