### PR TITLE
8335216: [windows] Missing error check for GetSystemDirectory in glass

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/win/RoActivationSupport.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/win/RoActivationSupport.cpp
@@ -69,12 +69,19 @@ void tryInitializeRoActivationSupport()
     wchar_t path[MAX_PATH];
     wchar_t file[MAX_PATH];
 
-    if (GetSystemDirectory(path, sizeof(path) / sizeof(wchar_t)) == 0) {
+    UINT pathSize = sizeof(path) / sizeof(wchar_t);
+    UINT rval = GetSystemDirectoryW(path, pathSize);
+    if (rval == 0 || rval >= pathSize) {
+        fprintf(stderr, "WinRT: Failed to fetch system directory");
         return;
     }
 
     memcpy_s(file, sizeof(file), path, sizeof(path));
-    wcscat_s(file, MAX_PATH-1, L"\\combase.dll");
+    if (wcscat_s(file, MAX_PATH-1, L"\\combase.dll") != 0) {
+        fprintf(stderr, "WinRT: Failed to form path to combase.dll");
+        return;
+    }
+
     hLibComBase = LoadLibraryW(file);
     if (!hLibComBase) {
         fprintf(stderr, moduleNotFoundMessage, "combase.dll");


### PR DESCRIPTION
When GetSystemDirectory does not have enough space to output a path to Windows' system directory, it will return a different value than 0 (more notably, the amount of bytes actually needed including null terminator). This was not checked, so the very rare hypothetical situation where Windows' system directory is different than the "standard" `C:\Windows` and longer than MAX_PATH was not properly handled.

For now I simply changed the code to print an error and exit. This could be improved further to instead dynamically allocate space for the system directory though.

Other changes, also mentioned in the issue:
- We use `wchar_t` explicitly here, so I changed `GetSystemDirectory` to `GetSystemDirectoryW` to ensure the code compiles even without UNICODE being defined
- `wcscat_s` can potentially fail for the same reasons as above, so this situation is also handled now.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8335216](https://bugs.openjdk.org/browse/JDK-8335216): [windows] Missing error check for GetSystemDirectory in glass (**Bug** - P4)


### Reviewers
 * [Michael Strauß](https://openjdk.org/census#mstrauss) (@mstr2 - Committer)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1498/head:pull/1498` \
`$ git checkout pull/1498`

Update a local copy of the PR: \
`$ git checkout pull/1498` \
`$ git pull https://git.openjdk.org/jfx.git pull/1498/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1498`

View PR using the GUI difftool: \
`$ git pr show -t 1498`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1498.diff">https://git.openjdk.org/jfx/pull/1498.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1498#issuecomment-2214235413)