### PR TITLE
8336592: Wrong type in documentation for TreeTableView

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableView.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableView.java
@@ -186,8 +186,8 @@ import com.sun.javafx.scene.control.behavior.TreeTableCellBehavior;
  * create a two-column TreeTableView to show the file name and size
  * properties, we write:
  *
- * <pre> {@code TreeTableColumns<File, String> fileNameCol = new TreeTableColumn<>("Filename");
- * TreeTableColumns<File, Long> sizeCol = new TreeTableColumn<>("Size");
+ * <pre> {@code TreeTableColumn<File, String> fileNameCol = new TreeTableColumn<>("Filename");
+ * TreeTableColumn<File, Long> sizeCol = new TreeTableColumn<>("Size");
  *
  * treeTable.getColumns().setAll(fileNameCol, sizeCol);}</pre>
  *


### PR DESCRIPTION
Hello,

There is a typo in TreeTableView.java documentation. TreeTableColumns is used instead of TreeTableColumn.
I have updated the below lines:

TreeTableColumn<File, String> fileNameCol = new TreeTableColumn<>("Filename");
 TreeTableColumn<File, Long> sizeCol = new TreeTableColumn<>("Size");

Please review.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336592](https://bugs.openjdk.org/browse/JDK-8336592): Wrong type in documentation for TreeTableView (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1509/head:pull/1509` \
`$ git checkout pull/1509`

Update a local copy of the PR: \
`$ git checkout pull/1509` \
`$ git pull https://git.openjdk.org/jfx.git pull/1509/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1509`

View PR using the GUI difftool: \
`$ git pr show -t 1509`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1509.diff">https://git.openjdk.org/jfx/pull/1509.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1509#issuecomment-2232446622)