### PR TITLE
8336331: Doc: Clarification in AccessibleAttribute, AccessibleRole

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/scene/AccessibleAction.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/AccessibleAction.java
@@ -119,7 +119,7 @@ public enum AccessibleAction {
 
     /**
      * Request the node to show a text range, scrolling if required.
-     * <p>Used by TextField and TextArea. </p>
+     * <p>Used by TextArea. </p>
      *
      * Parameters:
      * <ul>

--- a/modules/javafx.graphics/src/main/java/javafx/scene/AccessibleAttribute.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/AccessibleAttribute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -71,22 +71,23 @@ public enum AccessibleAttribute {
     ACCELERATOR(KeyCombination.class),
 
     /**
-     * Returns the bounds for the node.
+     * Returns the bounds for the node, in screen coordinates.
      * <ul>
      * <li>Used by: Node </li>
      * <li>Needs notify: no </li>
-     * <li>Return Type: {@link Bounds} </li>
+     * <li>Return Type: {@link Bounds} in screen coordinates</li>
      * <li>Parameters: </li>
      * </ul>
      */
     BOUNDS(Bounds.class),
 
     /**
-     * Returns the array of bounding rectangles for the given character range.
+     * Returns the array of bounding rectangles for the given character range,
+     * in screen coordinates.
      * <ul>
      * <li>Used by: TextField and TextArea </li>
      * <li>Needs notify: no </li>
-     * <li>Return Type: {@link Bounds}[] </li>
+     * <li>Return Type: {@link Bounds}[] in screen coordinates</li>
      * <li>Parameters:
      *   <ul>
      *    <li>{@link Integer} the start offset </li>
@@ -518,7 +519,7 @@ public enum AccessibleAttribute {
      * <li>Return Type: {@link Node} </li>
      * <li>Parameters:
      *   <ul>
-     *   <li> {@link javafx.geometry.Point2D} the point location </li>
+     *   <li> {@link javafx.geometry.Point2D} the point location, in screen coordinates </li>
      *   </ul>
      * </li>
      * </ul>
@@ -533,7 +534,7 @@ public enum AccessibleAttribute {
      * <li>Return Type: {@link Integer} </li>
      * <li>Parameters:
      *   <ul>
-     *   <li> {@link javafx.geometry.Point2D} the point location </li>
+     *   <li> {@link javafx.geometry.Point2D} the point location, in screen coordinates </li>
      *   </ul>
      * </li>
      * </ul>
@@ -678,6 +679,7 @@ public enum AccessibleAttribute {
 
     /**
      * Returns the text selection end offset for the node.
+     * Selection end corresponds to the larger offset in the selection range.
      * <ul>
      * <li>Used by: TextField and TextArea </li>
      * <li>Needs notify: yes </li>
@@ -689,6 +691,7 @@ public enum AccessibleAttribute {
 
     /**
      * Returns the text selection start offset for the node.
+     * Selection start corresponds to the smaller offset in the selection range.
      * <ul>
      * <li>Used by: TextField and TextArea </li>
      * <li>Needs notify: yes </li>

--- a/modules/javafx.graphics/src/main/java/javafx/scene/AccessibleAttribute.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/AccessibleAttribute.java
@@ -679,7 +679,7 @@ public enum AccessibleAttribute {
 
     /**
      * Returns the text selection end offset for the node.
-     * Selection end corresponds to the larger offset in the selection range.
+     * Selection end corresponds to the larger position in the selection range.
      * <ul>
      * <li>Used by: TextField and TextArea </li>
      * <li>Needs notify: yes </li>
@@ -691,7 +691,7 @@ public enum AccessibleAttribute {
 
     /**
      * Returns the text selection start offset for the node.
-     * Selection start corresponds to the smaller offset in the selection range.
+     * Selection start corresponds to the smaller position in the selection range.
      * <ul>
      * <li>Used by: TextField and TextArea </li>
      * <li>Needs notify: yes </li>

--- a/modules/javafx.graphics/src/main/java/javafx/scene/AccessibleRole.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/AccessibleRole.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -483,6 +483,7 @@ public enum AccessibleRole {
      * <ul>
      * <li> {@link AccessibleAction#SET_TEXT} </li>
      * <li> {@link AccessibleAction#SET_TEXT_SELECTION} </li>
+     * <li> {@link AccessibleAction#SHOW_TEXT_RANGE} </li>
      * </ul>
      */
     TEXT_AREA,


### PR DESCRIPTION
Minor clarifications in Javadoc

**AccessibleAttribute**:
- Point2D and Bound values uses screen coordinates. Example: `BOUNDS`, `BOUNDS_FOR_RANGE`, `OFFSET_AT_POINT`, ...
- clarified the meaning of `SELECTION_END`, `SELECTION_START`

**Accessible Role**:
- missing accessible action `SHOW_TEXT_RANGE`

This will be a minor clarification, so no CSR is required.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336331](https://bugs.openjdk.org/browse/JDK-8336331): Doc: Clarification in AccessibleAttribute, AccessibleRole (**Bug** - P4)


### Reviewers
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1512/head:pull/1512` \
`$ git checkout pull/1512`

Update a local copy of the PR: \
`$ git checkout pull/1512` \
`$ git pull https://git.openjdk.org/jfx.git pull/1512/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1512`

View PR using the GUI difftool: \
`$ git pr show -t 1512`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1512.diff">https://git.openjdk.org/jfx/pull/1512.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1512#issuecomment-2237343239)