### PR TITLE
8335630: Crash if Platform::exit called with fullScreen Stage on macOS 14

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/View.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/View.java
@@ -528,17 +528,26 @@ public abstract class View {
         this.eventHandler = eventHandler;
     }
 
+    private boolean shouldHandleEvent() {
+        // Don't send any more events if the application has shutdown
+        if (Application.GetApplication() == null) {
+            return false;
+        }
+
+        return this.eventHandler != null;
+    }
+
     //-------- EVENTS --------//
 
     private void handleViewEvent(long time, int type) {
-        if (this.eventHandler != null) {
+        if (shouldHandleEvent()) {
             this.eventHandler.handleViewEvent(this, time, type);
         }
     }
 
     private void handleKeyEvent(long time, int action,
             int keyCode, char[] keyChars, int modifiers) {
-        if (this.eventHandler != null) {
+        if (shouldHandleEvent()) {
             this.eventHandler.handleKeyEvent(this, time, action, keyCode, keyChars, modifiers);
         }
     }
@@ -547,7 +556,7 @@ public abstract class View {
                                   int xAbs, int yAbs,
                                   int modifiers, boolean isPopupTrigger,
                                   boolean isSynthesized) {
-        if (eventHandler != null) {
+        if (shouldHandleEvent()) {
             eventHandler.handleMouseEvent(this, time, type, button, x, y, xAbs,
                                           yAbs, modifiers,
                                           isPopupTrigger, isSynthesized);
@@ -555,14 +564,14 @@ public abstract class View {
     }
 
     private void handleMenuEvent(int x, int y, int xAbs, int yAbs, boolean isKeyboardTrigger) {
-        if (this.eventHandler != null) {
+        if (shouldHandleEvent()) {
             this.eventHandler.handleMenuEvent(this, x, y, xAbs, yAbs, isKeyboardTrigger);
         }
     }
 
     public void handleBeginTouchEvent(View view, long time, int modifiers,
                                       boolean isDirect, int touchEventCount) {
-        if (eventHandler != null) {
+        if (shouldHandleEvent()) {
             eventHandler.handleBeginTouchEvent(view, time, modifiers, isDirect,
                     touchEventCount);
         }
@@ -571,13 +580,13 @@ public abstract class View {
     public void handleNextTouchEvent(View view, long time, int type,
                                      long touchId, int x, int y, int xAbs,
                                      int yAbs) {
-        if (eventHandler != null) {
+        if (shouldHandleEvent()) {
             eventHandler.handleNextTouchEvent(view, time, type, touchId, x, y, xAbs, yAbs);
         }
     }
 
     public void handleEndTouchEvent(View view, long time) {
-        if (eventHandler != null) {
+        if (shouldHandleEvent()) {
             eventHandler.handleEndTouchEvent(view, time);
         }
     }
@@ -589,7 +598,7 @@ public abstract class View {
                                          double dx, double dy, double totaldx,
                                          double totaldy, double multiplierX,
                                          double multiplierY) {
-        if (eventHandler != null) {
+        if (shouldHandleEvent()) {
             eventHandler.handleScrollGestureEvent(view, time, type, modifiers, isDirect,
                     isInertia, touchCount, x, y, xAbs, yAbs,
                     dx, dy, totaldx, totaldy, multiplierX, multiplierY);
@@ -603,7 +612,7 @@ public abstract class View {
                                        int originyAbs, double scale,
                                        double expansion, double totalscale,
                                        double totalexpansion) {
-        if (eventHandler != null) {
+        if (shouldHandleEvent()) {
             eventHandler.handleZoomGestureEvent(view, time, type, modifiers, isDirect,
                                      isInertia, originx, originy, originxAbs,
                                      originyAbs, scale, expansion, totalscale,
@@ -617,7 +626,7 @@ public abstract class View {
                                          int originy, int originxAbs,
                                          int originyAbs, double dangle,
                                          double totalangle) {
-        if (eventHandler != null) {
+        if (shouldHandleEvent()) {
             eventHandler.handleRotateGestureEvent(view, time, type, modifiers, isDirect,
                     isInertia, originx, originy, originxAbs,
                     originyAbs, dangle, totalangle);
@@ -629,7 +638,7 @@ public abstract class View {
                                         boolean isInertia, int touchCount,
                                         int dir, int originx, int originy,
                                         int originxAbs, int originyAbs) {
-        if (eventHandler != null) {
+        if (shouldHandleEvent()) {
             eventHandler.handleSwipeGestureEvent(view, time, type, modifiers, isDirect,
                     isInertia, touchCount, dir, originx,
                     originy, originxAbs, originyAbs);
@@ -639,7 +648,7 @@ public abstract class View {
     private void handleInputMethodEvent(long time, String text, int[] clauseBoundary,
                 int[] attrBoundary, byte[] attrValue,
                 int commitCount, int cursorPos) {
-        if (this.eventHandler != null) {
+        if (shouldHandleEvent()) {
             this.eventHandler.handleInputMethodEvent(time, text, clauseBoundary,
                 attrBoundary, attrValue,
                 commitCount, cursorPos);
@@ -659,7 +668,7 @@ public abstract class View {
     }
 
     private double[] getInputMethodCandidatePos(int offset) {
-        if (this.eventHandler != null) {
+        if (shouldHandleEvent()) {
             return this.eventHandler.getInputMethodCandidatePos(offset);
         }
         return null;
@@ -667,20 +676,20 @@ public abstract class View {
 
     private void handleDragStart(int button, int x, int y, int xAbs, int yAbs,
             ClipboardAssistance dropSourceAssistant) {
-        if (this.eventHandler != null) {
+        if (shouldHandleEvent()) {
             this.eventHandler.handleDragStart(this, button, x, y, xAbs, yAbs, dropSourceAssistant);
         }
     }
 
     private void handleDragEnd(int performedAction) {
-        if (this.eventHandler != null) {
+        if (shouldHandleEvent()) {
             this.eventHandler.handleDragEnd(this, performedAction);
         }
     }
 
     private int handleDragEnter(int x, int y, int xAbs, int yAbs,
             int recommendedDropAction, ClipboardAssistance dropTargetAssistant) {
-        if (this.eventHandler != null) {
+        if (shouldHandleEvent()) {
             return this.eventHandler.handleDragEnter(this, x, y, xAbs, yAbs, recommendedDropAction, dropTargetAssistant);
         } else {
             return recommendedDropAction;
@@ -689,7 +698,7 @@ public abstract class View {
 
     private int handleDragOver(int x, int y, int xAbs, int yAbs,
             int recommendedDropAction, ClipboardAssistance dropTargetAssistant) {
-        if (this.eventHandler != null) {
+        if (shouldHandleEvent()) {
             return this.eventHandler.handleDragOver(this, x, y, xAbs, yAbs, recommendedDropAction, dropTargetAssistant);
         } else {
             return recommendedDropAction;
@@ -697,14 +706,14 @@ public abstract class View {
     }
 
     private void handleDragLeave(ClipboardAssistance dropTargetAssistant) {
-        if (this.eventHandler != null) {
+        if (shouldHandleEvent()) {
             this.eventHandler.handleDragLeave(this, dropTargetAssistant);
         }
     }
 
     private int handleDragDrop(int x, int y, int xAbs, int yAbs,
             int recommendedDropAction, ClipboardAssistance dropTargetAssistant) {
-        if (this.eventHandler != null) {
+        if (shouldHandleEvent()) {
             return this.eventHandler.handleDragDrop(this, x, y, xAbs, yAbs, recommendedDropAction, dropTargetAssistant);
         } else {
             return Clipboard.ACTION_NONE;
@@ -955,7 +964,7 @@ public abstract class View {
             int defaultLines, int defaultChars,
             double xMultiplier, double yMultiplier)
     {
-        if (this.eventHandler != null) {
+        if (shouldHandleEvent()) {
             this.eventHandler.handleScrollEvent(this, System.nanoTime(),
                     x, y, xAbs, yAbs, deltaX, deltaY, modifiers, lines, chars,
                     defaultLines, defaultChars, xMultiplier, yMultiplier);

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Window.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Window.java
@@ -395,7 +395,7 @@ public abstract class Window {
         final Screen old = this.screen;
         this.screen = screen;
 
-        if (this.eventHandler != null) {
+        if (shouldHandleEvent()) {
             if ((old == null && this.screen != null) ||
                 (old != null && !old.equals(this.screen))) {
                 this.eventHandler.handleScreenChangedEvent(this, System.nanoTime(), old, this.screen);
@@ -1251,11 +1251,20 @@ public abstract class Window {
         this.delegatePtr = ptr;
     }
 
+    private boolean shouldHandleEvent() {
+        // Don't send any more events if the application has shutdown
+        if (Application.GetApplication() == null) {
+            return false;
+        }
+
+        return this.eventHandler != null;
+    }
+
     // *****************************************************
     // window event handlers
     // *****************************************************
     protected void handleWindowEvent(long time, int type) {
-        if (this.eventHandler != null) {
+        if (shouldHandleEvent()) {
             this.eventHandler.handleWindowEvent(this, time, type);
         }
     }
@@ -1386,7 +1395,7 @@ public abstract class Window {
 
     protected void notifyLevelChanged(int level) {
         this.level = level;
-        if (this.eventHandler != null) {
+        if (shouldHandleEvent()) {
             this.eventHandler.handleLevelEvent(level);
         }
     }

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow+Overrides.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow+Overrides.m
@@ -93,8 +93,10 @@
 
     [self _ungrabFocus];
 
-    GET_MAIN_JENV;
-    (*env)->CallVoidMethod(env, self->jWindow, jWindowNotifyFocus, com_sun_glass_events_WindowEvent_FOCUS_LOST);
+    GET_MAIN_JENV_NOWARN;
+    if (env != NULL) {
+        (*env)->CallVoidMethod(env, self->jWindow, jWindowNotifyFocus, com_sun_glass_events_WindowEvent_FOCUS_LOST);
+    }
 }
 
 - (void)windowWillClose:(NSNotification *)notification
@@ -231,8 +233,10 @@
 {
     if (self->isEnabled)
     {
-        GET_MAIN_JENV;
-        (*env)->CallVoidMethod(env, jWindow, jWindowNotifyClose);
+        GET_MAIN_JENV_NOWARN;
+        if (env != NULL) {
+            (*env)->CallVoidMethod(env, jWindow, jWindowNotifyClose);
+        }
     }
 
     // it's up to app to decide if the window should be closed

--- a/tests/system/src/test/java/test/javafx/stage/FullScreenExitTest.java
+++ b/tests/system/src/test/java/test/javafx/stage/FullScreenExitTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.javafx.stage;
+
+import java.util.concurrent.CountDownLatch;
+import javafx.application.Application;
+import javafx.application.Platform;
+import javafx.scene.Scene;
+import javafx.scene.layout.BorderPane;
+import javafx.stage.Stage;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import test.util.Util;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/*
+ * Test that we can shutdown the JavaFX runtime cleanly via Platform::exit
+ * while in full screen mode.
+ *
+ * @bug 8335630 8299738
+ */
+public class FullScreenExitTest {
+    private static Stage stage;
+    private static Scene scene;
+    private static BorderPane borderPane;
+
+    private static volatile Throwable exception;
+
+    private static CountDownLatch startupLatch = new CountDownLatch(1);
+    private static CountDownLatch stopLatch = new CountDownLatch(1);
+
+    public static class TestApp extends Application {
+        @Override
+        public void start(Stage primaryStage) {
+            Thread.currentThread().setUncaughtExceptionHandler((thr, ex) -> {
+                System.err.println("Exception caught in thread: " + thr);
+                ex.printStackTrace();
+                exception = ex;
+            });
+
+            stage = primaryStage;
+
+            borderPane = new BorderPane();
+
+            scene = new Scene(borderPane, 400, 300);
+            stage.setScene(scene);
+            stage.setFullScreen(true);
+            stage.setOnShown(e -> Platform.runLater(startupLatch::countDown));
+            stage.show();
+        }
+
+        @Override
+        public void stop() {
+            stopLatch.countDown();
+        }
+    }
+
+    @BeforeAll
+    public static void initFX() throws Exception {
+        Util.launch(startupLatch, TestApp.class);
+        Util.runAndWait(() -> {
+            assertTrue(stage.isShowing());
+            assertTrue(stage.isFullScreen());
+        });
+    }
+
+    @Test
+    public void exitWhileInFullScreenDoesNotCrash() {
+        // Ensure that the window has had time to transition to full screen
+        Util.sleep(3000);
+
+        // Shutdown the JavaFX runtime with full-screen stage showing
+        Platform.exit();
+
+        // Wait until the application has been stopped and then sleep for
+        // one second to verify that it will not crash nor throw an exception
+        assertTrue(Util.await(stopLatch), "Timeout waiting for Application::stop");
+        Util.sleep(1000);
+
+        assertSame(null, exception, "Unexpected exception");
+    }
+
+}


### PR DESCRIPTION
Clean backport of this crash-on-exit fix to the `jfx23` stabilization branch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8335630](https://bugs.openjdk.org/browse/JDK-8335630): Crash if Platform::exit called with fullScreen Stage on macOS 14 (**Bug** - P3)
 * [JDK-8299738](https://bugs.openjdk.org/browse/JDK-8299738): ISE if Platform::exit called with fullScreen Stage on macOS 13 (**Bug** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1511/head:pull/1511` \
`$ git checkout pull/1511`

Update a local copy of the PR: \
`$ git checkout pull/1511` \
`$ git pull https://git.openjdk.org/jfx.git pull/1511/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1511`

View PR using the GUI difftool: \
`$ git pr show -t 1511`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1511.diff">https://git.openjdk.org/jfx/pull/1511.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1511#issuecomment-2233200352)