### PR TITLE
8336938: Update libFFI to 3.4.6

### DIFF
--- a/modules/javafx.media/src/main/legal/libffi.md
+++ b/modules/javafx.media/src/main/legal/libffi.md
@@ -1,9 +1,9 @@
-## LibFFI v3.4.4
+## LibFFI v3.4.6
 
 ### LibFFI License
 ```
 
-libffi - Copyright (c) 1996-2022  Anthony Green, Red Hat, Inc and others.
+libffi - Copyright (c) 1996-2024  Anthony Green, Red Hat, Inc and others.
 See source files for details.
 
 Permission is hereby granted, free of charge, to any person obtaining
@@ -26,7 +26,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 Copyright (C) 2007-2010  Free Software Foundation, Inc
-Copyright (C) 1996-2014  Red Hat, Inc.
+Copyright (C) 1996-2024  Red Hat, Inc.
 Copyright (C) 2009-2012 ARM Ltd.
 Copyright (C) 2011 Plausible Labs Cooperative, Inc.
 Copyright (C) 2002  Ranjit Mathew
@@ -34,6 +34,8 @@ Copyright (C) 2002  Bo Thorsen
 Copyright (C) 2002  Roger Sayle
 Copyright (C) 2013  The Written Word, Inc.
 Copyright (C) 2002-2007  Bo Thorsen <bo@suse.de>
+Copyright (C) 2021  Microsoft, Inc.
+Copyright (c) 2022 Oracle and/or its affiliates.
 
 ```
 

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/LICENSE
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/LICENSE
@@ -1,4 +1,4 @@
-libffi - Copyright (c) 1996-2022  Anthony Green, Red Hat, Inc and others.
+libffi - Copyright (c) 1996-2024  Anthony Green, Red Hat, Inc and others.
 See source files for details.
 
 Permission is hereby granted, free of charge, to any person obtaining

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/include/ffi_common.h
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/include/ffi_common.h
@@ -49,8 +49,10 @@ extern "C" {
 #  endif
 # endif
 # define MAYBE_UNUSED __attribute__((__unused__))
+# define NORETURN __attribute__((__noreturn__))
 #else
 # define MAYBE_UNUSED
+# define NORETURN
 # if HAVE_ALLOCA_H
 #  include <alloca.h>
 # else
@@ -82,9 +84,9 @@ char *alloca ();
 #endif
 
 #ifdef FFI_DEBUG
-void ffi_assert(char *expr, char *file, int line);
+NORETURN void ffi_assert(const char *expr, const char *file, int line);
 void ffi_stop_here(void);
-void ffi_type_test(ffi_type *a, char *file, int line);
+void ffi_type_test(ffi_type *a, const char *file, int line);
 
 #define FFI_ASSERT(x) ((x) ? (void)0 : ffi_assert(#x, __FILE__,__LINE__))
 #define FFI_ASSERT_AT(x, f, l) ((x) ? 0 : ffi_assert(#x, (f), (l)))
@@ -127,6 +129,10 @@ void *ffi_data_to_code_pointer (void *data) FFI_HIDDEN;
 /* The arch code calls this to determine if a given closure has a
    static trampoline. */
 int ffi_tramp_is_present (void *closure) FFI_HIDDEN;
+
+/* Return a file descriptor of a temporary zero-sized file in a
+   writable and executable filesystem. */
+int open_temp_exec_file(void) FFI_HIDDEN;
 
 /* Extended cif, used in callback from assembly routine */
 typedef struct

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/include/mac/aarch64/ffi.h
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/include/mac/aarch64/ffi.h
@@ -1,6 +1,6 @@
 /* -----------------------------------------------------------------*-C-*-
-   libffi 3.4.4
-     - Copyright (c) 2011, 2014, 2019, 2021, 2022 Anthony Green
+   libffi 3.4.6
+     - Copyright (c) 2011, 2014, 2019, 2021, 2022, 2024 Anthony Green
      - Copyright (c) 1996-2003, 2007, 2008 Red Hat, Inc.
 
    Permission is hereby granted, free of charge, to any person
@@ -55,6 +55,31 @@ extern "C" {
 #endif
 
 /* ---- System configuration information --------------------------------- */
+
+/* If these change, update src/mips/ffitarget.h. */
+#define FFI_TYPE_VOID       0
+#define FFI_TYPE_INT        1
+#define FFI_TYPE_FLOAT      2
+#define FFI_TYPE_DOUBLE     3
+#if 0
+#define FFI_TYPE_LONGDOUBLE 4
+#else
+#define FFI_TYPE_LONGDOUBLE FFI_TYPE_DOUBLE
+#endif
+#define FFI_TYPE_UINT8      5
+#define FFI_TYPE_SINT8      6
+#define FFI_TYPE_UINT16     7
+#define FFI_TYPE_SINT16     8
+#define FFI_TYPE_UINT32     9
+#define FFI_TYPE_SINT32     10
+#define FFI_TYPE_UINT64     11
+#define FFI_TYPE_SINT64     12
+#define FFI_TYPE_STRUCT     13
+#define FFI_TYPE_POINTER    14
+#define FFI_TYPE_COMPLEX    15
+
+/* This should always refer to the last type code (for sanity checks).  */
+#define FFI_TYPE_LAST       FFI_TYPE_COMPLEX
 
 #include <ffitarget.h>
 
@@ -115,13 +140,11 @@ typedef struct _ffi_type
    when using the static version of the library.
    Besides, as a workaround, they can define FFI_BUILDING if they
    *know* they are going to link with the static library.  */
-#if defined _MSC_VER
+#if defined _MSC_VER && !defined(FFI_STATIC_BUILD)
 # if defined FFI_BUILDING_DLL /* Building libffi.DLL with msvcc.sh */
 #  define FFI_API __declspec(dllexport)
-# elif !defined FFI_BUILDING  /* Importing libffi.DLL */
+# else  /* Importing libffi.DLL */
 #  define FFI_API __declspec(dllimport)
-# else                        /* Building/linking static library */
-#  define FFI_API
 # endif
 #else
 # define FFI_API
@@ -197,21 +220,12 @@ FFI_EXTERN ffi_type ffi_type_sint64;
 FFI_EXTERN ffi_type ffi_type_float;
 FFI_EXTERN ffi_type ffi_type_double;
 FFI_EXTERN ffi_type ffi_type_pointer;
-
-#if 0
 FFI_EXTERN ffi_type ffi_type_longdouble;
-#else
-#define ffi_type_longdouble ffi_type_double
-#endif
 
 #ifdef FFI_TARGET_HAS_COMPLEX_TYPE
 FFI_EXTERN ffi_type ffi_type_complex_float;
 FFI_EXTERN ffi_type ffi_type_complex_double;
-#if 0
 FFI_EXTERN ffi_type ffi_type_complex_longdouble;
-#else
-#define ffi_type_complex_longdouble ffi_type_complex_double
-#endif
 #endif
 #endif /* LIBFFI_HIDE_BASIC_TYPES */
 
@@ -338,14 +352,6 @@ typedef struct {
 FFI_API void *ffi_closure_alloc (size_t size, void **code);
 FFI_API void ffi_closure_free (void *);
 
-#if defined(PA_LINUX) || defined(PA_HPUX)
-#define FFI_CLOSURE_PTR(X) ((void *)((unsigned int)(X) | 2))
-#define FFI_RESTORE_PTR(X) ((void *)((unsigned int)(X) & ~3))
-#else
-#define FFI_CLOSURE_PTR(X) (X)
-#define FFI_RESTORE_PTR(X) (X)
-#endif
-
 FFI_API ffi_status
 ffi_prep_closure (ffi_closure*,
           ffi_cif *,
@@ -449,7 +455,7 @@ ffi_prep_java_raw_closure_loc (ffi_java_raw_closure*,
 
 #endif /* FFI_CLOSURES */
 
-#if FFI_GO_CLOSURES
+#ifdef FFI_GO_CLOSURES
 
 typedef struct {
   void      *tramp;
@@ -492,37 +498,18 @@ FFI_API
 ffi_status ffi_get_struct_offsets (ffi_abi abi, ffi_type *struct_type,
                    size_t *offsets);
 
-/* Useful for eliminating compiler warnings.  */
+/* Convert between closure and function pointers.  */
+#if defined(PA_LINUX) || defined(PA_HPUX)
+#define FFI_FN(f) ((void (*)(void))((unsigned int)(f) | 2))
+#define FFI_CL(f) ((void *)((unsigned int)(f) & ~3))
+#else
 #define FFI_FN(f) ((void (*)(void))f)
+#define FFI_CL(f) ((void *)(f))
+#endif
 
 /* ---- Definitions shared with assembly code ---------------------------- */
 
 #endif
-
-/* If these change, update src/mips/ffitarget.h. */
-#define FFI_TYPE_VOID       0
-#define FFI_TYPE_INT        1
-#define FFI_TYPE_FLOAT      2
-#define FFI_TYPE_DOUBLE     3
-#if 0
-#define FFI_TYPE_LONGDOUBLE 4
-#else
-#define FFI_TYPE_LONGDOUBLE FFI_TYPE_DOUBLE
-#endif
-#define FFI_TYPE_UINT8      5
-#define FFI_TYPE_SINT8      6
-#define FFI_TYPE_UINT16     7
-#define FFI_TYPE_SINT16     8
-#define FFI_TYPE_UINT32     9
-#define FFI_TYPE_SINT32     10
-#define FFI_TYPE_UINT64     11
-#define FFI_TYPE_SINT64     12
-#define FFI_TYPE_STRUCT     13
-#define FFI_TYPE_POINTER    14
-#define FFI_TYPE_COMPLEX    15
-
-/* This should always refer to the last type code (for sanity checks).  */
-#define FFI_TYPE_LAST       FFI_TYPE_COMPLEX
 
 #ifdef __cplusplus
 }

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/include/mac/aarch64/fficonfig.h
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/include/mac/aarch64/fficonfig.h
@@ -4,9 +4,6 @@
 /* Define if building universal (internal helper macro) */
 /* #undef AC_APPLE_UNIVERSAL_BUILD */
 
-/* Define to 1 if using 'alloca.c'. */
-/* #undef C_ALLOCA */
-
 /* Define to the flags needed for the .section .eh_frame directive. */
 #define EH_FRAME_FLAGS "a"
 
@@ -32,10 +29,7 @@
 /* Define this if you do not want support for aggregate types. */
 /* #undef FFI_NO_STRUCTS */
 
-/* Define to 1 if you have 'alloca', as a function or macro. */
-#define HAVE_ALLOCA 1
-
-/* Define to 1 if <alloca.h> works. */
+/* Define to 1 if you have the <alloca.h> header file. */
 #define HAVE_ALLOCA_H 1
 
 /* Define if your assembler supports .cfi_* directives. */
@@ -78,27 +72,6 @@
 /* Define to 1 if you have the `memfd_create' function. */
 /* #undef HAVE_MEMFD_CREATE */
 
-/* Define to 1 if you have the <memory.h> header file. */
-#define HAVE_MEMORY_H 1
-
-/* Define to 1 if you have the `mkostemp' function. */
-#define HAVE_MKOSTEMP 1
-
-/* Define to 1 if you have the `mkstemp' function. */
-/* #undef HAVE_MKSTEMP */
-
-/* Define to 1 if you have the `mmap' function. */
-#define HAVE_MMAP 1
-
-/* Define if mmap with MAP_ANON(YMOUS) works. */
-#define HAVE_MMAP_ANON 1
-
-/* Define if mmap of /dev/zero works. */
-/* #undef HAVE_MMAP_DEV_ZERO */
-
-/* Define if read-only mmap of a plain file works. */
-#define HAVE_MMAP_FILE 1
-
 /* Define if your compiler supports pointer authentication. */
 /* #undef HAVE_PTRAUTH */
 
@@ -122,9 +95,6 @@
 
 /* Define to 1 if you have the <sys/memfd.h> header file. */
 /* #undef HAVE_SYS_MEMFD_H */
-
-/* Define to 1 if you have the <sys/mman.h> header file. */
-#define HAVE_SYS_MMAN_H 1
 
 /* Define to 1 if you have the <sys/stat.h> header file. */
 #define HAVE_SYS_STAT_H 1
@@ -151,7 +121,7 @@
 #define PACKAGE_NAME "libffi"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "libffi 3.4.4"
+#define PACKAGE_STRING "libffi 3.4.6"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "libffi"
@@ -160,7 +130,7 @@
 #define PACKAGE_URL ""
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "3.4.4"
+#define PACKAGE_VERSION "3.4.6"
 
 /* The size of `double', as computed by sizeof. */
 #define SIZEOF_DOUBLE 8
@@ -170,14 +140,6 @@
 
 /* The size of `size_t', as computed by sizeof. */
 #define SIZEOF_SIZE_T 8
-
-/* If using the C implementation of alloca, define if you know the
-   direction of stack growth for your system; otherwise it will be
-   automatically deduced at runtime.
-    STACK_DIRECTION > 0 => grows toward higher addresses
-    STACK_DIRECTION < 0 => grows toward lower addresses
-    STACK_DIRECTION = 0 => direction of growth unknown */
-/* #undef STACK_DIRECTION */
 
 /* Define to 1 if all of the C90 standard headers exist (not just the ones
    required in a freestanding environment). This macro is provided for
@@ -192,7 +154,7 @@
 /* #undef USING_PURIFY */
 
 /* Version number of package */
-#define VERSION "3.4.4"
+#define VERSION "3.4.6"
 
 /* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
    significant byte first (like Motorola and SPARC, unlike Intel). */
@@ -205,9 +167,6 @@
 /* #  undef WORDS_BIGENDIAN */
 # endif
 #endif
-
-/* Define to `unsigned int' if <sys/types.h> does not define. */
-/* #undef size_t */
 
 
 #ifdef HAVE_HIDDEN_VISIBILITY_ATTRIBUTE

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/include/mac/x64/ffi.h
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/include/mac/x64/ffi.h
@@ -1,6 +1,6 @@
 /* -----------------------------------------------------------------*-C-*-
-   libffi 3.4.4
-     - Copyright (c) 2011, 2014, 2019, 2021, 2022 Anthony Green
+   libffi 3.4.6
+     - Copyright (c) 2011, 2014, 2019, 2021, 2022, 2024 Anthony Green
      - Copyright (c) 1996-2003, 2007, 2008 Red Hat, Inc.
 
    Permission is hereby granted, free of charge, to any person
@@ -55,6 +55,31 @@ extern "C" {
 #endif
 
 /* ---- System configuration information --------------------------------- */
+
+/* If these change, update src/mips/ffitarget.h. */
+#define FFI_TYPE_VOID       0
+#define FFI_TYPE_INT        1
+#define FFI_TYPE_FLOAT      2
+#define FFI_TYPE_DOUBLE     3
+#if 1
+#define FFI_TYPE_LONGDOUBLE 4
+#else
+#define FFI_TYPE_LONGDOUBLE FFI_TYPE_DOUBLE
+#endif
+#define FFI_TYPE_UINT8      5
+#define FFI_TYPE_SINT8      6
+#define FFI_TYPE_UINT16     7
+#define FFI_TYPE_SINT16     8
+#define FFI_TYPE_UINT32     9
+#define FFI_TYPE_SINT32     10
+#define FFI_TYPE_UINT64     11
+#define FFI_TYPE_SINT64     12
+#define FFI_TYPE_STRUCT     13
+#define FFI_TYPE_POINTER    14
+#define FFI_TYPE_COMPLEX    15
+
+/* This should always refer to the last type code (for sanity checks).  */
+#define FFI_TYPE_LAST       FFI_TYPE_COMPLEX
 
 #include <ffitarget.h>
 
@@ -115,13 +140,11 @@ typedef struct _ffi_type
    when using the static version of the library.
    Besides, as a workaround, they can define FFI_BUILDING if they
    *know* they are going to link with the static library.  */
-#if defined _MSC_VER
+#if defined _MSC_VER && !defined(FFI_STATIC_BUILD)
 # if defined FFI_BUILDING_DLL /* Building libffi.DLL with msvcc.sh */
 #  define FFI_API __declspec(dllexport)
-# elif !defined FFI_BUILDING  /* Importing libffi.DLL */
+# else  /* Importing libffi.DLL */
 #  define FFI_API __declspec(dllimport)
-# else                        /* Building/linking static library */
-#  define FFI_API
 # endif
 #else
 # define FFI_API
@@ -197,21 +220,12 @@ FFI_EXTERN ffi_type ffi_type_sint64;
 FFI_EXTERN ffi_type ffi_type_float;
 FFI_EXTERN ffi_type ffi_type_double;
 FFI_EXTERN ffi_type ffi_type_pointer;
-
-#if 1
 FFI_EXTERN ffi_type ffi_type_longdouble;
-#else
-#define ffi_type_longdouble ffi_type_double
-#endif
 
 #ifdef FFI_TARGET_HAS_COMPLEX_TYPE
 FFI_EXTERN ffi_type ffi_type_complex_float;
 FFI_EXTERN ffi_type ffi_type_complex_double;
-#if 1
 FFI_EXTERN ffi_type ffi_type_complex_longdouble;
-#else
-#define ffi_type_complex_longdouble ffi_type_complex_double
-#endif
 #endif
 #endif /* LIBFFI_HIDE_BASIC_TYPES */
 
@@ -338,14 +352,6 @@ typedef struct {
 FFI_API void *ffi_closure_alloc (size_t size, void **code);
 FFI_API void ffi_closure_free (void *);
 
-#if defined(PA_LINUX) || defined(PA_HPUX)
-#define FFI_CLOSURE_PTR(X) ((void *)((unsigned int)(X) | 2))
-#define FFI_RESTORE_PTR(X) ((void *)((unsigned int)(X) & ~3))
-#else
-#define FFI_CLOSURE_PTR(X) (X)
-#define FFI_RESTORE_PTR(X) (X)
-#endif
-
 FFI_API ffi_status
 ffi_prep_closure (ffi_closure*,
           ffi_cif *,
@@ -449,7 +455,7 @@ ffi_prep_java_raw_closure_loc (ffi_java_raw_closure*,
 
 #endif /* FFI_CLOSURES */
 
-#if FFI_GO_CLOSURES
+#ifdef FFI_GO_CLOSURES
 
 typedef struct {
   void      *tramp;
@@ -492,37 +498,18 @@ FFI_API
 ffi_status ffi_get_struct_offsets (ffi_abi abi, ffi_type *struct_type,
                    size_t *offsets);
 
-/* Useful for eliminating compiler warnings.  */
+/* Convert between closure and function pointers.  */
+#if defined(PA_LINUX) || defined(PA_HPUX)
+#define FFI_FN(f) ((void (*)(void))((unsigned int)(f) | 2))
+#define FFI_CL(f) ((void *)((unsigned int)(f) & ~3))
+#else
 #define FFI_FN(f) ((void (*)(void))f)
+#define FFI_CL(f) ((void *)(f))
+#endif
 
 /* ---- Definitions shared with assembly code ---------------------------- */
 
 #endif
-
-/* If these change, update src/mips/ffitarget.h. */
-#define FFI_TYPE_VOID       0
-#define FFI_TYPE_INT        1
-#define FFI_TYPE_FLOAT      2
-#define FFI_TYPE_DOUBLE     3
-#if 1
-#define FFI_TYPE_LONGDOUBLE 4
-#else
-#define FFI_TYPE_LONGDOUBLE FFI_TYPE_DOUBLE
-#endif
-#define FFI_TYPE_UINT8      5
-#define FFI_TYPE_SINT8      6
-#define FFI_TYPE_UINT16     7
-#define FFI_TYPE_SINT16     8
-#define FFI_TYPE_UINT32     9
-#define FFI_TYPE_SINT32     10
-#define FFI_TYPE_UINT64     11
-#define FFI_TYPE_SINT64     12
-#define FFI_TYPE_STRUCT     13
-#define FFI_TYPE_POINTER    14
-#define FFI_TYPE_COMPLEX    15
-
-/* This should always refer to the last type code (for sanity checks).  */
-#define FFI_TYPE_LAST       FFI_TYPE_COMPLEX
 
 #ifdef __cplusplus
 }

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/include/mac/x64/fficonfig.h
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/include/mac/x64/fficonfig.h
@@ -4,9 +4,6 @@
 /* Define if building universal (internal helper macro) */
 /* #undef AC_APPLE_UNIVERSAL_BUILD */
 
-/* Define to 1 if using 'alloca.c'. */
-/* #undef C_ALLOCA */
-
 /* Define to the flags needed for the .section .eh_frame directive. */
 #define EH_FRAME_FLAGS "a"
 
@@ -32,10 +29,7 @@
 /* Define this if you do not want support for aggregate types. */
 /* #undef FFI_NO_STRUCTS */
 
-/* Define to 1 if you have 'alloca', as a function or macro. */
-#define HAVE_ALLOCA 1
-
-/* Define to 1 if <alloca.h> works. */
+/* Define to 1 if you have the <alloca.h> header file. */
 #define HAVE_ALLOCA_H 1
 
 /* Define if your assembler supports .cfi_* directives. */
@@ -77,27 +71,6 @@
 
 /* Define to 1 if you have the `memfd_create' function. */
 /* #undef HAVE_MEMFD_CREATE */
-
-/* Define to 1 if you have the <memory.h> header file. */
-#define HAVE_MEMORY_H 1
-
-/* Define to 1 if you have the `mkostemp' function. */
-#define HAVE_MKOSTEMP 1
-
-/* Define to 1 if you have the `mkstemp' function. */
-/* #undef HAVE_MKSTEMP */
-
-/* Define to 1 if you have the `mmap' function. */
-#define HAVE_MMAP 1
-
-/* Define if mmap with MAP_ANON(YMOUS) works. */
-#define HAVE_MMAP_ANON 1
-
-/* Define if mmap of /dev/zero works. */
-/* #undef HAVE_MMAP_DEV_ZERO */
-
-/* Define if read-only mmap of a plain file works. */
-#define HAVE_MMAP_FILE 1
 
 /* Define if your compiler supports pointer authentication. */
 /* #undef HAVE_PTRAUTH */
@@ -151,7 +124,7 @@
 #define PACKAGE_NAME "libffi"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "libffi 3.4.4"
+#define PACKAGE_STRING "libffi 3.4.6"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "libffi"
@@ -160,7 +133,7 @@
 #define PACKAGE_URL ""
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "3.4.4"
+#define PACKAGE_VERSION "3.4.6"
 
 /* The size of `double', as computed by sizeof. */
 #define SIZEOF_DOUBLE 8
@@ -170,14 +143,6 @@
 
 /* The size of `size_t', as computed by sizeof. */
 #define SIZEOF_SIZE_T 8
-
-/* If using the C implementation of alloca, define if you know the
-   direction of stack growth for your system; otherwise it will be
-   automatically deduced at runtime.
-    STACK_DIRECTION > 0 => grows toward higher addresses
-    STACK_DIRECTION < 0 => grows toward lower addresses
-    STACK_DIRECTION = 0 => direction of growth unknown */
-/* #undef STACK_DIRECTION */
 
 /* Define to 1 if all of the C90 standard headers exist (not just the ones
    required in a freestanding environment). This macro is provided for
@@ -192,7 +157,7 @@
 /* #undef USING_PURIFY */
 
 /* Version number of package */
-#define VERSION "3.4.4"
+#define VERSION "3.4.6"
 
 /* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
    significant byte first (like Motorola and SPARC, unlike Intel). */
@@ -205,9 +170,6 @@
 /* #  undef WORDS_BIGENDIAN */
 # endif
 #endif
-
-/* Define to `unsigned int' if <sys/types.h> does not define. */
-/* #undef size_t */
 
 
 #ifdef HAVE_HIDDEN_VISIBILITY_ATTRIBUTE

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/include/win/x64/ffi.h
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/include/win/x64/ffi.h
@@ -1,6 +1,6 @@
 /* -----------------------------------------------------------------*-C-*-
-   libffi 3.4.4
-     - Copyright (c) 2011, 2014, 2019, 2021, 2022 Anthony Green
+   libffi 3.4.6
+     - Copyright (c) 2011, 2014, 2019, 2021, 2022, 2024 Anthony Green
      - Copyright (c) 1996-2003, 2007, 2008 Red Hat, Inc.
 
    Permission is hereby granted, free of charge, to any person
@@ -55,6 +55,31 @@ extern "C" {
 #endif
 
 /* ---- System configuration information --------------------------------- */
+
+/* If these change, update src/mips/ffitarget.h. */
+#define FFI_TYPE_VOID       0
+#define FFI_TYPE_INT        1
+#define FFI_TYPE_FLOAT      2
+#define FFI_TYPE_DOUBLE     3
+#if 0
+#define FFI_TYPE_LONGDOUBLE 4
+#else
+#define FFI_TYPE_LONGDOUBLE FFI_TYPE_DOUBLE
+#endif
+#define FFI_TYPE_UINT8      5
+#define FFI_TYPE_SINT8      6
+#define FFI_TYPE_UINT16     7
+#define FFI_TYPE_SINT16     8
+#define FFI_TYPE_UINT32     9
+#define FFI_TYPE_SINT32     10
+#define FFI_TYPE_UINT64     11
+#define FFI_TYPE_SINT64     12
+#define FFI_TYPE_STRUCT     13
+#define FFI_TYPE_POINTER    14
+#define FFI_TYPE_COMPLEX    15
+
+/* This should always refer to the last type code (for sanity checks).  */
+#define FFI_TYPE_LAST       FFI_TYPE_COMPLEX
 
 #include <ffitarget.h>
 
@@ -115,13 +140,11 @@ typedef struct _ffi_type
    when using the static version of the library.
    Besides, as a workaround, they can define FFI_BUILDING if they
    *know* they are going to link with the static library.  */
-#if defined _MSC_VER
+#if defined _MSC_VER && !defined(FFI_STATIC_BUILD)
 # if defined FFI_BUILDING_DLL /* Building libffi.DLL with msvcc.sh */
 #  define FFI_API __declspec(dllexport)
-# elif !defined FFI_BUILDING  /* Importing libffi.DLL */
+# else  /* Importing libffi.DLL */
 #  define FFI_API __declspec(dllimport)
-# else                        /* Building/linking static library */
-#  define FFI_API
 # endif
 #else
 # define FFI_API
@@ -197,21 +220,12 @@ FFI_EXTERN ffi_type ffi_type_sint64;
 FFI_EXTERN ffi_type ffi_type_float;
 FFI_EXTERN ffi_type ffi_type_double;
 FFI_EXTERN ffi_type ffi_type_pointer;
-
-#if 0
 FFI_EXTERN ffi_type ffi_type_longdouble;
-#else
-#define ffi_type_longdouble ffi_type_double
-#endif
 
 #ifdef FFI_TARGET_HAS_COMPLEX_TYPE
 FFI_EXTERN ffi_type ffi_type_complex_float;
 FFI_EXTERN ffi_type ffi_type_complex_double;
-#if 0
 FFI_EXTERN ffi_type ffi_type_complex_longdouble;
-#else
-#define ffi_type_complex_longdouble ffi_type_complex_double
-#endif
 #endif
 #endif /* LIBFFI_HIDE_BASIC_TYPES */
 
@@ -338,14 +352,6 @@ typedef struct {
 FFI_API void *ffi_closure_alloc (size_t size, void **code);
 FFI_API void ffi_closure_free (void *);
 
-#if defined(PA_LINUX) || defined(PA_HPUX)
-#define FFI_CLOSURE_PTR(X) ((void *)((unsigned int)(X) | 2))
-#define FFI_RESTORE_PTR(X) ((void *)((unsigned int)(X) & ~3))
-#else
-#define FFI_CLOSURE_PTR(X) (X)
-#define FFI_RESTORE_PTR(X) (X)
-#endif
-
 FFI_API ffi_status
 ffi_prep_closure (ffi_closure*,
           ffi_cif *,
@@ -449,7 +455,7 @@ ffi_prep_java_raw_closure_loc (ffi_java_raw_closure*,
 
 #endif /* FFI_CLOSURES */
 
-#if FFI_GO_CLOSURES
+#ifdef FFI_GO_CLOSURES
 
 typedef struct {
   void      *tramp;
@@ -492,37 +498,18 @@ FFI_API
 ffi_status ffi_get_struct_offsets (ffi_abi abi, ffi_type *struct_type,
                    size_t *offsets);
 
-/* Useful for eliminating compiler warnings.  */
+/* Convert between closure and function pointers.  */
+#if defined(PA_LINUX) || defined(PA_HPUX)
+#define FFI_FN(f) ((void (*)(void))((unsigned int)(f) | 2))
+#define FFI_CL(f) ((void *)((unsigned int)(f) & ~3))
+#else
 #define FFI_FN(f) ((void (*)(void))f)
+#define FFI_CL(f) ((void *)(f))
+#endif
 
 /* ---- Definitions shared with assembly code ---------------------------- */
 
 #endif
-
-/* If these change, update src/mips/ffitarget.h. */
-#define FFI_TYPE_VOID       0
-#define FFI_TYPE_INT        1
-#define FFI_TYPE_FLOAT      2
-#define FFI_TYPE_DOUBLE     3
-#if 0
-#define FFI_TYPE_LONGDOUBLE 4
-#else
-#define FFI_TYPE_LONGDOUBLE FFI_TYPE_DOUBLE
-#endif
-#define FFI_TYPE_UINT8      5
-#define FFI_TYPE_SINT8      6
-#define FFI_TYPE_UINT16     7
-#define FFI_TYPE_SINT16     8
-#define FFI_TYPE_UINT32     9
-#define FFI_TYPE_SINT32     10
-#define FFI_TYPE_UINT64     11
-#define FFI_TYPE_SINT64     12
-#define FFI_TYPE_STRUCT     13
-#define FFI_TYPE_POINTER    14
-#define FFI_TYPE_COMPLEX    15
-
-/* This should always refer to the last type code (for sanity checks).  */
-#define FFI_TYPE_LAST       FFI_TYPE_COMPLEX
 
 #ifdef __cplusplus
 }

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/include/win/x64/fficonfig.h
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/include/win/x64/fficonfig.h
@@ -4,9 +4,6 @@
 /* Define if building universal (internal helper macro) */
 /* #undef AC_APPLE_UNIVERSAL_BUILD */
 
-/* Define to 1 if using 'alloca.c'. */
-/* #undef C_ALLOCA */
-
 /* Define to the flags needed for the .section .eh_frame directive. */
 /* #undef EH_FRAME_FLAGS */
 
@@ -32,10 +29,7 @@
 /* Define this if you do not want support for aggregate types. */
 /* #undef FFI_NO_STRUCTS */
 
-/* Define to 1 if you have 'alloca', as a function or macro. */
-#define HAVE_ALLOCA 1
-
-/* Define to 1 if <alloca.h> works. */
+/* Define to 1 if you have the <alloca.h> header file. */
 /* #undef HAVE_ALLOCA_H */
 
 /* Define if your assembler supports .cfi_* directives. */
@@ -78,27 +72,6 @@
 /* Define to 1 if you have the `memfd_create' function. */
 /* #undef HAVE_MEMFD_CREATE */
 
-/* Define to 1 if you have the <memory.h> header file. */
-#define HAVE_MEMORY_H 1
-
-/* Define to 1 if you have the `mkostemp' function. */
-/* #undef HAVE_MKOSTEMP */
-
-/* Define to 1 if you have the `mkstemp' function. */
-/* #undef HAVE_MKSTEMP */
-
-/* Define to 1 if you have the `mmap' function. */
-/* #undef HAVE_MMAP */
-
-/* Define if mmap with MAP_ANON(YMOUS) works. */
-/* #undef HAVE_MMAP_ANON */
-
-/* Define if mmap of /dev/zero works. */
-/* #undef HAVE_MMAP_DEV_ZERO */
-
-/* Define if read-only mmap of a plain file works. */
-/* #undef HAVE_MMAP_FILE */
-
 /* Define if your compiler supports pointer authentication. */
 /* #undef HAVE_PTRAUTH */
 
@@ -122,9 +95,6 @@
 
 /* Define to 1 if you have the <sys/memfd.h> header file. */
 /* #undef HAVE_SYS_MEMFD_H */
-
-/* Define to 1 if you have the <sys/mman.h> header file. */
-/* #undef HAVE_SYS_MMAN_H */
 
 /* Define to 1 if you have the <sys/stat.h> header file. */
 #define HAVE_SYS_STAT_H 1
@@ -151,7 +121,7 @@
 #define PACKAGE_NAME "libffi"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "libffi 3.4.4"
+#define PACKAGE_STRING "libffi 3.4.6"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "libffi"
@@ -160,7 +130,7 @@
 #define PACKAGE_URL ""
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "3.4.4"
+#define PACKAGE_VERSION "3.4.6"
 
 /* The size of `double', as computed by sizeof. */
 #define SIZEOF_DOUBLE 8
@@ -170,14 +140,6 @@
 
 /* The size of `size_t', as computed by sizeof. */
 #define SIZEOF_SIZE_T 8
-
-/* If using the C implementation of alloca, define if you know the
-   direction of stack growth for your system; otherwise it will be
-   automatically deduced at runtime.
-    STACK_DIRECTION > 0 => grows toward higher addresses
-    STACK_DIRECTION < 0 => grows toward lower addresses
-    STACK_DIRECTION = 0 => direction of growth unknown */
-/* #undef STACK_DIRECTION */
 
 /* Define to 1 if all of the C90 standard headers exist (not just the ones
    required in a freestanding environment). This macro is provided for
@@ -192,7 +154,7 @@
 /* #undef USING_PURIFY */
 
 /* Version number of package */
-#define VERSION "3.4.4"
+#define VERSION "3.4.6"
 
 /* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
    significant byte first (like Motorola and SPARC, unlike Intel). */
@@ -205,9 +167,6 @@
 /* #  undef WORDS_BIGENDIAN */
 # endif
 #endif
-
-/* Define to `unsigned int' if <sys/types.h> does not define. */
-/* #undef size_t */
 
 
 #ifdef HAVE_HIDDEN_VISIBILITY_ATTRIBUTE

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/include/win/x86/ffi.h
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/include/win/x86/ffi.h
@@ -1,6 +1,6 @@
 /* -----------------------------------------------------------------*-C-*-
-   libffi 3.4.4
-     - Copyright (c) 2011, 2014, 2019, 2021, 2022 Anthony Green
+   libffi 3.4.6
+     - Copyright (c) 2011, 2014, 2019, 2021, 2022, 2024 Anthony Green
      - Copyright (c) 1996-2003, 2007, 2008 Red Hat, Inc.
 
    Permission is hereby granted, free of charge, to any person
@@ -55,6 +55,31 @@ extern "C" {
 #endif
 
 /* ---- System configuration information --------------------------------- */
+
+/* If these change, update src/mips/ffitarget.h. */
+#define FFI_TYPE_VOID       0
+#define FFI_TYPE_INT        1
+#define FFI_TYPE_FLOAT      2
+#define FFI_TYPE_DOUBLE     3
+#if 0
+#define FFI_TYPE_LONGDOUBLE 4
+#else
+#define FFI_TYPE_LONGDOUBLE FFI_TYPE_DOUBLE
+#endif
+#define FFI_TYPE_UINT8      5
+#define FFI_TYPE_SINT8      6
+#define FFI_TYPE_UINT16     7
+#define FFI_TYPE_SINT16     8
+#define FFI_TYPE_UINT32     9
+#define FFI_TYPE_SINT32     10
+#define FFI_TYPE_UINT64     11
+#define FFI_TYPE_SINT64     12
+#define FFI_TYPE_STRUCT     13
+#define FFI_TYPE_POINTER    14
+#define FFI_TYPE_COMPLEX    15
+
+/* This should always refer to the last type code (for sanity checks).  */
+#define FFI_TYPE_LAST       FFI_TYPE_COMPLEX
 
 #include <ffitarget.h>
 
@@ -115,13 +140,11 @@ typedef struct _ffi_type
    when using the static version of the library.
    Besides, as a workaround, they can define FFI_BUILDING if they
    *know* they are going to link with the static library.  */
-#if defined _MSC_VER
+#if defined _MSC_VER && !defined(FFI_STATIC_BUILD)
 # if defined FFI_BUILDING_DLL /* Building libffi.DLL with msvcc.sh */
 #  define FFI_API __declspec(dllexport)
-# elif !defined FFI_BUILDING  /* Importing libffi.DLL */
+# else  /* Importing libffi.DLL */
 #  define FFI_API __declspec(dllimport)
-# else                        /* Building/linking static library */
-#  define FFI_API
 # endif
 #else
 # define FFI_API
@@ -197,21 +220,12 @@ FFI_EXTERN ffi_type ffi_type_sint64;
 FFI_EXTERN ffi_type ffi_type_float;
 FFI_EXTERN ffi_type ffi_type_double;
 FFI_EXTERN ffi_type ffi_type_pointer;
-
-#if 0
 FFI_EXTERN ffi_type ffi_type_longdouble;
-#else
-#define ffi_type_longdouble ffi_type_double
-#endif
 
 #ifdef FFI_TARGET_HAS_COMPLEX_TYPE
 FFI_EXTERN ffi_type ffi_type_complex_float;
 FFI_EXTERN ffi_type ffi_type_complex_double;
-#if 0
 FFI_EXTERN ffi_type ffi_type_complex_longdouble;
-#else
-#define ffi_type_complex_longdouble ffi_type_complex_double
-#endif
 #endif
 #endif /* LIBFFI_HIDE_BASIC_TYPES */
 
@@ -338,14 +352,6 @@ typedef struct {
 FFI_API void *ffi_closure_alloc (size_t size, void **code);
 FFI_API void ffi_closure_free (void *);
 
-#if defined(PA_LINUX) || defined(PA_HPUX)
-#define FFI_CLOSURE_PTR(X) ((void *)((unsigned int)(X) | 2))
-#define FFI_RESTORE_PTR(X) ((void *)((unsigned int)(X) & ~3))
-#else
-#define FFI_CLOSURE_PTR(X) (X)
-#define FFI_RESTORE_PTR(X) (X)
-#endif
-
 FFI_API ffi_status
 ffi_prep_closure (ffi_closure*,
           ffi_cif *,
@@ -449,7 +455,7 @@ ffi_prep_java_raw_closure_loc (ffi_java_raw_closure*,
 
 #endif /* FFI_CLOSURES */
 
-#if FFI_GO_CLOSURES
+#ifdef FFI_GO_CLOSURES
 
 typedef struct {
   void      *tramp;
@@ -492,37 +498,18 @@ FFI_API
 ffi_status ffi_get_struct_offsets (ffi_abi abi, ffi_type *struct_type,
                    size_t *offsets);
 
-/* Useful for eliminating compiler warnings.  */
+/* Convert between closure and function pointers.  */
+#if defined(PA_LINUX) || defined(PA_HPUX)
+#define FFI_FN(f) ((void (*)(void))((unsigned int)(f) | 2))
+#define FFI_CL(f) ((void *)((unsigned int)(f) & ~3))
+#else
 #define FFI_FN(f) ((void (*)(void))f)
+#define FFI_CL(f) ((void *)(f))
+#endif
 
 /* ---- Definitions shared with assembly code ---------------------------- */
 
 #endif
-
-/* If these change, update src/mips/ffitarget.h. */
-#define FFI_TYPE_VOID       0
-#define FFI_TYPE_INT        1
-#define FFI_TYPE_FLOAT      2
-#define FFI_TYPE_DOUBLE     3
-#if 0
-#define FFI_TYPE_LONGDOUBLE 4
-#else
-#define FFI_TYPE_LONGDOUBLE FFI_TYPE_DOUBLE
-#endif
-#define FFI_TYPE_UINT8      5
-#define FFI_TYPE_SINT8      6
-#define FFI_TYPE_UINT16     7
-#define FFI_TYPE_SINT16     8
-#define FFI_TYPE_UINT32     9
-#define FFI_TYPE_SINT32     10
-#define FFI_TYPE_UINT64     11
-#define FFI_TYPE_SINT64     12
-#define FFI_TYPE_STRUCT     13
-#define FFI_TYPE_POINTER    14
-#define FFI_TYPE_COMPLEX    15
-
-/* This should always refer to the last type code (for sanity checks).  */
-#define FFI_TYPE_LAST       FFI_TYPE_COMPLEX
 
 #ifdef __cplusplus
 }

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/include/win/x86/fficonfig.h
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/include/win/x86/fficonfig.h
@@ -4,9 +4,6 @@
 /* Define if building universal (internal helper macro) */
 /* #undef AC_APPLE_UNIVERSAL_BUILD */
 
-/* Define to 1 if using 'alloca.c'. */
-/* #undef C_ALLOCA */
-
 /* Define to the flags needed for the .section .eh_frame directive. */
 /* #undef EH_FRAME_FLAGS */
 
@@ -32,10 +29,7 @@
 /* Define this if you do not want support for aggregate types. */
 /* #undef FFI_NO_STRUCTS */
 
-/* Define to 1 if you have 'alloca', as a function or macro. */
-#define HAVE_ALLOCA 1
-
-/* Define to 1 if <alloca.h> works. */
+/* Define to 1 if you have the <alloca.h> header file. */
 /* #undef HAVE_ALLOCA_H */
 
 /* Define if your assembler supports .cfi_* directives. */
@@ -78,27 +72,6 @@
 /* Define to 1 if you have the `memfd_create' function. */
 /* #undef HAVE_MEMFD_CREATE */
 
-/* Define to 1 if you have the <memory.h> header file. */
-#define HAVE_MEMORY_H 1
-
-/* Define to 1 if you have the `mkostemp' function. */
-/* #undef HAVE_MKOSTEMP */
-
-/* Define to 1 if you have the `mkstemp' function. */
-/* #undef HAVE_MKSTEMP */
-
-/* Define to 1 if you have the `mmap' function. */
-/* #undef HAVE_MMAP */
-
-/* Define if mmap with MAP_ANON(YMOUS) works. */
-/* #undef HAVE_MMAP_ANON */
-
-/* Define if mmap of /dev/zero works. */
-/* #undef HAVE_MMAP_DEV_ZERO */
-
-/* Define if read-only mmap of a plain file works. */
-/* #undef HAVE_MMAP_FILE */
-
 /* Define if your compiler supports pointer authentication. */
 /* #undef HAVE_PTRAUTH */
 
@@ -122,9 +95,6 @@
 
 /* Define to 1 if you have the <sys/memfd.h> header file. */
 /* #undef HAVE_SYS_MEMFD_H */
-
-/* Define to 1 if you have the <sys/mman.h> header file. */
-/* #undef HAVE_SYS_MMAN_H */
 
 /* Define to 1 if you have the <sys/stat.h> header file. */
 #define HAVE_SYS_STAT_H 1
@@ -151,7 +121,7 @@
 #define PACKAGE_NAME "libffi"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "libffi 3.4.4"
+#define PACKAGE_STRING "libffi 3.4.6"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "libffi"
@@ -160,7 +130,7 @@
 #define PACKAGE_URL ""
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "3.4.4"
+#define PACKAGE_VERSION "3.4.6"
 
 /* The size of `double', as computed by sizeof. */
 #define SIZEOF_DOUBLE 8
@@ -170,14 +140,6 @@
 
 /* The size of `size_t', as computed by sizeof. */
 #define SIZEOF_SIZE_T 4
-
-/* If using the C implementation of alloca, define if you know the
-   direction of stack growth for your system; otherwise it will be
-   automatically deduced at runtime.
-    STACK_DIRECTION > 0 => grows toward higher addresses
-    STACK_DIRECTION < 0 => grows toward lower addresses
-    STACK_DIRECTION = 0 => direction of growth unknown */
-/* #undef STACK_DIRECTION */
 
 /* Define to 1 if all of the C90 standard headers exist (not just the ones
    required in a freestanding environment). This macro is provided for
@@ -192,7 +154,7 @@
 /* #undef USING_PURIFY */
 
 /* Version number of package */
-#define VERSION "3.4.4"
+#define VERSION "3.4.6"
 
 /* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
    significant byte first (like Motorola and SPARC, unlike Intel). */
@@ -205,9 +167,6 @@
 /* #  undef WORDS_BIGENDIAN */
 # endif
 #endif
-
-/* Define to `unsigned int' if <sys/types.h> does not define. */
-/* #undef size_t */
 
 
 #ifdef HAVE_HIDDEN_VISIBILITY_ATTRIBUTE

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/aarch64/ffi.c
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/aarch64/ffi.c
@@ -386,51 +386,64 @@ extend_hfa_type (void *dest, void *src, int h)
   ssize_t f = h - AARCH64_RET_S4;
   void *x0;
 
+#define BTI_J "hint #36"
   asm volatile (
 "adr    %0, 0f\n"
-"       add     %0, %0, %1\n"
-"       br      %0\n"
-"0:     ldp     s16, s17, [%3]\n"       /* S4 */
-"       ldp     s18, s19, [%3, #8]\n"
-"       b       4f\n"
-"       ldp     s16, s17, [%3]\n"       /* S3 */
-"       ldr     s18, [%3, #8]\n"
-"       b       3f\n"
-"       ldp     s16, s17, [%3]\n"       /* S2 */
-"       b       2f\n"
-"       nop\n"
-"       ldr     s16, [%3]\n"            /* S1 */
-"       b       1f\n"
-"       nop\n"
-"       ldp     d16, d17, [%3]\n"       /* D4 */
-"       ldp     d18, d19, [%3, #16]\n"
-"       b       4f\n"
-"       ldp     d16, d17, [%3]\n"       /* D3 */
-"       ldr     d18, [%3, #16]\n"
-"       b       3f\n"
-"       ldp     d16, d17, [%3]\n"       /* D2 */
-"       b       2f\n"
-"       nop\n"
-"       ldr     d16, [%3]\n"            /* D1 */
-"       b       1f\n"
-"       nop\n"
-"       ldp     q16, q17, [%3]\n"       /* Q4 */
-"       ldp     q18, q19, [%3, #32]\n"
-"       b       4f\n"
-"       ldp     q16, q17, [%3]\n"       /* Q3 */
-"       ldr     q18, [%3, #32]\n"
-"       b       3f\n"
-"       ldp     q16, q17, [%3]\n"       /* Q2 */
-"       b       2f\n"
-"       nop\n"
-"       ldr     q16, [%3]\n"            /* Q1 */
-"       b       1f\n"
-"4:     str     q19, [%2, #48]\n"
-"3:     str     q18, [%2, #32]\n"
-"2:     str     q17, [%2, #16]\n"
-"1:     str     q16, [%2]"
+"  add  %0, %0, %1\n"
+"  br  %0\n"
+"0:  "BTI_J"\n"      /* S4 */
+"  ldp  s16, s17, [%3]\n"
+"  ldp  s18, s19, [%3, #8]\n"
+"  b  4f\n"
+"  "BTI_J"\n"      /* S3 */
+"  ldp  s16, s17, [%3]\n"
+"  ldr  s18, [%3, #8]\n"
+"  b  3f\n"
+"  "BTI_J"\n"      /* S2 */
+"  ldp  s16, s17, [%3]\n"
+"  b  2f\n"
+"  nop\n"
+"  "BTI_J"\n"      /* S1 */
+"  ldr  s16, [%3]\n"
+"  b  1f\n"
+"  nop\n"
+"  "BTI_J"\n"      /* D4 */
+"  ldp  d16, d17, [%3]\n"
+"  ldp  d18, d19, [%3, #16]\n"
+"  b  4f\n"
+"  "BTI_J"\n"      /* D3 */
+"  ldp  d16, d17, [%3]\n"
+"  ldr  d18, [%3, #16]\n"
+"  b  3f\n"
+"  "BTI_J"\n"      /* D2 */
+"  ldp  d16, d17, [%3]\n"
+"  b  2f\n"
+"  nop\n"
+"  "BTI_J"\n"      /* D1 */
+"  ldr  d16, [%3]\n"
+"  b  1f\n"
+"  nop\n"
+"  "BTI_J"\n"      /* Q4 */
+"  ldp  q16, q17, [%3]\n"
+"  ldp  q18, q19, [%3, #32]\n"
+"  b  4f\n"
+"  "BTI_J"\n"      /* Q3 */
+"  ldp  q16, q17, [%3]\n"
+"  ldr  q18, [%3, #32]\n"
+"  b  3f\n"
+"  "BTI_J"\n"      /* Q2 */
+"  ldp  q16, q17, [%3]\n"
+"  b  2f\n"
+"  nop\n"
+"  "BTI_J"\n"      /* Q1 */
+"  ldr  q16, [%3]\n"
+"  b  1f\n"
+"4:  str  q19, [%2, #48]\n"
+"3:  str  q18, [%2, #32]\n"
+"2:  str  q17, [%2, #16]\n"
+"1:  str  q16, [%2]"
     : "=&r"(x0)
-    : "r"(f * 12), "r"(dest), "r"(src)
+    : "r"(f * 16), "r"(dest), "r"(src)
     : "memory", "v16", "v17", "v18", "v19");
 }
 #endif

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/aarch64/sysv.S
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/aarch64/sysv.S
@@ -40,6 +40,12 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #endif
 #endif
 
+#ifdef __APPLE__
+# define L(X)     CONCAT1(L, X)
+#else
+# define L(X)     CONCAT1(.L, X)
+#endif
+
 #ifdef __AARCH64EB__
 # define BE(X)  X
 #else
@@ -58,6 +64,13 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #define PTR_SIZE        8
 #endif
 
+#define BTI_C hint #34
+#define BTI_J hint #36
+/*
+ * The ELF Notes section needs to indicate if BTI is supported, as the first ELF loaded that doesn't
+ * declare this support disables it for the whole process.
+ */
+# define GNU_PROPERTY_AARCH64_BTI (1 << 0)         /* Has Branch Target Identification */
         .text
         .align 4
 
@@ -78,6 +91,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 
         cfi_startproc
 CNAME(ffi_call_SYSV):
+        BTI_C
         /* Sign the lr with x1 since that is where it will be stored */
         SIGN_LR_WITH_REG(x1)
 
@@ -122,93 +136,157 @@ CNAME(ffi_call_SYSV):
         ldp     x6, x7, [sp, #16*N_V_ARG_REG + 48]
 
         /* Deallocate the context, leaving the stacked arguments.  */
-        add     sp, sp, #CALL_CONTEXT_SIZE
+        add    sp, sp, #CALL_CONTEXT_SIZE
 
-        BRANCH_AND_LINK_TO_REG     x9   /* call fn */
+        BRANCH_AND_LINK_TO_REG     x9            /* call fn */
 
-        ldp     x3, x4, [x29, #16]      /* reload rvalue and flags */
+        ldp    x3, x4, [x29, #16]    /* reload rvalue and flags */
 
         /* Partially deconstruct the stack frame.  */
-        ldr     x9, [x29, #32]
-        mov     sp, x9
+        ldr    x9, [x29, #32]
+        mov    sp, x9
         cfi_def_cfa_register (sp)
-        mov     x2, x29                 /* Preserve for auth */
+        mov    x2, x29            /* Preserve for auth */
         ldp     x29, x30, [x29]
 
         /* Save the return value as directed.  */
-        adr     x5, 0f
-        and     w4, w4, #AARCH64_RET_MASK
-        add     x5, x5, x4, lsl #3
-        br      x5
+        adr    x5, 0f
+        and    w4, w4, #AARCH64_RET_MASK
+        add    x5, x5, x4, lsl #4
+        br    x5
 
-        /* Note that each table entry is 2 insns, and thus 8 bytes.
+        /* Note that each table entry is 4 insns, and thus 16 bytes.
            For integer data, note that we're storing into ffi_arg
            and therefore we want to extend to 64 bits; these types
            have two consecutive entries allocated for them.  */
-        .align  4
-0:      b 99f                           /* VOID */
+        .align    4
+0:      BTI_J                /* VOID */
+        b 99f
         nop
-1:      str     x0, [x3]                /* INT64 */
-        b 99f
-2:      stp     x0, x1, [x3]            /* INT128 */
-        b 99f
-3:      brk     #1000                   /* UNUSED */
-        b 99f
-4:      brk     #1000                   /* UNUSED */
-        b 99f
-5:      brk     #1000                   /* UNUSED */
-        b 99f
-6:      brk     #1000                   /* UNUSED */
-        b 99f
-7:      brk     #1000                   /* UNUSED */
-        b 99f
-8:      st4     { v0.s, v1.s, v2.s, v3.s }[0], [x3]  /* S4 */
-        b 99f
-9:      st3     { v0.s, v1.s, v2.s }[0], [x3]        /* S3 */
-        b 99f
-10:     stp     s0, s1, [x3]                         /* S2 */
-        b 99f
-11:     str     s0, [x3]                             /* S1 */
-        b 99f
-12:     st4     { v0.d, v1.d, v2.d, v3.d }[0], [x3]  /* D4 */
-        b 99f
-13:     st3     { v0.d, v1.d, v2.d }[0], [x3]        /* D3 */
-        b 99f
-14:     stp     d0, d1, [x3]                         /* D2 */
-        b 99f
-15:     str     d0, [x3]                             /* D1 */
-        b 99f
-16:     str     q3, [x3, #48]                        /* Q4 */
         nop
-17:     str     q2, [x3, #32]                        /* Q3 */
-        nop
-18:     stp     q0, q1, [x3]                         /* Q2 */
+1:      BTI_J                /* INT64 */
+        str    x0, [x3]
         b 99f
-19:     str     q0, [x3]                             /* Q1 */
+        nop
+2:      BTI_J                /* INT128 */
+        stp    x0, x1, [x3]
         b 99f
-20:     uxtb    w0, w0                               /* UINT8 */
-        str     x0, [x3]
-21:     b 99f                                        /* reserved */
         nop
-22:     uxth    w0, w0                               /* UINT16 */
-        str     x0, [x3]
-23:     b 99f                                        /* reserved */
+3:      brk    #1000            /* UNUSED */
+        b 99f
         nop
-24:     mov     w0, w0                               /* UINT32 */
-        str     x0, [x3]
-25:     b 99f                                        /* reserved */
         nop
-26:     sxtb    x0, w0                               /* SINT8 */
-        str     x0, [x3]
-27:     b 99f                                        /* reserved */
+4:      brk    #1000            /* UNUSED */
+        b 99f
         nop
-28:     sxth    x0, w0                               /* SINT16 */
-        str     x0, [x3]
-29:     b 99f                                        /* reserved */
         nop
-30:     sxtw    x0, w0                               /* SINT32 */
-        str     x0, [x3]
-31:     b 99f                                        /* reserved */
+5:      brk    #1000            /* UNUSED */
+        b 99f
+        nop
+        nop
+6:      brk    #1000            /* UNUSED */
+        b 99f
+    nop
+    nop
+7:    brk    #1000            /* UNUSED */
+        b 99f
+    nop
+    nop
+8:    BTI_J                /* S4 */
+    st4    { v0.s, v1.s, v2.s, v3.s }[0], [x3]
+        b 99f
+    nop
+9:    BTI_J                /* S3 */
+    st3    { v0.s, v1.s, v2.s }[0], [x3]
+        b 99f
+    nop
+10:    BTI_J                /* S2 */
+    stp    s0, s1, [x3]
+        b 99f
+    nop
+11:    BTI_J
+    str    s0, [x3]        /* S1 */
+        b 99f
+    nop
+12:    BTI_J                /* D4 */
+    st4    { v0.d, v1.d, v2.d, v3.d }[0], [x3]
+        b 99f
+    nop
+13:    BTI_J                /* D3 */
+    st3    { v0.d, v1.d, v2.d }[0], [x3]
+        b 99f
+    nop
+14:    BTI_J                /* D2 */
+    stp    d0, d1, [x3]
+        b 99f
+    nop
+15:    BTI_J                /* D1 */
+    str    d0, [x3]
+        b 99f
+    nop
+16:    BTI_J                /* Q4 */
+    str    q3, [x3, #48]
+    nop
+        nop
+17:    BTI_J                /* Q3 */
+    str    q2, [x3, #32]
+    nop
+        nop
+18:    BTI_J                /* Q2 */
+    stp    q0, q1, [x3]
+        b 99f
+    nop
+19:    BTI_J                /* Q1 */
+    str    q0, [x3]
+        b 99f
+    nop
+20:    BTI_J                /* UINT8 */
+    uxtb    w0, w0
+    str    x0, [x3]
+    nop
+21:    b 99f                /* reserved */
+    nop
+    nop
+    nop
+22:    BTI_J                /* UINT16 */
+    uxth    w0, w0
+    str    x0, [x3]
+    nop
+23:    b 99f                /* reserved */
+    nop
+    nop
+    nop
+24:    BTI_J                /* UINT32 */
+    mov    w0, w0
+    str    x0, [x3]
+    nop
+25:    b 99f                /* reserved */
+    nop
+    nop
+    nop
+26:    BTI_J                /* SINT8 */
+    sxtb    x0, w0
+    str    x0, [x3]
+    nop
+27:    b 99f                /* reserved */
+    nop
+    nop
+    nop
+28:    BTI_J                /* SINT16 */
+    sxth    x0, w0
+    str    x0, [x3]
+    nop
+29:    b 99f                /* reserved */
+    nop
+    nop
+    nop
+30:    BTI_J                /* SINT32 */
+    sxtw    x0, w0
+    str    x0, [x3]
+    nop
+31:    b 99f                /* reserved */
+    nop
+    nop
         nop
 
         /* Return now that result has been populated. */
@@ -218,10 +296,10 @@ CNAME(ffi_call_SYSV):
 
         cfi_endproc
 
-        .globl  CNAME(ffi_call_SYSV)
+    .globl    CNAME(ffi_call_SYSV)
         FFI_HIDDEN(CNAME(ffi_call_SYSV))
 #ifdef __ELF__
-        .type CNAME(ffi_call_SYSV), #function
+    .type    CNAME(ffi_call_SYSV), #function
         .size CNAME(ffi_call_SYSV), .-CNAME(ffi_call_SYSV)
 #endif
 
@@ -246,6 +324,7 @@ CNAME(ffi_call_SYSV):
         .align 4
 CNAME(ffi_closure_SYSV_V):
         cfi_startproc
+    BTI_C
         SIGN_LR
         stp     x29, x30, [sp, #-ffi_closure_SYSV_FS]!
         cfi_adjust_cfa_offset (ffi_closure_SYSV_FS)
@@ -257,19 +336,20 @@ CNAME(ffi_closure_SYSV_V):
         stp     q2, q3, [sp, #16 + 32]
         stp     q4, q5, [sp, #16 + 64]
         stp     q6, q7, [sp, #16 + 96]
-        b       0f
+    b    0f
         cfi_endproc
 
-        .globl  CNAME(ffi_closure_SYSV_V)
+    .globl    CNAME(ffi_closure_SYSV_V)
         FFI_HIDDEN(CNAME(ffi_closure_SYSV_V))
 #ifdef __ELF__
-        .type   CNAME(ffi_closure_SYSV_V), #function
-        .size   CNAME(ffi_closure_SYSV_V), . - CNAME(ffi_closure_SYSV_V)
+    .type    CNAME(ffi_closure_SYSV_V), #function
+    .size    CNAME(ffi_closure_SYSV_V), . - CNAME(ffi_closure_SYSV_V)
 #endif
 
-        .align  4
+    .align    4
         cfi_startproc
 CNAME(ffi_closure_SYSV):
+    BTI_C
         SIGN_LR
         stp     x29, x30, [sp, #-ffi_closure_SYSV_FS]!
         cfi_adjust_cfa_offset (ffi_closure_SYSV_FS)
@@ -285,130 +365,192 @@ CNAME(ffi_closure_SYSV):
         stp     x6, x7, [sp, #16 + 16*N_V_ARG_REG + 48]
 
         /* Load ffi_closure_inner arguments.  */
-        ldp     PTR_REG(0), PTR_REG(1), [x17, #FFI_TRAMPOLINE_CLOSURE_OFFSET]   /* load cif, fn */
-        ldr     PTR_REG(2), [x17, #FFI_TRAMPOLINE_CLOSURE_OFFSET+PTR_SIZE*2]    /* load user_data */
+    ldp    PTR_REG(0), PTR_REG(1), [x17, #FFI_TRAMPOLINE_CLOSURE_OFFSET]    /* load cif, fn */
+    ldr    PTR_REG(2), [x17, #FFI_TRAMPOLINE_CLOSURE_OFFSET+PTR_SIZE*2]    /* load user_data */
 #ifdef FFI_GO_CLOSURES
-.Ldo_closure:
+L(do_closure):
 #endif
-        add     x3, sp, #16                             /* load context */
-        add     x4, sp, #ffi_closure_SYSV_FS            /* load stack */
-        add     x5, sp, #16+CALL_CONTEXT_SIZE           /* load rvalue */
-        mov     x6, x8                                  /* load struct_rval */
+    add    x3, sp, #16                /* load context */
+    add    x4, sp, #ffi_closure_SYSV_FS        /* load stack */
+    add    x5, sp, #16+CALL_CONTEXT_SIZE        /* load rvalue */
+    mov    x6, x8                    /* load struct_rval */
         bl      CNAME(ffi_closure_SYSV_inner)
 
         /* Load the return value as directed.  */
-        adr     x1, 0f
-        and     w0, w0, #AARCH64_RET_MASK
-        add     x1, x1, x0, lsl #3
-        add     x3, sp, #16+CALL_CONTEXT_SIZE
-        br      x1
+    adr    x1, 0f
+    and    w0, w0, #AARCH64_RET_MASK
+    add    x1, x1, x0, lsl #4
+    add    x3, sp, #16+CALL_CONTEXT_SIZE
+    br    x1
 
-        /* Note that each table entry is 2 insns, and thus 8 bytes.  */
-        .align  4
-0:      b       99f                     /* VOID */
+    /* Note that each table entry is 4 insns, and thus 16 bytes.  */
+    .align    4
+0:    BTI_J                /* VOID */
+    b    99f
+    nop
+    nop
+1:    BTI_J                /* INT64 */
+    ldr    x0, [x3]
+    b    99f
+    nop
+2:    BTI_J                /* INT128 */
+    ldp    x0, x1, [x3]
+    b    99f
+    nop
+3:    brk    #1000            /* UNUSED */
+    nop
+    nop
+    nop
+4:    brk    #1000            /* UNUSED */
+    nop
+    nop
+    nop
+5:    brk    #1000            /* UNUSED */
+    nop
+    nop
+    nop
+6:    brk    #1000            /* UNUSED */
+    nop
+    nop
+    nop
+7:    brk    #1000            /* UNUSED */
+    nop
+    nop
+    nop
+8:    BTI_J                /* S4 */
+    ldr    s3, [x3, #12]
+    nop
         nop
-1:      ldr     x0, [x3]                /* INT64 */
-        b       99f
-2:      ldp     x0, x1, [x3]            /* INT128 */
-        b       99f
-3:      brk     #1000                   /* UNUSED */
+9:    BTI_J                /* S3 */
+    ldr    s2, [x3, #8]
+    nop
         nop
-4:      brk     #1000                   /* UNUSED */
+10:    BTI_J                /* S2 */
+    ldp    s0, s1, [x3]
+    b    99f
+    nop
+11:    BTI_J                /* S1 */
+    ldr    s0, [x3]
+    b    99f
+    nop
+12:    BTI_J                /* D4 */
+    ldr    d3, [x3, #24]
+    nop
         nop
-5:      brk     #1000                   /* UNUSED */
+13:    BTI_J                /* D3 */
+    ldr    d2, [x3, #16]
+    nop
         nop
-6:      brk     #1000                   /* UNUSED */
+14:    BTI_J                /* D2 */
+    ldp    d0, d1, [x3]
+    b    99f
+    nop
+15:    BTI_J                /* D1 */
+    ldr    d0, [x3]
+    b    99f
+    nop
+16:    BTI_J                /* Q4 */
+    ldr    q3, [x3, #48]
+    nop
         nop
-7:      brk     #1000                   /* UNUSED */
+17:    BTI_J                /* Q3 */
+    ldr    q2, [x3, #32]
+    nop
         nop
-8:      ldr     s3, [x3, #12]           /* S4 */
+18:    BTI_J                /* Q2 */
+    ldp    q0, q1, [x3]
+    b    99f
+    nop
+19:    BTI_J                /* Q1 */
+    ldr    q0, [x3]
+    b    99f
+    nop
+20:    BTI_J                /* UINT8 */
+    ldrb    w0, [x3, #BE(7)]
+    b    99f
+    nop
+21:    brk    #1000            /* reserved */
+    nop
+    nop
+    nop
+22:    BTI_J                /* UINT16 */
+    ldrh    w0, [x3, #BE(6)]
+    b    99f
+    nop
+23:    brk    #1000            /* reserved */
+    nop
+    nop
+    nop
+24:    BTI_J                /* UINT32 */
+    ldr    w0, [x3, #BE(4)]
+    b    99f
+    nop
+25:    brk    #1000            /* reserved */
+    nop
+    nop
+    nop
+26:    BTI_J                /* SINT8 */
+    ldrsb    x0, [x3, #BE(7)]
+    b    99f
+    nop
+27:    brk    #1000            /* reserved */
+    nop
+    nop
+    nop
+28:    BTI_J                /* SINT16 */
+    ldrsh    x0, [x3, #BE(6)]
+    b    99f
+    nop
+29:    brk    #1000            /* reserved */
+    nop
+    nop
+    nop
+30:    BTI_J                /* SINT32 */
+    ldrsw    x0, [x3, #BE(4)]
+    nop
         nop
-9:      ldr     s2, [x3, #8]            /* S3 */
-        nop
-10:     ldp     s0, s1, [x3]            /* S2 */
-        b       99f
-11:     ldr     s0, [x3]                /* S1 */
-        b       99f
-12:     ldr     d3, [x3, #24]           /* D4 */
-        nop
-13:     ldr     d2, [x3, #16]           /* D3 */
-        nop
-14:     ldp     d0, d1, [x3]            /* D2 */
-        b       99f
-15:     ldr     d0, [x3]                /* D1 */
-        b       99f
-16:     ldr     q3, [x3, #48]           /* Q4 */
-        nop
-17:     ldr     q2, [x3, #32]           /* Q3 */
-        nop
-18:     ldp     q0, q1, [x3]            /* Q2 */
-        b       99f
-19:     ldr     q0, [x3]                /* Q1 */
-        b       99f
-20:     ldrb    w0, [x3, #BE(7)]        /* UINT8 */
-        b       99f
-21:     brk     #1000                   /* reserved */
-        nop
-22:     ldrh    w0, [x3, #BE(6)]        /* UINT16 */
-        b       99f
-23:     brk     #1000                   /* reserved */
-        nop
-24:     ldr     w0, [x3, #BE(4)]        /* UINT32 */
-        b       99f
-25:     brk     #1000                   /* reserved */
-        nop
-26:     ldrsb   x0, [x3, #BE(7)]        /* SINT8 */
-        b       99f
-27:     brk     #1000                   /* reserved */
-        nop
-28:     ldrsh   x0, [x3, #BE(6)]        /* SINT16 */
-        b       99f
-29:     brk     #1000                   /* reserved */
-        nop
-30:     ldrsw   x0, [x3, #BE(4)]        /* SINT32 */
-        nop
-31:                                     /* reserved */
-99:     ldp     x29, x30, [sp], #ffi_closure_SYSV_FS
+31:                    /* reserved */
+99:    ldp     x29, x30, [sp], #ffi_closure_SYSV_FS
         cfi_adjust_cfa_offset (-ffi_closure_SYSV_FS)
         cfi_restore (x29)
         cfi_restore (x30)
         AUTH_LR_AND_RET
         cfi_endproc
 
-        .globl  CNAME(ffi_closure_SYSV)
+    .globl    CNAME(ffi_closure_SYSV)
         FFI_HIDDEN(CNAME(ffi_closure_SYSV))
 #ifdef __ELF__
-        .type   CNAME(ffi_closure_SYSV), #function
-        .size   CNAME(ffi_closure_SYSV), . - CNAME(ffi_closure_SYSV)
+    .type    CNAME(ffi_closure_SYSV), #function
+    .size    CNAME(ffi_closure_SYSV), . - CNAME(ffi_closure_SYSV)
 #endif
 
 #if defined(FFI_EXEC_STATIC_TRAMP)
         .align 4
 CNAME(ffi_closure_SYSV_V_alt):
         /* See the comments above trampoline_code_table. */
-        ldr     x17, [sp, #8]                   /* Load closure in x17 */
-        add     sp, sp, #16                     /* Restore the stack */
-        b       CNAME(ffi_closure_SYSV_V)
+    ldr    x17, [sp, #8]            /* Load closure in x17 */
+    add    sp, sp, #16            /* Restore the stack */
+    b    CNAME(ffi_closure_SYSV_V)
 
-        .globl  CNAME(ffi_closure_SYSV_V_alt)
+    .globl    CNAME(ffi_closure_SYSV_V_alt)
         FFI_HIDDEN(CNAME(ffi_closure_SYSV_V_alt))
 #ifdef __ELF__
-        .type   CNAME(ffi_closure_SYSV_V_alt), #function
-        .size   CNAME(ffi_closure_SYSV_V_alt), . - CNAME(ffi_closure_SYSV_V_alt)
+    .type    CNAME(ffi_closure_SYSV_V_alt), #function
+    .size    CNAME(ffi_closure_SYSV_V_alt), . - CNAME(ffi_closure_SYSV_V_alt)
 #endif
 
         .align 4
 CNAME(ffi_closure_SYSV_alt):
         /* See the comments above trampoline_code_table. */
-        ldr     x17, [sp, #8]                   /* Load closure in x17 */
-        add     sp, sp, #16                     /* Restore the stack */
-        b       CNAME(ffi_closure_SYSV)
+    ldr    x17, [sp, #8]            /* Load closure in x17 */
+    add    sp, sp, #16            /* Restore the stack */
+    b    CNAME(ffi_closure_SYSV)
 
-        .globl  CNAME(ffi_closure_SYSV_alt)
+    .globl    CNAME(ffi_closure_SYSV_alt)
         FFI_HIDDEN(CNAME(ffi_closure_SYSV_alt))
 #ifdef __ELF__
-        .type   CNAME(ffi_closure_SYSV_alt), #function
-        .size   CNAME(ffi_closure_SYSV_alt), . - CNAME(ffi_closure_SYSV_alt)
+    .type    CNAME(ffi_closure_SYSV_alt), #function
+    .size    CNAME(ffi_closure_SYSV_alt), . - CNAME(ffi_closure_SYSV_alt)
 #endif
 
 /*
@@ -430,26 +572,26 @@ CNAME(ffi_closure_SYSV_alt):
  * - load the data address in a register
  * - restore the stack pointer to what it was when the trampoline was invoked.
  */
-        .align  AARCH64_TRAMP_MAP_SHIFT
+    .align    AARCH64_TRAMP_MAP_SHIFT
 CNAME(trampoline_code_table):
-        .rept   AARCH64_TRAMP_MAP_SIZE / AARCH64_TRAMP_SIZE
-        sub     sp, sp, #16             /* Make space on the stack */
-        str     x17, [sp]               /* Save x17 on stack */
-        adr     x17, #16376             /* Get data address */
-        ldr     x17, [x17]              /* Copy data into x17 */
-        str     x17, [sp, #8]           /* Save data on stack */
-        adr     x17, #16372             /* Get code address */
-        ldr     x17, [x17]              /* Load code address into x17 */
-        br      x17                     /* Jump to code */
+    .rept    AARCH64_TRAMP_MAP_SIZE / AARCH64_TRAMP_SIZE
+    sub    sp, sp, #16        /* Make space on the stack */
+    str    x17, [sp]        /* Save x17 on stack */
+    adr    x17, #16376        /* Get data address */
+    ldr    x17, [x17]        /* Copy data into x17 */
+    str    x17, [sp, #8]        /* Save data on stack */
+    adr    x17, #16372        /* Get code address */
+    ldr    x17, [x17]        /* Load code address into x17 */
+    br    x17            /* Jump to code */
         .endr
 
         .globl CNAME(trampoline_code_table)
         FFI_HIDDEN(CNAME(trampoline_code_table))
 #ifdef __ELF__
-        .type   CNAME(trampoline_code_table), #function
-        .size   CNAME(trampoline_code_table), . - CNAME(trampoline_code_table)
+    .type    CNAME(trampoline_code_table), #function
+    .size    CNAME(trampoline_code_table), . - CNAME(trampoline_code_table)
 #endif
-        .align  AARCH64_TRAMP_MAP_SHIFT
+    .align    AARCH64_TRAMP_MAP_SHIFT
 #endif /* FFI_EXEC_STATIC_TRAMP */
 
 #if FFI_EXEC_TRAMPOLINE_TABLE
@@ -462,14 +604,14 @@ CNAME(ffi_closure_trampoline_table_page):
     adr x16, -PAGE_MAX_SIZE
     ldp x17, x16, [x16]
     br x16
-        nop           /* each entry in the trampoline config page is 2*sizeof(void*) so the trampoline itself cannot be smaller than 16 bytes */
+    nop        /* each entry in the trampoline config page is 2*sizeof(void*) so the trampoline itself cannot be smaller than 16 bytes */
     .endr
 
     .globl CNAME(ffi_closure_trampoline_table_page)
     FFI_HIDDEN(CNAME(ffi_closure_trampoline_table_page))
     #ifdef __ELF__
-        .type   CNAME(ffi_closure_trampoline_table_page), #function
-        .size   CNAME(ffi_closure_trampoline_table_page), . - CNAME(ffi_closure_trampoline_table_page)
+        .type    CNAME(ffi_closure_trampoline_table_page), #function
+        .size    CNAME(ffi_closure_trampoline_table_page), . - CNAME(ffi_closure_trampoline_table_page)
     #endif
 #endif
 
@@ -479,6 +621,7 @@ CNAME(ffi_closure_trampoline_table_page):
         .align 4
 CNAME(ffi_go_closure_SYSV_V):
         cfi_startproc
+    BTI_C
         stp     x29, x30, [sp, #-ffi_closure_SYSV_FS]!
         cfi_adjust_cfa_offset (ffi_closure_SYSV_FS)
         cfi_rel_offset (x29, 0)
@@ -489,19 +632,20 @@ CNAME(ffi_go_closure_SYSV_V):
         stp     q2, q3, [sp, #16 + 32]
         stp     q4, q5, [sp, #16 + 64]
         stp     q6, q7, [sp, #16 + 96]
-        b       0f
+    b    0f
         cfi_endproc
 
-        .globl  CNAME(ffi_go_closure_SYSV_V)
+    .globl    CNAME(ffi_go_closure_SYSV_V)
         FFI_HIDDEN(CNAME(ffi_go_closure_SYSV_V))
 #ifdef __ELF__
-        .type   CNAME(ffi_go_closure_SYSV_V), #function
-        .size   CNAME(ffi_go_closure_SYSV_V), . - CNAME(ffi_go_closure_SYSV_V)
+    .type    CNAME(ffi_go_closure_SYSV_V), #function
+    .size    CNAME(ffi_go_closure_SYSV_V), . - CNAME(ffi_go_closure_SYSV_V)
 #endif
 
-        .align  4
+    .align    4
         cfi_startproc
 CNAME(ffi_go_closure_SYSV):
+    BTI_C
         stp     x29, x30, [sp, #-ffi_closure_SYSV_FS]!
         cfi_adjust_cfa_offset (ffi_closure_SYSV_FS)
         cfi_rel_offset (x29, 0)
@@ -516,16 +660,16 @@ CNAME(ffi_go_closure_SYSV):
         stp     x6, x7, [sp, #16 + 16*N_V_ARG_REG + 48]
 
         /* Load ffi_closure_inner arguments.  */
-        ldp     PTR_REG(0), PTR_REG(1), [x18, #PTR_SIZE]/* load cif, fn */
-        mov     x2, x18                                 /* load user_data */
-        b       .Ldo_closure
+    ldp    PTR_REG(0), PTR_REG(1), [x18, #PTR_SIZE]/* load cif, fn */
+    mov    x2, x18                    /* load user_data */
+    b    L(do_closure)
         cfi_endproc
 
-        .globl  CNAME(ffi_go_closure_SYSV)
+    .globl    CNAME(ffi_go_closure_SYSV)
         FFI_HIDDEN(CNAME(ffi_go_closure_SYSV))
 #ifdef __ELF__
-        .type   CNAME(ffi_go_closure_SYSV), #function
-        .size   CNAME(ffi_go_closure_SYSV), . - CNAME(ffi_go_closure_SYSV)
+    .type    CNAME(ffi_go_closure_SYSV), #function
+    .size    CNAME(ffi_go_closure_SYSV), . - CNAME(ffi_go_closure_SYSV)
 #endif
 #endif /* FFI_GO_CLOSURES */
 #endif /* FFI_CLOSURES */
@@ -533,5 +677,17 @@ CNAME(ffi_go_closure_SYSV):
 
 #if defined __ELF__ && defined __linux__
         .section .note.GNU-stack,"",%progbits
+
+    .pushsection .note.gnu.property, "a";
+    .balign 8;
+    .long 4;
+    .long 0x10;
+    .long 0x5;
+    .asciz "GNU";
+    .long 0xc0000000; /* GNU_PROPERTY_AARCH64_FEATURE_1_AND */
+    .long 4;
+    .long GNU_PROPERTY_AARCH64_BTI;
+    .long 0;
+    .popsection;
 #endif
 

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/debug.c
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/debug.c
@@ -38,7 +38,7 @@ void ffi_stop_here(void)
 
 /* This function should only be called via the FFI_ASSERT() macro */
 
-void ffi_assert(char *expr, char *file, int line)
+NORETURN void ffi_assert(const char *expr, const char *file, int line)
 {
   fprintf(stderr, "ASSERTION FAILURE: %s at %s:%d\n", expr, file, line);
   ffi_stop_here();
@@ -47,7 +47,7 @@ void ffi_assert(char *expr, char *file, int line)
 
 /* Perform a sanity check on an ffi_type structure */
 
-void ffi_type_test(ffi_type *a, char *file, int line)
+void ffi_type_test(ffi_type *a, const char *file, int line)
 {
   FFI_ASSERT_AT(a != NULL, file, line);
 

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/dlmalloc.c
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/dlmalloc.c
@@ -4452,7 +4452,7 @@ struct mallinfo dlmallinfo(void) {
 }
 #endif /* NO_MALLINFO */
 
-void dlmalloc_stats() {
+void dlmalloc_stats(void) {
   internal_malloc_stats(gm);
 }
 

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/prep_cif.c
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/prep_cif.c
@@ -1,7 +1,7 @@
 /* -----------------------------------------------------------------------
    prep_cif.c - Copyright (c) 2011, 2012, 2021  Anthony Green
                 Copyright (c) 1996, 1998, 2007  Red Hat, Inc.
-                Copyright (c) 2022, 2023, Oracle and/or its affiliates.
+                Copyright (c) 2022 Oracle and/or its affiliates.
 
    Permission is hereby granted, free of charge, to any person obtaining
    a copy of this software and associated documentation files (the
@@ -234,7 +234,7 @@ ffi_status ffi_prep_cif_var(ffi_cif *cif,
 {
   ffi_status rc;
   size_t int_size = ffi_type_sint.size;
-  int i;
+  unsigned int i;
 
   rc = ffi_prep_cif_core(cif, abi, 1, nfixedargs, ntotalargs, rtype, atypes);
 

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/types.c
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/types.c
@@ -1,5 +1,5 @@
 /* -----------------------------------------------------------------------
-   types.c - Copyright (c) 1996, 1998  Red Hat, Inc.
+   types.c - Copyright (c) 1996, 1998, 2024  Red Hat, Inc.
 
    Predefined ffi_types needed by libffi.
 
@@ -95,14 +95,12 @@ FFI_TYPEDEF(double, double, FFI_TYPE_DOUBLE, const);
 #  error FFI_TYPE_LONGDOUBLE out of date
 # endif
 const ffi_type ffi_type_longdouble = { 16, 16, 4, NULL };
-#elif FFI_TYPE_LONGDOUBLE != FFI_TYPE_DOUBLE
+#else
 FFI_TYPEDEF(longdouble, long double, FFI_TYPE_LONGDOUBLE, FFI_LDBL_CONST);
 #endif
 
 #ifdef FFI_TARGET_HAS_COMPLEX_TYPE
 FFI_COMPLEX_TYPEDEF(float, float, const);
 FFI_COMPLEX_TYPEDEF(double, double, const);
-#if FFI_TYPE_LONGDOUBLE != FFI_TYPE_DOUBLE
 FFI_COMPLEX_TYPEDEF(longdouble, long double, FFI_LDBL_CONST);
-#endif
 #endif

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/x86/ffiw64.c
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/x86/ffiw64.c
@@ -227,7 +227,7 @@ EFI64(ffi_prep_closure_loc)(ffi_closure* closure,
               ffi_cif* cif,
               void (*fun)(ffi_cif*, void*, void**, void*),
               void *user_data,
-              void *codeloc)
+              void *codeloc MAYBE_UNUSED)
 {
   static const unsigned char trampoline[FFI_TRAMPOLINE_SIZE - 8] = {
     /* endbr64 */

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/x86/sysv.S
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/x86/sysv.S
@@ -888,14 +888,31 @@ ENDF(C(ffi_closure_raw_THISCALL))
 #endif /* !FFI_NO_RAW_API */
 
 #ifdef X86_DARWIN
-# define COMDAT(X)                                                      \
-        .section __TEXT,__text,coalesced,pure_instructions;             \
+/* The linker in use on earlier Darwin needs weak definitions to be
+   placed in a coalesced section.  That section should not be called
+   __TEXT,__text since that would be re-defining the attributes of the
+   .text section (which is an error for earlier tools). Here we use
+   '__textcoal_nt' which is what GCC emits for this.
+   Later linker versions are happy to use a normal section and, after
+   Darwin12 / OSX 10.8, the tools warn that using coalesced sections
+   for this is deprecated so we must switch to avoid build fails and/or
+   deprecation warnings.  */
+# if defined(__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__) &&          \
+   __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 1080
+#  define COMDAT(X)                                                     \
+        .section __TEXT,__textcoal_nt,coalesced,pure_instructions;      \
         .weak_definition X;                                             \
         FFI_HIDDEN(X)
+# else
+#  define COMDAT(X)                                                     \
+        .text;                                                          \
+        .weak_definition X;                                             \
+        FFI_HIDDEN(X)
+# endif
 #elif defined __ELF__ && !(defined(__sun__) && defined(__svr4__))
 # define COMDAT(X)                                                      \
         .section .text.X,"axG",@progbits,X,comdat;                      \
-        .globl  X;                                                      \
+        .globl	X;                                                      \
         FFI_HIDDEN(X)
 #else
 # define COMDAT(X)
@@ -916,7 +933,37 @@ ENDF(C(__x86.get_pc_thunk.dx))
 #endif /* DARWIN || HIDDEN */
 #endif /* __PIC__ */
 
-/* Sadly, OSX cctools-as doesn't understand .cfi directives at all.  */
+/* Sadly, OSX cctools-as does not understand .cfi directives at all so
+   we build an eh frame by hand.  */
+
+#ifdef __APPLE__
+/* The cctools assembler will try to make a difference between two local
+   symbols into a relocation against, which will not work in the eh (produces
+   link-time fails).
+   To avoid this, we compute the symbol difference with a .set directive and
+   then substitute this value.  */
+# define LEN(N, P)      .set Llen$N$P,L(N)-L(P); .long Llen$N$P
+/* Note, this assume DW_CFA_advance_loc1 fits into 7 bits.  */
+# define ADV(N, P)      .set Ladv$N$P,L(N)-L(P); .byte 2, Ladv$N$P
+/* For historical reasons, the EH reg numbers for SP and FP are swapped from
+   the DWARF ones for 32b Darwin.  */
+# define SP 5
+# define FP 4
+# define ENC 0x10
+#else
+# define LEN(N, P)      .long L(N)-L(P)
+/* Assume DW_CFA_advance_loc1 fits.  */
+# define ADV(N, P)      .byte 2, L(N)-L(P)
+# define SP 4
+# define FP 5
+# define ENC 0x1b
+#endif
+
+#ifdef HAVE_AS_X86_PCREL
+# define PCREL(X)	X-.
+#else
+# define PCREL(X)	X@rel
+#endif
 
 #ifdef __APPLE__
 .section __TEXT,__eh_frame,coalesced,no_toc+strip_static_syms+live_support
@@ -928,17 +975,11 @@ EHFrame0:
 #else
 .section .eh_frame,EH_FRAME_FLAGS,@progbits
 #endif
-
-#ifdef HAVE_AS_X86_PCREL
-# define PCREL(X)       X - .
-#else
-# define PCREL(X)       X@rel
+#ifndef __APPLE__
+/* EH sections are already suitably aligned on Darwin.  */
+        .balign 4
 #endif
 
-/* Simplify advancing between labels.  Assume DW_CFA_advance_loc1 fits.  */
-#define ADV(N, P)       .byte 2, L(N)-L(P)
-
-        .balign 4
 L(CIE):
         .set    L(set0),L(ECIE)-L(SCIE)
         .long   L(set0)                 /* CIE Length */
@@ -950,8 +991,8 @@ L(SCIE):
         .byte   0x7c                    /* CIE Data Alignment Factor */
         .byte   0x8                     /* CIE RA Column */
         .byte   1                       /* Augmentation size */
-        .byte   0x1b                    /* FDE Encoding (pcrel sdata4) */
-        .byte   0xc, 4, 4               /* DW_CFA_def_cfa, %esp offset 4 */
+        .byte   ENC                     /* FDE Encoding (pcrel abs/4byte) */
+        .byte   0xc, SP, 4              /* DW_CFA_def_cfa, %esp offset 4 */
         .byte   0x80+8, 1               /* DW_CFA_offset, %eip offset 1*-4 */
         .balign 4
 L(ECIE):
@@ -959,20 +1000,20 @@ L(ECIE):
         .set    L(set1),L(EFDE1)-L(SFDE1)
         .long   L(set1)                 /* FDE Length */
 L(SFDE1):
-        .long   L(SFDE1)-L(CIE)         /* FDE CIE offset */
+        LEN(SFDE1, CIE)                 /* FDE CIE offset */
         .long   PCREL(L(UW0))           /* Initial location */
-        .long   L(UW5)-L(UW0)           /* Address range */
+        LEN(UW5, UW0)                   /* Address range */
         .byte   0                       /* Augmentation size */
         ADV(UW1, UW0)
-        .byte   0xc, 5, 8               /* DW_CFA_def_cfa, %ebp 8 */
-        .byte   0x80+5, 2               /* DW_CFA_offset, %ebp 2*-4 */
+        .byte   0xc, FP, 8              /* DW_CFA_def_cfa, %ebp 8 */
+        .byte   0x80+FP, 2              /* DW_CFA_offset, %ebp 2*-4 */
         ADV(UW2, UW1)
         .byte   0x80+3, 0               /* DW_CFA_offset, %ebx 0*-4 */
         ADV(UW3, UW2)
         .byte   0xa                     /* DW_CFA_remember_state */
-        .byte   0xc, 4, 4               /* DW_CFA_def_cfa, %esp 4 */
+        .byte   0xc, SP, 4              /* DW_CFA_def_cfa, %esp 4 */
         .byte   0xc0+3                  /* DW_CFA_restore, %ebx */
-        .byte   0xc0+5                  /* DW_CFA_restore, %ebp */
+        .byte   0xc0+FP                 /* DW_CFA_restore, %ebp */
         ADV(UW4, UW3)
         .byte   0xb                     /* DW_CFA_restore_state */
         .balign 4
@@ -981,9 +1022,9 @@ L(EFDE1):
         .set    L(set2),L(EFDE2)-L(SFDE2)
         .long   L(set2)                 /* FDE Length */
 L(SFDE2):
-        .long   L(SFDE2)-L(CIE)         /* FDE CIE offset */
+        LEN(SFDE2, CIE)                 /* FDE CIE offset */
         .long   PCREL(L(UW6))           /* Initial location */
-        .long   L(UW8)-L(UW6)           /* Address range */
+        LEN(UW8,UW6)                    /* Address range */
         .byte   0                       /* Augmentation size */
         ADV(UW7, UW6)
         .byte   0xe, closure_FS+4       /* DW_CFA_def_cfa_offset */
@@ -993,9 +1034,9 @@ L(EFDE2):
         .set    L(set3),L(EFDE3)-L(SFDE3)
         .long   L(set3)                 /* FDE Length */
 L(SFDE3):
-        .long   L(SFDE3)-L(CIE)         /* FDE CIE offset */
+        LEN(SFDE3, CIE)                 /* FDE CIE offset */
         .long   PCREL(L(UW9))           /* Initial location */
-        .long   L(UW11)-L(UW9)          /* Address range */
+        LEN(UW11, UW9)                  /* Address range */
         .byte   0                       /* Augmentation size */
         ADV(UW10, UW9)
         .byte   0xe, closure_FS+4       /* DW_CFA_def_cfa_offset */
@@ -1005,9 +1046,9 @@ L(EFDE3):
         .set    L(set4),L(EFDE4)-L(SFDE4)
         .long   L(set4)                 /* FDE Length */
 L(SFDE4):
-        .long   L(SFDE4)-L(CIE)         /* FDE CIE offset */
+        LEN(SFDE4, CIE)                 /* FDE CIE offset */
         .long   PCREL(L(UW12))          /* Initial location */
-        .long   L(UW20)-L(UW12)         /* Address range */
+        LEN(UW20, UW12)                 /* Address range */
         .byte   0                       /* Augmentation size */
         ADV(UW13, UW12)
         .byte   0xe, closure_FS+4       /* DW_CFA_def_cfa_offset */
@@ -1033,9 +1074,9 @@ L(EFDE4):
         .set    L(set5),L(EFDE5)-L(SFDE5)
         .long   L(set5)                 /* FDE Length */
 L(SFDE5):
-        .long   L(SFDE5)-L(CIE)         /* FDE CIE offset */
+        LEN(SFDE5, CIE)                 /* FDE CIE offset */
         .long   PCREL(L(UW21))          /* Initial location */
-        .long   L(UW23)-L(UW21)         /* Address range */
+        LEN(UW23, UW21)                 /* Address range */
         .byte   0                       /* Augmentation size */
         ADV(UW22, UW21)
         .byte   0xe, closure_FS+4       /* DW_CFA_def_cfa_offset */
@@ -1045,9 +1086,9 @@ L(EFDE5):
         .set    L(set6),L(EFDE6)-L(SFDE6)
         .long   L(set6)                 /* FDE Length */
 L(SFDE6):
-        .long   L(SFDE6)-L(CIE)         /* FDE CIE offset */
+        LEN(SFDE6, CIE)                 /* FDE CIE offset */
         .long   PCREL(L(UW24))          /* Initial location */
-        .long   L(UW26)-L(UW24)         /* Address range */
+        LEN(UW26, UW24)                 /* Address range */
         .byte   0                       /* Augmentation size */
         .byte   0xe, 8                  /* DW_CFA_def_cfa_offset */
         .byte   0x80+8, 2               /* DW_CFA_offset %eip, 2*-4 */
@@ -1059,9 +1100,9 @@ L(EFDE6):
         .set    L(set7),L(EFDE7)-L(SFDE7)
         .long   L(set7)                 /* FDE Length */
 L(SFDE7):
-        .long   L(SFDE7)-L(CIE)         /* FDE CIE offset */
+        LEN(SFDE7, CIE)                 /* FDE CIE offset */
         .long   PCREL(L(UW27))          /* Initial location */
-        .long   L(UW31)-L(UW27)         /* Address range */
+        LEN(UW31, UW27)                 /* Address range */
         .byte   0                       /* Augmentation size */
         ADV(UW28, UW27)
         .byte   0xe, closure_FS+4       /* DW_CFA_def_cfa_offset */
@@ -1078,9 +1119,9 @@ L(EFDE7):
         .set    L(set8),L(EFDE8)-L(SFDE8)
         .long   L(set8)                 /* FDE Length */
 L(SFDE8):
-        .long   L(SFDE8)-L(CIE)         /* FDE CIE offset */
+        LEN(SFDE8, CIE)                 /* FDE CIE offset */
         .long   PCREL(L(UW32))          /* Initial location */
-        .long   L(UW40)-L(UW32)         /* Address range */
+        LEN(UW40, UW32)                 /* Address range */
         .byte   0                       /* Augmentation size */
         ADV(UW33, UW32)
         .byte   0xe, raw_closure_S_FS+4 /* DW_CFA_def_cfa_offset */
@@ -1102,9 +1143,9 @@ L(EFDE8):
         .set    L(set9),L(EFDE9)-L(SFDE9)
         .long   L(set9)                 /* FDE Length */
 L(SFDE9):
-        .long   L(SFDE9)-L(CIE)         /* FDE CIE offset */
+        LEN(SFDE9, CIE)                 /* FDE CIE offset */
         .long   PCREL(L(UW41))          /* Initial location */
-        .long   L(UW52)-L(UW41)         /* Address range */
+        LEN(UW52, UW41)                 /* Address range */
         .byte   0                       /* Augmentation size */
         ADV(UW42, UW41)
         .byte   0xe, 0                  /* DW_CFA_def_cfa_offset */
@@ -1141,8 +1182,12 @@ L(EFDE9):
 @feat.00 = 1
 #endif
 
-#ifdef __APPLE__
+#if defined(__APPLE__)
     .subsections_via_symbols
+# if defined(__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__) &&          \
+   __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ >= 1070 && __clang__
+/* compact unwind is not used with GCC at present, was not present before 10.6
+   but has some bugs there, so do not emit until 10.7.  */
     .section __LD,__compact_unwind,regular,debug
 
     /* compact unwind for ffi_call_i386 */
@@ -1216,6 +1261,7 @@ L(EFDE9):
     .long    0x04000000 /* use dwarf unwind info */
     .long    0
     .long    0
+#endif /* use compact unwind */
 #endif /* __APPLE__ */
 
 #endif /* ifndef _MSC_VER */

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/x86/sysv_intel.S
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/x86/sysv_intel.S
@@ -102,7 +102,7 @@ L(UW1):
         mov         ecx, [12+ebp]               /* load return type code */
         mov     [ebp+8], ebx            /* preserve %ebx */
 L(UW2):
-        // cfi_rel_offset(%ebx, 8)
+        /* cfi_rel_offset(%ebx, 8) */
 
         and     ecx, X86_RET_TYPE_MASK
         lea     ebx, [L(store_table) + ecx * 8]

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/x86/sysv_intel.S
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/x86/sysv_intel.S
@@ -254,7 +254,7 @@ L(UW7):
         mov     [esp+closure_CF+36], eax        /* closure is user_data */
         jmp     L(do_closure_i386)
 L(UW8):
-        // cfi_endproc
+	/* cfi_endproc */
 ENDF(ffi_go_closure_EAX)
 
 ALIGN 16

--- a/modules/javafx.media/src/main/native/gstreamer/projects/win/glib-lite/Makefile.ffi
+++ b/modules/javafx.media/src/main/native/gstreamer/projects/win/glib-lite/Makefile.ffi
@@ -23,7 +23,7 @@ COMPILER_FLAGS = -nologo -W3 -WX- -EHsc -GS -fp:precise -Gm- \
 INCLUDES = -I$(SRCBASE_DIR)/include \
            -I$(SRCBASE_DIR)/src/x86
 
-CFLAGS = -DFFI_BUILDING \
+CFLAGS = -DFFI_STATIC_BUILD \
          -DGSTREAMER_LITE \
 	 $(INCLUDES) \
 	 $(COMPILER_FLAGS)
@@ -69,7 +69,7 @@ OBJECTS = $(patsubst %.c,$(OBJBASE_DIR)/%.obj,$(C_SOURCES)) \
 default: $(TARGET)
 
 $(TARGET): $(OBJECTS)
-	$(AR) $(LIBFLAGS) $(foreach object,$(OBJECTS),$(shell cygpath -ma $(object))) 
+	$(AR) $(LIBFLAGS) $(foreach object,$(OBJECTS),$(shell cygpath -ma $(object)))
 
 $(OBJECTS): | $(DEP_DIRS)
 

--- a/modules/javafx.media/src/main/native/gstreamer/projects/win/glib-lite/Makefile.glib
+++ b/modules/javafx.media/src/main/native/gstreamer/projects/win/glib-lite/Makefile.glib
@@ -134,7 +134,7 @@ CFLAGS =   -DWIN32 \
            -DLIBDIR \
            -DNVALGRIND \
            -DG_OS_WIN32 \
-           -DFFI_BUILDING \
+           -DFFI_STATIC_BUILD \
            -DG_DISABLE_DEPRECATED \
            $(INCLUDES) \
            $(COMPILER_FLAGS)

--- a/modules/javafx.media/src/main/native/gstreamer/projects/win/glib-lite/Makefile.gmodule
+++ b/modules/javafx.media/src/main/native/gstreamer/projects/win/glib-lite/Makefile.gmodule
@@ -30,7 +30,7 @@ CFLAGS =   -DWIN32 \
            -DG_LOG_DOMAIN=\"GModule\" \
            -D_MBCS \
            -DG_OS_WIN32 \
-           -DFFI_BUILDING \
+           -DFFI_STATIC_BUILD \
            -DG_DISABLE_DEPRECATED \
            $(INCLUDES) \
            $(COMPILER_FLAGS)

--- a/modules/javafx.media/src/main/native/gstreamer/projects/win/glib-lite/Makefile.gobject
+++ b/modules/javafx.media/src/main/native/gstreamer/projects/win/glib-lite/Makefile.gobject
@@ -52,7 +52,7 @@ CFLAGS =   -DWIN32 \
            -DG_LOG_DOMAIN=\"Glib-GObject\" \
            -D_MBCS \
            -DG_OS_WIN32 \
-           -DFFI_BUILDING \
+           -DFFI_STATIC_BUILD \
            -DG_DISABLE_DEPRECATED \
            $(INCLUDES) \
            $(COMPILER_FLAGS)

--- a/modules/javafx.media/src/main/native/gstreamer/projects/win/glib-lite/Makefile.gthread
+++ b/modules/javafx.media/src/main/native/gstreamer/projects/win/glib-lite/Makefile.gthread
@@ -30,7 +30,7 @@ CFLAGS =   -DWIN32 \
            -DG_LOG_DOMAIN=\"GThread\" \
            -D_MBCS \
            -DG_OS_WIN32 \
-           -DFFI_BUILDING \
+           -DFFI_STATIC_BUILD \
            -DG_DISABLE_DEPRECATED \
            $(INCLUDES) \
            $(COMPILER_FLAGS)


### PR DESCRIPTION
- libFFI updated to 3.4.6.
- No additional changes are done.
- Tested on Windows, macOS and Linux with all supported formats.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8336938](https://bugs.openjdk.org/browse/JDK-8336938): Update libFFI to 3.4.6 (**Bug** - P3)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Joeri Sykora](https://openjdk.org/census#sykora) (@tiainen - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1531/head:pull/1531` \
`$ git checkout pull/1531`

Update a local copy of the PR: \
`$ git checkout pull/1531` \
`$ git pull https://git.openjdk.org/jfx.git pull/1531/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1531`

View PR using the GUI difftool: \
`$ git pr show -t 1531`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1531.diff">https://git.openjdk.org/jfx/pull/1531.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1531#issuecomment-2272399007)