### PR TITLE
8289174: JavaFX build fails on Windows when VS150COMNTOOLS is not set

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -333,8 +333,6 @@ jobs:
       ANT_DIR: "apache-ant-1.10.5"
       ANT_FILENAME: "apache-ant-1.10.5.tar.gz"
       ANT_URL: "https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.5-bin.tar.gz"
-      # FIXME: hard-code the location of VS 2022 for now
-      VS150COMNTOOLS: "C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Auxiliary\\Build"
 
     steps:
       - name: Checkout the source
@@ -379,15 +377,10 @@ jobs:
 
       - name: Setup environment
         run: |
-          echo "VS150COMNTOOLS=$env:VS150COMNTOOLS"
           echo "dir ...\VC\Tools\MSVC"
           dir "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC"
-          echo "dir VS150COMNTOOLS"
-          dir "$env:VS150COMNTOOLS"
           # echo "dir ...\VC\Tools\MSVC"
           # dir "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC"
-          # echo "dir VS150COMNTOOLS"
-          # dir "$env:VS150COMNTOOLS"
 
           $env:Path = "$HOME\cygwin\cygwin64\bin;$HOME\cygwin\cygwin64\bin;$env:Path" ;
           $env:JAVA_HOME = "$HOME\bootjdk\jdk-$env:BOOT_JDK_VERSION" ;

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -410,6 +410,10 @@ jobs:
           java -version
           .\gradlew.bat -version
           .\gradlew.bat --info all
+          # FIXME KCR: BEGIN VERBOSE
+          cat build\windows_tools.properties
+          ls build/sdk/bin
+          # FIXME KCR: END VERBOSE
 
       - name: Run JavaFX headless tests
         working-directory: jfx

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -410,10 +410,6 @@ jobs:
           java -version
           .\gradlew.bat -version
           .\gradlew.bat --info all
-          # FIXME KCR: BEGIN VERBOSE
-          cat build\windows_tools.properties
-          ls build/sdk/bin
-          # FIXME KCR: END VERBOSE
 
       - name: Run JavaFX headless tests
         working-directory: jfx

--- a/build.gradle
+++ b/build.gradle
@@ -214,7 +214,7 @@ void setupTools(String name, Closure loader, Closure processor) {
     // then generate it. Once generated, we need to read the properties file to
     // help us define the defaults for this block of properties
     File propFile = file("$buildDir/${name}.properties");
-    if (!propFile.exists()) {
+    if (!propFile.exists() || propFile.length() == 0) {
         // Create the properties file
         propFile.getParentFile().mkdirs();
         propFile.createNewFile();
@@ -952,7 +952,6 @@ void ant(String conf,   // platform configuration
                     "INCLUDE"              : WINDOWS_VS_INCLUDE,
                     "LIB"                  : WINDOWS_VS_LIB,
                     "LIBPATH"              : WINDOWS_VS_LIBPATH,
-                    "DXSDK_DIR"            : WINDOWS_DXSDK_DIR,
                     "PATH"                 : WINDOWS_VS_PATH
             ]);
             commandLine "cmd", "/s", "/c", '"' + String.join(" ", cmdArgs) + '"'
@@ -5389,7 +5388,7 @@ compileTargets { t ->
             }
             if (IS_WINDOWS) {
                 from ("${graphicsProject.buildDir}/libs/prismD3D/${t.name}/${library(targetProperties.prismD3D.lib)}");
-                targetProperties.VS2017DLLs.each { vslib ->
+                targetProperties.VSDLLs.each { vslib ->
                     from ("$vslib");
                 }
                 targetProperties.WinSDKDLLs.each { winsdklib ->
@@ -5404,7 +5403,7 @@ compileTargets { t ->
                     inputFiles.include("*.dylib")
                     inputFiles.include("*.so")
                     // FIXME: if we ever need to strip on Windows platforms, we must
-                    // exclude the Microsoft DLLs (VS2017DLLNames and WinSDKDLLNames)
+                    // exclude the Microsoft DLLs (VSDLLNames and WinSDKDLLNames)
 
                     inputFiles.each { file ->
                         exec {
@@ -5421,7 +5420,7 @@ compileTargets { t ->
                     inputFiles.include("*.dylib")
                     inputFiles.include("*.so")
                     // FIXME: if we ever need to sign on Windows platforms, we must
-                    // exclude the Microsoft DLLs (VS2017DLLNames and WinSDKDLLNames)
+                    // exclude the Microsoft DLLs (VSDLLNames and WinSDKDLLNames)
 
                     inputFiles.each { file ->
                         exec {
@@ -5496,7 +5495,7 @@ compileTargets { t ->
                     inputFiles.include("*.dylib")
                     inputFiles.include("*.so")
                     // FIXME: if we ever need to sign on Windows platforms, we must
-                    // exclude the Microsoft DLLs (VS2017DLLNames and WinSDKDLLNames)
+                    // exclude the Microsoft DLLs (VSDLLNames and WinSDKDLLNames)
 
                     inputFiles.each { file ->
                         exec {
@@ -5549,7 +5548,7 @@ compileTargets { t ->
                     inputFiles.include("*.dylib")
                     inputFiles.include("*.so")
                     // FIXME: if we ever need to sign on Windows platforms, we must
-                    // exclude the Microsoft DLLs (VS2017DLLNames and WinSDKDLLNames)
+                    // exclude the Microsoft DLLs (VSDLLNames and WinSDKDLLNames)
 
                     inputFiles.each { file ->
                         exec {

--- a/buildSrc/genVSproperties.bat
+++ b/buildSrc/genVSproperties.bat
@@ -1,4 +1,4 @@
-REM Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
+REM Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
 REM DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 REM
 REM This code is free software; you can redistribute it and/or modify it
@@ -21,71 +21,59 @@ REM Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
 REM or visit www.oracle.com if you need additional information or have any
 REM questions.
 
-REM Windows bat file that runs vcvars32.bat for Visual Studio 2003
-REM   and echos out a property file with the values of the environment
-REM   variables we want, e.g. PATH, INCLUDE, LIB, and LIBPATH.
+setlocal ENABLEDELAYEDEXPANSION
+
+REM Windows bat file that runs vcvars64.bat for Visual Studio
+REM and echos out a property file with the values of the environment
+REM variables we want, e.g. PATH, INCLUDE, LIB, and LIBPATH.
 
 REM Clean out the current settings
 set INCLUDE=
 set LIB=
 set LIBPATH=
 
-REM Run the vsvars32.bat (12.0) / vcvars32.bat (15.0) file, sending it's output to neverland.
-REM The current officially supported Visual Studio version is 15.0.
-REM Handling of 11.0 and 14.0 is excluded here.
-REM The previous officially supported VS version was 12.0
-REM So, the search order is 150, then 120, then 100
-set VSVER=150
-set "VSVARS32FILE=C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\VC\Auxiliary\Build\vcvars32.bat"
-if not "%VS150COMNTOOLS%"=="" (
-    set "VS150COMNTOOLS=%VS150COMNTOOLS%"
+REM The current officially supported Visual Studio version is VS 2022
+
+REM Try the following in order of priority:
+REM 1. The VSCOMNTOOLS env var
+REM 2. The legacy VS150COMNTOOLS env var
+REM 3. Look in standard locations for Visual Studio (2022|2019|2017)
+
+
+set AUXBUILD=VC\Auxiliary\Build
+
+if not "%VSCOMNTOOLS%"=="" (
+    set "VSTOOLSDIR=%VSCOMNTOOLS%"
+) else if not "%VS150COMNTOOLS%"=="" (
+    set "VSTOOLSDIR=%VS150COMNTOOLS%"
 ) else (
-  if exist "%VSVARS32FILE%" set "VS150COMNTOOLS=C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\VC\Auxiliary\Build"
+    for %%a in (2022, 2019, 2017) do (
+        set year=%%a
+        for %%b in (Enterprise, Professional, Community) do (
+            set edition=%%b
+            for %%c in ("Program Files", "Program Files (x86)") do (
+                set ProgramFiles=%%~c
+                set "TMPDIR=C:\!ProgramFiles!\Microsoft Visual Studio\!year!\!edition!\%AUXBUILD%"
+                if exist "!TMPDIR!" (
+                    set "VSTOOLSDIR=!TMPDIR!"
+                    goto FOUNDVS
+                )
+            )
+        )
+    )
 )
-set VSVARSDIR=%VS150COMNTOOLS%
-if "%VSVARSDIR%"=="" set VSVER=120
-if "%VSVARSDIR%"=="" set VSVARSDIR=%VS120COMNTOOLS%
-if "%VSVARSDIR%"=="" set VSVER=100
-if "%VSVARSDIR%"=="" set VSVARSDIR=%VS100COMNTOOLS%
 
-REM We shouldn't depend on VSVARS32 as it's 32-bit only.
-REM   However, this var is still used somewhere in FX (e.g.
-REM   to build media), so we set it here.
+:FOUNDVS
 
-if "%VSVER%"=="100" set VSVARS32=%VSVARSDIR%\vsvars32.bat
-if "%VSVER%"=="120" set VSVARS32=%VSVARSDIR%\vsvars32.bat
-if "%VSVER%"=="150" set VSVARS32=%VSVARSDIR%\vcvars32.bat
-call "%VSVARS32%" > NUL
+if "%VSTOOLSDIR%"=="" exit
+if not exist "%VSTOOLSDIR%" exit
 
-if "%VSVER%"=="100" set VCVARSALL=%VCINSTALLDIR%\vcvarsall.bat
-if "%VSVER%"=="120" set VCVARSALL=%VCINSTALLDIR%\vcvarsall.bat
-if "%VSVER%"=="150" set VCVARSALL=%VSVARSDIR%\vcvarsall.bat
-call "%VCVARSALL%" %VCARCH% > NUL
-
-REM Some vars are reset by vcvarsall.bat, so save them here.
-set TEMPDEVENVDIR=%DEVENVDIR%
-set TEMPVCINSTALLDIR=%VCINSTALLDIR%
-set TEMPVSINSTALLDIR=%VSINSTALLDIR%
-if NOT "%WINSDKPATH%"=="" call "%WINSDKPATH%\Bin\SetEnv.Cmd" %SDKARCH% %CONF% > NUL
-set DEVENVDIR=%TEMPDEVENVDIR%
-set VSINSTALLDIR=%TEMPVSINSTALLDIR%
-set VCINSTALLDIR=%TEMPVCINSTALLDIR%
-
-REM Create some vars that are not set with VS Express 2008
-if "%MSVCDIR%"=="" set MSVCDIR=%VCINSTALLDIR%
-REM Try using exe, com might be hanging in ssh environment?
-REM     set DEVENVCMD=%DEVENVDIR%\devenv.exe
-set DEVENVCMD=%DEVENVDIR%\devenv.com
-
-REM Adjust for lack of devenv in express editions.  This needs more work.
-REM VCExpress is the correct executable, but cmd line is different...
-if not exist "%DEVENVCMD%" set DEVENVCMD=%DEVENVDIR%\VCExpress.exe
+call "%VSTOOLSDIR%\vcvars64.bat" > NUL
 
 REM Echo out a properties file
 echo ############################################################
 echo # DO NOT EDIT: This is a generated file.
 echo windows.vs.DEVENVDIR=%DEVENVDIR%@@ENDOFLINE@@
-echo windows.vs.DEVENVCMD=%DEVENVCMD%@@ENDOFLINE@@
 echo windows.vs.VCINSTALLDIR=%VCINSTALLDIR%@@ENDOFLINE@@
 echo windows.vs.VSINSTALLDIR=%VSINSTALLDIR%@@ENDOFLINE@@
 echo windows.vs.MSVCDIR=%MSVCDIR%@@ENDOFLINE@@
@@ -93,7 +81,6 @@ echo windows.vs.INCLUDE=%INCLUDE%@@ENDOFLINE@@
 echo windows.vs.LIB=%LIB%@@ENDOFLINE@@
 echo windows.vs.LIBPATH=%LIBPATH%@@ENDOFLINE@@
 echo windows.vs.PATH=%PARFAIT_PATH%;%PATH%@@ENDOFLINE@@
-echo windows.vs.VER=%VSVER%@@ENDOFLINE@@
 echo windows.vs.VC_TOOLS_INSTALL_DIR=%VCToolsInstallDir%@@ENDOFLINE@@
 echo windows.vs.VC_TOOLS_REDIST_DIR=%VCToolsRedistDir%@@ENDOFLINE@@
 echo WINDOWS_SDK_DIR=%WindowsSdkDir%@@ENDOFLINE@@

--- a/buildSrc/genVSproperties.bat
+++ b/buildSrc/genVSproperties.bat
@@ -49,7 +49,7 @@ if not "%VSCOMNTOOLS%"=="" (
 ) else (
     for %%a in (2022, 2019, 2017) do (
         set year=%%a
-        for %%b in (Enterprise, Professional, Community) do (
+        for %%b in (Enterprise, Professional, Community, BuildTools) do (
             set edition=%%b
             for %%c in ("Program Files", "Program Files (x86)") do (
                 set ProgramFiles=%%~c

--- a/buildSrc/genVSproperties.bat
+++ b/buildSrc/genVSproperties.bat
@@ -70,6 +70,9 @@ if not exist "%VSTOOLSDIR%" exit
 
 call "%VSTOOLSDIR%\vcvars64.bat" > NUL
 
+REM Set legacy MSVCDIR variable in case some Makefiles still need it
+if "%MSVCDIR%"=="" set MSVCDIR=%VCINSTALLDIR%
+
 REM Echo out a properties file
 echo ############################################################
 echo # DO NOT EDIT: This is a generated file.

--- a/buildSrc/genVSproperties.bat
+++ b/buildSrc/genVSproperties.bat
@@ -37,7 +37,7 @@ REM The current officially supported Visual Studio version is VS 2022
 REM Try the following in order of priority:
 REM 1. The VSCOMNTOOLS env var
 REM 2. The legacy VS150COMNTOOLS env var
-REM 3. Look in standard locations for Visual Studio (2022|2019|2017)
+REM 3. Look in standard locations for Visual Studio (2022,2019,2017)
 
 
 set AUXBUILD=VC\Auxiliary\Build

--- a/buildSrc/genVSproperties.bat
+++ b/buildSrc/genVSproperties.bat
@@ -24,7 +24,7 @@ REM questions.
 setlocal ENABLEDELAYEDEXPANSION
 
 REM Windows bat file that runs vcvars64.bat for Visual Studio
-REM and echos out a property file with the values of the environment
+REM and echoes out a property file with the values of the environment
 REM variables we want, e.g. PATH, INCLUDE, LIB, and LIBPATH.
 
 REM Clean out the current settings

--- a/buildSrc/win.gradle
+++ b/buildSrc/win.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -74,46 +74,33 @@ setupTools("windows_tools",
         }
     },
     { properties ->
-        defineProperty("WINDOWS_VS_VSINSTALLDIR", properties, "c:/Program Files (x86)/Microsoft Visual Studio/2017/Professional");
-        defineProperty("WINDOWS_VS_WINSDKDLLINSTALLDIR", properties, "c:/Program Files (x86)/Windows Kits/10/Redist/ucrt/DLLs");
-        defineProperty("WINDOWS_SDK_DIR", properties, System.getenv().get("WINSDK_DIR"))
+        defineProperty("WINDOWS_VS_VSINSTALLDIR", properties, "")
+        defineProperty("WINDOWS_VS_WINSDKDLLINSTALLDIR", properties, "")
+        defineProperty("WINDOWS_SDK_DIR", properties, "")
         defineProperty("WINDOWS_SDK_VERSION", properties, "")
         defineProperty("WINDOWS_VS_VCINSTALLDIR", properties, "$WINDOWS_VS_VSINSTALLDIR/VC")
         defineProperty("WINDOWS_VS_DEVENVDIR", properties, "$WINDOWS_VS_VSINSTALLDIR/Common7/IDE")
-        defineProperty("WINDOWS_VS_DEVENVCMD", properties, "$WINDOWS_VS_DEVENVDIR/VCExpress.exe")
         defineProperty("WINDOWS_VS_MSVCDIR", properties, WINDOWS_VS_VCINSTALLDIR)
         defineProperty("WINDOWS_VS_VC_TOOLS_INSTALL_DIR", properties, "")
         defineProperty("WINDOWS_VS_VC_TOOLS_REDIST_DIR", properties, "")
-        defineProperty("WINDOWS_DXSDK_DIR", properties, System.getenv().get("DXSDK_DIR"))
-        defineProperty("WINDOWS_VS_INCLUDE", properties, "$WINDOWS_VS_VCINSTALLDIR/INCLUDE;" + "$WINDOWS_SDK_DIR/include;")
-        defineProperty("WINDOWS_VS_VER", properties, "150")
-        defineProperty("WINDOWS_CRT_VER", properties, "150")
-        defineProperty("WINDOWS_VS_LIB", properties, "$WINDOWS_VS_VCINSTALLDIR/LIB;" + "$WINDOWS_SDK_DIR/lib;")
-        defineProperty("WINDOWS_VS_LIBPATH", properties, "$WINDOWS_VS_VCINSTALLDIR/LIB;")
-        def parfaitPath = IS_COMPILE_PARFAIT ? System.getenv().get("PARFAIT_PATH") + ";" : "";
-        defineProperty("WINDOWS_VS_PATH", properties, parfaitPath + "$WINDOWS_VS_DEVENVDIR;" +
-                "$WINDOWS_VS_VSINSTALLDIR/VC/BIN;" +
-                "$WINDOWS_VS_VSINSTALLDIR/Common7/Tools;" +
-                "$WINDOWS_VS_VCINSTALLDIR/VCPackages;" +
-                "$WINDOWS_SDK_DIR/bin/NETFX 4.0 Tools;" +
-                "$WINDOWS_SDK_DIR/bin;" +
-                System.getenv().get("PATH"))
+        defineProperty("WINDOWS_VS_INCLUDE", properties, "")
+        defineProperty("WINDOWS_CRT_VER", properties, "143")
+        defineProperty("WINDOWS_VS_LIB", properties, "")
+        defineProperty("WINDOWS_VS_LIBPATH", properties, "")
+        defineProperty("WINDOWS_VS_PATH", properties, "")
     }
 )
 
 if (WINDOWS_SDK_DIR == null || WINDOWS_SDK_DIR == "") {
-    throw new GradleException("FAIL: WINSDK_DIR not defined");
+    throw new GradleException("Cannot locate Visual Studio compilers; set the 'VSCOMNTOOLS' env var\nto the 'VC/Auxiliary/Build' dir in your Visual Studio installation");
 }
 
 // Define set of flags shared for all targets that support debug compilation
 def ccDebugFlags =
     IS_DEBUG_NATIVE ? ["/MDd", "/Od", "/Zi", "/DDEBUG"] : ["/O2", "/MD", "/DNDEBUG"]
 
-def winVsVer = Integer.parseInt(WINDOWS_VS_VER)
-if (winVsVer >= 120) {
-    // Serialize access to PDB file for debug builds if on VS2013 or later
-    if (IS_DEBUG_NATIVE) ccDebugFlags += "/FS"
-}
+// Serialize access to PDB file for debug builds if on VS2013 or later
+if (IS_DEBUG_NATIVE) ccDebugFlags += "/FS"
 
 // Enables reproducible builds when defined
 def sourceDateEpoch = System.getenv("SOURCE_DATE_EPOCH")
@@ -140,27 +127,23 @@ if (sourceDateEpoch != null) {
 }
 
 // Remove C++ static linking if not on VS2010
-if (WINDOWS_VS_VER != "100") {
-    ccFlags -= ["/D_STATIC_CPPLIB", "/D_DISABLE_DEPRECATE_STATIC_CPPLIB"]
-}
+ccFlags -= ["/D_STATIC_CPPLIB", "/D_DISABLE_DEPRECATE_STATIC_CPPLIB"]
 
 ext.WINDOWS_NATIVE_COMPILE_ENVIRONMENT = [
         "VCINSTALLDIR"         : WINDOWS_VS_VCINSTALLDIR,
         "VSINSTALLDIR"         : WINDOWS_VS_VSINSTALLDIR,
         "DEVENVDIR"            : WINDOWS_VS_DEVENVDIR,
         "MSVCDIR"              : WINDOWS_VS_MSVCDIR,
-        "VS_VER"               : WINDOWS_VS_VER,
         "PATH"                 : WINDOWS_VS_PATH,
         "INCLUDE"              : WINDOWS_VS_INCLUDE,
         "LIB"                  : WINDOWS_VS_LIB,
         "LIBPATH"              : WINDOWS_VS_LIBPATH,
-        "DXSDK_DIR"            : WINDOWS_DXSDK_DIR
 ];
 def msvcVer = System.getenv("MSVC_VER")
 def msvcBinDir = ""
 if (hasProperty('toolchainDir')) {
     msvcBinDir = "$WINDOWS_VS_VSINSTALLDIR/VC/bin/$TARGET_ARCH"
-} else if (winVsVer == 150) {
+} else {
     def msvcInstallDir = ""
     if (msvcVer) {
         msvcInstallDir = "$WINDOWS_VS_VSINSTALLDIR/VC/Tools/MSVC/$msvcVer"
@@ -168,23 +151,15 @@ if (hasProperty('toolchainDir')) {
         msvcInstallDir = "$WINDOWS_VS_VC_TOOLS_INSTALL_DIR"
     }
     msvcBinDir = "$msvcInstallDir/bin/Host${CPU_BITS}/$TARGET_ARCH"
-} else if (winVsVer <= 120) {
-    msvcBinDir = (IS_64
-                      ? "$WINDOWS_VS_VSINSTALLDIR/VC/BIN/amd64"
-                      : "$WINDOWS_VS_VSINSTALLDIR/VC/BIN")
 }
 def compiler = IS_COMPILE_PARFAIT ? "cl.exe" : cygpath("$msvcBinDir/cl.exe")
 def linker = IS_STATIC_BUILD ? (IS_COMPILE_PARFAIT ? "lib.exe" : cygpath("$msvcBinDir/lib.exe")) : (IS_COMPILE_PARFAIT ? "link.exe" : cygpath("$msvcBinDir/link.exe"))
 def winSdkBinDir = "$WINDOWS_SDK_DIR/Bin"
-if (WINDOWS_VS_VER != "100") {
-    winSdkBinDir += "/$TARGET_ARCH"
-}
+winSdkBinDir += "/$TARGET_ARCH"
 
 if (!file(cygpath("$winSdkBinDir/RC.Exe")).exists()) {
     winSdkBinDir = "$WINDOWS_SDK_DIR/Bin/$WINDOWS_SDK_VERSION"
-    if (WINDOWS_VS_VER != "100") {
-        winSdkBinDir += "/$TARGET_ARCH"
-    }
+    winSdkBinDir += "/$TARGET_ARCH"
 }
 
 ext.RC = cygpath("$winSdkBinDir/rc.exe")
@@ -192,15 +167,8 @@ ext.RC = cygpath("$winSdkBinDir/rc.exe")
 def hostWinSdkBinDir = "$WINDOWS_SDK_DIR/Bin/$WINDOWS_SDK_VERSION/$HOST_ARCH"
 ext.RC = !isExecutable(RC) ? cygpath("$hostWinSdkBinDir/rc.exe") : RC
 def rcCompiler = RC
+
 ext.FXC = cygpath("$winSdkBinDir/fxc.exe")
-
-if (!file(FXC).exists()) {
-    if (WINDOWS_DXSDK_DIR == null || WINDOWS_DXSDK_DIR == "") {
-        throw new GradleException("FAIL: DXSDK_DIR not defined");
-    }
-    ext.FXC = cygpath("$WINDOWS_DXSDK_DIR/utilities/bin/x86/fxc.exe")
-}
-
 // Use fxc from host system if it is not possible to run it from target system
 ext.FXC = !isExecutable(FXC) ? cygpath("$hostWinSdkBinDir/fxc.exe") : FXC
 
@@ -219,33 +187,30 @@ if (hasProperty('toolchainDir')) {
     }
 }
 
-def winSdkDllDir = "$WINDOWS_VS_WINSDKDLLINSTALLDIR/$TARGET_ARCH"
-
-def WINDOWS_DLL_VER = WINDOWS_VS_VER
+def winSdkDllDir = WINDOWS_VS_WINSDKDLLINSTALLDIR != "" ?
+    "$WINDOWS_VS_WINSDKDLLINSTALLDIR/$TARGET_ARCH" :
+    "${WINDOWS_SDK_DIR}/Redist/${WINDOWS_SDK_VERSION}/ucrt/DLLs/$TARGET_ARCH"
 
 def windowsCRTVer = System.getenv("WINDOWS_CRT_VER") ?: WINDOWS_CRT_VER
-if (WINDOWS_VS_VER == "150") {
-    WINDOWS_DLL_VER = "140"
-}
 
-def vs2017DllPath = cygpath("${msvcRedstDir}/Microsoft.VC${windowsCRTVer}.CRT")
-if (file(vs2017DllPath).exists()) {
-    ext.WIN.VS2017DLLNames = [
+def vsDllPath = cygpath("${msvcRedstDir}/Microsoft.VC${windowsCRTVer}.CRT")
+if (file(vsDllPath).exists()) {
+    ext.WIN.VSDLLNames = [
         "msvcp140.dll",
         "msvcp140_1.dll",
         "msvcp140_2.dll",
         "vcruntime140.dll",
         "vcruntime140_1.dll"
     ];
-    ext.WIN.VS2017DLLs = []
-    ext.WIN.VS2017DLLNames.each { vsdll->
-        ext.WIN.VS2017DLLs += "$vs2017DllPath/$vsdll"
+    ext.WIN.VSDLLs = []
+    ext.WIN.VSDLLNames.each { vsdll->
+        ext.WIN.VSDLLs += "$vsDllPath/$vsdll"
     }
 }
 else {
-    ext.WIN.VS2017DLLNames = [
+    ext.WIN.VSDLLNames = [
     ];
-    ext.WIN.VS2017DLLs = [
+    ext.WIN.VSDLLs = [
     ];
 }
 
@@ -345,8 +310,7 @@ WIN.glass.rcFlags = [
     "/d", "JFX_FNAME=glass.dll",
     "/d", "JFX_INTERNAL_NAME=glass",
     rcFlags].flatten();
-WIN.glass.ccFlags = [ccFlags, "/WX"].flatten()
-if (WINDOWS_VS_VER != "100") WIN.glass.ccFlags -= ["/WX"]
+WIN.glass.ccFlags = [ccFlags].flatten()
 WIN.glass.linker = linker
 WIN.glass.linkFlags = (IS_STATIC_BUILD ? [linkFlags] : [linkFlags, "delayimp.lib", "gdi32.lib", "urlmon.lib", "Comdlg32.lib",
         "winmm.lib", "imm32.lib", "shell32.lib", "Uiautomationcore.lib", "dwmapi.lib",

--- a/buildSrc/win.gradle
+++ b/buildSrc/win.gradle
@@ -110,7 +110,7 @@ if (WINDOWS_SDK_DIR == null || WINDOWS_SDK_DIR == "") {
 def ccDebugFlags =
     IS_DEBUG_NATIVE ? ["/MDd", "/Od", "/Zi", "/DDEBUG"] : ["/O2", "/MD", "/DNDEBUG"]
 
-// Serialize access to PDB file for debug builds if on VS2013 or later
+// Serialize access to PDB file for debug builds
 if (IS_DEBUG_NATIVE) ccDebugFlags += "/FS"
 
 // Enables reproducible builds when defined
@@ -137,7 +137,7 @@ if (sourceDateEpoch != null) {
     linkFlags.add("/experimental:deterministic")
 }
 
-// Remove C++ static linking if not on VS2010
+// Remove C++ static linking
 ccFlags -= ["/D_STATIC_CPPLIB", "/D_DISABLE_DEPRECATE_STATIC_CPPLIB"]
 
 ext.WINDOWS_NATIVE_COMPILE_ENVIRONMENT = [

--- a/buildSrc/win.gradle
+++ b/buildSrc/win.gradle
@@ -47,6 +47,17 @@ def IS_CROSS = HOST_ARCH != TARGET_ARCH
 
 setupTools("windows_tools",
     { propFile ->
+        if (System.getenv("VS150COMNTOOLS") != null) {
+            println "***********************************************************************"
+            if (System.getenv("VSCOMNTOOLS") != null) {
+                println "*** Using VSCOMNTOOLS and ignoring obsolete VS150COMNTOOLS.         ***"
+            } else {
+                println "*** VS150COMNTOOLS is deprecated and will be ignored in the future. ***"
+                println "*** Set VSCOMNTOOLS to your Visual Studio installation instead.     ***"
+            }
+            println "***********************************************************************"
+        }
+
         if (project.hasProperty('setupWinTools')) {
             setupWinTools(propFile)
         } else {

--- a/buildSrc/win.gradle
+++ b/buildSrc/win.gradle
@@ -91,6 +91,25 @@ setupTools("windows_tools",
     }
 )
 
+// FIXME KCR: BEGIN VERBOSE
+println "KCR: BEGIN"
+println "WINDOWS_VS_VSINSTALLDIR=$WINDOWS_VS_VSINSTALLDIR"
+println "WINDOWS_VS_WINSDKDLLINSTALLDIR=$WINDOWS_VS_WINSDKDLLINSTALLDIR"
+println "WINDOWS_SDK_DIR=$WINDOWS_SDK_DIR"
+println "WINDOWS_SDK_VERSION=$WINDOWS_SDK_VERSION"
+println "WINDOWS_VS_VCINSTALLDIR=$WINDOWS_VS_VCINSTALLDIR"
+println "WINDOWS_VS_DEVENVDIR=$WINDOWS_VS_DEVENVDIR"
+println "WINDOWS_VS_MSVCDIR=$WINDOWS_VS_MSVCDIR"
+println "WINDOWS_VS_VC_TOOLS_INSTALL_DIR=$WINDOWS_VS_VC_TOOLS_INSTALL_DIR"
+println "WINDOWS_VS_VC_TOOLS_REDIST_DIR=$WINDOWS_VS_VC_TOOLS_REDIST_DIR"
+println "WINDOWS_VS_INCLUDE=$WINDOWS_VS_INCLUDE"
+println "WINDOWS_CRT_VER=$WINDOWS_CRT_VER"
+println "WINDOWS_VS_LIB=$WINDOWS_VS_LIB"
+println "WINDOWS_VS_LIBPATH=$WINDOWS_VS_LIBPATH"
+println "WINDOWS_VS_PATH=$WINDOWS_VS_PATH"
+println "KCR: END"
+// FIXME KCR: END VERBOSE
+
 if (WINDOWS_SDK_DIR == null || WINDOWS_SDK_DIR == "") {
     throw new GradleException("Cannot locate Visual Studio compilers; set the 'VSCOMNTOOLS' env var\nto the 'VC/Auxiliary/Build' dir in your Visual Studio installation");
 }
@@ -191,6 +210,9 @@ def winSdkDllDir = WINDOWS_VS_WINSDKDLLINSTALLDIR != "" ?
     "$WINDOWS_VS_WINSDKDLLINSTALLDIR/$TARGET_ARCH" :
     "${WINDOWS_SDK_DIR}/Redist/${WINDOWS_SDK_VERSION}/ucrt/DLLs/$TARGET_ARCH"
 
+// FIXME KCR: VERBOSE
+println "KCR: winSdkDllDir = $winSdkDllDir"
+
 def windowsCRTVer = System.getenv("WINDOWS_CRT_VER") ?: WINDOWS_CRT_VER
 
 def vsDllPath = cygpath("${msvcRedstDir}/Microsoft.VC${windowsCRTVer}.CRT")
@@ -216,6 +238,8 @@ else {
 
 def WinSDKDLLsPath = cygpath("${winSdkDllDir}")
 if (file(WinSDKDLLsPath).exists()) {
+    // FIXME KCR: VERBOSE
+    println "KCR: WinSDKDLLsPath exists"
     ext.WIN.WinSDKDLLNames = [
         "api-ms-win-core-console-l1-1-0.dll",
         "api-ms-win-core-console-l1-2-0.dll",

--- a/buildSrc/win.gradle
+++ b/buildSrc/win.gradle
@@ -102,25 +102,6 @@ setupTools("windows_tools",
     }
 )
 
-// FIXME KCR: BEGIN VERBOSE
-println "KCR: BEGIN"
-println "WINDOWS_VS_VSINSTALLDIR=$WINDOWS_VS_VSINSTALLDIR"
-println "WINDOWS_VS_WINSDKDLLINSTALLDIR=$WINDOWS_VS_WINSDKDLLINSTALLDIR"
-println "WINDOWS_SDK_DIR=$WINDOWS_SDK_DIR"
-println "WINDOWS_SDK_VERSION=$WINDOWS_SDK_VERSION"
-println "WINDOWS_VS_VCINSTALLDIR=$WINDOWS_VS_VCINSTALLDIR"
-println "WINDOWS_VS_DEVENVDIR=$WINDOWS_VS_DEVENVDIR"
-println "WINDOWS_VS_MSVCDIR=$WINDOWS_VS_MSVCDIR"
-println "WINDOWS_VS_VC_TOOLS_INSTALL_DIR=$WINDOWS_VS_VC_TOOLS_INSTALL_DIR"
-println "WINDOWS_VS_VC_TOOLS_REDIST_DIR=$WINDOWS_VS_VC_TOOLS_REDIST_DIR"
-println "WINDOWS_VS_INCLUDE=$WINDOWS_VS_INCLUDE"
-println "WINDOWS_CRT_VER=$WINDOWS_CRT_VER"
-println "WINDOWS_VS_LIB=$WINDOWS_VS_LIB"
-println "WINDOWS_VS_LIBPATH=$WINDOWS_VS_LIBPATH"
-println "WINDOWS_VS_PATH=$WINDOWS_VS_PATH"
-println "KCR: END"
-// FIXME KCR: END VERBOSE
-
 if (WINDOWS_SDK_DIR == null || WINDOWS_SDK_DIR == "") {
     throw new GradleException("Cannot locate Visual Studio compilers; set the 'VSCOMNTOOLS' env var\nto the 'VC/Auxiliary/Build' dir in your Visual Studio installation");
 }
@@ -221,9 +202,6 @@ def winSdkDllDir = WINDOWS_VS_WINSDKDLLINSTALLDIR != "" ?
     "$WINDOWS_VS_WINSDKDLLINSTALLDIR/$TARGET_ARCH" :
     "${WINDOWS_SDK_DIR}/Redist/${WINDOWS_SDK_VERSION}/ucrt/DLLs/$TARGET_ARCH"
 
-// FIXME KCR: VERBOSE
-println "KCR: winSdkDllDir = $winSdkDllDir"
-
 def windowsCRTVer = System.getenv("WINDOWS_CRT_VER") ?: WINDOWS_CRT_VER
 
 def vsDllPath = cygpath("${msvcRedstDir}/Microsoft.VC${windowsCRTVer}.CRT")
@@ -249,8 +227,6 @@ else {
 
 def WinSDKDLLsPath = cygpath("${winSdkDllDir}")
 if (file(WinSDKDLLsPath).exists()) {
-    // FIXME KCR: VERBOSE
-    println "KCR: WinSDKDLLsPath exists"
     ext.WIN.WinSDKDLLNames = [
         "api-ms-win-core-console-l1-1-0.dll",
         "api-ms-win-core-console-l1-2-0.dll",

--- a/modules/javafx.media/src/main/native/jfxmedia/projects/win/Makefile
+++ b/modules/javafx.media/src/main/native/jfxmedia/projects/win/Makefile
@@ -85,10 +85,6 @@ CFLAGS = -DWIN32 \
          $(INCLUDES) \
          $(CL_COMPILER_FLAGS)
 
-ifeq ($(VS_VER), 100)
-    CFLAGS += -D_STATIC_CPPLIB -D_DISABLE_DEPRECATE_STATIC_CPPLIB
-endif
-
 LIBS = gstreamer-lite.lib \
        glib-lite.lib \
        Winmm.lib \


### PR DESCRIPTION
1. Added logic to look in the standard locations for Visual Studio 2022, with a fallback to 2019 and then 2017 if 2022 is not found. It will look in the following locations:
```
C:\("Program Files"|"Program Files (x86)")\Microsoft Visual Studio\(2022|2019|2017)\
     (Enterprise|Professional|Community)\VC\Auxiliary\Build
```
2. Use `VSCOMNTOOLS` as the primary way for a developer to specify a custom location for Visual Studio, with `VS150COMNTOOLS` as a legacy fallback (a warning is printed if `VS150COMNTOOLS` is set). If a developer installs Visual Studio in the default location, there will be no need to set this any more.
3. Removed support for older compilers (VS2010 and VS2013 in particular), since they will no longer work anyway. We were still using the 32-bit version of the script in many cases, which is unnecessary and no longer makes sense, so as part of this cleanup, I now consistently use `vcvars64.bat` to set up the environment.
4. Modified the GitHub actions build to no longer specify `VS150COMNTOOLS`, since it will now find it automatically.
5. Removed the following unused variables:
```
DEVENVCMD
DXSDK_DIR
VS_VER
```
6. Changed most of the defaults in `win.gradle` to the empty string. The defaults were a misguided attempt to set values to something in case the Visual Studio installation cannot be found. By not having defaults, it will be more obvious if something goes wrong (and will fail fast).
7. If the Visual Studio Installation cannot be found, it will print a sensible error message and retry the next time the build is run (making it less likely that a manual `rm -rf build` is needed).
8. Fixed a bug where the Microsoft redist files were not being located and copied into the build dir (build/sdk/bin).


I left some debug print statements in, and will remove them in a follow-on commit.

I have tested this with a local installation of Visual Studio 2022 Community and, via GitHub Actions, an installation of Visual Studio 2022 Enterprise. On my local system, I built with and without Media and WebKit.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8289174](https://bugs.openjdk.org/browse/JDK-8289174): JavaFX build fails on Windows when VS150COMNTOOLS is not set (**Bug** - P4)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**) 🔄 Re-review required (review applies to [4bd166ea](https://git.openjdk.org/jfx/pull/1534/files/4bd166eaba1152a1cee8da473d0e53141d7847f5))
 * [Nir Lisker](https://openjdk.org/census#nlisker) (@nlisker - **Reviewer**)
 * [Marius Hanl](https://openjdk.org/census#mhanl) (@Maran23 - Committer)
 * [Lukasz Kostyra](https://openjdk.org/census#lkostyra) (@lukostyra - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1534/head:pull/1534` \
`$ git checkout pull/1534`

Update a local copy of the PR: \
`$ git checkout pull/1534` \
`$ git pull https://git.openjdk.org/jfx.git pull/1534/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1534`

View PR using the GUI difftool: \
`$ git pr show -t 1534`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1534.diff">https://git.openjdk.org/jfx/pull/1534.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1534#issuecomment-2284163168)