### PR TITLE
8336882: Convert CssStyleHelperTest to use JUnit 5

### DIFF
--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/CssStyleHelperTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/CssStyleHelperTest.java
@@ -37,13 +37,12 @@ import javafx.scene.layout.Pane;
 import javafx.scene.layout.StackPane;
 import javafx.scene.paint.Color;
 import javafx.scene.text.Text;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class CssStyleHelperTest {
 
@@ -60,7 +59,7 @@ public class CssStyleHelperTest {
         sm.hasDefaultUserAgentStylesheet = false;
     }
 
-    @Before
+    @BeforeEach
     public void setup() {
         root = new StackPane();
         scene = new Scene(root);
@@ -69,7 +68,7 @@ public class CssStyleHelperTest {
         resetStyleManager();
     }
 
-    @AfterClass
+    @AfterAll
     public static void cleanupOnce() {
         resetStyleManager();
     }


### PR DESCRIPTION
Conversion of the CssStyleHelperTest to JUnit 5 for PR's #1503 and #1505

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336882](https://bugs.openjdk.org/browse/JDK-8336882): Convert CssStyleHelperTest to use JUnit 5 (**Bug** - P4)


### Reviewers
 * [Michael Strauß](https://openjdk.org/census#mstrauss) (@mstr2 - Committer)
 * [Marius Hanl](https://openjdk.org/census#mhanl) (@Maran23 - Committer)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1515/head:pull/1515` \
`$ git checkout pull/1515`

Update a local copy of the PR: \
`$ git checkout pull/1515` \
`$ git pull https://git.openjdk.org/jfx.git pull/1515/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1515`

View PR using the GUI difftool: \
`$ git pr show -t 1515`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1515.diff">https://git.openjdk.org/jfx/pull/1515.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1515#issuecomment-2242547757)