### PR TITLE
8339068: [Linux] NPE: Cannot read field "firstFont" because "<local4>" is null

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/LogicalFont.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/LogicalFont.java
@@ -174,8 +174,10 @@ public class LogicalFont implements CompositeFontResource {
         if (PrismFontFactory.isLinux) {
             FontConfigManager.FcCompFont fcCompFont =
                 FontConfigManager.getFontConfigFont(family, bold, italic);
-            physicalFullName = fcCompFont.firstFont.fullName;
-            physicalFileName = fcCompFont.firstFont.fontFile;
+            if (fcCompFont != null) {
+                physicalFullName = fcCompFont.firstFont.fullName;
+                physicalFileName = fcCompFont.firstFont.fontFile;
+            }
         } else {
             physicalFamily = PrismFontFactory.getSystemFont(familyName);
         }

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/freetype/FTFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/freetype/FTFactory.java
@@ -133,11 +133,13 @@ public class FTFactory extends PrismFontFactory {
         boolean isItalic = primaryResource.isItalic();
         FontConfigManager.FcCompFont font =
             FontConfigManager.getFontConfigFont("sans", isBold, isItalic);
-        ArrayList<String> linkedFontFiles = FontConfigManager.getFileNames(font, false);
-        ArrayList<String> linkedFontNames = FontConfigManager.getFontNames(font, false);
         FontFallbackInfo info = new FontFallbackInfo();
-        for (int i=0; i<linkedFontNames.size(); i++)  {
-            info.add(linkedFontNames.get(i), linkedFontFiles.get(i), null);
+        if (font != null) {
+            ArrayList<String> linkedFontFiles = FontConfigManager.getFileNames(font, false);
+            ArrayList<String> linkedFontNames = FontConfigManager.getFontNames(font, false);
+            for (int i=0; i<linkedFontNames.size(); i++)  {
+                info.add(linkedFontNames.get(i), linkedFontFiles.get(i), null);
+            }
         }
         return info;
     }

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/freetype/FTFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/freetype/FTFactory.java
@@ -27,6 +27,7 @@ package com.sun.javafx.font.freetype;
 
 import java.util.ArrayList;
 
+import com.sun.javafx.PlatformUtil;
 import com.sun.javafx.font.FontConfigManager;
 import com.sun.javafx.font.FontFallbackInfo;
 import com.sun.javafx.font.FontResource;
@@ -40,6 +41,7 @@ import com.sun.javafx.text.TextRun;
 public class FTFactory extends PrismFontFactory {
 
     static boolean LCD_SUPPORT;
+    static boolean isLinux = PlatformUtil.isLinux();
 
     public static PrismFontFactory getFactory() {
         PrismFontFactory factory = null;
@@ -129,12 +131,12 @@ public class FTFactory extends PrismFontFactory {
 
     @Override
     public FontFallbackInfo getFallbacks(FontResource primaryResource) {
-        boolean isBold = primaryResource.isBold();
-        boolean isItalic = primaryResource.isItalic();
-        FontConfigManager.FcCompFont font =
-            FontConfigManager.getFontConfigFont("sans", isBold, isItalic);
         FontFallbackInfo info = new FontFallbackInfo();
-        if (font != null) {
+        if (isLinux) {
+            boolean isBold = primaryResource.isBold();
+            boolean isItalic = primaryResource.isItalic();
+            FontConfigManager.FcCompFont font =
+                    FontConfigManager.getFontConfigFont("sans", isBold, isItalic);
             ArrayList<String> linkedFontFiles = FontConfigManager.getFileNames(font, false);
             ArrayList<String> linkedFontNames = FontConfigManager.getFontNames(font, false);
             for (int i=0; i<linkedFontNames.size(); i++)  {


### PR DESCRIPTION
This PR adds a couple of null checks to `LogicalFont` and `FTFactory`, that make use of `FontConfigManager::getFontConfigFont`, which under certain cases, can return null.

I've tested this PR on both Linux (Ubuntu 22.04.4) and Android, just using `-Dprism.useFontConfig=false`.

On Ubuntu, I've manually added some font files to the JDK path `$JAVA_HOME/lib/fonts` (which didn't exist), and the test passes now, though this message is still printed out:
```
Error: JavaFX detected no fonts! Please refer to release notes for proper font configuration
```
which is confusing to me, because fonts where found in the JDK path after all, and even in the case that there were no fonts found, "the release notes" is an ambiguous reference for the user. 

Also, instead of adding fonts to the JDK, I tested adding a `logicalfonts.properties` file with `-Dprism.fontdir` and without `fontConfig`, but this case was already working before the patch for this PR, and still works after it.

Note that if there are no fonts in the JDK path, and `prism.fontdir` is not provided, without `fontConfig`, after this PR, there will still be an exception:

```
Caused by: java.lang.NullPointerException: Cannot invoke "com.sun.javafx.font.FontResource.getDefaultAAMode()" because the return value of "com.sun.javafx.font.LogicalFont.getSlot0Resource()" is null
        at javafx.graphics@24-internal/com.sun.javafx.font.LogicalFont.getDefaultAAMode(LogicalFont.java:456)
        at javafx.graphics@24-internal/com.sun.javafx.font.LogicalFont.getStrike(LogicalFont.java:461)
        at javafx.graphics@24-internal/com.sun.javafx.font.PrismFont.getStrike(PrismFont.java:79)
        at javafx.graphics@24-internal/com.sun.javafx.text.PrismTextLayout.setContent(PrismTextLayout.java:139)
        at javafx.graphics@24-internal/javafx.scene.text.Text.getTextLayout(Text.java:303)
        at javafx.graphics@24-internal/javafx.scene.text.Text.needsFullTextLayout(Text.java:258)
        at javafx.graphics@24-internal/javafx.scene.text.Text$6.invalidated(Text.java:576)
 ...
```

because `LogicalFont::getSlot0Resource` will return null. Adding null checks after this point will require many changes (`LogicalFont::getSlotResource(0)` is used in many places). Shouldn't we fail gracefully after `LogicalFont::getSlot0Resource` if `slot0FontResource` is finally null?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339068](https://bugs.openjdk.org/browse/JDK-8339068): [Linux] NPE: Cannot read field "firstFont" because "&lt;local4&gt;" is null (**Bug** - P4)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1546/head:pull/1546` \
`$ git checkout pull/1546`

Update a local copy of the PR: \
`$ git checkout pull/1546` \
`$ git pull https://git.openjdk.org/jfx.git pull/1546/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1546`

View PR using the GUI difftool: \
`$ git pr show -t 1546`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1546.diff">https://git.openjdk.org/jfx/pull/1546.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1546#issuecomment-2312945622)