### PR TITLE
8337400: [Linux] Initial window position is not centered on Ubuntu 24.04 / Xorg

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/gtk/GlassApplication.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/GlassApplication.cpp
@@ -545,6 +545,7 @@ static void process_events(GdkEvent* event, gpointer data)
                     process_dnd_target(ctx, &event->dnd);
                     break;
                 case GDK_MAP:
+                    ctx->process_map();
                     // fall-through
                 case GDK_UNMAP:
                 case GDK_CLIENT_EVENT:

--- a/modules/javafx.graphics/src/main/native-glass/gtk/glass_window.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/glass_window.cpp
@@ -731,7 +731,8 @@ WindowContextTop::WindowContextTop(jobject _jwindow, WindowContext* _owner, long
             geometry(),
             resizable(),
             on_top(false),
-            is_fullscreen(false) {
+            is_fullscreen(false),
+            map_received(false) {
     jwindow = mainEnv->NewGlobalRef(_jwindow);
     gdk_windowManagerFunctions = wmf;
 
@@ -959,6 +960,10 @@ void WindowContextTop::process_state(GdkEventWindowState* event) {
     WindowContextBase::process_state(event);
 }
 
+void WindowContextTop::process_map() {
+    map_received = true;
+}
+
 void WindowContextTop::process_realize() {
     gdk_window = gtk_widget_get_window(gtk_widget);
     if (frame_type == TITLED) {
@@ -975,6 +980,10 @@ void WindowContextTop::process_realize() {
 }
 
 void WindowContextTop::process_configure(GdkEventConfigure* event) {
+    if (!map_received) {
+        return;
+    }
+
     int ww = event->width + geometry.extents.left + geometry.extents.right;
     int wh = event->height + geometry.extents.top + geometry.extents.bottom;
 
@@ -1003,6 +1012,7 @@ void WindowContextTop::process_configure(GdkEventConfigure* event) {
 
     int x, y;
     gdk_window_get_origin(gdk_window, &x, &y);
+
     if (frame_type == TITLED && !is_fullscreen) {
         x -= geometry.extents.left;
         y -= geometry.extents.top;

--- a/modules/javafx.graphics/src/main/native-glass/gtk/glass_window.h
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/glass_window.h
@@ -131,6 +131,7 @@ public:
     virtual void set_level(int) = 0;
     virtual void set_background(float, float, float) = 0;
 
+    virtual void process_map() = 0;
     virtual void process_realize() = 0;
     virtual void process_property_notify(GdkEventProperty*) = 0;
     virtual void process_configure(GdkEventConfigure*) = 0;
@@ -271,6 +272,7 @@ class WindowContextTop: public WindowContextBase {
 
     bool on_top;
     bool is_fullscreen;
+    bool map_received;
 
     static WindowFrameExtents normal_extents;
     static WindowFrameExtents utility_extents;
@@ -279,6 +281,7 @@ class WindowContextTop: public WindowContextBase {
 public:
     WindowContextTop(jobject, WindowContext*, long, WindowFrameType, WindowType, GdkWMFunction);
 
+    void process_map();
     void process_realize();
     void process_property_notify(GdkEventProperty*);
     void process_state(GdkEventWindowState*);


### PR DESCRIPTION
On Ubuntu 24.04 with Xorg windows are not shown centered.

This is due a configure event being received with position 0,0 which is wrong.

The fix ignores the configure events until the window is mapped.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8337400](https://bugs.openjdk.org/browse/JDK-8337400): [Linux] Initial window position is not centered on Ubuntu 24.04 / Xorg (**Bug** - P4)


### Reviewers
 * [Lukasz Kostyra](https://openjdk.org/census#lkostyra) (@lukostyra - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1520/head:pull/1520` \
`$ git checkout pull/1520`

Update a local copy of the PR: \
`$ git checkout pull/1520` \
`$ git pull https://git.openjdk.org/jfx.git pull/1520/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1520`

View PR using the GUI difftool: \
`$ git pr show -t 1520`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1520.diff">https://git.openjdk.org/jfx/pull/1520.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1520#issuecomment-2256563228)