### PR TITLE
8334593: Adding, removing and then adding a JFXPanel again leads to NullPointerException

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/EmbeddedScene.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/EmbeddedScene.java
@@ -157,7 +157,9 @@ final class EmbeddedScene extends GlassScene implements EmbeddedSceneInterface {
         entireSceneNeedsRepaint();
         Platform.runLater(() -> {
             QuantumToolkit.runWithRenderLock(() -> {
-                updateSceneState();
+                if (host != null) {
+                    updateSceneState();
+                }
                 return null;
             });
         });

--- a/tests/system/src/test/java/test/javafx/embed/swing/JFXPanelNPETest.java
+++ b/tests/system/src/test/java/test/javafx/embed/swing/JFXPanelNPETest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package test.javafx.embed.swing;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
+
+import javafx.application.Application;
+import javafx.application.Platform;
+import javafx.embed.swing.JFXPanel;
+import javafx.scene.Scene;
+import javafx.scene.control.Button;
+import javafx.stage.Stage;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import test.util.Util;
+
+public class JFXPanelNPETest implements Thread.UncaughtExceptionHandler {
+    // Used to launch the application before running any test
+    private static final CountDownLatch launchLatch = new CountDownLatch(1);
+    private static CountDownLatch latch = new CountDownLatch(1);
+    private static Throwable th;
+
+    JFrame jframe;
+
+    // Application class. An instance is created and initialized before running
+    // the first test, and it lives through the execution of all tests.
+    public static class MyApp extends Application {
+        @Override
+        public void start(Stage primaryStage) throws Exception {
+            Platform.setImplicitExit(false);
+            Assert.assertTrue(Platform.isFxApplicationThread());
+            Assert.assertNotNull(primaryStage);
+
+            launchLatch.countDown();
+        }
+    }
+
+    @BeforeClass
+    public static void doSetupOnce() throws Exception {
+        Util.launch(launchLatch, MyApp.class);
+        Assert.assertEquals(0, launchLatch.getCount());
+    }
+
+    @AfterClass
+    public static void doTeardownOnce() {
+        Util.shutdown();
+    }
+
+    @After
+    public void doCleanup() {
+        if (jframe != null) {
+            SwingUtilities.invokeLater(() -> jframe.dispose());
+        }
+    }
+
+    @Test
+    public void testRemoveAddJFXPanel() throws Throwable {
+
+        JFrame frame = new JFrame("FX");
+        final JFXPanel fxPanel = new JFXPanel();
+        // fxPanel added to frame for the first time
+        frame.add(fxPanel);
+        frame.setSize(200, 200);
+        frame.setVisible(true);
+
+        Platform.runLater(() -> {
+            Scene scene = new Scene(new Button("Testbutton"));
+            fxPanel.setScene(scene);
+                Thread.currentThread().setUncaughtExceptionHandler(this);
+                SwingUtilities.invokeLater(() -> {
+		    // fxPanel removed from frame
+		    frame.remove(fxPanel);
+		    // fxPanel added to frame again
+		    frame.add(fxPanel); // <-- leads to NullPointerException
+            });
+        });
+        latch.await(5, TimeUnit.SECONDS);
+        System.out.println("throwable " + th);
+        if (th != null) {
+            throw th;
+        }
+    }
+
+    public void uncaughtException(Thread thread, Throwable throwable) {
+        th = throwable;
+        latch.countDown();
+    }
+}

--- a/tests/system/src/test/java/test/javafx/embed/swing/JFXPanelNPETest.java
+++ b/tests/system/src/test/java/test/javafx/embed/swing/JFXPanelNPETest.java
@@ -27,8 +27,6 @@ package test.javafx.embed.swing;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
 import javax.swing.JFrame;
 import javax.swing.SwingUtilities;
 
@@ -52,6 +50,7 @@ public class JFXPanelNPETest implements Thread.UncaughtExceptionHandler {
     private static final CountDownLatch launchLatch = new CountDownLatch(1);
     private static CountDownLatch latch = new CountDownLatch(1);
     private static Throwable th;
+    private static JFrame frame;
 
     JFrame jframe;
 
@@ -81,15 +80,15 @@ public class JFXPanelNPETest implements Thread.UncaughtExceptionHandler {
 
     @After
     public void doCleanup() {
-        if (jframe != null) {
-            SwingUtilities.invokeLater(() -> jframe.dispose());
+        if (frame != null) {
+            SwingUtilities.invokeLater(() -> frame.dispose());
         }
     }
 
     @Test
     public void testRemoveAddJFXPanel() throws Throwable {
 
-        JFrame frame = new JFrame("FX");
+        frame = new JFrame("FX");
         final JFXPanel fxPanel = new JFXPanel();
         // fxPanel added to frame for the first time
         frame.add(fxPanel);

--- a/tests/system/src/test/java/test/javafx/embed/swing/JFXPanelNPETest.java
+++ b/tests/system/src/test/java/test/javafx/embed/swing/JFXPanelNPETest.java
@@ -99,12 +99,12 @@ public class JFXPanelNPETest implements Thread.UncaughtExceptionHandler {
         Platform.runLater(() -> {
             Scene scene = new Scene(new Button("Testbutton"));
             fxPanel.setScene(scene);
-                Thread.currentThread().setUncaughtExceptionHandler(this);
-                SwingUtilities.invokeLater(() -> {
-		    // fxPanel removed from frame
-		    frame.remove(fxPanel);
-		    // fxPanel added to frame again
-		    frame.add(fxPanel); // <-- leads to NullPointerException
+            Thread.currentThread().setUncaughtExceptionHandler(this);
+            SwingUtilities.invokeLater(() -> {
+                // fxPanel removed from frame
+                frame.remove(fxPanel);
+                // fxPanel added to frame again
+                frame.add(fxPanel); // <-- leads to NullPointerException
             });
         });
         latch.await(5, TimeUnit.SECONDS);


### PR DESCRIPTION
Adding, then removing, and then adding a JFXPanel to the same component in the Swing scene graph leads to a NullPointerException in GlassScene because the sceneState is null.
Removing JFXPanel calls JFXPanel.removeNotify which calls Window.hide which calls SceneHelper.disposePeer -> Scene.disposePeer -> EmbeddedScene.dispose -> GlassScene.dispose which sets "sceneState" to null...
so when GlassScene.updateSceneState is called, it results in NPE.
Fix is to check if `host` (which is usually javafx.embed.swing.JFXPanel$HostContainer for active JFXPanel) has been reset/deleted which is done when `EmbeddedScene.dispose` is called during removeNotify and abstain from updating the scene state

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334593](https://bugs.openjdk.org/browse/JDK-8334593): Adding, removing and then adding a JFXPanel again leads to NullPointerException (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1493/head:pull/1493` \
`$ git checkout pull/1493`

Update a local copy of the PR: \
`$ git checkout pull/1493` \
`$ git pull https://git.openjdk.org/jfx.git pull/1493/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1493`

View PR using the GUI difftool: \
`$ git pr show -t 1493`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1493.diff">https://git.openjdk.org/jfx/pull/1493.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1493#issuecomment-2196442641)