### PR TITLE
8339236: Suppress removal warnings for Security Manager methods in iOS sources

### DIFF
--- a/modules/javafx.web/src/ios/java/javafx/scene/web/ExportedJavaObject.java
+++ b/modules/javafx.web/src/ios/java/javafx/scene/web/ExportedJavaObject.java
@@ -172,12 +172,14 @@ class ExportedJavaObject {
     // returns JSON-encoded result
     public String call(final String methodName, final String args) throws CallException {
         try {
-            return AccessController.doPrivileged(new PrivilegedExceptionAction<String>() {
+            @SuppressWarnings("removal")
+            String result = AccessController.doPrivileged(new PrivilegedExceptionAction<String>() {
                 @Override
                 public String run() throws Exception {
                     return callWorker(methodName, args);
                 }
             }, getJSBridge().getAccessControlContext());
+            return result;
         } catch (Exception e) {
             if (e instanceof CallException) {
                 throw (CallException) e;

--- a/modules/javafx.web/src/ios/java/javafx/scene/web/HTMLEditorSkin.java
+++ b/modules/javafx.web/src/ios/java/javafx/scene/web/HTMLEditorSkin.java
@@ -823,6 +823,7 @@ public class HTMLEditorSkin extends SkinBase<HTMLEditor> implements TraverseList
         button.getStyleClass().add(styleClass);
         toolbar.getItems().add(button);
 
+        @SuppressWarnings("removal")
         Image icon = AccessController.doPrivileged(new PrivilegedAction<Image>() {
             @Override public Image run() {
                 return new Image(HTMLEditorSkin.class.getResource(iconName).toString());
@@ -854,6 +855,7 @@ public class HTMLEditorSkin extends SkinBase<HTMLEditor> implements TraverseList
             toggleButton.setToggleGroup(toggleGroup);
         }
 
+        @SuppressWarnings("removal")
         Image icon = AccessController.doPrivileged(new PrivilegedAction<Image>() {
             @Override public Image run() {
                 return new Image(HTMLEditorSkin.class.getResource(iconName).toString());
@@ -901,6 +903,7 @@ public class HTMLEditorSkin extends SkinBase<HTMLEditor> implements TraverseList
         if (orientation == RIGHT_TO_LEFT) {
             try {
                 final String iconName = resources.getString("numbersIcon-rtl");
+                @SuppressWarnings("removal")
                 Image icon = AccessController.doPrivileged(new PrivilegedAction<Image>() {
                     @Override public Image run() {
                         return new Image(HTMLEditorSkin.class.getResource(iconName).toString());

--- a/modules/javafx.web/src/ios/java/javafx/scene/web/JS2JavaBridge.java
+++ b/modules/javafx.web/src/ios/java/javafx/scene/web/JS2JavaBridge.java
@@ -103,6 +103,7 @@ class JS2JavaBridge {
         return javaBridge;
     }
 
+    @SuppressWarnings("removal")
     AccessControlContext getAccessControlContext() {
         return webEngine.getAccessControlContext();
     }

--- a/modules/javafx.web/src/ios/java/javafx/scene/web/WebEngine.java
+++ b/modules/javafx.web/src/ios/java/javafx/scene/web/WebEngine.java
@@ -517,7 +517,9 @@ final public class WebEngine {
      * Creates a new engine and loads a Web page into it.
      */
     public WebEngine(String url) {
-        accessControlContext = AccessController.getContext();
+        @SuppressWarnings("removal")
+        AccessControlContext tmpAcc = AccessController.getContext();
+        accessControlContext = tmpAcc;
         js2javaBridge = new JS2JavaBridge(this);
         load(url);
     }
@@ -947,14 +949,17 @@ final public class WebEngine {
         }
     }
 
+    @SuppressWarnings("removal")
     final private AccessControlContext accessControlContext;
 
+    @SuppressWarnings("removal")
     AccessControlContext getAccessControlContext() {
         return accessControlContext;
     }
 
     private void dispatchWebEvent(final EventHandler handler, final WebEvent ev) {
-        AccessController.doPrivileged(new PrivilegedAction<Void>() {
+        @SuppressWarnings("removal")
+        Void result = AccessController.doPrivileged(new PrivilegedAction<Void>() {
             @Override
             public Void run() {
                 handler.handle(ev);


### PR DESCRIPTION
This PR adds the required annotations to the iOS sources in the JavaFX Web module, to allow the compilation of such sources, now that `-Werror` is enabled, in the same way that was done for https://bugs.openjdk.java.net/browse/JDK-8264139 (where it was already mentioned https://github.com/openjdk/jfx/pull/528#issue-910936512 the need of a follow-up for iOS/Android).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339236](https://bugs.openjdk.org/browse/JDK-8339236): Suppress removal warnings for Security Manager methods in iOS sources (**Bug** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Johan Vos](https://openjdk.org/census#jvos) (@johanvos - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1550/head:pull/1550` \
`$ git checkout pull/1550`

Update a local copy of the PR: \
`$ git checkout pull/1550` \
`$ git pull https://git.openjdk.org/jfx.git pull/1550/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1550`

View PR using the GUI difftool: \
`$ git pr show -t 1550`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1550.diff">https://git.openjdk.org/jfx/pull/1550.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1550#issuecomment-2317439071)