### PR TITLE
8334874: Horizontal scroll events from touch pads should scroll the TabPane tabs

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TabPaneSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TabPaneSkin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -934,17 +934,23 @@ public class TabPaneSkin extends SkinBase<TabPane> {
             // Scrolling the mouse wheel downwards results in the tabs scrolling left (i.e. exposing the right-most tabs)
             // Scrolling the mouse wheel upwards results in the tabs scrolling right (i.e. exposing th left-most tabs)
             addEventHandler(ScrollEvent.SCROLL, (ScrollEvent e) -> {
+                double dx = e.getDeltaX();
+                double dy = e.getDeltaY();
+
                 Side side = getSkinnable().getSide();
                 side = side == null ? Side.TOP : side;
                 switch (side) {
                     default:
                     case TOP:
                     case BOTTOM:
-                        setScrollOffset(scrollOffset + e.getDeltaY());
+                        // Consider vertical scroll events (dy > dx) from mouse wheel and trackpad,
+                        // and horizontal scroll events from a trackpad (dx > dy)
+                        dx = Math.abs(dy) > Math.abs(dx) ? dy : dx;
+                        setScrollOffset(scrollOffset + dx);
                         break;
                     case LEFT:
                     case RIGHT:
-                        setScrollOffset(scrollOffset - e.getDeltaY());
+                        setScrollOffset(scrollOffset - dy);
                         break;
                 }
 

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TabPaneTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TabPaneTest.java
@@ -1244,27 +1244,48 @@ public class TabPaneTest {
     }
 
     @Test
-    public void testVerticalScroll() {
-        scrollTabPane(0, -100);
+    public void testVerticalScrollTopSide() {
+        scrollTabPane(Side.TOP, 0, -100);
     }
 
     @Test
-    public void testVerticalScrollWithSmallHorizontalAmount() {
-        scrollTabPane(10, -100);
+    public void testVerticalScrollRightSide() {
+        scrollTabPane(Side.RIGHT, 0, 100);
     }
 
     @Test
-    public void testHorizontalScroll() {
-        scrollTabPane(-100, 0);
+    public void testVerticalScrollBottomSide() {
+        scrollTabPane(Side.BOTTOM, 0, -100);
     }
 
     @Test
-    public void testHorizontalScrollWithSmallVerticalAmount() {
-        scrollTabPane(-100, 10);
+    public void testVerticalScrollLeftSide() {
+        scrollTabPane(Side.LEFT, 0, 100);
     }
 
-    private void scrollTabPane(double deltaX, double deltaY) {
+    @Test
+    public void testHorizontalScrollTopSide() {
+        scrollTabPane(Side.TOP, -100, 0);
+    }
+
+    @Test
+    public void testHorizontalScrollRightSide() {
+        scrollTabPane(Side.RIGHT, 100, 0);
+    }
+
+    @Test
+    public void testHorizontalScrollBottomSide() {
+        scrollTabPane(Side.BOTTOM, -100, 0);
+    }
+
+    @Test
+    public void testHorizontalScrollLeftSide() {
+        scrollTabPane(Side.LEFT, 100, 0);
+    }
+
+    private void scrollTabPane(Side side, double deltaX, double deltaY) {
         tabPane.setMaxSize(400, 100);
+        tabPane.setSide(side);
         for (int i = 0; i < 40; i++) {
             Tab tab = new Tab("Tab " + (1000 + i));
             tabPane.getTabs().add(tab);
@@ -1272,19 +1293,16 @@ public class TabPaneTest {
         root.getChildren().add(tabPane);
         stage.show();
 
-        root.applyCss();
-        root.layout();
-
-        double minXFirstTab = tabPane.lookupAll(".tab-label")
+        Bounds firstTabBounds = tabPane.lookupAll(".tab-label")
                 .stream()
                 .findFirst()
-                .map(n -> n.localToScene(n.getLayoutBounds()).getMinX())
-                .orElse(-1d);
+                .map(n -> n.localToScene(n.getLayoutBounds()))
+                .orElse(null);
+        assertNotNull(firstTabBounds);
 
         Bounds layoutBounds = tabPane.getLayoutBounds();
         double minX = tabPane.localToScene(layoutBounds).getMinX();
         double minY = tabPane.localToScene(layoutBounds).getMinY();
-
         double minScrX = tabPane.localToScreen(layoutBounds).getMinX();
         double minScrY = tabPane.localToScreen(layoutBounds).getMinY();
         double x = 50;
@@ -1295,6 +1313,8 @@ public class TabPaneTest {
         tk.firePulse();
 
         StackPane tabHeaderArea = (StackPane) tabPane.lookup(".tab-header-area");
+        assertNotNull(tabHeaderArea);
+
         Event.fireEvent(tabHeaderArea, new ScrollEvent(
                 ScrollEvent.SCROLL,
                 minX + x, minY + y,
@@ -1304,17 +1324,23 @@ public class TabPaneTest {
                 ScrollEvent.HorizontalTextScrollUnits.NONE, 0.0,
                 ScrollEvent.VerticalTextScrollUnits.NONE, 0.0,
                 0, null));
-
         tk.firePulse();
 
-        double newMinXFirstTab = tabPane.lookupAll(".tab-label")
+        Bounds newFirstTabBounds = tabPane.lookupAll(".tab-label")
                 .stream()
                 .findFirst()
-                .map(n -> n.localToScene(n.getLayoutBounds()).getMinX())
-                .orElse(-1d);
+                .map(n -> n.localToScene(n.getLayoutBounds()))
+                .orElse(null);
+        assertNotNull(newFirstTabBounds);
 
-        double delta = Math.abs(deltaY) > Math.abs(deltaX) ? deltaY : deltaX;
-        assertEquals(minXFirstTab + delta, newMinXFirstTab, 0);
+        if (side.equals(Side.TOP) || side.equals(Side.BOTTOM)) {
+            double delta = Math.abs(deltaY) > Math.abs(deltaX) ? deltaY : deltaX;
+            assertEquals(firstTabBounds.getMinX() + delta, newFirstTabBounds.getMinX(), 0);
+            assertEquals(firstTabBounds.getMinY(), newFirstTabBounds.getMinY(), 0);
+        } else {
+            assertEquals(firstTabBounds.getMinX(), newFirstTabBounds.getMinX(), 0);
+            assertEquals(firstTabBounds.getMinY() - deltaY, newFirstTabBounds.getMinY(), 0);
+        }
     }
 
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TabPaneTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TabPaneTest.java
@@ -1342,5 +1342,4 @@ public class TabPaneTest {
             assertEquals(firstTabBounds.getMinY() - deltaY, newFirstTabBounds.getMinY(), 0);
         }
     }
-
 }


### PR DESCRIPTION
This PR considers the horizontal scroll events that can be generated on a trackpad, on an horizontally sided `TabPane` control (top or bottom), adding to the existing vertical scroll events from mouse wheel and trackpad, to scroll its tabs.

Therefore, scrolling a `TabPane` will behave in the same way that `ScrollBar` does regarding those same events and control orientation (vertical/horizontal).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8334874](https://bugs.openjdk.org/browse/JDK-8334874): Horizontal scroll events from touch pads should scroll the TabPane tabs (**Enhancement** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1486/head:pull/1486` \
`$ git checkout pull/1486`

Update a local copy of the PR: \
`$ git checkout pull/1486` \
`$ git pull https://git.openjdk.org/jfx.git pull/1486/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1486`

View PR using the GUI difftool: \
`$ git pr show -t 1486`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1486.diff">https://git.openjdk.org/jfx/pull/1486.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1486#issuecomment-2187133415)