### PR TITLE
8295945: Revert unintended change to copyright start year

### DIFF
--- a/modules/javafx.web/src/main/native/Source/WebKitLegacy/java/storage/WebDatabaseProviderJava.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebKitLegacy/java/storage/WebDatabaseProviderJava.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
A quick fix to correct the created copyright year. 
The created year in the header was unintentionally modified previously from 2021 to 2017.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295945](https://bugs.openjdk.org/browse/JDK-8295945): Revert unintended change to copyright start year (**Bug** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1496/head:pull/1496` \
`$ git checkout pull/1496`

Update a local copy of the PR: \
`$ git checkout pull/1496` \
`$ git pull https://git.openjdk.org/jfx.git pull/1496/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1496`

View PR using the GUI difftool: \
`$ git pr show -t 1496`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1496.diff">https://git.openjdk.org/jfx/pull/1496.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1496#issuecomment-2214097518)