### PR TITLE
8337481: File API: file.name contains path instead of name

### DIFF
--- a/modules/javafx.web/src/main/native/Source/WTF/wtf/java/FileSystemJava.cpp
+++ b/modules/javafx.web/src/main/native/Source/WTF/wtf/java/FileSystemJava.cpp
@@ -273,7 +273,7 @@ int readFromFile(PlatformFileHandle handle, void* data, int length)
     return result;
 }
 
-String pathGetFileName(const String& path)
+String pathFileName(const String& path)
 {
     JNIEnv* env = WTF::GetJavaEnv();
 
@@ -439,13 +439,6 @@ bool isHiddenFile(const String& path)
     fprintf(stderr, "isHiddenFile(const String& path) NOT IMPLEMENTED\n");
     UNUSED_PARAM(path);
     return false;
-}
-
-String pathFileName(const String& path)
-{
-    UNUSED_PARAM(path);
-   // return path.substring(path.reverseFind('/') + 1);
-   return nullString();
 }
 
 bool hardLinkOrCopyFile(const String& targetPath, const String& linkPath)

--- a/modules/javafx.web/src/main/native/Source/WebCore/fileapi/File.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/fileapi/File.cpp
@@ -135,12 +135,7 @@ void File::computeNameAndContentType(const String& path, const String& nameOverr
     }
 #endif
 
-#if !PLATFORM(JAVA)
     effectiveName = nameOverride.isEmpty() ? FileSystem::pathFileName(path) : nameOverride;
-#else
-    // Use simple path not from std::FileSystem
-    effectiveName = nameOverride.isEmpty() ? path : nameOverride;
-#endif
     size_t index = effectiveName.reverseFind('.');
     if (index != notFound) {
         callOnMainThreadAndWait([&effectiveContentType, &effectiveName, index] {

--- a/modules/javafx.web/src/main/native/Source/WebCore/fileapi/FileCocoa.mm
+++ b/modules/javafx.web/src/main/native/Source/WebCore/fileapi/FileCocoa.mm
@@ -59,9 +59,9 @@ bool File::shouldReplaceFile(const String& path)
 
 void File::computeNameAndContentTypeForReplacedFile(const String& path, const String& nameOverride, String& effectiveName, String& effectiveContentType)
 {
-    ASSERT(!FileSystem::pathGetFileName(path).endsWith('/')); // Expecting to get a path without trailing slash, even for directories.
+    ASSERT(!FileSystem::pathFileName(path).endsWith('/')); // Expecting to get a path without trailing slash, even for directories.
     effectiveContentType = "application/zip"_s;
-    effectiveName = makeString((nameOverride.isNull() ? FileSystem::pathGetFileName(path) : nameOverride), ".zip"_s);
+    effectiveName = makeString((nameOverride.isNull() ? FileSystem::pathFileName(path) : nameOverride), ".zip"_s);
 }
 
 }

--- a/modules/javafx.web/src/test/java/test/javafx/scene/web/FileTest.java
+++ b/modules/javafx.web/src/test/java/test/javafx/scene/web/FileTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.javafx.scene.web;
+
+import com.sun.javafx.webkit.UIClientImplShim;
+import com.sun.webkit.WebPage;
+import com.sun.webkit.WebPageShim;
+import javafx.concurrent.Worker.State;
+import javafx.scene.web.WebEngineShim;
+import netscape.javascript.JSObject;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.util.Base64;
+import java.util.concurrent.CountDownLatch;
+
+import static javafx.concurrent.Worker.State.SUCCEEDED;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class FileTest extends TestBase {
+    private final WebPage page = WebEngineShim.getPage(getEngine());
+    private String[] fileList = { new File("src/test/resources/test/html/HelloWorld.txt").getAbsolutePath() };
+
+    private State getLoadState() {
+        return submit(() -> getEngine().getLoadWorker().getState());
+    }
+
+    private String getScriptString(String api) {
+        String scriptContent = String.format("<script type='text/javascript'>" +
+                                    "var result;" +
+                                    "window.addEventListener('click', (e) => {" +
+                                        "document.getElementById('file').click();" +
+                                    "});" +
+                                    "function readFile()" +
+                                    "{" +
+                                        "file = event.target.files[0];" +
+                                        "result = file." + api + ";" +
+                                    "}" +
+                               "</script>" +
+                               "<body> <input type='file' id='file' onchange='readFile()'/></body>");
+        return scriptContent;
+    }
+
+    @Before
+    public void before() {
+        UIClientImplShim.test_setChooseFiles(fileList);
+    }
+
+    private void loadFileReaderTestScript(String testScript) {
+        loadContent(testScript);
+        submit(() -> {
+            // we send a dummy mouse click event at (0,0) to simulate click on file chooser button.
+            WebPageShim.click(page, 0, 0);
+        });
+    }
+
+    @Test public void testFileName() {
+        loadFileReaderTestScript(getScriptString("name"));
+        submit(() -> {
+            assertEquals("Unexpected file name received", "HelloWorld.txt", getEngine().executeScript("window.result"));
+        });
+    }
+}

--- a/modules/javafx.web/src/test/java/test/javafx/scene/web/FileTest.java
+++ b/modules/javafx.web/src/test/java/test/javafx/scene/web/FileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,39 +25,23 @@
 
 package test.javafx.scene.web;
 
+import java.io.File;
+
 import com.sun.javafx.webkit.UIClientImplShim;
 import com.sun.webkit.WebPage;
 import com.sun.webkit.WebPageShim;
 import javafx.concurrent.Worker.State;
 import javafx.scene.web.WebEngineShim;
-import netscape.javascript.JSObject;
+
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.util.Base64;
-import java.util.concurrent.CountDownLatch;
-
-import static javafx.concurrent.Worker.State.SUCCEEDED;
-import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
 public class FileTest extends TestBase {
     private final WebPage page = WebEngineShim.getPage(getEngine());
-    private String[] fileList = { new File("src/test/resources/test/html/HelloWorld.txt").getAbsolutePath() };
-
-    private State getLoadState() {
-        return submit(() -> getEngine().getLoadWorker().getState());
-    }
-
-    private String getScriptString(String api) {
-        String scriptContent = String.format("<script type='text/javascript'>" +
+    private final String[] fileList = { new File("src/test/resources/test/html/HelloWorld.txt").getAbsolutePath() };
+    private final String script = String.format("<script type='text/javascript'>" +
                                     "var result;" +
                                     "window.addEventListener('click', (e) => {" +
                                         "document.getElementById('file').click();" +
@@ -65,13 +49,10 @@ public class FileTest extends TestBase {
                                     "function readFile()" +
                                     "{" +
                                         "file = event.target.files[0];" +
-                                        "result = file." + api + ";" +
+                                        "result = file.name;" +
                                     "}" +
-                               "</script>" +
-                               "<body> <input type='file' id='file' onchange='readFile()'/></body>");
-        return scriptContent;
-    }
-
+                                    "</script>" +
+                                    "<body> <input type='file' id='file' onchange='readFile()'/> </body>");
     @Before
     public void before() {
         UIClientImplShim.test_setChooseFiles(fileList);
@@ -80,13 +61,14 @@ public class FileTest extends TestBase {
     private void loadFileReaderTestScript(String testScript) {
         loadContent(testScript);
         submit(() -> {
-            // we send a dummy mouse click event at (0,0) to simulate click on file chooser button.
+            // Send a dummy mouse click event at (0,0) to simulate click on file chooser button.
             WebPageShim.click(page, 0, 0);
         });
     }
 
-    @Test public void testFileName() {
-        loadFileReaderTestScript(getScriptString("name"));
+    @Test
+    public void testFileName() {
+        loadFileReaderTestScript(script);
         submit(() -> {
             assertEquals("Unexpected file name received", "HelloWorld.txt", getEngine().executeScript("window.result"));
         });


### PR DESCRIPTION
FileSystemJava had no valid implementation for pathFileName since the function was renamed from pathGetFileName to pathFileName in the FileSystem.h from WebKit

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8337481](https://bugs.openjdk.org/browse/JDK-8337481): File API: file.name contains path instead of name (**Bug** - P3)


### Reviewers
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)
 * [Hima Bindu Meda](https://openjdk.org/census#hmeda) (@HimaBinduMeda - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1551/head:pull/1551` \
`$ git checkout pull/1551`

Update a local copy of the PR: \
`$ git checkout pull/1551` \
`$ git pull https://git.openjdk.org/jfx.git pull/1551/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1551`

View PR using the GUI difftool: \
`$ git pr show -t 1551`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1551.diff">https://git.openjdk.org/jfx/pull/1551.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1551#issuecomment-2317642613)