### PR TITLE
8338016: SplitMenuButton constructors should match MenuButton

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/SplitMenuButton.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/SplitMenuButton.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@ import javafx.event.ActionEvent;
 import javafx.scene.AccessibleAction;
 import javafx.scene.AccessibleAttribute;
 import javafx.scene.AccessibleRole;
+import javafx.scene.Node;
 import javafx.scene.control.skin.SplitMenuButtonSkin;
 
 /**
@@ -76,7 +77,31 @@ public class SplitMenuButton extends MenuButton {
      * {@link #setGraphic(Node)} and {@link #getItems()} to set the content.
      */
     public SplitMenuButton() {
-        this((MenuItem[])null);
+        this(null, null, (MenuItem[])null);
+    }
+
+    /**
+     * Creates a new empty split menu button with the given text to display on the
+     * button. Use {@link #setGraphic(Node)} and {@link #getItems()} to set the
+     * content.
+     *
+     * @param text the text to display on the menu button
+     * @since 24
+     */
+    public SplitMenuButton(String text) {
+        this(text, null, (MenuItem[])null);
+    }
+
+    /**
+     * Creates a new empty split menu button with the given text and graphic to
+     * display on the button. Use {@link #getItems()} to set the content.
+     *
+     * @param text the text to display on the menu button
+     * @param graphic the graphic to display on the menu button
+     * @since 24
+     */
+    public SplitMenuButton(String text, Node graphic) {
+        this(text, graphic, (MenuItem[])null);
     }
 
     /**
@@ -85,6 +110,26 @@ public class SplitMenuButton extends MenuButton {
      * @param items The items to show within this button's menu
      */
     public SplitMenuButton(MenuItem... items) {
+        this(null, null, items);
+    }
+
+    /**
+     * Creates a new split menu button with the given text and graphic to
+     * display on the button, and inserts the given items
+     * into the {@link #getItems() items} list.
+     *
+     * @param text the text to display on the menu button
+     * @param graphic the graphic to display on the menu button
+     * @param items The items to display in the popup menu.
+     * @since 24
+     */
+    public SplitMenuButton(String text, Node graphic, MenuItem... items) {
+        if (text != null) {
+            setText(text);
+        }
+        if (graphic != null) {
+            setGraphic(graphic);
+        }
         if (items != null) {
             getItems().addAll(items);
         }

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/SplitMenuButton.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/SplitMenuButton.java
@@ -120,7 +120,7 @@ public class SplitMenuButton extends MenuButton {
      *
      * @param text the text to display on the menu button
      * @param graphic the graphic to display on the menu button
-     * @param items The items to display in the popup menu.
+     * @param items the items to display in the popup menu
      * @since 24
      */
     public SplitMenuButton(String text, Node graphic, MenuItem... items) {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/SplitMenuButtonTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/SplitMenuButtonTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,12 +27,14 @@ package test.javafx.scene.control;
 
 import javafx.scene.control.MenuItem;
 import javafx.scene.control.SplitMenuButton;
+import javafx.scene.shape.Rectangle;
 import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
 
 /**
+ * Basic SplitMenuButton Tests.
  *
  * @author lubermud
  */
@@ -81,7 +83,67 @@ public class SplitMenuButtonTest {
         assertTrue(smb2.isMnemonicParsing());
     }
 
+    @Test
+    public void oneArgConstructorShouldHaveNoGraphic1() {
+        SplitMenuButton mb2 = new SplitMenuButton((String)null);
+        assertNull(mb2.getGraphic());
+    }
 
+    @Test
+    public void oneArgConstructorShouldHaveNoGraphic2() {
+        SplitMenuButton mb2 = new SplitMenuButton("");
+        assertNull(mb2.getGraphic());
+    }
+
+    @Test
+    public void oneArgConstructorShouldHaveNoGraphic3() {
+        SplitMenuButton mb2 = new SplitMenuButton("Hello");
+        assertNull(mb2.getGraphic());
+    }
+
+    @Test
+    public void oneArgConstructorShouldHaveSpecifiedString1() {
+        SplitMenuButton mb2 = new SplitMenuButton((String)null);
+        assertEquals("", mb2.getText());
+    }
+
+    @Test
+    public void oneArgConstructorShouldHaveSpecifiedString2() {
+        SplitMenuButton mb2 = new SplitMenuButton("");
+        assertEquals("", mb2.getText());
+    }
+
+    @Test
+    public void oneArgConstructorShouldHaveSpecifiedString3() {
+        SplitMenuButton mb2 = new SplitMenuButton("Hello");
+        assertEquals("Hello", mb2.getText());
+    }
+
+    @Test
+    public void twoArgConstructorShouldHaveSpecifiedGraphic1() {
+        SplitMenuButton mb2 = new SplitMenuButton(null, null);
+        assertNull(mb2.getGraphic());
+    }
+
+    @Test
+    public void twoArgConstructorShouldHaveSpecifiedGraphic2() {
+        Rectangle rect = new Rectangle();
+        SplitMenuButton mb2 = new SplitMenuButton("Hello", rect);
+        assertSame(rect, mb2.getGraphic());
+    }
+
+    @Test
+    public void twoArgConstructorShouldHaveSpecifiedString1() {
+        SplitMenuButton mb2 = new SplitMenuButton(null, null);
+        assertEquals("", mb2.getText());
+    }
+
+    @Test
+    public void twoArgConstructorShouldHaveSpecifiedString2() {
+        Rectangle rect = new Rectangle();
+        SplitMenuButton mb2 = new SplitMenuButton("Hello", rect);
+        assertEquals("Hello", mb2.getText());
+    }
 
     @Test public void splitMenuButtonIsFiredIsNoOp() {
         splitMenuButton.fire(); // should throw no exceptions, if it does, the test fails


### PR DESCRIPTION
Adding SplitMenuButton constructors matching MenuButton:

- public SplitMenuButton(String text)
- public SplitMenuButton(String text, Node graphic)
- public SplitMenuButton(String text, Node graphic, MenuItem... items)

/csr

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change requires CSR request [JDK-8338337](https://bugs.openjdk.org/browse/JDK-8338337) to be approved
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issues
 * [JDK-8338016](https://bugs.openjdk.org/browse/JDK-8338016): SplitMenuButton constructors should match MenuButton (**Enhancement** - P4)
 * [JDK-8338337](https://bugs.openjdk.org/browse/JDK-8338337): SplitMenuButton constructors should match MenuButton (**CSR**)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Michael Strauß](https://openjdk.org/census#mstrauss) (@mstr2 - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1535/head:pull/1535` \
`$ git checkout pull/1535`

Update a local copy of the PR: \
`$ git checkout pull/1535` \
`$ git pull https://git.openjdk.org/jfx.git pull/1535/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1535`

View PR using the GUI difftool: \
`$ git pr show -t 1535`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1535.diff">https://git.openjdk.org/jfx/pull/1535.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1535#issuecomment-2289399175)