### PR TITLE
8336277: Colors are incorrect when playing H.265/HEVC on Windows 11

### DIFF
--- a/modules/javafx.media/src/main/native/gstreamer/plugins/mfwrapper/mfwrapper.h
+++ b/modules/javafx.media/src/main/native/gstreamer/plugins/mfwrapper/mfwrapper.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,6 +33,16 @@
 #include <mftransform.h>
 
 G_BEGIN_DECLS
+
+// Media Foundation Color Convert:
+// NV12 -> IYUV
+// P010 -> NV12 -> IYUV
+// Maximum number of color converters
+#define MAX_COLOR_CONVERT 2
+// Index in array for color convert with IYUV output format
+#define COLOR_CONVERT_IYUV 0
+// Index in array for color convert with NV12 output format
+#define COLOR_CONVERT_NV12 1
 
 #define GST_TYPE_MFWRAPPER \
     (gst_mfwrapper_get_type())
@@ -68,12 +78,10 @@ struct _GstMFWrapper
     HRESULT hr_mfstartup;
 
     IMFTransform *pDecoder;
-
     IMFSample *pDecoderOutput;
 
-    IMFTransform *pColorConvert;
-
-    IMFSample *pColorConvertOutput;
+    IMFTransform *pColorConvert[MAX_COLOR_CONVERT];
+    IMFSample *pColorConvertOutput[MAX_COLOR_CONVERT];
 
     BYTE *header;
     gsize header_size;
@@ -82,6 +90,10 @@ struct _GstMFWrapper
     guint height;
     guint framerate_num;
     guint framerate_den;
+
+    guint defaultStride;
+    guint pixel_num;
+    guint pixel_den;
 };
 
 struct _GstMFWrapperClass


### PR DESCRIPTION
- For some reason H.265 decoder on Windows accepts proposed media format without error, but does not actually change output format.
- For 8-bit we proposed IYUV, but decoder outputs NV12. For 10-bit we proposed NV12, but decoder outputs P010. As result colors where not correct during rendering.
- To detect such condition we will propose media format and then read it back to determine actual decoder output format.
- Added color conversion for P010 format, which was missing. P010 conversion is done in two stages (P010->NV12->IYUV), since color converter does not support direct conversion from P010 to IYUV.
- Note: Color conversion from P010->NV12->IYUV and NV12->IYUV is temporary solution and will be disabled/removed once JDK-8337686 is implemented. JDK-8337686 will add native support for P010 and NV12 to Graphics.
- Added debug trace for formats. Disabled by default.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8336277](https://bugs.openjdk.org/browse/JDK-8336277): Colors are incorrect when playing H.265/HEVC on Windows 11 (**Bug** - P3)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1525/head:pull/1525` \
`$ git checkout pull/1525`

Update a local copy of the PR: \
`$ git checkout pull/1525` \
`$ git pull https://git.openjdk.org/jfx.git pull/1525/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1525`

View PR using the GUI difftool: \
`$ git pr show -t 1525`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1525.diff">https://git.openjdk.org/jfx/pull/1525.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1525#issuecomment-2259588520)