### PR TITLE
8331603: Cleanup native AbstractSurface methods getRGBImpl, setRGBImpl

### DIFF
--- a/modules/javafx.graphics/src/main/native-prism-sw/JAbstractSurface.c
+++ b/modules/javafx.graphics/src/main/native-prism-sw/JAbstractSurface.c
@@ -66,8 +66,8 @@ JNIEXPORT void JNICALL
 Java_com_sun_pisces_AbstractSurface_getRGBImpl(JNIEnv* env, jobject objectHandle,
         jintArray arrayHandle, jint offset, jint scanLength,
         jint x, jint y, jint width, jint height) {
-    jint dstX = 0;
-    jint dstY = 0;
+    const jint dstX = 0;
+    const jint dstY = 0;
 
     Surface* surface;
 
@@ -144,8 +144,8 @@ JNIEXPORT void JNICALL
 Java_com_sun_pisces_AbstractSurface_setRGBImpl(JNIEnv* env, jobject objectHandle,
         jintArray arrayHandle, jint offset, jint scanLength,
         jint x, jint y, jint width, jint height) {
-    jint srcX = 0;
-    jint srcY = 0;
+    const jint srcX = 0;
+    const jint srcY = 0;
 
     Surface* surface;
     surface = (Surface*)JLongToPointer(

--- a/modules/javafx.graphics/src/main/native-prism-sw/JAbstractSurface.c
+++ b/modules/javafx.graphics/src/main/native-prism-sw/JAbstractSurface.c
@@ -85,7 +85,7 @@ Java_com_sun_pisces_AbstractSurface_getRGBImpl(JNIEnv* env, jobject objectHandle
         y < 0 || y >= surfaceHeight ||
         width  < 0 || width  > (surfaceWidth  - x) ||
         height < 0 || height > (surfaceHeight - y) ||
-        scanLength < width) {
+        scanLength < width || offset < 0) {
         JNI_ThrowNew(env, "java/lang/IllegalArgumentException", "Illegal arguments");
         return;
     }
@@ -162,7 +162,7 @@ Java_com_sun_pisces_AbstractSurface_setRGBImpl(JNIEnv* env, jobject objectHandle
         y < 0 || y >= surfaceHeight ||
         width  < 0 || width  > (surfaceWidth  - x) ||
         height < 0 || height > (surfaceHeight - y) ||
-        scanLength < width) {
+        scanLength < width || offset < 0) {
         JNI_ThrowNew(env, "java/lang/IllegalArgumentException", "Illegal arguments");
         return;
     }


### PR DESCRIPTION
The parameter "offset" is not validated in the 2 native methods getRGBImpl() and setRGBImpl() of com.sun.pisces.AbstractSurface (in JAbstractSurface.c).
The PR adds the "offset < 0" check to both the methods.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8331603](https://bugs.openjdk.org/browse/JDK-8331603): Cleanup native AbstractSurface methods getRGBImpl, setRGBImpl (**Bug** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1497/head:pull/1497` \
`$ git checkout pull/1497`

Update a local copy of the PR: \
`$ git checkout pull/1497` \
`$ git pull https://git.openjdk.org/jfx.git pull/1497/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1497`

View PR using the GUI difftool: \
`$ git pr show -t 1497`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1497.diff">https://git.openjdk.org/jfx/pull/1497.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1497#issuecomment-2214117741)