### PR TITLE
8334739: XYChart and (Stacked)AreaChart properties return incorrect beans

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/chart/AreaChart.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/chart/AreaChart.java
@@ -106,7 +106,7 @@ public class AreaChart<X,Y> extends XYChart<X,Y> {
 
         @Override
         public Object getBean() {
-            return this;
+            return AreaChart.this;
         }
 
         @Override

--- a/modules/javafx.controls/src/main/java/javafx/scene/chart/StackedAreaChart.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/chart/StackedAreaChart.java
@@ -107,7 +107,7 @@ public class StackedAreaChart<X,Y> extends XYChart<X,Y> {
 
         @Override
         public Object getBean() {
-            return this;
+            return StackedAreaChart.this;
         }
 
         @Override

--- a/modules/javafx.controls/src/main/java/javafx/scene/chart/XYChart.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/chart/XYChart.java
@@ -182,7 +182,7 @@ public abstract class XYChart<X,Y> extends Chart {
     private ReadOnlyObjectProperty<Axis<X>> xAxisProperty = new ReadOnlyObjectPropertyBase<Axis<X>>() {
         @Override
         public Object getBean() {
-            return this;
+            return XYChart.this;
         }
 
         @Override
@@ -211,7 +211,7 @@ public abstract class XYChart<X,Y> extends Chart {
     private ReadOnlyObjectProperty<Axis<Y>> yAxisProperty = new ReadOnlyObjectPropertyBase<Axis<Y>>() {
         @Override
         public Object getBean() {
-            return this;
+            return XYChart.this;
         }
 
         @Override


### PR DESCRIPTION
This PR makes the `XYChart` axes properties return the correct parent XYChart object.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334739](https://bugs.openjdk.org/browse/JDK-8334739): XYChart and (Stacked)AreaChart properties return incorrect beans (**Bug** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1485/head:pull/1485` \
`$ git checkout pull/1485`

Update a local copy of the PR: \
`$ git checkout pull/1485` \
`$ git pull https://git.openjdk.org/jfx.git pull/1485/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1485`

View PR using the GUI difftool: \
`$ git pr show -t 1485`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1485.diff">https://git.openjdk.org/jfx/pull/1485.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1485#issuecomment-2183047894)