### PR TITLE
8338478: [macos] Crash in CoreText with certain strings using JDK 22 or later

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/coretext/CTFontFile.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/coretext/CTFontFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/coretext/CTFontFile.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/coretext/CTFontFile.java
@@ -25,6 +25,8 @@
 
 package com.sun.javafx.font.coretext;
 
+import java.lang.ref.Reference;
+
 import com.sun.javafx.font.Disposer;
 import com.sun.javafx.font.DisposerRecord;
 import com.sun.javafx.font.FontFallbackInfo;
@@ -148,33 +150,45 @@ class CTFontFile extends PrismFontFile {
 
     CGRect getBBox(int gc, float size) {
         CTFontStrike strike = (CTFontStrike)getStrike(size, BaseTransform.IDENTITY_TRANSFORM);
-        long fontRef = strike.getFontRef();
-        if (fontRef == 0) return null;
-        long pathRef = OS.CTFontCreatePathForGlyph(fontRef, (short)gc, tx);
-        if (pathRef == 0) return null;
-        CGRect rect = OS.CGPathGetPathBoundingBox(pathRef);
-        OS.CGPathRelease(pathRef);
-        return rect;
+        try {
+            long fontRef = strike.getFontRef();
+            if (fontRef == 0) return null;
+            long pathRef = OS.CTFontCreatePathForGlyph(fontRef, (short)gc, tx);
+            if (pathRef == 0) return null;
+            CGRect rect = OS.CGPathGetPathBoundingBox(pathRef);
+            OS.CGPathRelease(pathRef);
+            return rect;
+      } finally {
+          Reference.reachabilityFence(strike);
+      }
     }
 
     Path2D getGlyphOutline(int gc, float size) {
         CTFontStrike strike = (CTFontStrike)getStrike(size, BaseTransform.IDENTITY_TRANSFORM);
-        long fontRef = strike.getFontRef();
-        if (fontRef == 0) return null;
-        long pathRef = OS.CTFontCreatePathForGlyph(fontRef, (short)gc, tx);
-        if (pathRef == 0) return null;
-        Path2D path = OS.CGPathApply(pathRef);
-        OS.CGPathRelease(pathRef);
-        return path;
+        try {
+            long fontRef = strike.getFontRef();
+            if (fontRef == 0) return null;
+            long pathRef = OS.CTFontCreatePathForGlyph(fontRef, (short)gc, tx);
+            if (pathRef == 0) return null;
+            Path2D path = OS.CGPathApply(pathRef);
+            OS.CGPathRelease(pathRef);
+            return path;
+      } finally {
+          Reference.reachabilityFence(strike);
+      }
     }
 
    @Override protected float getAdvanceFromPlatform(int glyphCode, float ptSize) {
       CTFontStrike strike =
           (CTFontStrike)getStrike(ptSize, BaseTransform.IDENTITY_TRANSFORM);
-      long fontRef = strike.getFontRef();
-      int orientation = OS.kCTFontOrientationDefault;
-      CGSize size = new CGSize();
-      return (float)OS.CTFontGetAdvancesForGlyphs(fontRef, orientation, (short)glyphCode, size);
+      try {
+          long fontRef = strike.getFontRef();
+          int orientation = OS.kCTFontOrientationDefault;
+          CGSize size = new CGSize();
+          return (float)OS.CTFontGetAdvancesForGlyphs(fontRef, orientation, (short)glyphCode, size);
+      } finally {
+          Reference.reachabilityFence(strike);
+      }
    }
 
    @Override protected int[] createGlyphBoundingBox(int gc) {
@@ -187,46 +201,50 @@ class CTFontFile extends PrismFontFile {
         CTFontStrike strike = (CTFontStrike)getStrike(size,
                                                       BaseTransform.IDENTITY_TRANSFORM);
 
-        long fontRef = strike.getFontRef();
-        if (fontRef == 0) return null;
-        int[] bb = new int[4];
+        try {
+            long fontRef = strike.getFontRef();
+            if (fontRef == 0) return null;
+            int[] bb = new int[4];
 
-        /* For some reason CTFontGetBoundingRectsForGlyphs has poor performance.
-         * The fix is to use the 'loca' and the 'glyf' tables to determine
-         * the glyph bounding box (same as T2K). This implementation
-         * uses native code to read these tables since they can be large.
-         * However for color (emoji) glyphs this returns the wrong bounds,
-         * so use CTFontGetBoundingRectsForGlyphs anyway.
-         * In case it fails, or the font doesn't have a glyph table
-         * (CFF fonts), then the bounds of the glyph outline is used instead.
-         */
-        if (!isCFF()) {
-            if (isColorGlyph(gc)) {
-                CGRect rect = OS.CTFontGetBoundingRectForGlyphs(fontRef, (short)gc);
-                float scale = getUnitsPerEm() / size;
-                bb[0] = (int)(Math.round(rect.origin.x * scale));
-                bb[1] = (int)(Math.round(rect.origin.y * scale));
-                bb[2] = (int)(Math.round((rect.origin.x + rect.size.width) * scale));
-                bb[3] = (int)(Math.round((rect.origin.y + rect.size.height) * scale));
-                return bb;
-            } else {
-                short format = getIndexToLocFormat();
-                if (OS.CTFontGetBoundingRectForGlyphUsingTables(fontRef, (short)gc, format, bb)) {
+            /* For some reason CTFontGetBoundingRectsForGlyphs has poor performance.
+             * The fix is to use the 'loca' and the 'glyf' tables to determine
+             * the glyph bounding box (same as T2K). This implementation
+             * uses native code to read these tables since they can be large.
+             * However for color (emoji) glyphs this returns the wrong bounds,
+             * so use CTFontGetBoundingRectsForGlyphs anyway.
+             * In case it fails, or the font doesn't have a glyph table
+             * (CFF fonts), then the bounds of the glyph outline is used instead.
+             */
+            if (!isCFF()) {
+                if (isColorGlyph(gc)) {
+                    CGRect rect = OS.CTFontGetBoundingRectForGlyphs(fontRef, (short)gc);
+                    float scale = getUnitsPerEm() / size;
+                    bb[0] = (int)(Math.round(rect.origin.x * scale));
+                    bb[1] = (int)(Math.round(rect.origin.y * scale));
+                    bb[2] = (int)(Math.round((rect.origin.x + rect.size.width) * scale));
+                    bb[3] = (int)(Math.round((rect.origin.y + rect.size.height) * scale));
                     return bb;
+                } else {
+                    short format = getIndexToLocFormat();
+                    if (OS.CTFontGetBoundingRectForGlyphUsingTables(fontRef, (short)gc, format, bb)) {
+                        return bb;
+                    }
                 }
             }
+            /* Note: not using tx here as the bounds need to be y up */
+            long pathRef = OS.CTFontCreatePathForGlyph(fontRef, (short)gc, null);
+            if (pathRef == 0) return null;
+            CGRect rect = OS.CGPathGetPathBoundingBox(pathRef);
+            OS.CGPathRelease(pathRef);
+            float scale = getUnitsPerEm() / size;
+            bb[0] = (int)(Math.round(rect.origin.x * scale));
+            bb[1] = (int)(Math.round(rect.origin.y * scale));
+            bb[2] = (int)(Math.round((rect.origin.x + rect.size.width) * scale));
+            bb[3] = (int)(Math.round((rect.origin.y + rect.size.height) * scale));
+            return bb;
+        } finally {
+            Reference.reachabilityFence(strike);
         }
-        /* Note: not using tx here as the bounds need to be y up */
-        long pathRef = OS.CTFontCreatePathForGlyph(fontRef, (short)gc, null);
-        if (pathRef == 0) return null;
-        CGRect rect = OS.CGPathGetPathBoundingBox(pathRef);
-        OS.CGPathRelease(pathRef);
-        float scale = getUnitsPerEm() / size;
-        bb[0] = (int)(Math.round(rect.origin.x * scale));
-        bb[1] = (int)(Math.round(rect.origin.y * scale));
-        bb[2] = (int)(Math.round((rect.origin.x + rect.size.width) * scale));
-        bb[3] = (int)(Math.round((rect.origin.y + rect.size.height) * scale));
-        return bb;
     }
 
     @Override


### PR DESCRIPTION
The test in the bug report crashes reliably with JDK 22 on retina.
It coincides with an update to the macOS compilers which seem likely to eagerly invalidate the target of a CFRelease on the native CTFontRef.
Adding a ReachabilityFence to prevent the GC from collecting CTFontStrike until after the method has finished using the native fontRef from the strike fixes it.
The same pattern is observed in 3 other methods (although no crash)  and a fence is added there too.

There is an existing test, which is how this problem was found.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8338478](https://bugs.openjdk.org/browse/JDK-8338478): [macos] Crash in CoreText with certain strings using JDK 22 or later (**Bug** - P2)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1537/head:pull/1537` \
`$ git checkout pull/1537`

Update a local copy of the PR: \
`$ git checkout pull/1537` \
`$ git pull https://git.openjdk.org/jfx.git pull/1537/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1537`

View PR using the GUI difftool: \
`$ git pr show -t 1537`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1537.diff">https://git.openjdk.org/jfx/pull/1537.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1537#issuecomment-2294986063)