### PR TITLE
8335548: testCookieEnabled fails with WebKit 619.1

### DIFF
--- a/modules/javafx.web/src/test/java/test/javafx/scene/web/MiscellaneousTest.java
+++ b/modules/javafx.web/src/test/java/test/javafx/scene/web/MiscellaneousTest.java
@@ -217,9 +217,15 @@ public class MiscellaneousTest extends TestBase {
         }
     }
 
-    @Ignore("JDK-8335548")
-    @Test public void testCookieEnabled() {
+
+    @Test public void testCookieEnabled() throws Exception {
         final WebEngine webEngine = createWebEngine();
+        String location = new File("src/test/resources/test/html/cookie.html")
+                .toURI().toASCIIString().replaceAll("^file:/", "file:///");
+        Platform.runLater(() -> {
+            webEngine.load(location);
+        });
+        Thread.sleep(1000);
         submit(() -> {
             final JSObject window = (JSObject) webEngine.executeScript("window");
             assertNotNull(window);

--- a/modules/javafx.web/src/test/resources/test/html/cookie.html
+++ b/modules/javafx.web/src/test/resources/test/html/cookie.html
@@ -1,8 +1,5 @@
 <!DOCTYPE html>
 <html>
-<head>
-    <meta http-equiv="Refresh" content="100; URL=ipsum.html" />
-</head>
 <body>
 test cookie
 </body>

--- a/modules/javafx.web/src/test/resources/test/html/cookie.html
+++ b/modules/javafx.web/src/test/resources/test/html/cookie.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta http-equiv="Refresh" content="100; URL=ipsum.html" />
+</head>
+<body>
+test cookie
+</body>
+</html>


### PR DESCRIPTION
Issue : CookieEnable method returns false when WebView url is empty
Solution: Use a dummy file URI in WebView before testing cookie.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335548](https://bugs.openjdk.org/browse/JDK-8335548): testCookieEnabled fails with WebKit 619.1 (**Bug** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1513/head:pull/1513` \
`$ git checkout pull/1513`

Update a local copy of the PR: \
`$ git checkout pull/1513` \
`$ git pull https://git.openjdk.org/jfx.git pull/1513/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1513`

View PR using the GUI difftool: \
`$ git pr show -t 1513`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1513.diff">https://git.openjdk.org/jfx/pull/1513.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1513#issuecomment-2238497017)