### PR TITLE
8335218: Eclipse Config: Remove Gradle Integration

### DIFF
--- a/.project
+++ b/.project
@@ -4,10 +4,5 @@
 	<projects>
 	</projects>
 	<buildSpec>
-		<buildCommand>
-			<name>org.eclipse.buildship.core.gradleprojectbuilder</name>
-			<arguments>
-			</arguments>
-		</buildCommand>
 	</buildSpec>
 </projectDescription>

--- a/.project
+++ b/.project
@@ -10,7 +10,4 @@
 			</arguments>
 		</buildCommand>
 	</buildSpec>
-	<natures>
-		<nature>org.eclipse.buildship.core.gradleprojectnature</nature>
-	</natures>
 </projectDescription>

--- a/apps/samples/3DViewer/.project
+++ b/apps/samples/3DViewer/.project
@@ -10,14 +10,8 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
-		<buildCommand>
-			<name>org.eclipse.buildship.core.gradleprojectbuilder</name>
-			<arguments>
-			</arguments>
-		</buildCommand>
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.jdt.core.javanature</nature>
-		<nature>org.eclipse.buildship.core.gradleprojectnature</nature>
 	</natures>
 </projectDescription>

--- a/apps/samples/Ensemble8/.project
+++ b/apps/samples/Ensemble8/.project
@@ -10,14 +10,8 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
-		<buildCommand>
-			<name>org.eclipse.buildship.core.gradleprojectbuilder</name>
-			<arguments>
-			</arguments>
-		</buildCommand>
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.jdt.core.javanature</nature>
-		<nature>org.eclipse.buildship.core.gradleprojectnature</nature>
 	</natures>
 </projectDescription>

--- a/apps/samples/Modena/.project
+++ b/apps/samples/Modena/.project
@@ -10,14 +10,8 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
-		<buildCommand>
-			<name>org.eclipse.buildship.core.gradleprojectbuilder</name>
-			<arguments>
-			</arguments>
-		</buildCommand>
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.jdt.core.javanature</nature>
-		<nature>org.eclipse.buildship.core.gradleprojectnature</nature>
 	</natures>
 </projectDescription>


### PR DESCRIPTION
This might be controversial. I am proposing to remove the Gradle integration in the Eclipse config files.

Problem
=======
Eclipse Gradle integration (Buildship) cannot import the OpenJFX build.gradle cleanly. Every time the project is imported into a new workspace (or re-opened after being closed) it executes Gradle, creates and modifies a number of Eclipse .project and .classpath files, all of which need to be reverted for Eclipse workspace to become usable again.

Solution
======
Remove Gradle nature from the Eclipse project files. This change only affects Eclipse config files and does not impact build.gradle or other IDEs.

Advantages
=========
1. The multiple nested projects in the repo will get imported cleanly on the first attempt, will not require additional steps to clear the Buildship changes.
2. completely removes the dependency on the Eclipse Buildship and its idiosyncrasies.

NOTES:
- even though the reverse was done for IntelliJ, but its gradle import still does not import tests cleanly, see [JDK-8223373](https://bugs.openjdk.org/browse/JDK-8223373)
- this improvement contradicts [JDK-8223374](https://bugs.openjdk.org/browse/JDK-8223374) as without Eclipse files in the repo, it will be impossible to use Eclipse in a meaningful way without the fully functional Buildship support, and that is a big IF.
- once integrated, Eclipse users would only need to re-import the main project with 'search for nested projects' enabled

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8335218](https://bugs.openjdk.org/browse/JDK-8335218): Eclipse Config: Remove Gradle Integration (**Enhancement** - P4)


### Reviewers
 * [Nir Lisker](https://openjdk.org/census#nlisker) (@nlisker - **Reviewer**)
 * [John Hendrikx](https://openjdk.org/census#jhendrikx) (@hjohn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1491/head:pull/1491` \
`$ git checkout pull/1491`

Update a local copy of the PR: \
`$ git checkout pull/1491` \
`$ git pull https://git.openjdk.org/jfx.git pull/1491/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1491`

View PR using the GUI difftool: \
`$ git pr show -t 1491`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1491.diff">https://git.openjdk.org/jfx/pull/1491.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1491#issuecomment-2192685852)