### PR TITLE
8311124: [Windows] User installed font 8281327 fix does not work for all cases

### DIFF
--- a/modules/javafx.graphics/src/main/native-font/fontpath.c
+++ b/modules/javafx.graphics/src/main/native-font/fontpath.c
@@ -656,7 +656,7 @@ static void populateFontFileNameFromRegistryKey(HKEY regKey,
     for (nval = 0; nval < dwNumValues; nval++ ) {
         DWORD dwNameSize = dwMaxValueNameLen;
         DWORD dwDataValueSize = dwMaxValueDataLen;
-        ret = RegEnumValueW(hkeyFonts, nval, (LPWSTR)wname, &dwNameSize,
+        ret = RegEnumValueW(hkeyFonts, nval, wname, &dwNameSize,
                             NULL, &type, (LPBYTE)data, &dwDataValueSize);
 
         if (ret != ERROR_SUCCESS) {

--- a/modules/javafx.graphics/src/main/native-font/fontpath.c
+++ b/modules/javafx.graphics/src/main/native-font/fontpath.c
@@ -29,6 +29,7 @@
 #include <stdio.h>
 #include <stddef.h>
 #include <stdlib.h>
+#include <malloc.h>
 
 #include <jni.h>
 #include <com_sun_javafx_font_PrismFontFactory.h>
@@ -627,15 +628,10 @@ static void populateFontFileNameFromRegistryKey(HKEY regKey,
                                                 GdiFontMapInfo *fmi,
                                                 jobject fontToFileMap)
 {
-#define MAX_BUFFER (FILENAME_MAX+1)
-    const wchar_t wname[MAX_BUFFER];
-    const char data[MAX_BUFFER];
 
     DWORD type;
     LONG ret;
     HKEY hkeyFonts;
-    DWORD dwNameSize;
-    DWORD dwDataValueSize;
     DWORD nval;
     DWORD dwNumValues, dwMaxValueNameLen, dwMaxValueDataLen;
 
@@ -650,15 +646,16 @@ static void populateFontFileNameFromRegistryKey(HKEY regKey,
                            &dwNumValues, &dwMaxValueNameLen,
                            &dwMaxValueDataLen, NULL, NULL);
 
-    if (ret != ERROR_SUCCESS ||
-        dwMaxValueNameLen >= MAX_BUFFER ||
-        dwMaxValueDataLen >= MAX_BUFFER) {
+    if (ret != ERROR_SUCCESS) {
         RegCloseKey(hkeyFonts);
         return;
     }
+    dwMaxValueNameLen++; /* Account for NULL-terminator */
+    wchar_t *wname = (wchar_t*)malloc(dwMaxValueNameLen * sizeof(wchar_t));
+    wchar_t *data = (wchar_t*)malloc(dwMaxValueDataLen);
     for (nval = 0; nval < dwNumValues; nval++ ) {
-        dwNameSize = MAX_BUFFER;
-        dwDataValueSize = MAX_BUFFER;
+        DWORD dwNameSize = dwMaxValueNameLen;
+        DWORD dwDataValueSize = dwMaxValueDataLen;
         ret = RegEnumValueW(hkeyFonts, nval, (LPWSTR)wname, &dwNameSize,
                             NULL, &type, (LPBYTE)data, &dwDataValueSize);
 
@@ -669,20 +666,22 @@ static void populateFontFileNameFromRegistryKey(HKEY regKey,
             continue;
         }
 
-        if (!RegistryToBaseTTNameW((LPWSTR)wname) ) {
+        if (!RegistryToBaseTTNameW(wname) ) {
             /* If the filename ends with ".ttf" or ".otf" also accept it.
              * Not expecting to need to do this for .ttc files.
              * Also note this code is not mirrored in the "A" (win9x) path.
              */
-            LPWSTR dot = wcsrchr((LPWSTR)data, L'.');
+            LPWSTR dot = wcsrchr(data, L'.');
             if (dot == NULL || ((wcsicmp(dot, L".ttf") != 0)
                                   && (wcsicmp(dot, L".otf") != 0))) {
                 continue;  /* not a TT font... */
             }
         }
-        registerFontW(fmi, fontToFileMap, (LPWSTR)wname, (LPWSTR)data);
+        registerFontW(fmi, fontToFileMap, wname, data);
     }
 
+    free(wname);
+    free(data);
     RegCloseKey(hkeyFonts);
 }
 


### PR DESCRIPTION
The problem is due to per-user install fonts on windows having full paths so they may be too long.
This is identical to the JDK fix that was done some time ago https://github.com/openjdk/jdk/pull/13359
I've tested that per-user fonts still work and so do the system-wide installed fonts.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8311124](https://bugs.openjdk.org/browse/JDK-8311124): [Windows] User installed font 8281327 fix does not work for all cases (**Bug** - P4)


### Reviewers
 * [Lukasz Kostyra](https://openjdk.org/census#lkostyra) (@lukostyra - Committer)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1487/head:pull/1487` \
`$ git checkout pull/1487`

Update a local copy of the PR: \
`$ git checkout pull/1487` \
`$ git pull https://git.openjdk.org/jfx.git pull/1487/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1487`

View PR using the GUI difftool: \
`$ git pr show -t 1487`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1487.diff">https://git.openjdk.org/jfx/pull/1487.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1487#issuecomment-2187503939)