### PR TITLE
8339178: [macos] Swing InterOp Platform.exit() crash

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
@@ -536,8 +536,7 @@ jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved)
 
     NSAutoreleasePool *pool1 = [[NSAutoreleasePool alloc] init];
 
-    jint error = (*jVM)->AttachCurrentThread(jVM, (void **)&jEnv, NULL);
-    //jint error = (*jVM)->AttachCurrentThreadAsDaemon(jVM, (void **)&jEnv, NULL);
+    jint error = (*jVM)->AttachCurrentThreadAsDaemon(jVM, (void **)&jEnv, NULL);
     if (error == 0)
     {
         NSAutoreleasePool *pool2 = [[NSAutoreleasePool alloc] init];
@@ -735,12 +734,6 @@ jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved)
 
             (*jEnv)->CallVoidMethod(jEnv, self->jApplication, javaIDs.MacApplication.notifyApplicationDidTerminate);
             GLASS_CHECK_EXCEPTION(jEnv);
-
-            jint err = (*jVM)->DetachCurrentThread(jVM);
-            if (err < 0)
-            {
-                NSLog(@"Unable to detach from JVM. Error code: %d\n", (int)err);
-            }
 
             jEnv = NULL;
         }

--- a/tests/system/src/test/java/test/launchertest/MainLauncherTest.java
+++ b/tests/system/src/test/java/test/launchertest/MainLauncherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/tests/system/src/test/java/test/launchertest/MainLauncherTest.java
+++ b/tests/system/src/test/java/test/launchertest/MainLauncherTest.java
@@ -100,6 +100,9 @@ public class MainLauncherTest {
         new TestData("TestAppNoMainCCL3", ERROR_NONE),
         new TestData("TestNotApplicationCCL", ERROR_NONE),
         new TestData("TestHeadlessApp", true, ERROR_NONE),
+        new TestData("TestAWTAppDaemon", ERROR_NONE),
+        new TestData("TestAppDaemon", ERROR_NONE),
+        new TestData("TestAppPlatformExitAWT", ERROR_NONE),
     };
 
     @Parameters

--- a/tests/system/src/test/java/test/launchertest/PlatformExitApp.java
+++ b/tests/system/src/test/java/test/launchertest/PlatformExitApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/tests/system/src/test/java/test/launchertest/TestAppPlatformExitAWT.java
+++ b/tests/system/src/test/java/test/launchertest/TestAppPlatformExitAWT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,38 +27,43 @@ package test.launchertest;
 
 import javafx.application.Application;
 import javafx.application.Platform;
-import javafx.scene.layout.StackPane;
-import javafx.scene.Scene;
-import javafx.scene.control.Label;
 import javafx.stage.Stage;
+import javax.swing.JDialog;
+import javax.swing.SwingUtilities;
 
 import static test.launchertest.Constants.*;
 
 /**
- * Test application that calls Platform.exit while Stage is still showing
- * the Scene.
+ * Test application, also using AWT, that calls Platform.exit and then
+ * tries to show an AWT window. The test might hang after the call to
+ * Platform.exit, but should not crash.
  *
- * This is launched by PlatformExitTest.
+ * This is launched by MainLauncherTest.
  */
-public class PlatformExitApp extends Application {
+public class TestAppPlatformExitAWT extends Application {
 
-    @Override public void start(Stage stage) throws Exception {
-        StackPane root = new StackPane();
-        Scene scene = new Scene(root, 400, 300);
-
-        final Label label = new Label("Hello");
-
-        root.getChildren().add(label);
-
-        stage.setScene(scene);
-        stage.show();
-
-        // Show window for 1 second before calling Platform.exit
-        Thread thr = new Thread(() -> {
-            Util.sleep(1000);
+    private void createSwing() {
+        JDialog d = new JDialog();
+        Platform.runLater(()-> {
             Platform.exit();
         });
+        d.setVisible(true);
+    }
+
+    @Override
+    public void stop() {
+        // Sleep for 5 seconds to ensure no crash, then exit normally.
+        Thread thr = new Thread(() -> {
+            Util.sleep(5000);
+            System.exit(ERROR_NONE);
+        });
+        thr.setDaemon(true);
         thr.start();
+    }
+
+    @Override
+    public void start(Stage st) {
+        SwingUtilities.invokeLater(this::createSwing);
     }
 
     /**
@@ -67,10 +72,6 @@ public class PlatformExitApp extends Application {
     public static void main(String[] args) {
         Util.setupTimeoutThread();
         Application.launch(args);
-
-        // Short delay to allow any pending output to be flushed
-        Util.sleep(500);
-        System.exit(ERROR_NONE);
     }
 
 }

--- a/tests/system/src/test/java/test/launchertest/TestAppPlatformExitAWT.java
+++ b/tests/system/src/test/java/test/launchertest/TestAppPlatformExitAWT.java
@@ -46,8 +46,8 @@ public class TestAppPlatformExitAWT extends Application {
         JDialog d = new JDialog();
         Platform.runLater(()-> {
             Platform.exit();
+            SwingUtilities.invokeLater(() -> d.setVisible(true));
         });
-        d.setVisible(true);
     }
 
     @Override

--- a/tests/system/src/test/java/test/launchertest/Util.java
+++ b/tests/system/src/test/java/test/launchertest/Util.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.launchertest;
+
+import static test.launchertest.Constants.*;
+
+public class Util {
+
+    // Timeout in milliseconds (must be at least 15 seconds)
+    private static final int TIMEOUT = 20000;
+
+    public static void sleep(long msec) {
+        try {
+            Thread.sleep(msec);
+        } catch (InterruptedException ex) {
+            ex.printStackTrace();
+            System.exit(ERROR_UNEXPECTED_EXCEPTION);
+        }
+    }
+
+    public static void setupTimeoutThread() {
+        // Timeout thread
+        Thread th = new Thread(() -> {
+            sleep(TIMEOUT);
+            System.exit(ERROR_TIMEOUT);
+        });
+        th.setDaemon(true);
+        th.start();
+    }
+
+    // No need to ever create an instance of this class
+    private Util() {}
+
+}


### PR DESCRIPTION
A Swing / FX interop app will crash if an application creates a new AWT / Swing window after calling Platform.exit. The root cause of the crash is that AWT caches the JNI env pointer for the AppKit thread, and assumes that it is valid for the life of the application. In the case where JavaFX is the owner of the NSApplication, we detach the AppKit thread from the JVM, after which AWT's env pointer is no longer valid. AWT will therefore crash the next time it does a JNI upcall.

This PR fixes the crash by leaving the macOS AppKit thread attached to the JVM after the JavaFX main event loop terminates. This requires attaching the AppKit thread to the JVM as a daemon thread when JavaFX is the NSApplication owner, matching what AWT does when it is the owner. In order to prevent a JavaFX application from exiting prematurely, create a non-daemon "KeepAlive" thread that can be terminated when the FX toolkit exits. This also solves a somewhat-related problem where the JavaFX toolkit will exit prematurely if the AWT toolkit is started first, and all AWT windows are disposed.

This fix is in addition to the AWT fix: [JDK-8190329](https://bugs.openjdk.org/browse/JDK-8190329) / openjdk/jdk#20688. Either the AWT fix or the JavaFX fix is sufficient to avoid this specific problem, but there is value in fixing it in both places, so I cloned the AWT bug to create a JavaFX bug that we can use for this PR.

Summary of the changes:

* Attach the AppKit thread to the JVM as a daemon
* Do not detach the thread when the FX main event loop terminates
* Create and start a KeepAlive thread in MacApplication, when the FX toolkit starts
* Terminate the KeepAlive thread when the FX toolkit finishes

Testing:

I created automated systems tests from the manual test programs in the bugs as well as a test to ensure that we don't regress and exit prematurely in the pure JavaFX case (which would happen without the KeepAlive thread). Two of the new tests fail on macOS without the fix and pass with the fix. All three pass on all platforms with the fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issues
 * [JDK-8339178](https://bugs.openjdk.org/browse/JDK-8339178): [macos] Swing InterOp Platform.exit() crash (**Bug** - P3)
 * [JDK-8339183](https://bugs.openjdk.org/browse/JDK-8339183): [macos] Premature exit in Swing interop when last JFrame is disposed (**Bug** - P4)


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.org/census#psadhukhan) (@prsadhuk - **Reviewer**)
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1545/head:pull/1545` \
`$ git checkout pull/1545`

Update a local copy of the PR: \
`$ git checkout pull/1545` \
`$ git pull https://git.openjdk.org/jfx.git pull/1545/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1545`

View PR using the GUI difftool: \
`$ git pr show -t 1545`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1545.diff">https://git.openjdk.org/jfx/pull/1545.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1545#issuecomment-2316224131)