### PR TITLE
8336272: SizeToSceneTest: fullScreen tests fail on Ubuntu 22.04

### DIFF
--- a/tests/system/src/test/java/test/javafx/stage/SizeToSceneTest.java
+++ b/tests/system/src/test/java/test/javafx/stage/SizeToSceneTest.java
@@ -39,7 +39,6 @@ import test.util.Util;
 import java.util.concurrent.CountDownLatch;
 import java.util.function.Consumer;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class SizeToSceneTest {
@@ -71,11 +70,20 @@ class SizeToSceneTest {
     }
 
     private static void assertStageScreenBounds() {
-        Rectangle2D bounds = Screen.getPrimary().getVisualBounds();
+        Rectangle2D visualBounds = Screen.getPrimary().getVisualBounds();
+        double visualWidth = visualBounds.getWidth() - BOUNDS_DELTA;
+        double visualHeight = visualBounds.getHeight() - BOUNDS_DELTA;
 
-        // There might be small inconsistencies because of decoration, so we expect the bounds to be in the range.
-        assertEquals(mainStage.getWidth(), bounds.getWidth(), BOUNDS_DELTA);
-        assertEquals(mainStage.getHeight(), bounds.getHeight(), BOUNDS_DELTA);
+        Rectangle2D bounds = Screen.getPrimary().getBounds();
+        double width = bounds.getWidth() + BOUNDS_DELTA;
+        double height = bounds.getHeight() + BOUNDS_DELTA;
+
+        // There might be small inconsistencies because of decoration or different window managers.
+        assertTrue(mainStage.getWidth() >= visualWidth, mainStage.getWidth() + " >= " + visualWidth);
+        assertTrue(mainStage.getHeight() >= visualHeight, mainStage.getHeight() + " >= " + visualHeight);
+
+        assertTrue(mainStage.getWidth() <= width, mainStage.getWidth() + " <= " + width);
+        assertTrue(mainStage.getHeight() <= height, mainStage.getHeight() + " <= " + height);
     }
 
     private static void assertStageSceneBounds() {


### PR DESCRIPTION
Tests that the `Stage Size` is between the `Visual Screen bounds - 50 (delta)` and `Screen bounds + 50 (delta)`.
-> `stageSize >= (visualBounds - 50)` & `stageSize <= (bounds + 50)`.

Tested only on Windows 10 for now.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336272](https://bugs.openjdk.org/browse/JDK-8336272): SizeToSceneTest: fullScreen tests fail on Ubuntu 22.04 (**Bug** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1501/head:pull/1501` \
`$ git checkout pull/1501`

Update a local copy of the PR: \
`$ git checkout pull/1501` \
`$ git pull https://git.openjdk.org/jfx.git pull/1501/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1501`

View PR using the GUI difftool: \
`$ git pr show -t 1501`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1501.diff">https://git.openjdk.org/jfx/pull/1501.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1501#issuecomment-2224070997)