### PR TITLE
8336624: Improve Decora Shader loading for modern APIs

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DResourceFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DResourceFactory.java
@@ -429,7 +429,8 @@ class D3DResourceFactory extends BaseShaderFactory {
     }
 
     @Override
-    public Shader createShader(InputStream pixelShaderCode,
+    public Shader createShader(String pixelShaderName,
+                               InputStream pixelShaderCode,
                                Map<String, Integer> samplers,
                                Map<String, Integer> params,
                                int maxTexCoordIndex,
@@ -458,8 +459,8 @@ class D3DResourceFactory extends BaseShaderFactory {
             );
             Class klass = Class.forName("com.sun.prism.shader." + name + "_Loader");
             Method m = klass.getMethod("loadShader",
-                new Class[] { ShaderFactory.class, InputStream.class });
-            return (Shader)m.invoke(null, new Object[] { this, stream });
+                new Class[] { ShaderFactory.class, String.class, InputStream.class });
+            return (Shader)m.invoke(null, new Object[] { this, name, stream });
         } catch (Throwable e) {
             e.printStackTrace();
             throw new InternalError("Error loading stock shader " + name);

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2ResourceFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2ResourceFactory.java
@@ -217,7 +217,8 @@ public class ES2ResourceFactory extends BaseShaderFactory {
     }
 
     @Override
-    public Shader createShader(InputStream pixelShaderCode,
+    public Shader createShader(String pixelShaderName,
+            InputStream pixelShaderCode,
             Map<String, Integer> samplers,
             Map<String, Integer> params,
             int maxTexCoordIndex,
@@ -320,8 +321,8 @@ public class ES2ResourceFactory extends BaseShaderFactory {
             }
             Method m =
                     klass.getMethod("loadShader", new Class[]{ShaderFactory.class,
-                        InputStream.class});
-            return (Shader) m.invoke(null, new Object[]{this, stream});
+                        String.class, InputStream.class});
+            return (Shader) m.invoke(null, new Object[]{this, name, stream});
         } catch (Throwable e) {
             e.printStackTrace();
             throw new InternalError("Error loading stock shader " + name);

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/null3d/DummyResourceFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/null3d/DummyResourceFactory.java
@@ -108,7 +108,8 @@ class DummyResourceFactory extends BaseShaderFactory {
     }
 
     @Override
-    public Shader createShader(InputStream pixelShaderCode,
+    public Shader createShader(String pixelShaderName,
+                               InputStream pixelShaderCode,
                                Map<String, Integer> samplers,
                                Map<String, Integer> params,
                                int maxTexCoordIndex,

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/ps/ShaderFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/ps/ShaderFactory.java
@@ -31,7 +31,8 @@ import java.util.Map;
 
 public interface ShaderFactory extends ResourceFactory {
 
-    public Shader createShader(InputStream pixelShaderCode,
+    public Shader createShader(String pixelShaderName,
+                               InputStream pixelShaderCode,
                                Map<String, Integer> samplers,
                                Map<String, Integer> params,
                                int maxTexCoordIndex,

--- a/modules/javafx.graphics/src/main/java/com/sun/scenario/effect/impl/prism/ps/PPSRenderer.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/scenario/effect/impl/prism/ps/PPSRenderer.java
@@ -267,7 +267,7 @@ public class PPSRenderer extends PrRenderer {
         InputStream pscode = shaderSource.loadSource(name);
         int maxTexCoordIndex = samplers.keySet().size()-1;
         ShaderFactory factory = (ShaderFactory)rf;
-        return factory.createShader(pscode, samplers, params,
+        return factory.createShader(name, pscode, samplers, params,
                                     maxTexCoordIndex,
                                     isPixcoordUsed, false);
     }

--- a/modules/javafx.graphics/src/main/jsl-prism/PrismLoaderGlue.stg
+++ b/modules/javafx.graphics/src/main/jsl-prism/PrismLoaderGlue.stg
@@ -43,13 +43,14 @@ public class $shaderName$_Loader {
     }
 
     public static Shader loadShader(ShaderFactory factory,
+                                    String pixelShaderName,
                                     InputStream pixelShaderCode)
     {
         HashMap<String, Integer> samplers = new HashMap<String, Integer>();
         $samplerInit$
         HashMap<String, Integer> params = new HashMap<String, Integer>();
         $paramInit$
-        return factory.createShader(pixelShaderCode, samplers, params,
+        return factory.createShader(pixelShaderName, pixelShaderCode, samplers, params,
                                     $maxTexCoordIndex$,
                                     $isPixcoordUsed$, true);
     }


### PR DESCRIPTION
In modern graphics APIs having the knowledge of Shader's name can be necessary - whether it is because of a different Shader storage/loading behavior, or to fetch some additional metadata generated upon Shader precompilation. A good example is shown on development branch for Metal backend, where [a temporary workaround was added](https://github.com/openjdk/jfx-sandbox/blob/metal/modules/javafx.graphics/src/main/java/com/sun/scenario/effect/impl/prism/ps/PPSRenderer.java#L270) to provide Metal with loaded Shader's name. Metal API uses shaders stored in a Metal-specific shader library, which makes our "usual ways" of loading shader code and providing it via an InputStream not possible.

This change resolves above problem by adding a `pixelShaderName` argument to `ShaderFactory` interface. Additionally, Glue template for Prism Shaders was updated to also provide both Shader's name and Shader code to the backend. Thanks to this change, Prism backends can determine the best course of action - old backends can ignore newly added `pixelShaderName` parameter and proceed "as usual", while new backends like Metal can adjust shader loading for their needs.

Both D3D and ES2 Prism backends were updated to properly handle these changes.

NOTE: Because Glue template was changed for Prism stock shaders, it might be necessary to run a full clean-rebuild sequence to regenerate JSL Shaders and properly test this change.

I tested this change on Windows, macOS and Linux, both full test run and by randomly picking Ensemble8 examples.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336624](https://bugs.openjdk.org/browse/JDK-8336624): Improve Decora Shader loading for modern APIs (**Enhancement** - P4)


### Reviewers
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1530/head:pull/1530` \
`$ git checkout pull/1530`

Update a local copy of the PR: \
`$ git checkout pull/1530` \
`$ git pull https://git.openjdk.org/jfx.git pull/1530/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1530`

View PR using the GUI difftool: \
`$ git pr show -t 1530`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1530.diff">https://git.openjdk.org/jfx/pull/1530.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1530#issuecomment-2269421474)