### PR TITLE
8314754: Minor ticks are not getting updated both the axes in LineChart

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/chart/Axis.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/chart/Axis.java
@@ -698,8 +698,6 @@ public abstract class Axis<T> extends Region {
                 }
             }
 
-            // call tick marks updated to inform subclasses that we have updated tick marks
-            tickMarksUpdated();
             // mark all done
             oldLength = length;
             rangeValid = true;
@@ -750,6 +748,9 @@ public abstract class Axis<T> extends Region {
                 }
             }
             updateTickMarks(side, length);
+
+            // call tick marks updated to inform subclasses that we have updated tick marks
+            tickMarksUpdated();
         }
     }
 

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/chart/XYNumberLineChartsTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/chart/XYNumberLineChartsTest.java
@@ -27,7 +27,6 @@ package test.javafx.scene.chart;
 
 import javafx.scene.shape.MoveTo;
 import javafx.scene.shape.Path;
-import org.junit.jupiter.api.Assertions;
 import test.com.sun.javafx.scene.control.infrastructure.ControlTestUtils;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -170,8 +169,8 @@ public class XYNumberLineChartsTest extends XYNumberChartsTestBase {
         double minorTickSpacing = minorTickYValues.get(1) - minorTickYValues.get(0);
 
         double delta = 0.001;
-        Assertions.assertEquals(5, yAxis.getMinorTickCount());
-        Assertions.assertEquals(5, majorTickSpacing / minorTickSpacing, delta);
+        assertEquals(5, yAxis.getMinorTickCount());
+        assertEquals(5, majorTickSpacing / minorTickSpacing, delta);
     }
 
     @Override

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/chart/XYNumberLineChartsTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/chart/XYNumberLineChartsTest.java
@@ -25,11 +25,17 @@
 
 package test.javafx.scene.chart;
 
+import javafx.scene.shape.MoveTo;
+import javafx.scene.shape.Path;
+import org.junit.jupiter.api.Assertions;
 import test.com.sun.javafx.scene.control.infrastructure.ControlTestUtils;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import javafx.scene.chart.AreaChart;
 import javafx.scene.chart.Axis;
 import javafx.scene.chart.Chart;
@@ -135,6 +141,38 @@ public class XYNumberLineChartsTest extends XYNumberChartsTestBase {
         toolkit.setAnimationTime(dataFadeOutTime);
         // removed instantly
         assertEquals(0, XYChartShim.Series_getDataSize(series));
+    }
+
+    @Test
+    public void testMinorTicksMatchMajorTicksAfterAnimation() {
+        startAppWithSeries();
+        chart.setAnimated(true);
+        // increase ranges, starting axis animation
+        chart.getData().getFirst().getData().add(new XYChart.Data<>(100, 100));
+        pulse();
+        toolkit.setAnimationTime(1000);
+        NumberAxis yAxis = (NumberAxis)chart.getYAxis();
+
+        List<Double> majorTickYValues = yAxis.getChildrenUnmodifiable().stream()
+                .filter(obj -> obj instanceof Path && obj.getStyleClass().contains("axis-tick-mark"))
+                .flatMap(obj -> ((Path) obj).getElements().stream())
+                .filter(path -> path instanceof MoveTo)
+                .map(moveTo -> ((MoveTo) moveTo).getY())
+                .toList();
+
+        List<Double> minorTickYValues = yAxis.getChildrenUnmodifiable().stream()
+                .filter(obj -> obj instanceof Path && obj.getStyleClass().contains("axis-minor-tick-mark"))
+                .flatMap(obj -> ((Path) obj).getElements().stream())
+                .filter(path -> path instanceof MoveTo)
+                .map(moveTo -> ((MoveTo) moveTo).getY())
+                .toList();
+
+        double majorTickSpacing = majorTickYValues.get(1) - majorTickYValues.get(0);
+        double minorTickSpacing = minorTickYValues.get(1) - minorTickYValues.get(0);
+
+        double delta = 0.001;
+        Assertions.assertEquals(5, yAxis.getMinorTickCount());
+        Assertions.assertEquals(5, majorTickSpacing / minorTickSpacing, delta);
     }
 
     @Override

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/chart/XYNumberLineChartsTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/chart/XYNumberLineChartsTest.java
@@ -34,8 +34,6 @@ import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
-import java.util.stream.Collectors;
-
 import javafx.scene.chart.AreaChart;
 import javafx.scene.chart.Axis;
 import javafx.scene.chart.Chart;

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/chart/XYNumberLineChartsTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/chart/XYNumberLineChartsTest.java
@@ -150,6 +150,7 @@ public class XYNumberLineChartsTest extends XYNumberChartsTestBase {
         // increase ranges, starting axis animation
         chart.getData().getFirst().getData().add(new XYChart.Data<>(100, 100));
         pulse();
+        // forward time until after animation is finished
         toolkit.setAnimationTime(1000);
         NumberAxis yAxis = (NumberAxis)chart.getYAxis();
 


### PR DESCRIPTION
This PR ensures the `tickMarksUpdated()` method (overriden with minor tick mark layout code in subclasses) is called during `Chart` `Axis` layout when needed.
Previously, it was only called when tick mark length or range was changed, which is not happening during axis animations, causing minor ticks to become outdated when animations are enabled.

I've added a test that fails with the previous code, specifically checking the tick mark spacing.
Alternatively the test could be implemented by accessing ValueAxis.minorTickMarkValues, which would need to be made at least package-private however (with a shim). This implementation checks the tick mark `Path` shape instead, which is already publicly accessible (but could be considered an implementation detail).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314754](https://bugs.openjdk.org/browse/JDK-8314754): Minor ticks are not getting updated both the axes in LineChart (**Bug** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Marius Hanl](https://openjdk.org/census#mhanl) (@Maran23 - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1489/head:pull/1489` \
`$ git checkout pull/1489`

Update a local copy of the PR: \
`$ git checkout pull/1489` \
`$ git pull https://git.openjdk.org/jfx.git pull/1489/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1489`

View PR using the GUI difftool: \
`$ git pr show -t 1489`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1489.diff">https://git.openjdk.org/jfx/pull/1489.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1489#issuecomment-2189242931)