### PR TITLE
8338886: JavaFX debug builds fail on macOS

### DIFF
--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/JavaDOMUtils.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/JavaDOMUtils.cpp
@@ -47,7 +47,7 @@ namespace WebCore {
 
 static void raiseDOMErrorException(JNIEnv* env, WebCore::ExceptionCode ec)
 {
-    ASSERT(ec);
+    ASSERT(ec == ExceptionCode::TypeError);
 
     auto description = DOMException::description(ec);
 


### PR DESCRIPTION
Issue: ASSERT Statement: The ASSERT macro or function seems to be used to check if a condition involving ExceptionCode is true, but it's failing to compile.
Solution: The expression for ASSERT should be checked with type.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338886](https://bugs.openjdk.org/browse/JDK-8338886): JavaFX debug builds fail on macOS (**Bug** - P3)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1544/head:pull/1544` \
`$ git checkout pull/1544`

Update a local copy of the PR: \
`$ git checkout pull/1544` \
`$ git pull https://git.openjdk.org/jfx.git pull/1544/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1544`

View PR using the GUI difftool: \
`$ git pr show -t 1544`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1544.diff">https://git.openjdk.org/jfx/pull/1544.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1544#issuecomment-2306317246)