### PR TITLE
8337281: build.gradle assumes all modules are named "javafx.$project"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1795,7 +1795,8 @@ void addMavenPublication(Project project, List<String> projectDependencies) {
                         projectDependencyPlatform.appendNode("classifier", "\${javafx.platform}")
 
                         if (!projectDependencies.empty) {
-                            projectDependencies.each { dep ->
+                            projectDependencies.each { projName ->
+                                def dep = project.project(":$projName")
                                 def depName = dep.moduleName.replace('.', '-')
                                 Node projectDependency = dependencies.appendNode("dependency")
                                 projectDependency.appendNode("groupId", MAVEN_GROUP_ID)

--- a/build.gradle
+++ b/build.gradle
@@ -1713,13 +1713,11 @@ void addMavenPublication(Project project, List<String> projectDependencies) {
     if (!project.hasProperty("moduleName")) {
         fail("Project ${project} has no module name")
     }
-    println "KCR: project = $project"
     projectDependencies.each { projName ->
         def dep = project.project(":$projName")
         if (!dep.hasProperty("moduleName")) {
             fail("${project} dependency ${dep} has no module name")
         }
-        println "KCR: dependency = $dep"
     }
 
     project.apply plugin: 'maven-publish'
@@ -1774,7 +1772,6 @@ void addMavenPublication(Project project, List<String> projectDependencies) {
                 maven(MavenPublication) {
                     def artifactName = project.moduleName.replace('.', '-')
                     artifactId = artifactName
-                    println "KCR: artifactId = $artifactName"
 
                     afterEvaluate {
                         artifact project.tasks."moduleEmptyPublicationJar$t.capital"
@@ -1794,7 +1791,6 @@ void addMavenPublication(Project project, List<String> projectDependencies) {
                         Node projectDependencyPlatform = dependencies.appendNode("dependency")
                         projectDependencyPlatform.appendNode("groupId", MAVEN_GROUP_ID)
                         projectDependencyPlatform.appendNode("artifactId", artifactName)
-                        println "KCR: artifactId = ${artifactName}"
                         projectDependencyPlatform.appendNode("version", MAVEN_VERSION)
                         projectDependencyPlatform.appendNode("classifier", "\${javafx.platform}")
 
@@ -1804,7 +1800,6 @@ void addMavenPublication(Project project, List<String> projectDependencies) {
                                 Node projectDependency = dependencies.appendNode("dependency")
                                 projectDependency.appendNode("groupId", MAVEN_GROUP_ID)
                                 projectDependency.appendNode("artifactId", depName)
-                                println "KCR: artifactId = $depName"
                                 projectDependency.appendNode("version", MAVEN_VERSION)
                            }
                         }

--- a/build.gradle
+++ b/build.gradle
@@ -967,7 +967,7 @@ List<String> computeLibraryPath(boolean working) {
     List<String> lp = []
 
     if (HAS_JAVAFX_MODULES) {
-        List<String> modsWithNative = [ 'graphics', 'media', 'web' ]
+        List<String> modsWithNative = [ 'javafx.graphics', 'javafx.media', 'javafx.web' ]
 
         // the build/modular-sdk area
         def platformPrefix = ""
@@ -976,7 +976,7 @@ List<String> computeLibraryPath(boolean working) {
         def modulesLibsDir = "${bundledSdkDir}/modules_libs"
 
         modsWithNative.each() { m ->
-            lp << cygpath("${modulesLibsDir}/javafx.${m}")
+            lp << cygpath("${modulesLibsDir}/${m}")
         }
     } else {
         def platformPrefix = ""
@@ -1710,6 +1710,18 @@ void addMavenPublication(Project project, List<String> projectDependencies) {
         return
     }
 
+    if (!project.hasProperty("moduleName")) {
+        fail("Project ${project} has no module name")
+    }
+    println "KCR: project = $project"
+    projectDependencies.each { projName ->
+        def dep = project.project(":$projName")
+        if (!dep.hasProperty("moduleName")) {
+            fail("${project} dependency ${dep} has no module name")
+        }
+        println "KCR: dependency = $dep"
+    }
+
     project.apply plugin: 'maven-publish'
 
     project.group = MAVEN_GROUP_ID
@@ -1760,7 +1772,9 @@ void addMavenPublication(Project project, List<String> projectDependencies) {
         project.publishing {
             publications {
                 maven(MavenPublication) {
-                    artifactId = "javafx-${project.name}"
+                    def artifactName = project.moduleName.replace('.', '-')
+                    artifactId = artifactName
+                    println "KCR: artifactId = $artifactName"
 
                     afterEvaluate {
                         artifact project.tasks."moduleEmptyPublicationJar$t.capital"
@@ -1779,15 +1793,18 @@ void addMavenPublication(Project project, List<String> projectDependencies) {
 
                         Node projectDependencyPlatform = dependencies.appendNode("dependency")
                         projectDependencyPlatform.appendNode("groupId", MAVEN_GROUP_ID)
-                        projectDependencyPlatform.appendNode("artifactId", "javafx-${project.name}")
+                        projectDependencyPlatform.appendNode("artifactId", artifactName)
+                        println "KCR: artifactId = ${artifactName}"
                         projectDependencyPlatform.appendNode("version", MAVEN_VERSION)
                         projectDependencyPlatform.appendNode("classifier", "\${javafx.platform}")
 
                         if (!projectDependencies.empty) {
                             projectDependencies.each { dep ->
+                                def depName = dep.moduleName.replace('.', '-')
                                 Node projectDependency = dependencies.appendNode("dependency")
                                 projectDependency.appendNode("groupId", MAVEN_GROUP_ID)
-                                projectDependency.appendNode("artifactId", "javafx-$dep")
+                                projectDependency.appendNode("artifactId", depName)
+                                println "KCR: artifactId = $depName"
                                 projectDependency.appendNode("version", MAVEN_VERSION)
                            }
                         }


### PR DESCRIPTION
This PR fixes a bad assumption in a few places in `build.gradle`, which assumes that the module name can be derived from the name of the gradle project name by prepending `"javafx."` to the name rather than using the `moduleName` property of the project. In many of these places, the logic replaces dots with dashes in the name, but it does so by prefixing the project name with `"javafx-"` rather than doing a string replacement. This means that a module with more than one dot will only have the first one replaced.

I discovered this while working on the following two RFEs, both of which hit this bug:

[JDK-8309381](https://bugs.openjdk.org/browse/JDK-8309381): Support JavaFX incubator modules
[JDK-8337280](https://bugs.openjdk.org/browse/JDK-8337280): Include jdk.jsobject module with JavaFX

Both of them need this bug to be fixed, so I am separating it out into its own issue.

### Notes to reviewers

Most of the problematic logic is in the maven publication method, which is only enabled via `gradle -PMAVEN_PUBLISH=true` (in the absence of any other params, that won't actually try to publish anything, so is safe to use for testing). I left in some print statements for the purpose of testing, that I will remove with the next commit.

I tested this with the following branch, which is a preliminary prototype of adding jdk.jsobject to the build with the fix from _this_ PR applied: [test-module-name-jsobject](https://github.com/kevinrushforth/jfx/tree/test-module-name-jsobject).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8337281](https://bugs.openjdk.org/browse/JDK-8337281): build.gradle assumes all modules are named "javafx.$project" (**Bug** - P3)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1518/head:pull/1518` \
`$ git checkout pull/1518`

Update a local copy of the PR: \
`$ git checkout pull/1518` \
`$ git pull https://git.openjdk.org/jfx.git pull/1518/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1518`

View PR using the GUI difftool: \
`$ git pr show -t 1518`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1518.diff">https://git.openjdk.org/jfx/pull/1518.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1518#issuecomment-2253162327)