### PR TITLE
8338849: Update copyright header for files modified in 2024

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Window.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Window.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassSystemMenu.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassSystemMenu.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DResourceFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DResourceFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2ResourceFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2ResourceFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/null3d/DummyResourceFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/null3d/DummyResourceFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/ps/ShaderFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/ps/ShaderFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/java/com/sun/scenario/effect/impl/prism/ps/PPSRenderer.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/scenario/effect/impl/prism/ps/PPSRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/java/javafx/scene/AccessibleAction.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/AccessibleAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/jsl-prism/PrismLoaderGlue.stg
+++ b/modules/javafx.graphics/src/main/jsl-prism/PrismLoaderGlue.stg
@@ -2,7 +2,7 @@ group PrismLoaderGlue;
 
 glue(shaderName,samplerInit,paramInit,maxTexCoordIndex,isPixcoordUsed) ::= <<
 /*
- * Copyright (c) 2009, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassLayer3D.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassLayer3D.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassPixels.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassPixels.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow+Overrides.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow+Overrides.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/native-glass/mac/PlatformSupport.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/PlatformSupport.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.media/src/main/legal/libffi.md
+++ b/modules/javafx.media/src/main/legal/libffi.md
@@ -35,7 +35,7 @@ Copyright (C) 2002  Roger Sayle
 Copyright (C) 2013  The Written Word, Inc.
 Copyright (C) 2002-2007  Bo Thorsen <bo@suse.de>
 Copyright (C) 2021  Microsoft, Inc.
-Copyright (c) 2022 Oracle and/or its affiliates.
+Copyright (c) 2022, 2024, Oracle and/or its affiliates.
 
 ```
 

--- a/modules/javafx.media/src/main/legal/libffi.md
+++ b/modules/javafx.media/src/main/legal/libffi.md
@@ -35,7 +35,7 @@ Copyright (C) 2002  Roger Sayle
 Copyright (C) 2013  The Written Word, Inc.
 Copyright (C) 2002-2007  Bo Thorsen <bo@suse.de>
 Copyright (C) 2021  Microsoft, Inc.
-Copyright (c) 2022, 2024, Oracle and/or its affiliates.
+Copyright (c) 2022 Oracle and/or its affiliates.
 
 ```
 

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/prep_cif.c
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/prep_cif.c
@@ -1,7 +1,7 @@
 /* -----------------------------------------------------------------------
    prep_cif.c - Copyright (c) 2011, 2012, 2021  Anthony Green
                 Copyright (c) 1996, 1998, 2007  Red Hat, Inc.
-                Copyright (c) 2022, 2024, Oracle and/or its affiliates.
+                Copyright (c) 2022 Oracle and/or its affiliates.
 
    Permission is hereby granted, free of charge, to any person obtaining
    a copy of this software and associated documentation files (the

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/prep_cif.c
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/prep_cif.c
@@ -1,7 +1,7 @@
 /* -----------------------------------------------------------------------
    prep_cif.c - Copyright (c) 2011, 2012, 2021  Anthony Green
                 Copyright (c) 1996, 1998, 2007  Red Hat, Inc.
-                Copyright (c) 2022 Oracle and/or its affiliates.
+                Copyright (c) 2022, 2024, Oracle and/or its affiliates.
 
    Permission is hereby granted, free of charge, to any person obtaining
    a copy of this software and associated documentation files (the

--- a/modules/javafx.media/src/main/native/jfxmedia/projects/win/Makefile
+++ b/modules/javafx.media/src/main/native/jfxmedia/projects/win/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.web/src/main/native/Source/WebCore/bridge/jni/jsc/BridgeUtils.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bridge/jni/jsc/BridgeUtils.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.web/src/main/native/Source/WebCore/editing/java/EditorJava.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/editing/java/EditorJava.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/java/BitmapImageJava.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/java/BitmapImageJava.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/java/BufferImageJava.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/java/BufferImageJava.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/java/BufferImageJava.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/java/BufferImageJava.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/java/FontCacheJava.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/java/FontCacheJava.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/java/ImageJava.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/java/ImageJava.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/java/NativeImageJava.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/java/NativeImageJava.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/texmap/BitmapTextureJava.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/texmap/BitmapTextureJava.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/texmap/BitmapTextureJava.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/texmap/BitmapTextureJava.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/java/ContextMenuJava.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/java/ContextMenuJava.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/java/CursorJava.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/java/CursorJava.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/java/MouseEventJava.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/java/MouseEventJava.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/java/PageSupplementJava.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/java/PageSupplementJava.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/java/PageSupplementJava.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/java/PageSupplementJava.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/java/RenderThemeJava.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/java/RenderThemeJava.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/network/java/URLLoader.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/network/java/URLLoader.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.web/src/main/native/Source/WebKitLegacy/java/DOM/JavaDocument.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebKitLegacy/java/DOM/JavaDocument.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.web/src/main/native/Source/WebKitLegacy/java/DOM/JavaKeyboardEvent.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebKitLegacy/java/DOM/JavaKeyboardEvent.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.web/src/main/native/Source/WebKitLegacy/java/DOM/JavaMouseEvent.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebKitLegacy/java/DOM/JavaMouseEvent.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.web/src/main/native/Source/WebKitLegacy/java/DOM/JavaRange.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebKitLegacy/java/DOM/JavaRange.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.web/src/test/java/test/javafx/scene/web/HistoryTest.java
+++ b/modules/javafx.web/src/test/java/test/javafx/scene/web/HistoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.web/src/test/java/test/javafx/scene/web/MiscellaneousTest.java
+++ b/modules/javafx.web/src/test/java/test/javafx/scene/web/MiscellaneousTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Update copyright year in files updated in year 2024.
This update is done specifically to update the year in webkit files, so that the webkit source shows no diff.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338849](https://bugs.openjdk.org/browse/JDK-8338849): Update copyright header for files modified in 2024 (**Task** - P2)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1543/head:pull/1543` \
`$ git checkout pull/1543`

Update a local copy of the PR: \
`$ git checkout pull/1543` \
`$ git pull https://git.openjdk.org/jfx.git pull/1543/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1543`

View PR using the GUI difftool: \
`$ git pr show -t 1543`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1543.diff">https://git.openjdk.org/jfx/pull/1543.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1543#issuecomment-2305149168)