### PR TITLE
8198830: BarChart: auto-range of CategoryAxis not working on dynamically setting data

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/chart/BarChart.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/chart/BarChart.java
@@ -423,9 +423,9 @@ public class BarChart<X,Y> extends XYChart<X,Y> {
                         bar.resizeRelocate( bottom, categoryPos + barOffset + (barWidth + getBarGap()) * index,
                                             top-bottom, barWidth);
                     }
-
-                    index++;
                 }
+
+                index++;
             }
             catIndex++;
         }

--- a/modules/javafx.controls/src/main/java/javafx/scene/chart/BarChart.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/chart/BarChart.java
@@ -384,7 +384,7 @@ public class BarChart<X,Y> extends XYChart<X,Y> {
     @Override protected void layoutPlotChildren() {
         double catSpace = categoryAxis.getCategorySpacing();
         // calculate bar spacing
-        final double availableBarSpace = catSpace - (getCategoryGap() + getBarGap());
+        final double availableBarSpace = catSpace - getCategoryGap() + getBarGap();
         double barWidth = (availableBarSpace / getSeriesSize()) - getBarGap();
         final double barOffset = -((catSpace - getCategoryGap()) / 2);
         final double zeroPos = (valueAxis.getLowerBound() > 0) ?

--- a/modules/javafx.controls/src/main/java/javafx/scene/chart/CategoryAxis.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/chart/CategoryAxis.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.controls/src/main/java/javafx/scene/chart/CategoryAxis.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/chart/CategoryAxis.java
@@ -71,13 +71,13 @@ public final class CategoryAxis extends Axis<String> {
 
     /** This is the position of the first category along this axis */
     private final DoubleProperty firstCategoryPos =
-            new SimpleDoubleProperty(this, "firstCategoryPos", 0) {
-                @Override
-                protected void invalidated() {
-                    requestAxisLayout();
-                    measureInvalid = true;
-                }
-            };
+        new SimpleDoubleProperty(this, "firstCategoryPos", 0) {
+            @Override
+            protected void invalidated() {
+                requestAxisLayout();
+                measureInvalid = true;
+            }
+        };
 
     private Object currentAnimationID;
     private final ChartLayoutAnimator animator = new ChartLayoutAnimator(this);
@@ -249,13 +249,13 @@ public final class CategoryAxis extends Axis<String> {
 
     /** This is the gap between one category and the next along this axis */
     private final ReadOnlyDoubleWrapper categorySpacing =
-            new ReadOnlyDoubleWrapper(this, "categorySpacing", 1) {
-                @Override
-                protected void invalidated() {
-                    requestAxisLayout();
-                    measureInvalid = true;
-                }
-            };
+        new ReadOnlyDoubleWrapper(this, "categorySpacing", 1) {
+            @Override
+            protected void invalidated() {
+                requestAxisLayout();
+                measureInvalid = true;
+            }
+        };
 
     public final double getCategorySpacing() {
         return categorySpacing.get();

--- a/modules/javafx.controls/src/main/java/javafx/scene/chart/CategoryAxis.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/chart/CategoryAxis.java
@@ -68,8 +68,17 @@ public final class CategoryAxis extends Axis<String> {
     // -------------- PRIVATE FIELDS -------------------------------------------
     private List<String> allDataCategories = new ArrayList<>();
     private boolean changeIsLocal = false;
-    /** This is the gap between one category and the next along this axis */
-    private final DoubleProperty firstCategoryPos = new SimpleDoubleProperty(this, "firstCategoryPos", 0);
+
+    /** This is the position of the first category along this axis */
+    private final DoubleProperty firstCategoryPos =
+            new SimpleDoubleProperty(this, "firstCategoryPos", 0) {
+                @Override
+                protected void invalidated() {
+                    requestAxisLayout();
+                    measureInvalid = true;
+                }
+            };
+
     private Object currentAnimationID;
     private final ChartLayoutAnimator animator = new ChartLayoutAnimator(this);
     private ListChangeListener<String> itemsListener = c -> {
@@ -239,7 +248,15 @@ public final class CategoryAxis extends Axis<String> {
     }
 
     /** This is the gap between one category and the next along this axis */
-    private final ReadOnlyDoubleWrapper categorySpacing = new ReadOnlyDoubleWrapper(this, "categorySpacing", 1);
+    private final ReadOnlyDoubleWrapper categorySpacing =
+            new ReadOnlyDoubleWrapper(this, "categorySpacing", 1) {
+                @Override
+                protected void invalidated() {
+                    requestAxisLayout();
+                    measureInvalid = true;
+                }
+            };
+
     public final double getCategorySpacing() {
         return categorySpacing.get();
     }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/chart/BarChartTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/chart/BarChartTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/chart/BarChartTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/chart/BarChartTest.java
@@ -30,6 +30,8 @@ import java.util.List;
 
 import javafx.collections.FXCollections;
 import javafx.scene.Scene;
+import javafx.scene.shape.MoveTo;
+import javafx.scene.shape.Path;
 import javafx.stage.Stage;
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
@@ -275,19 +277,55 @@ public class BarChartTest extends XYChartTestBase {
     }
 
     @Test
+    public void testTickMarksMatchBarPositionsAfterAnimation() {
+        startApp();
+        CategoryAxis xAxis = new CategoryAxis();
+        NumberAxis yAxis = new NumberAxis();
+        BarChart<String, Number> chart = new BarChart<>(xAxis, yAxis);
+        Series<String, Number> series = new Series<>();
+        chart.getData().add(series);
+        chart.setAnimated(true);
+        getTestScene().setRoot(chart);
+
+        // add some categories, starting axis animation
+        series.getData().add(new XYChart.Data<>("1", 1));
+        series.getData().add(new XYChart.Data<>("2", 2));
+        series.getData().add(new XYChart.Data<>("3", 3));
+        pulse();
+        // forward time until after animation is finished
+        toolkit.setAnimationTime(1000);
+
+        List<Node> bars = series.getData().stream().map(XYChart.Data::getNode).toList();
+
+        List<Double> barCenterXValues = series.getData().stream()
+                .map(XYChart.Data::getNode)
+                .map(bar -> bar.getLayoutX() + bar.getLayoutBounds().getCenterX())
+                .toList();
+
+        List<Double> tickXValues = xAxis.getChildrenUnmodifiable().stream()
+                .filter(obj -> obj instanceof Path && obj.getStyleClass().contains("axis-tick-mark"))
+                .flatMap(obj -> ((Path) obj).getElements().stream())
+                .filter(path -> path instanceof MoveTo)
+                .map(moveTo -> ((MoveTo) moveTo).getX())
+                .toList();
+
+        double delta = 0.001;
+        assertEquals(barCenterXValues.size(), tickXValues.size());
+        for (int i = 0; i < barCenterXValues.size(); i++) {
+            assertEquals(barCenterXValues.get(i), tickXValues.get(i), delta);
+        }
+    }
+
+    @Test
     public void testBarPositionsWithMultipleIncompleteSeries() {
         startApp();
-
         CategoryAxis xAxis = new CategoryAxis();
         NumberAxis yAxis = new NumberAxis();
         BarChart<String, Number> chart = new BarChart<>(xAxis, yAxis);
         chart.setAnimated(false);
         chart.setBarGap(0.0);
         chart.setCategoryGap(0.0);
-
-        Stage primaryStage = new Stage();
-        primaryStage.setScene(new Scene(chart));
-        primaryStage.show();
+        getTestScene().setRoot(chart);
 
         XYChart.Series<String, Number> series1 = new XYChart.Series<>();
         series1.setName("S1");
@@ -326,4 +364,5 @@ public class BarChartTest extends XYChartTestBase {
         assertEquals(3, normalized2.get(0), delta);
         assertEquals(5, normalized2.get(1), delta);
     }
+
 }


### PR DESCRIPTION
This PR fixes the placement of `BarChart` bars and category tick marks, particularly when adding data / multiple series and enabling animations.
It covers all cases mentioned in the JBS ticket and adds a unit test.

The settable `barGap` and `categoryGap` now should also behave as expected.

There's a change regarding consistent placement of bars when there is more than one series:
Now, for example, if there are two series S1 and S2, S1 bars will always be on the left and S2 bars will always be on the right side of the tick mark.
This means that if some data category (=x-value) is only present in S2, but not S1, the bar will still be drawn on the right. The previous behavior, if the marks weren't off completely, would have put it on the left which I'd say looks inconsistent.
There's a test for this situation as well.

Note this does not fix [JDK-8334873](https://bugs.openjdk.org/browse/JDK-8334873) where bars get stuck while having different widths. There seem to be additional issues which seem not directly related to the changed code and are probably out of scope for this PR (unless we see some regressions).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8198830](https://bugs.openjdk.org/browse/JDK-8198830): BarChart: auto-range of CategoryAxis not working on dynamically setting data (**Bug** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1492/head:pull/1492` \
`$ git checkout pull/1492`

Update a local copy of the PR: \
`$ git checkout pull/1492` \
`$ git pull https://git.openjdk.org/jfx.git pull/1492/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1492`

View PR using the GUI difftool: \
`$ git pr show -t 1492`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1492.diff">https://git.openjdk.org/jfx/pull/1492.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1492#issuecomment-2195612462)