### PR TITLE
6586559: Support for vertex colors

### DIFF
--- a/apps/toys/FX8-3DFeatures/src/fx83dfeatures/DynamicMeshViewer.java
+++ b/apps/toys/FX8-3DFeatures/src/fx83dfeatures/DynamicMeshViewer.java
@@ -1,0 +1,531 @@
+/*
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package fx83dfeatures;
+
+import java.util.Arrays;
+import javafx.application.Application;
+import javafx.event.EventHandler;
+import javafx.scene.*;
+import javafx.scene.control.Button;
+import javafx.scene.image.Image;
+import javafx.scene.input.KeyEvent;
+import javafx.scene.paint.Color;
+import javafx.scene.paint.PhongMaterial;
+import javafx.scene.shape.*;
+import javafx.scene.transform.Rotate;
+import javafx.stage.Stage;
+
+public class DynamicMeshViewer extends Application {
+
+    Group root;
+    PointLight pointLight;
+    MeshView meshView;
+    TriangleMesh triMesh;
+    PhongMaterial material;
+    VertexFormat vertexFormat = VertexFormat.POINT_TEXCOORD_COLOR;
+
+    int divX = 100;
+    int divY = 100;
+    boolean smooth = true;
+    int smoothGroups[];
+    float rotateAngle = 0.0f;
+    float funcValue = -10.0f;
+    float resolution = 0.1f;
+    boolean texture = false;
+    boolean textureSwitch = false;
+    final Image diffuseMap = new Image("resources/cup_diffuseMap_1024.png");
+    final Image bumpMap = new Image("resources/cup_normalMap_1024.png");
+
+    final static ToysVec3f v1 = new ToysVec3f();
+    final static ToysVec3f v2 = new ToysVec3f();
+    static void computeNormal(ToysVec3f pa, ToysVec3f pb, ToysVec3f pc, ToysVec3f normal) {
+        // compute Normal |(v1-v0)X(v2-v0)|
+        v1.sub(pb, pa);
+        v2.sub(pc, pa);
+        normal.cross(v1, v2);
+        normal.normalize();
+    }
+
+    final static float meshScale = 20;
+    final static float minX = -10;
+    final static float minY = -10;
+    final static float maxX = 10;
+    final static float maxY = 10;
+
+    double getSinDivX(double x, double y) {
+        double r = Math.sqrt(x*x + y*y);
+        return funcValue * (r == 0 ? 1 : Math.sin(r) / r);
+    }
+
+    void computeMesh(int subDivX, int subDivY, float scale) {
+        final int pointSize = 3;
+        int numDivX = subDivX + 1;
+        float[] points = triMesh.getPoints().toArray(null);
+        float[] normals = triMesh.getNormals().toArray(null);
+        int[] faces = triMesh.getFaces().toArray(null);
+        VertexFormat format = triMesh.getVertexFormat();
+        int faceElementCount = format.getVertexIndexSize();
+
+        // Initial points and texCoords
+        for (int y = 0; y <= subDivY; y++) {
+            float dy = (float) y / subDivY;
+            double fy = (1 - dy) * minY + dy * maxY;
+//            System.err.println("dy = " + dy + ", fy = " + fy);
+            for (int x = 0; x <= subDivX; x++) {
+                float dx = (float) x / subDivX;
+                double fx = (1 - dx) * minX + dx * maxX;
+//                System.err.println("dx = " + dx + ", fx = " + fx);
+                int index = y * numDivX * pointSize + (x * pointSize);
+//                System.err.println("point index = " + index);
+                points[index] = (float) fx * scale;
+                points[index + 1] = (float) fy * scale;
+                points[index + 2] = (float) getSinDivX(fx, fy) * scale;
+//                System.err.println("points[" + (index + 2) + " = " + points[index + 2]);
+            }
+        }
+        triMesh.getPoints().set(0, points, 0, points.length);
+
+        ToysVec3f[] triPoints = new ToysVec3f[3];
+        triPoints[0] = new ToysVec3f();
+        triPoints[1] = new ToysVec3f();
+        triPoints[2] = new ToysVec3f();
+        ToysVec3f normal = new ToysVec3f();
+        for (int index = 0; index < faces.length; index += 3 * faceElementCount) {
+            int pIndex = faces[index] * 3;
+            triPoints[0].x = points[pIndex];
+            triPoints[0].y = points[pIndex + 1];
+            triPoints[0].z = points[pIndex + 2];
+            pIndex = faces[index + faceElementCount] * 3;
+            triPoints[1].x = points[pIndex];
+            triPoints[1].y = points[pIndex + 1];
+            triPoints[1].z = points[pIndex + 2];
+            pIndex = faces[index + (2 * faceElementCount)] * 3;
+            triPoints[2].x = points[pIndex];
+            triPoints[2].y = points[pIndex + 1];
+            triPoints[2].z = points[pIndex + 2];
+//            System.err.println("point 0 = " + triPoints[0]);
+//            System.err.println("point 1 = " + triPoints[1]);
+//            System.err.println("point 2 = " + triPoints[2]);
+
+            computeNormal(triPoints[0], triPoints[1], triPoints[2], normal);
+//            System.err.println(faces[index + 1] + ": normal = " + normal);
+            assert (faces[index + 1] == faces[index + faceElementCount + 1])
+                    && (faces[index + 1] == faces[index + (2 * faceElementCount) + 1]);
+            int nIndex = faces[index + 1] * 3;
+            normals[nIndex] = normal.x;
+            normals[nIndex + 1] = normal.y;
+            normals[nIndex + 2] = normal.z;
+        }
+
+        triMesh.getNormals().set(0, normals, 0, normals.length);
+
+    }
+
+    TriangleMesh buildTriangleMesh(int subDivX, int subDivY,
+                                   float scale) {
+
+//        System.err.println("subDivX = " + subDivX + ", subDivY = " + subDivY);
+
+        final int pointSize = 3;
+        final int normalSize = 3;
+        final int texCoordSize = 2;
+        final int colorSize = 4;
+        final int faceElementCount = vertexFormat.getVertexIndexSize();
+        final int faceSize = 3 * faceElementCount;
+        int numDivX = subDivX + 1;
+        int numVerts = (subDivY + 1) * numDivX;
+        float points[] = new float[numVerts * pointSize];
+        float texCoords[] = new float[numVerts * texCoordSize];
+        float colors[] = new float[numVerts * colorSize];
+        int faceCount = subDivX * subDivY * 2;
+        float normals[] = new float[faceCount * normalSize];
+        int faces[] = new int[ faceCount * faceSize];
+
+        // Create points and texCoords
+        for (int y = 0; y <= subDivY; y++) {
+            float dy = (float) y / subDivY;
+            double fy = (1 - dy) * minY + dy * maxY;
+//            System.err.println("dy = " + dy + ", fy = " + fy);
+            for (int x = 0; x <= subDivX; x++) {
+                float dx = (float) x / subDivX;
+                double fx = (1 - dx) * minX + dx * maxX;
+//                System.err.println("dx = " + dx + ", fx = " + fx);
+                int index = y * numDivX * pointSize + (x * pointSize);
+//                System.err.println("point index = " + index);
+                points[index] = (float) fx * scale;
+                points[index + 1] = (float) fy * scale;
+                points[index + 2] = (float) getSinDivX(fx, fy) * scale;
+                index = y * numDivX * texCoordSize + (x * texCoordSize);
+//                System.err.println("texCoord index = " + index);
+                texCoords[index] = dx;
+                texCoords[index + 1] = dy;
+                index = y * numDivX * colorSize + (x * colorSize);
+                colors[index] = dx;
+                colors[index + 1] = 1F - dy;
+                colors[index + 2] = Math.max(0F, dy - dx);
+                colors[index + 3] = 1F;
+            }
+        }
+
+        // Initial faces and normals
+        int normalCount = 0;
+        ToysVec3f[] triPoints = new ToysVec3f[3];
+        triPoints[0] = new ToysVec3f();
+        triPoints[1] = new ToysVec3f();
+        triPoints[2] = new ToysVec3f();
+        ToysVec3f normal = new ToysVec3f();
+        for (int y = 0; y < subDivY; y++) {
+            for (int x = 0; x < subDivX; x++) {
+                int p00 = y * numDivX + x;
+                int p01 = p00 + 1;
+                int p10 = p00 + numDivX;
+                int p11 = p10 + 1;
+                int tc00 = y * numDivX + x;
+                int tc01 = tc00 + 1;
+                int tc10 = tc00 + numDivX;
+                int tc11 = tc10 + 1;
+                int vc00 = y * numDivX + x;
+                int vc01 = vc00 + 1;
+                int vc10 = vc00 + numDivX;
+                int vc11 = vc10 + 1;
+
+                int ii = p00 * 3;
+                triPoints[0].x = points[ii];
+                triPoints[0].y = points[ii + 1];
+                triPoints[0].z = points[ii + 2];
+                ii = p10 * 3;
+                triPoints[1].x = points[ii];
+                triPoints[1].y = points[ii + 1];
+                triPoints[1].z = points[ii + 2];
+                ii = p11 * 3;
+                triPoints[2].x = points[ii];
+                triPoints[2].y = points[ii + 1];
+                triPoints[2].z = points[ii + 2];
+                computeNormal(triPoints[0], triPoints[1], triPoints[2], normal);
+//                System.err.println("normal = " + normal);
+                int normalIndex = normalCount * normalSize;
+                normals[normalIndex] = normal.x; //nx
+                normals[normalIndex + 1] = normal.y; //ny
+                normals[normalIndex + 2] = normal.z; //nz
+
+                int index = (y * subDivX * faceSize + (x * faceSize)) * 2;
+//                System.err.println("face  0 index = " + index);
+
+                if (vertexFormat.getPointIndexOffset() >= 0)
+                    faces[index++] = p00;
+                if (vertexFormat.getNormalIndexOffset() >= 0)
+                    faces[index++] = normalCount;
+                if (vertexFormat.getTexCoordIndexOffset() >= 0)
+                    faces[index++] = tc00;
+                if (vertexFormat.getColorIndexOffset() >= 0)
+                    faces[index++] = vc00;
+                if (vertexFormat.getPointIndexOffset() >= 0)
+                    faces[index++] = p10;
+                if (vertexFormat.getNormalIndexOffset() >= 0)
+                    faces[index++] = normalCount;
+                if (vertexFormat.getTexCoordIndexOffset() >= 0)
+                    faces[index++] = tc10;
+                if (vertexFormat.getColorIndexOffset() >= 0)
+                    faces[index++] = vc10;
+                if (vertexFormat.getPointIndexOffset() >= 0)
+                    faces[index++] = p11;
+                if (vertexFormat.getNormalIndexOffset() >= 0)
+                    faces[index++] = normalCount++;
+                if (vertexFormat.getTexCoordIndexOffset() >= 0)
+                    faces[index++] = tc11;
+                if (vertexFormat.getColorIndexOffset() >= 0)
+                    faces[index++] = vc11;
+
+                ii = p11 * 3;
+                triPoints[0].x = points[ii];
+                triPoints[0].y = points[ii + 1];
+                triPoints[0].z = points[ii + 2];
+                ii = p01 * 3;
+                triPoints[1].x = points[ii];
+                triPoints[1].y = points[ii + 1];
+                triPoints[1].z = points[ii + 2];
+                ii = p00 * 3;
+                triPoints[2].x = points[ii];
+                triPoints[2].y = points[ii + 1];
+                triPoints[2].z = points[ii + 2];
+                computeNormal(triPoints[0], triPoints[1], triPoints[2], normal);
+//                System.err.println("normal = " + normal);
+                normalIndex = normalCount * normalSize;
+                normals[normalIndex] = normal.x; //nx
+                normals[normalIndex + 1] = normal.y; //ny
+                normals[normalIndex + 2] = normal.z; //nz
+
+//                System.err.println("face  1 index = " + index);
+                if (vertexFormat.getPointIndexOffset() >= 0)
+                    faces[index++] = p11;
+                if (vertexFormat.getNormalIndexOffset() >= 0)
+                    faces[index++] = normalCount;
+                if (vertexFormat.getTexCoordIndexOffset() >= 0)
+                    faces[index++] = tc11;
+                if (vertexFormat.getColorIndexOffset() >= 0)
+                    faces[index++] = vc11;
+                if (vertexFormat.getPointIndexOffset() >= 0)
+                    faces[index++] = p01;
+                if (vertexFormat.getNormalIndexOffset() >= 0)
+                    faces[index++] = normalCount;
+                if (vertexFormat.getTexCoordIndexOffset() >= 0)
+                    faces[index++] = tc01;
+                if (vertexFormat.getColorIndexOffset() >= 0)
+                    faces[index++] = vc01;
+                if (vertexFormat.getPointIndexOffset() >= 0)
+                    faces[index++] = p00;
+                if (vertexFormat.getNormalIndexOffset() >= 0)
+                    faces[index++] = normalCount++;
+                if (vertexFormat.getTexCoordIndexOffset() >= 0)
+                    faces[index++] = tc00;
+                if (vertexFormat.getColorIndexOffset() >= 0)
+                    faces[index++] = vc00;
+            }
+        }
+//        for(int i = 0; i < points.length; i++) {
+//            System.err.println("points[" + i + "] = " + points[i]);
+//        }
+//        for(int i = 0; i < texCoords.length; i++) {
+//            System.err.println("texCoords[" + i + "] = " + texCoords[i]);
+//        }
+//        for(int i = 0; i < normals.length; i++) {
+//            System.err.println("normals[" + i + "] = " + normals[i]);
+//        }
+//        for(int i = 0; i < faces.length; i++) {
+//            System.err.println("faces[" + i + "] = " + faces[i]);
+//        }
+
+        TriangleMesh triangleMesh = new TriangleMesh(vertexFormat);
+        triangleMesh.getPoints().setAll(points);
+        triangleMesh.getNormals().setAll(normals);
+        triangleMesh.getTexCoords().setAll(texCoords);
+        triangleMesh.getColors().setAll(colors);
+        triangleMesh.getFaces().setAll(faces);
+
+        return triangleMesh;
+    }
+
+    private Scene buildScene(int width, int height, boolean depthBuffer) {
+
+        triMesh = buildTriangleMesh(divX, divY, meshScale);
+        smoothGroups = new int[divX * divY * 2];
+        material = new PhongMaterial();
+        material.setDiffuseColor(Color.LIGHTGRAY);
+        material.setSpecularColor(Color.WHITE);
+        material.setSpecularPower(64);
+        meshView = new MeshView(triMesh);
+        meshView.setMaterial(material);
+
+        //Set Wireframe mode
+        meshView.setDrawMode(DrawMode.FILL);
+        meshView.setCullFace(CullFace.BACK);
+
+        final Group grp1 = new Group(meshView);
+        grp1.setRotate(0);
+        grp1.setRotationAxis(Rotate.X_AXIS);
+        Group grp2 = new Group(grp1);
+        grp2.setRotate(-30);
+        grp2.setRotationAxis(Rotate.X_AXIS);
+        Group grp3 = new Group(grp2);
+        grp3.setTranslateX(400);
+        grp3.setTranslateY(400);
+        grp3.setTranslateZ(10);
+
+        pointLight = new PointLight(Color.ANTIQUEWHITE);
+        pointLight.setTranslateX(300);
+        pointLight.setTranslateY(-50);
+        pointLight.setTranslateZ(-1000);
+
+        root = new Group(grp3, pointLight);
+        Scene scene = new Scene(root, width, height, depthBuffer);
+        scene.setOnKeyTyped(new EventHandler<KeyEvent>() {
+            @Override
+            public void handle(KeyEvent e) {
+                switch (e.getCharacter()) {
+                    case "[":
+                        funcValue -= resolution;
+                        if (funcValue < -20.0f) {
+                            funcValue = -20.0f;
+                        }
+                        computeMesh(divX, divY, meshScale);
+                        break;
+                    case "]":
+                        funcValue += resolution;
+                        if (funcValue > 20.0f) {
+                            funcValue = 20.0f;
+                        }
+                        computeMesh(divX, divY, meshScale);
+                        break;
+                    case "p":
+                        funcValue = -10;
+                        computeMesh(divX, divY, meshScale);
+                        break;
+                    case "i":
+                        System.err.print("i ");
+                        if (!textureSwitch) {
+                            texture = texture ? false : true;
+                        } else {
+                            textureSwitch = false;
+                        }
+                        if (texture) {
+                            material.setDiffuseMap(diffuseMap);
+                            material.setBumpMap(bumpMap);
+                            material.setDiffuseColor(Color.WHITE);
+                        } else {
+                            material.setDiffuseMap(null);
+                            material.setBumpMap(null);
+                            material.setDiffuseColor(Color.LIGHTGRAY);
+                        }
+                        break;
+                    case "s":
+                        smooth = !smooth;
+                        if (smooth) {
+                            Arrays.fill(smoothGroups, 0);
+                        } else {
+                            for (int i = 0; i < smoothGroups.length; i++) {
+                                smoothGroups[i] = i % 32;
+//                                System.err.println("XXX smoothGroups[" + i + "] = " + smoothGroups[i]);
+                            }
+                        }
+                        triMesh.getFaceSmoothingGroups().setAll(smoothGroups);
+                        break;
+                    case "k":
+                        System.err.print("k ");
+                        if ((texture) || (!textureSwitch)) {
+                            material.setDiffuseMap(diffuseMap);
+                            material.setBumpMap(null);
+                            material.setDiffuseColor(Color.WHITE);
+                            texture = true;
+                            textureSwitch = true;
+                        } else {
+                            material.setDiffuseMap(null);
+                            material.setBumpMap(null);
+                            material.setDiffuseColor(Color.LIGHTGRAY);
+                        }
+                        break;
+                    case "u":
+                        System.err.print("u ");
+                        if (texture) {
+                            material.setDiffuseMap(null);
+                            material.setBumpMap(bumpMap);
+                            material.setDiffuseColor(Color.LIGHTGRAY);
+                            textureSwitch = true;
+                        } else {
+                            material.setDiffuseMap(null);
+                            material.setBumpMap(null);
+                            material.setDiffuseColor(Color.LIGHTGRAY);
+                        }
+                        break;
+                    case "l":
+                        System.err.print("l ");
+                        boolean wireframe = meshView.getDrawMode() == DrawMode.LINE;
+                        meshView.setDrawMode(wireframe ? DrawMode.FILL : DrawMode.LINE);
+                        break;
+                    case "<":
+                        grp1.setRotate(rotateAngle -= (resolution * 5));
+                        break;
+                    case ">":
+                        grp1.setRotate(rotateAngle += (resolution * 5));
+                        break;
+                    case "X":
+                        grp1.setRotationAxis(Rotate.X_AXIS);
+                        break;
+                    case "Y":
+                        grp1.setRotationAxis(Rotate.Y_AXIS);
+                        break;
+                    case "Z":
+                        grp1.setRotationAxis(Rotate.Z_AXIS);
+                        break;
+                    case "P":
+                        rotateAngle = 0;
+                        grp1.setRotate(rotateAngle);
+                    case "1":
+                        System.err.print("1 ");
+                        divX = 5;
+                        divY = 5;
+                        smooth = true;
+                        smoothGroups = new int[divX * divY * 2];
+                        rotateAngle = 0.0f;
+                        funcValue = 0.0f;
+                        triMesh = buildTriangleMesh(divX, divY, meshScale);
+                        meshView.setMesh(triMesh);
+                        break;
+                    case "2":
+                        System.err.print("2 ");
+                        divX = 70;
+                        divY = 70;
+                        smooth = true;
+                        smoothGroups = new int[divX * divY * 2];
+                        rotateAngle = 0.0f;
+                        funcValue = 0.0f;
+                        triMesh = buildTriangleMesh(divX, divY, meshScale);
+                        meshView.setMesh(triMesh);
+                        break;
+                    case "f":
+                        System.err.print("f ");
+                        if (vertexFormat == VertexFormat.POINT_NORMAL_TEXCOORD_COLOR) {
+                            vertexFormat = VertexFormat.POINT_TEXCOORD;
+                        } else if (vertexFormat == VertexFormat.POINT_TEXCOORD) {
+                            vertexFormat = VertexFormat.POINT_NORMAL_TEXCOORD;
+                        } else if (vertexFormat == VertexFormat.POINT_NORMAL_TEXCOORD) {
+                            vertexFormat = VertexFormat.POINT_TEXCOORD_COLOR;
+                        } else {
+                            vertexFormat = VertexFormat.POINT_NORMAL_TEXCOORD_COLOR;
+                        }
+
+                        triMesh = buildTriangleMesh(divX, divY, meshScale);
+                        meshView.setMesh(triMesh);
+                        break;
+                    case " ":
+                        root.getChildren().add(new Button("Button"));
+                        break;
+
+                }
+            }
+        });
+        return scene;
+    }
+
+    private PerspectiveCamera addCamera(Scene scene) {
+        PerspectiveCamera perspectiveCamera = new PerspectiveCamera();
+        scene.setCamera(perspectiveCamera);
+        return perspectiveCamera;
+    }
+
+    @Override
+    public void start(Stage primaryStage) {
+        Scene scene = buildScene(800, 800, true);
+        scene.setFill(Color.rgb(10, 10, 40));
+        addCamera(scene);
+        primaryStage.setTitle("Dynamic MeshViewer");
+        primaryStage.setScene(scene);
+        primaryStage.show();
+    }
+
+    public static void main(String[] args) {
+        launch(args);
+    }
+}

--- a/modules/javafx.fxml/src/main/java/com/sun/javafx/fxml/builder/TriangleMeshBuilder.java
+++ b/modules/javafx.fxml/src/main/java/com/sun/javafx/fxml/builder/TriangleMeshBuilder.java
@@ -41,6 +41,7 @@ public class TriangleMeshBuilder extends TreeMap<String, Object> implements Buil
     private float[] points;
     private float[] texCoords;
     private float[] normals;
+    private float[] colors;
     private int[] faces;
     private int[] faceSmoothingGroups;
     private VertexFormat vertexFormat;
@@ -62,6 +63,9 @@ public class TriangleMeshBuilder extends TreeMap<String, Object> implements Buil
         }
         if (normals != null) {
             mesh.getNormals().setAll(normals);
+        }
+        if (colors != null) {
+            mesh.getColors().setAll(colors);
         }
         if (vertexFormat != null) {
             mesh.setVertexFormat(vertexFormat);
@@ -102,13 +106,23 @@ public class TriangleMeshBuilder extends TreeMap<String, Object> implements Buil
             for (int i = 0; i < split.length; ++i) {
                 normals[i] = Float.parseFloat(split[i]);
             }
+        } else if ("colors".equalsIgnoreCase(key)) {
+            String[] split = ((String) value).split(VALUE_SEPARATOR_REGEX);
+            colors = new float[split.length];
+            for (int i = 0; i < split.length; ++i) {
+                colors[i] = Float.parseFloat(split[i]);
+            }
         } else if ("vertexformat".equalsIgnoreCase(key)) {
             if (value instanceof VertexFormat) {
                 vertexFormat = (VertexFormat) value;
             } else if ("point_texcoord".equalsIgnoreCase((String)value)) {
                 vertexFormat = VertexFormat.POINT_TEXCOORD;
+            } else if ("point_texcoord_color".equalsIgnoreCase((String)value)) {
+                vertexFormat = VertexFormat.POINT_TEXCOORD_COLOR;
             } else if ("point_normal_texcoord".equalsIgnoreCase((String)value)) {
                 vertexFormat = VertexFormat.POINT_NORMAL_TEXCOORD;
+            } else if ("point_normal_texcoord_color".equalsIgnoreCase((String)value)) {
+                vertexFormat = VertexFormat.POINT_NORMAL_TEXCOORD_COLOR;
             }
         }
 

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/geom/Vec4f.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/geom/Vec4f.java
@@ -73,6 +73,13 @@ public class Vec4f {
         this.w = v.w;
     }
 
+    public void set(float x, float y, float z, float w) {
+        this.x = x;
+        this.y = y;
+        this.z = z;
+        this.w = w;
+    }
+
     @Override
     public String toString() {
         return "(" + x + ", " + y + ", " + z + ", " + w + ")";

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/Mesh.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/Mesh.java
@@ -25,6 +25,8 @@
 
 package com.sun.prism;
 
+import javafx.scene.shape.VertexFormat;
+
 /**
  * TODO: 3D - Need documentation
  * This class represents mesh geometry data object
@@ -32,10 +34,13 @@ package com.sun.prism;
 public interface Mesh extends GraphicsResource {
     // This method will fail if and only if ALL faces are wrong.
     // A wrong face is one with zero area or with any index out of range
-    public boolean buildGeometry(boolean userDefinedNormals,
+    public boolean buildGeometry(
+            VertexFormat vertexFormat,
+            boolean userDefinedNormals, boolean userDefinedColors,
             float points[], int[] pointsFromAndLengthIndices,
             float normals[], int[] normalsFromAndLengthIndices,
             float texCoords[],  int[] texCoordsFromAndLengthIndices,
+            float colors[],  int[] colorsFromAndLengthIndices,
             int faces[],  int[] facesFromAndLengthIndices,
             int faceSmoothingGroups[], int[] faceSmoothingGroupsFromAndLengthIndices);
 

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2PhongShader.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2PhongShader.java
@@ -167,6 +167,7 @@ class ES2PhongShader {
             attributes.put("pos", 0);
             attributes.put("texCoords", 1);
             attributes.put("tangent", 2);
+            attributes.put("color", 3);
 
             Map<String, Integer> samplers = new HashMap<>();
             samplers.put("diffuseTexture", 0);

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/impl/MeshVertex.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/impl/MeshVertex.java
@@ -36,6 +36,7 @@ class MeshVertex {
     int smGroup;
     int pVert; // vertexBuffer
     int tVert; // vertexBuffer
+    int cVert; // vertexBuffer
     int fIdx;
     int index; // indexBuffer
     Vec3f[] norm; // {N, T, B}
@@ -216,7 +217,7 @@ class MeshVertex {
                 + "\tnorm[0] = " + norm[0] + "\n"
                 + "\tnorm[1] = " + norm[1] + "\n"
                 + "\tnorm[2] = " + norm[2] + "\n"
-                + "\ttIndex = " + tVert + ", fIndex = " + fIdx + "\n"
+                + "\ttIndex = " + tVert + ", cIndex = " + cVert + ", fIndex = " + fIdx + "\n"
                 + "\tpIdx = " + index + "\n"
                 + "\tnext = " + ((next == null) ? next : next.getClass().getName()
                 + "@0x" + Integer.toHexString(next.hashCode())) + "\n";

--- a/modules/javafx.graphics/src/main/java/javafx/scene/shape/VertexFormat.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/shape/VertexFormat.java
@@ -26,7 +26,7 @@ package javafx.scene.shape;
 
 /**
  * Defines the format of the vertices in a mesh. A vertex consists of an array
- * of points, normals (optional), and texture coordinates.
+ * of points, normals (optional), texture coordinates, and colors (optional).
  *
  * @since JavaFX 8u40
  */
@@ -35,31 +35,45 @@ public final class VertexFormat {
     /**
      * Specifies the format of a vertex that consists of a point and texture coordinates.
      */
-    public static final VertexFormat POINT_TEXCOORD = new VertexFormat("POINT_TEXCOORD", 2, 0, -1, 1);
+    public static final VertexFormat POINT_TEXCOORD = new VertexFormat("POINT_TEXCOORD", 2, 0, -1, 1, -1);
+
+    /**
+     * Specifies the format of a vertex that consists of a point, texture coordinates, and a color.
+     */
+    public static final VertexFormat POINT_TEXCOORD_COLOR = new VertexFormat("POINT_TEXCOORD_COLOR", 3, 0, -1, 1, 2);
 
     /**
      * Specifies the format of a vertex that consists of a point, normal and texture coordinates.
      */
-    public static final VertexFormat POINT_NORMAL_TEXCOORD = new VertexFormat("POINT_NORMAL_TEXCOORD", 3, 0, 1, 2);
+    public static final VertexFormat POINT_NORMAL_TEXCOORD = new VertexFormat("POINT_NORMAL_TEXCOORD", 3, 0, 1, 2, -1);
+
+    /**
+     * Specifies the format of a vertex that consists of a point, normal, texture coordinates, and a color.
+     */
+    public static final VertexFormat POINT_NORMAL_TEXCOORD_COLOR
+            = new VertexFormat("POINT_NORMAL_TEXCOORD_COLOR", 4, 0, 1, 2, 3);
 
     // For internal use only
     private static final int POINT_ELEMENT_SIZE = 3;
     private static final int NORMAL_ELEMENT_SIZE = 3;
     private static final int TEXCOORD_ELEMENT_SIZE = 2;
+    private static final int COLOR_ELEMENT_SIZE = 4;
 
     private final String name;
     private final int vertexIndexSize;
     private final int pointIndexOffset;
     private final int normalIndexOffset;
     private final int texCoordIndexOffset;
+    private final int colorIndexOffset;
 
     private VertexFormat(String name, int vertexIndexSize,
-            int pointIndexOffset, int normalIndexOffset, int texCoordIndexOffset) {
+            int pointIndexOffset, int normalIndexOffset, int texCoordIndexOffset, int colorIndexOffset) {
         this.name = name;
         this.vertexIndexSize = vertexIndexSize;
         this.pointIndexOffset = pointIndexOffset;
         this.normalIndexOffset = normalIndexOffset;
         this.texCoordIndexOffset = texCoordIndexOffset;
+        this.colorIndexOffset = colorIndexOffset;
     }
 
     int getPointElementSize() {
@@ -72,6 +86,10 @@ public final class VertexFormat {
 
     int getTexCoordElementSize() {
         return TEXCOORD_ELEMENT_SIZE;
+    }
+
+    int getColorElementSize() {
+        return COLOR_ELEMENT_SIZE;
     }
 
     /**
@@ -113,6 +131,16 @@ public final class VertexFormat {
      */
     public int getTexCoordIndexOffset() {
         return texCoordIndexOffset;
+    }
+
+    /**
+     * Returns the index offset in the face array of the color component
+     * within a vertex.
+     *
+     * @return the offset to the color component.
+     */
+    public int getColorIndexOffset() {
+        return colorIndexOffset;
     }
 
     @Override

--- a/modules/javafx.graphics/src/main/native-prism-d3d/D3DContext.h
+++ b/modules/javafx.graphics/src/main/native-prism-d3d/D3DContext.h
@@ -52,6 +52,7 @@ struct PRISM_VERTEX_3D {
     float x, y, z;
     float tu, tv;
     float nx, ny, nz, nw;
+    float red, green, blue, alpha;
 };
 
 const D3DVERTEXELEMENT9 PrismVDecl[5] = {

--- a/modules/javafx.graphics/src/main/native-prism-d3d/D3DMesh.cc
+++ b/modules/javafx.graphics/src/main/native-prism-d3d/D3DMesh.cc
@@ -44,7 +44,7 @@ D3DMesh::D3DMesh(D3DContext *ctx) {
     indexBuffer = NULL;
     vertexBuffer = NULL;
     // See MeshData.cc where n = 1
-    fvf = D3DFVF_XYZ | (2 << D3DFVF_TEXCOUNT_SHIFT) | D3DFVF_TEXCOORDSIZE4(1);
+    fvf = D3DFVF_XYZ | (3 << D3DFVF_TEXCOUNT_SHIFT) | D3DFVF_TEXCOORDSIZE4(2) | D3DFVF_TEXCOORDSIZE4(1);
     numVertices = 0;
     numIndices = 0;
 }

--- a/modules/javafx.graphics/src/main/native-prism-d3d/hlsl/Mtl1PS.hlsl
+++ b/modules/javafx.graphics/src/main/native-prism-d3d/hlsl/Mtl1PS.hlsl
@@ -72,8 +72,8 @@ float4 main(PsInput psInput) : color {
 
     // diffuse
     float4 tDiff = tex2D(mapDiffuse, texD);
+    tDiff = tDiff * gDiffuseColor * psInput.vertColor;
     if (tDiff.a == 0.0) discard;
-    tDiff = tDiff * gDiffuseColor;
 
     // return gDiffuseColor.aaaa;
 
@@ -125,7 +125,7 @@ float4 main(PsInput psInput) : color {
 
     // self-illumination
     if (isIlluminated) {
-        rez += tex2D(mapSelfIllum, texD).rgb;
+        rez += tex2D(mapSelfIllum, texD).rgb * psInput.vertColor;
     }
 
     return float4(saturate(rez), tDiff.a);

--- a/modules/javafx.graphics/src/main/native-prism-d3d/hlsl/Mtl1VS.hlsl
+++ b/modules/javafx.graphics/src/main/native-prism-d3d/hlsl/Mtl1VS.hlsl
@@ -31,6 +31,7 @@ VsOutput main(VertexType vsInput) {
     VsOutput vsOutput;
 
     vsOutput.texD = vsInput.texD;
+    vsOutput.vertColor = vsInput.modelVertexColor;
     transformVertexAttributes(vsInput.modelVertexPos, vsInput.modelVertexNormal, vsOutput);
 
     return vsOutput;

--- a/modules/javafx.graphics/src/main/native-prism-d3d/hlsl/vs2ps.h
+++ b/modules/javafx.graphics/src/main/native-prism-d3d/hlsl/vs2ps.h
@@ -45,6 +45,8 @@ typedef struct PsInput {
 
     float2 texD : texcoord0;
 
+    float4 vertColor : color0;
+
 //  float  oFog  : fog;
 //  float3 debug : texcoord11;
 } VsOutput;

--- a/modules/javafx.graphics/src/main/native-prism-d3d/hlsl/vsDecl.h
+++ b/modules/javafx.graphics/src/main/native-prism-d3d/hlsl/vsDecl.h
@@ -31,5 +31,6 @@ struct VsInput {
     // model space = local space = object space
     float4  modelVertexPos    : position;
     float2  texD              : texcoord0;
-    float4  modelVertexNormal : texcoord1;
+    float4  modelVertexNormal : texcoord1; // Presumably these are declared as texcoords to make FVF vertex buffers work.
+    float4  modelVertexColor  : texcoord2;
 };

--- a/modules/javafx.graphics/src/main/native-prism-es2/GLContext.c
+++ b/modules/javafx.graphics/src/main/native-prism-es2/GLContext.c
@@ -1740,6 +1740,7 @@ JNIEXPORT void JNICALL Java_com_sun_prism_es2_GLContext_nSetDeviceParametersFor2
     ctxInfo->glDisableVertexAttribArray(VC_3D_INDEX);
     ctxInfo->glDisableVertexAttribArray(NC_3D_INDEX);
     ctxInfo->glDisableVertexAttribArray(TC_3D_INDEX);
+    ctxInfo->glDisableVertexAttribArray(CC_3D_INDEX);
 
     ctxInfo->vbFloatData = NULL;
     ctxInfo->vbByteData = NULL;
@@ -2348,6 +2349,7 @@ JNIEXPORT void JNICALL Java_com_sun_prism_es2_GLContext_nRenderMeshView
     ctxInfo->glEnableVertexAttribArray(VC_3D_INDEX);
     ctxInfo->glEnableVertexAttribArray(TC_3D_INDEX);
     ctxInfo->glEnableVertexAttribArray(NC_3D_INDEX);
+    ctxInfo->glEnableVertexAttribArray(CC_3D_INDEX);
 
     ctxInfo->glVertexAttribPointer(VC_3D_INDEX, VC_3D_SIZE, GL_FLOAT, GL_FALSE,
             VERT_3D_STRIDE, (const GLvoid *) jlong_to_ptr((jlong) offset));
@@ -2357,6 +2359,9 @@ JNIEXPORT void JNICALL Java_com_sun_prism_es2_GLContext_nRenderMeshView
     offset += TC_3D_SIZE * sizeof(GLfloat);
     ctxInfo->glVertexAttribPointer(NC_3D_INDEX, NC_3D_SIZE, GL_FLOAT, GL_FALSE,
             VERT_3D_STRIDE, (const GLvoid *) jlong_to_ptr((jlong) offset));
+    offset += NC_3D_SIZE * sizeof(GLfloat);
+    ctxInfo->glVertexAttribPointer(CC_3D_INDEX, CC_3D_SIZE, GL_FLOAT, GL_FALSE,
+            VERT_3D_STRIDE, (const GLvoid *) jlong_to_ptr((jlong) offset));
 
     glDrawElements(GL_TRIANGLES, mvInfo->meshInfo->indexBufferSize,
             mvInfo->meshInfo->indexBufferType, 0);
@@ -2365,6 +2370,7 @@ JNIEXPORT void JNICALL Java_com_sun_prism_es2_GLContext_nRenderMeshView
     ctxInfo->glDisableVertexAttribArray(VC_3D_INDEX);
     ctxInfo->glDisableVertexAttribArray(NC_3D_INDEX);
     ctxInfo->glDisableVertexAttribArray(TC_3D_INDEX);
+    ctxInfo->glDisableVertexAttribArray(CC_3D_INDEX);
     ctxInfo->glBindBuffer(GL_ARRAY_BUFFER, 0);
     ctxInfo->glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
 }

--- a/modules/javafx.graphics/src/main/native-prism-es2/PrismES2Defs.h
+++ b/modules/javafx.graphics/src/main/native-prism-es2/PrismES2Defs.h
@@ -346,10 +346,12 @@ extern void deletePixelFormatInfo(PixelFormatInfo *pfInfo);
 #define VC_3D_INDEX 0
 #define TC_3D_INDEX 1
 #define NC_3D_INDEX 2
+#define CC_3D_INDEX 3
 #define VC_3D_SIZE 3  /* x, y, z */
 #define TC_3D_SIZE 2  /* tu, tv */
 #define NC_3D_SIZE 4  /* nx, ny, nz, nw */
-#define VERT_3D_SIZE (VC_3D_SIZE + TC_3D_SIZE + NC_3D_SIZE)
+#define CC_3D_SIZE 4  /* red, green, blue, alpha */
+#define VERT_3D_SIZE (VC_3D_SIZE + TC_3D_SIZE + NC_3D_SIZE + CC_3D_SIZE)
 #define VERT_3D_STRIDE (sizeof(GLfloat) * VERT_3D_SIZE)
 
 #define MESH_VERTEXBUFFER 0

--- a/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/diffuse_color.frag
+++ b/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/diffuse_color.frag
@@ -57,6 +57,6 @@ uniform sampler2D diffuseTexture;
 varying vec2 oTexCoords;
 
 vec4 apply_diffuse() {
-    return diffuseColor;
+    return diffuseColor * vtxColor;
 }
 */

--- a/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/diffuse_none.frag
+++ b/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/diffuse_none.frag
@@ -56,6 +56,6 @@ uniform sampler2D diffuseTexture;
 varying vec2 oTexCoords;
 
 vec4 apply_diffuse() {
-    return vec4(0);
+    return vtxColor;
 }
 

--- a/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/diffuse_texture.frag
+++ b/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/diffuse_texture.frag
@@ -57,5 +57,5 @@ varying vec2 oTexCoords;
 
 vec4 apply_diffuse() {
     vec4 dTexColor = texture2D(diffuseTexture, oTexCoords);
-    return dTexColor * diffuseColor;
+    return dTexColor * diffuseColor * vtxColor;
 }

--- a/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/main.vert
+++ b/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/main.vert
@@ -31,6 +31,7 @@ uniform vec3 ambientColor;
 attribute vec3 pos;
 attribute vec2 texCoords;
 attribute vec4 tangent;
+attribute vec4 color;
 
 struct Light {
     vec4 pos;
@@ -49,6 +50,7 @@ uniform Light lights[3];
 varying vec4 lightTangentSpacePositions[3];
 varying vec4 lightTangentSpaceDirections[3];
 varying vec2 oTexCoords;
+varying vec4 vtxColor;
 varying vec3 eyePos;
 
 vec3 getLocalVector(vec3 global, vec3 tangentFrame[3]) {
@@ -113,7 +115,8 @@ void main()
 
     mat4 mvpMatrix = viewProjectionMatrix * worldMatrix;
 
-    //Send texcoords to Pixel Shader and calculate vertex position.
+    //Send color & texcoords to Pixel Shader and calculate vertex position.
     oTexCoords = texCoords;
+    vtxColor = color;
     gl_Position = mvpMatrix * vec4(pos,1.0);
 }

--- a/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/main0Lights.frag
+++ b/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/main0Lights.frag
@@ -50,6 +50,8 @@ precision mediump int;
 
 #endif
 
+varying vec4 vtxColor;
+
 vec4 apply_diffuse();
 vec4 apply_selfIllum();
 

--- a/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/main1Light.frag
+++ b/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/main1Light.frag
@@ -50,6 +50,8 @@ precision mediump int;
 
 #endif
 
+varying vec4 vtxColor;
+
 vec4 apply_diffuse();
 vec4 apply_specular();
 vec3 apply_normal();

--- a/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/main2Lights.frag
+++ b/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/main2Lights.frag
@@ -50,6 +50,8 @@ precision mediump int;
 
 #endif
 
+varying vec4 vtxColor;
+
 vec4 apply_diffuse();
 vec4 apply_specular();
 vec3 apply_normal();

--- a/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/main3Lights.frag
+++ b/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/main3Lights.frag
@@ -50,6 +50,8 @@ precision mediump int;
 
 #endif
 
+varying vec4 vtxColor;
+
 vec4 apply_diffuse();
 vec4 apply_specular();
 vec3 apply_normal();

--- a/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/selfIllum_texture.frag
+++ b/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/selfIllum_texture.frag
@@ -53,6 +53,6 @@ precision mediump int;
 uniform sampler2D selfIllumTexture;
 
 vec4 apply_selfIllum() {
-    return texture2D(selfIllumTexture, oTexCoords);
+    return texture2D(selfIllumTexture, oTexCoords) * vtxColor;
 }
 

--- a/modules/javafx.graphics/src/shims/java/com/sun/javafx/sg/prism/NGTriangleMeshShim.java
+++ b/modules/javafx.graphics/src/shims/java/com/sun/javafx/sg/prism/NGTriangleMeshShim.java
@@ -54,6 +54,11 @@ public class NGTriangleMeshShim extends NGTriangleMesh {
         return super.test_getTexCoords();
     }
 
+    @Override
+    public float[] test_getColors() {
+        return super.test_getColors();
+    }
+
     public static BaseMesh test_getMesh(NGTriangleMesh triMesh) {
         return (BaseMesh) triMesh.test_getMesh();
     }

--- a/modules/javafx.graphics/src/test/java/test/com/sun/javafx/sg/prism/NGTriangleMeshTest.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/javafx/sg/prism/NGTriangleMeshTest.java
@@ -154,6 +154,36 @@ public class NGTriangleMeshTest {
     }
 
     /**
+     * Test of syncColors method, of class NGTriangleMesh.
+     */
+    @Test
+    public void testSyncColors() {
+        final float[] colors = new float[]{0, 1, 2, 3, 4, 5};
+        NGTriangleMeshShim instance = new NGTriangleMeshShim();
+        instance.syncColors((array, fromAndLengthIndices) -> colors);
+        float[] actuals = instance.test_getColors();
+        float[] expecteds = new float[]{0, 1, 2, 3, 4, 5};
+        assertArrayEquals(expecteds, actuals, EPSILON_FLOAT);
+    }
+
+    /**
+     * Test of syncColors method, of class NGTriangleMesh.
+     */
+    @Test
+    public void testSyncColors2() {
+        final float[] colors = new float[]{0, 1, 2, 3, 4, 5};
+        NGTriangleMeshShim instance = new NGTriangleMeshShim();
+        instance.syncColors((array, fromAndLengthIndices) -> colors);
+        instance.syncColors((array, fromAndLengthIndices) -> {
+            Arrays.fill(array, 1, 1 + 4, 1);
+            return array;
+        });
+        float[] actuals = instance.test_getColors();
+        float[] expecteds = new float[]{0, 1, 1, 1, 1, 5};
+        assertArrayEquals(expecteds, actuals, EPSILON_FLOAT);
+    }
+
+    /**
      * Test of syncFaces method, of class NGTriangleMesh.
      */
     @Test

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/shape/TriangleMeshTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/shape/TriangleMeshTest.java
@@ -27,6 +27,8 @@ package test.javafx.scene.shape;
 import java.util.Arrays;
 import javafx.scene.shape.TriangleMesh;
 import static org.junit.Assert.*;
+
+import javafx.scene.shape.VertexFormat;
 import org.junit.Test;
 
 public class TriangleMeshTest {
@@ -442,6 +444,146 @@ public class TriangleMeshTest {
 
         triangleMesh.getPoints().setAll(points);
         triangleMesh.getTexCoords().setAll(texCoords);
+        triangleMesh.getFaces().setAll(faces);
+
+        return triangleMesh;
+    }
+
+    /**
+     * Test of setColors method, of class TriangleMesh.
+     */
+    @Test
+    public void testSetColors_4args() {
+        int divX = 10;
+        int divY = 10;
+        TriangleMesh instance = buildColoredTriangleMesh(divX, divY); // 121 colors
+        float colors[] = {
+                1, 1, 1, 1,
+                1, 1, -1, 1,
+                1, -1, 1, 1,
+                1, -1, -1, 1,
+                -1, 1, 1, 1,
+                -1, 1, -1, 1,
+                -1, -1, 1, 1,
+                -1, -1, -1, 1,};
+        float[] expecteds = new float[colors.length];
+        int index = 4;
+        int start = 0;
+        int length = colors.length;
+        instance.getColors().set(index, colors, start, length);
+        assertArrayEquals(instance.getColors().toArray(index, expecteds, length), colors, 1e-3f);
+    }
+
+    /**
+     * Test setColors with illegal value, of class TriangleMesh.
+     */
+    @Test(expected = ArrayIndexOutOfBoundsException.class)
+    public void testSetColors_4argsIllegalArgument() {
+        int divX = 10;
+        int divY = 10;
+        TriangleMesh instance = buildColoredTriangleMesh(divX, divY); // 121 colors
+        float colors[] = {
+                1, 1, 1, 1,
+                1, 1, -1, 1,
+                1, -1, 1, 1,
+                1, -1, -1, 1,
+                -1, 1, 1, 1,
+                -1, 1, -1, 1,
+                -1, -1, 1, 1,
+                -1, -1, -1, 1,};
+        float[] expecteds = instance.getColors().toArray(null);
+        int length = colors.length;
+        instance.getColors().set(-1, colors, -1, length);
+        // colors should not change
+        assertArrayEquals(instance.getColors().toArray(null), expecteds, 1e-3f);
+    }
+
+    /**
+     * Test setColors with index argument out of range of the
+     * setColors method, of class TriangleMesh.
+     */
+    @Test(expected = ArrayIndexOutOfBoundsException.class)
+    public void testSetColors_4argsIndexOutOfRange() {
+        int divX = 10;
+        int divY = 10;
+        TriangleMesh instance = buildColoredTriangleMesh(divX, divY); // 121 colors
+        float colors[] = {
+                1, 1, 1, 1,
+                1, 1, -1, 1,
+                1, -1, 1, 1,
+                1, -1, -1, 1,
+                -1, 1, 1, 1,
+                -1, 1, -1, 1,
+                -1, -1, 1, 1,
+                -1, -1, -1, 1,};
+        float[] expecteds = instance.getColors().toArray(null);
+        int start = 0;
+        int length = colors.length;
+        instance.getColors().set(120 * 4, colors, start, length);
+        // colors should not change
+        assertArrayEquals(instance.getColors().toArray(null), expecteds, 1e-3f);
+    }
+
+    /**
+     * Test setColors with start argument out of range of
+     * the setColors method, of class TriangleMesh.
+     */
+    @Test(expected = ArrayIndexOutOfBoundsException.class)
+    public void testSetColors_4argsStartOutOfRange() {
+        int divX = 10;
+        int divY = 10;
+        TriangleMesh instance = buildColoredTriangleMesh(divX, divY); // 121 colors
+        float colors[] = {
+                1, 1, 1, 1,
+                1, 1, -1, 1,
+                1, -1, 1, 1,
+                1, -1, -1, 1,
+                -1, 1, 1, 1,
+                -1, 1, -1, 1,
+                -1, -1, 1, 1,
+                -1, -1, -1, 1,};
+        float[] expecteds = instance.getColors().toArray(null);
+        int index = 4;
+        int length = colors.length;
+        instance.getColors().set(index, colors, 1, length);
+        // colors should not change
+        assertArrayEquals(instance.getColors().toArray(null), expecteds, 1e-3f);
+    }
+
+    /**
+     * Test the vertex format length (point, texcoord, color, and face) of the colored test TriangleMesh.
+     */
+    @Test
+    public void testVertexFormatOfColoredTriangleMesh() {
+        TriangleMesh triMesh = new TriangleMesh(VertexFormat.POINT_TEXCOORD_COLOR);
+        // x, y, z
+        assertEquals(3, triMesh.getPointElementSize());
+        // u, v
+        assertEquals(2, triMesh.getTexCoordElementSize());
+        // red, green, blue, alpha
+        assertEquals(4, triMesh.getColorElementSize());
+
+        // 3 point indices, 3 texCoord indices, and 3 color indices per triangle
+        assertEquals(9, triMesh.getFaceElementSize());
+    }
+
+    TriangleMesh buildColoredTriangleMesh(int subDivX, int subDivY) {
+        TriangleMesh triangleMesh = new TriangleMesh(VertexFormat.POINT_TEXCOORD_COLOR);
+        final int pointSize = triangleMesh.getPointElementSize();
+        final int texCoordSize = triangleMesh.getTexCoordElementSize();
+        final int colorSize = triangleMesh.getColorElementSize();
+        final int faceSize = triangleMesh.getFaceElementSize();
+        int numDivX = subDivX + 1;
+        int numVerts = (subDivY + 1) * numDivX;
+        float points[] = new float[numVerts * pointSize];
+        float texCoords[] = new float[numVerts * texCoordSize];
+        float colors[] = new float[numVerts * colorSize];
+        int faceCount = subDivX * subDivY * 2;
+        int faces[] = new int[faceCount * faceSize];
+
+        triangleMesh.getPoints().setAll(points);
+        triangleMesh.getTexCoords().setAll(texCoords);
+        triangleMesh.getColors().setAll(colors);
         triangleMesh.getFaces().setAll(faces);
 
         return triangleMesh;

--- a/tests/system/src/test/java/test/com/sun/prism/impl/PNTMeshVertexBufferLengthTest.java
+++ b/tests/system/src/test/java/test/com/sun/prism/impl/PNTMeshVertexBufferLengthTest.java
@@ -67,7 +67,7 @@ public class PNTMeshVertexBufferLengthTest {
     private static final int SLEEP_TIME = 1000;
 
     // Size of a vertex
-    private static final int VERTEX_SIZE = 9;
+    private static final int VERTEX_SIZE = 13;
 
     private static final float meshScale = 15;
     private static final float minX = -10;
@@ -98,11 +98,14 @@ public class PNTMeshVertexBufferLengthTest {
         final int pointSize = 3;
         final int normalSize = 3;
         final int texCoordSize = 2;
-        final int faceSize = 9; // 3 point indices, 3 normal indices and 3 texCoord indices per triangle
+        final int colorSize = 4;
+        // 3 point indices, 3 normal indices, 3 texCoord indices, and 3 color indices per triangle
+        final int faceSize = 12;
         int numDivX = subDivX + 1;
         int numVerts = (subDivY + 1) * numDivX;
         float points[] = new float[numVerts * pointSize];
         float texCoords[] = new float[numVerts * texCoordSize];
+        float colors[] = new float[numVerts * colorSize];
         int faceCount = subDivX * subDivY * 2;
         float normals[] = new float[faceCount * normalSize];
         int faces[] = new int[faceCount * faceSize];
@@ -121,6 +124,11 @@ public class PNTMeshVertexBufferLengthTest {
                 index = y * numDivX * texCoordSize + (x * texCoordSize);
                 texCoords[index] = dx;
                 texCoords[index + 1] = dy;
+                index = y * numDivX * colorSize + (x * colorSize);
+                colors[index] = dx;
+                colors[index + 1] = 1F - dy;
+                colors[index + 2] = Math.max(0F, dy - dx);
+                colors[index + 3] = 1F;
             }
         }
 
@@ -141,6 +149,10 @@ public class PNTMeshVertexBufferLengthTest {
                 int tc01 = tc00 + 1;
                 int tc10 = tc00 + numDivX;
                 int tc11 = tc10 + 1;
+                int vc00 = y * numDivX + x;
+                int vc01 = vc00 + 1;
+                int vc10 = vc00 + numDivX;
+                int vc11 = vc10 + 1;
 
                 int ii = p00 * 3;
                 triPoints[0].x = points[ii];
@@ -165,12 +177,15 @@ public class PNTMeshVertexBufferLengthTest {
                 faces[index + 0] = p00;
                 faces[index + 1] = normalCount;
                 faces[index + 2] = tc00;
-                faces[index + 3] = p10;
-                faces[index + 4] = normalCount;
-                faces[index + 5] = tc10;
-                faces[index + 6] = p11;
-                faces[index + 7] = normalCount++;
-                faces[index + 8] = tc11;
+                faces[index + 3] = vc00;
+                faces[index + 4] = p10;
+                faces[index + 5] = normalCount;
+                faces[index + 6] = tc10;
+                faces[index + 7] = vc10;
+                faces[index + 8] = p11;
+                faces[index + 9] = normalCount++;
+                faces[index + 10] = tc11;
+                faces[index + 11] = vc11;
                 index += faceSize;
 
                 ii = p11 * 3;
@@ -194,20 +209,24 @@ public class PNTMeshVertexBufferLengthTest {
                 faces[index + 0] = p11;
                 faces[index + 1] = normalCount;
                 faces[index + 2] = tc11;
-                faces[index + 3] = p01;
-                faces[index + 4] = normalCount;
-                faces[index + 5] = tc01;
-                faces[index + 6] = p00;
-                faces[index + 7] = normalCount++;
-                faces[index + 8] = tc00;
+                faces[index + 3] = vc11;
+                faces[index + 4] = p01;
+                faces[index + 5] = normalCount;
+                faces[index + 6] = tc01;
+                faces[index + 7] = vc01;
+                faces[index + 8] = p00;
+                faces[index + 9] = normalCount++;
+                faces[index + 10] = tc00;
+                faces[index + 11] = vc00;
             }
         }
 
 
-        TriangleMesh triangleMesh = new TriangleMesh(VertexFormat.POINT_NORMAL_TEXCOORD);
+        TriangleMesh triangleMesh = new TriangleMesh(VertexFormat.POINT_NORMAL_TEXCOORD_COLOR);
         triangleMesh.getPoints().setAll(points);
         triangleMesh.getNormals().setAll(normals);
         triangleMesh.getTexCoords().setAll(texCoords);
+        triangleMesh.getColors().setAll(colors);
         triangleMesh.getFaces().setAll(faces);
         meshView.setMesh(triangleMesh);
     }
@@ -235,7 +254,7 @@ public class PNTMeshVertexBufferLengthTest {
         @Override
         public void start(Stage primaryStage) throws Exception {
             primaryStage.setTitle("PNTMeshVertexBufferLengthTest");
-            TriangleMesh triangleMesh = new TriangleMesh(VertexFormat.POINT_NORMAL_TEXCOORD);
+            TriangleMesh triangleMesh = new TriangleMesh(VertexFormat.POINT_NORMAL_TEXCOORD_COLOR);
             meshView = new MeshView(triangleMesh);
             Group rotateGrp = new Group(meshView);
             rotateGrp.setRotate(-30);
@@ -309,7 +328,7 @@ public class PNTMeshVertexBufferLengthTest {
         // mesh with 6 vertices (2 triangles)
         assertEquals(6, BaseMeshShim.test_getNumberOfVertices(baseMesh));
         // vertexBuffer started with 4 vertices and grew by 6 (since 12.5% or 1/8th
-        // of 4 is  less than 6). Size of vertex is 9 floats (10 * VERTEX_SIZE = 90)
+        // of 4 is  less than 6). Size of vertex is 12 floats (10 * VERTEX_SIZE = 120)
         assertEquals(10 * VERTEX_SIZE, BaseMeshShim.test_getVertexBufferLength(baseMesh));
     }
 
@@ -328,7 +347,7 @@ public class PNTMeshVertexBufferLengthTest {
         // mesh with 24 vertices (8 triangles)
         assertEquals(24, BaseMeshShim.test_getNumberOfVertices(baseMesh));
         // vertexBuffer started with 9 vertices and grew by 6, 3 times, to a
-        // capacity of 27 vertices (27 * VERTEX_SIZE = 243)
+        // capacity of 27 vertices (27 * VERTEX_SIZE = 324)
         assertEquals(27 * VERTEX_SIZE, BaseMeshShim.test_getVertexBufferLength(baseMesh));
     }
 
@@ -348,7 +367,7 @@ public class PNTMeshVertexBufferLengthTest {
         assertEquals(294, BaseMeshShim.test_getNumberOfVertices(baseMesh));
         // vertexBuffer started with 64 vertices and grew by 6 the first time
         // then crossed over to 12.5% growth rate at each subsequence increase
-        // to a capacity of 325 vertices (325 * VERTEX_SIZE = 2925)
+        // to a capacity of 325 vertices (325 * VERTEX_SIZE = 3900)
         assertEquals(325 * VERTEX_SIZE, BaseMeshShim.test_getVertexBufferLength(baseMesh));
     }
 
@@ -368,7 +387,7 @@ public class PNTMeshVertexBufferLengthTest {
         assertEquals(15000, BaseMeshShim.test_getNumberOfVertices(baseMesh));
         // vertexBuffer started with 2601 vertices and grew at 12.5% growth rate
         // at each subsequence increase to a capacity of 15201 vertices
-        // (15201 * VERTEX_SIZE = 136809)
+        // (15201 * VERTEX_SIZE = 182412)
         assertEquals(15201 * VERTEX_SIZE, BaseMeshShim.test_getVertexBufferLength(baseMesh));
     }
 

--- a/tests/system/src/test/java/test/robot/test3d/TriangleMeshPTCValidationTest.java
+++ b/tests/system/src/test/java/test/robot/test3d/TriangleMeshPTCValidationTest.java
@@ -1,0 +1,254 @@
+/*
+ * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.robot.test3d;
+
+import javafx.application.ConditionalFeature;
+import javafx.application.Platform;
+import javafx.scene.AmbientLight;
+import javafx.scene.Group;
+import javafx.scene.PerspectiveCamera;
+import javafx.scene.Scene;
+import javafx.scene.paint.Color;
+import javafx.scene.paint.PhongMaterial;
+import javafx.scene.shape.MeshView;
+import javafx.scene.shape.TriangleMesh;
+import javafx.scene.shape.VertexFormat;
+import javafx.stage.Stage;
+import org.junit.Before;
+import org.junit.Test;
+import test.robot.testharness.VisualTestBase;
+
+import java.util.stream.Stream;
+
+import static org.junit.Assume.assumeTrue;
+
+/**
+ * Basic TriangleMesh color validation.
+ */
+public class TriangleMeshPTCValidationTest extends VisualTestBase {
+    private Stage testStage;
+    private Scene testScene;
+    private MeshView meshView;
+    private TriangleMesh triMesh;
+    private PhongMaterial material;
+    private Group root;
+
+    private static final double TOLERANCE = 0.07;
+    private static final int WIDTH = 800;
+    private static final int HEIGHT = 800;
+    private Color bgColor = Color.rgb(10, 10, 40);
+
+    @Before
+    public void setupEach() {
+        assumeTrue(Platform.isSupported(ConditionalFeature.SCENE3D));
+    }
+
+    @Test(timeout = 15000)
+    public void testInvalidColorsLength() {
+        runAndWait(() -> {
+            testStage = getStage();
+            testStage.setTitle("TriangleMesh PTC Validation Test");
+
+            // Intentionally set depth buffer to false to reduce test complexity
+            testScene = new Scene(buildScene(), WIDTH, HEIGHT, true);
+            testScene.setFill(bgColor);
+            addCamera(testScene);
+            buildSquare();
+            // set invalid colors
+            triMesh.getColors().setAll(0f, 0f, 0f /*, 1.0f */);
+            testStage.setScene(testScene);
+            testStage.show();
+        });
+        waitFirstFrame();
+        runAndWait(() -> {
+
+            // Rendering nothing. Should receive warning from validatePoints
+            Color color = getColor(testScene, WIDTH / 3, WIDTH / 3);
+            assertColorEquals(bgColor, color, TOLERANCE);
+        });
+    }
+
+    @Test(timeout = 15000)
+    public void testColorsLengthChange() {
+        runAndWait(() -> {
+            testStage = getStage();
+            testStage.setTitle("TriangleMesh PTC Validation Test");
+
+            // Intentionally set depth buffer to false to reduce test complexity
+            testScene = new Scene(buildScene(), WIDTH, HEIGHT, true);
+            testScene.setFill(bgColor);
+            addCamera(testScene);
+            buildSquare();
+            testStage.setScene(testScene);
+            testStage.show();
+        });
+        waitFirstFrame();
+        runAndWait(() -> {
+
+            Color color = getColor(testScene, WIDTH / 3, WIDTH / 3);
+            assertColorEquals(Color.RED, color, TOLERANCE);
+
+            // Valid change of points
+            triMesh.getPoints().setAll(0, 0, 1);
+        });
+        waitFirstFrame();
+        runAndWait(() -> {
+
+            // Rendering nothing because faces is invalid.
+            // Should receive warning from validateFaces
+            Color color = getColor(testScene, WIDTH / 3, WIDTH / 3);
+            assertColorEquals(bgColor, color, TOLERANCE);
+        });
+    }
+
+    @Test(timeout = 15000)
+    public void testInvisibleMeshUpdateColors() {
+        runAndWait(() -> {
+            testStage = getStage();
+            testStage.setTitle("TriangleMesh PTC Validation Test");
+
+            // Intentionally set depth buffer to false to reduce test complexity
+            testScene = new Scene(buildScene(), WIDTH, HEIGHT, true);
+            testScene.setFill(bgColor);
+            addCamera(testScene);
+            buildSquare();
+            testStage.setScene(testScene);
+            testStage.show();
+        });
+        waitFirstFrame();
+        runAndWait(() -> {
+
+            // Rendering 2 Triangles that form a square (First triangle is red)
+            Color color = getColor(testScene, WIDTH / 3, WIDTH / 3);
+            assertColorEquals(Color.RED, color, TOLERANCE);
+
+            // Second triangle is blue
+            color = getColor(testScene, WIDTH / 2 + 10, WIDTH / 2 + 10);
+            assertColorEquals(Color.BLUE, color, TOLERANCE);
+
+            // set normal with invisible vertex colors.
+            triMesh.getColors().setAll(1F, 1F, 1F, 0F, 1F, 1F, 1F, 0F);
+        });
+        waitFirstFrame();
+        runAndWait(() -> {
+
+            // Rendering nothing. No warning.
+            Color color = getColor(testScene, WIDTH / 3, WIDTH / 3);
+            assertColorEquals(bgColor, color, TOLERANCE);
+
+        });
+    }
+
+    @Test(timeout = 15000)
+    public void testDegeneratedMeshUpdatePoints() {
+        runAndWait(() -> {
+            testStage = getStage();
+            testStage.setTitle("TriangleMesh PTC Validation Test");
+
+            // Intentionally set depth buffer to false to reduce test complexity
+            testScene = new Scene(buildScene(), WIDTH, HEIGHT, true);
+            testScene.setFill(bgColor);
+            addCamera(testScene);
+            buildSquare();
+            testStage.setScene(testScene);
+            testStage.show();
+        });
+        waitFirstFrame();
+        runAndWait(() -> {
+
+            // Rendering 2 Triangles that form a square (First triangle is red)
+            Color color = getColor(testScene, WIDTH / 3, WIDTH / 3);
+            assertColorEquals(Color.RED, color, TOLERANCE);
+
+            // Second triangle is blue
+            color = getColor(testScene, WIDTH / 2 + 10, WIDTH / 2 + 10);
+            assertColorEquals(Color.BLUE, color, TOLERANCE);
+
+            // set points that casuses a degenerated triangle
+            triMesh.getPoints().setAll(
+                    0.5f, -1.5f, 0f,
+                    0.5f, -1.5f, 0f,
+                    0.5f, 1.5f, 0f,
+                    0.5f, -1.5f, 0f);
+        });
+        waitFirstFrame();
+        runAndWait(() -> {
+
+            Color color = getColor(testScene, WIDTH / 2 + 10, WIDTH / 2 + 10);
+            assertColorEquals(bgColor, color, TOLERANCE);
+
+        });
+    }
+
+    void buildSquare() {
+
+        float points[] = {
+                1.5f, 1.5f, 0f,
+                1.5f, -1.5f, 0f,
+                -1.5f, 1.5f, 0f,
+                -1.5f, -1.5f, 0f
+        };
+
+        float colors[] = {
+                1f, 0f, 0f, 1f, 0f, 0f, 1f, 1f // Only the first normal is refered.
+        };
+
+        float texCoords[] = {0, 0
+        };
+
+        int faces[] = {
+                2, 0, 0, 1, 0, 0, 3, 0, 0,
+                2, 0, 1, 0, 0, 1, 1, 0, 1,};
+
+        triMesh.getPoints().setAll(points);
+        triMesh.getColors().setAll(colors);
+        triMesh.getTexCoords().setAll(texCoords);
+        triMesh.getFaces().setAll(faces);
+    }
+
+    private Group buildScene() {
+        triMesh = new TriangleMesh(VertexFormat.POINT_TEXCOORD_COLOR);
+        material = new PhongMaterial();
+        material.setDiffuseColor(Color.WHITE);
+        meshView = new MeshView(triMesh);
+        meshView.setMaterial(material);
+        meshView.setScaleX(200);
+        meshView.setScaleY(200);
+        meshView.setScaleZ(200);
+        meshView.setTranslateX(400);
+        meshView.setTranslateY(400);
+        meshView.setTranslateZ(10);
+
+        root = new Group(meshView);
+        return root;
+    }
+
+    private PerspectiveCamera addCamera(Scene scene) {
+        PerspectiveCamera perspectiveCamera = new PerspectiveCamera(false);
+        scene.setCamera(perspectiveCamera);
+        return perspectiveCamera;
+    }
+}


### PR DESCRIPTION
Implements vertex color support for TriangleMesh.
Demonstrates a possible implementation of [this feature proposal](https://github.com/Kneesnap/misc-public/blob/main/documents/javafx/feature-proposals/vertex-colors/proposal.md).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Errors
&nbsp;⚠️ OCA signatory status must be verified
&nbsp;⚠️ Pull request body is missing required line: `- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).`

### Issue
 * [JDK-6586559](https://bugs.openjdk.org/browse/JDK-6586559): Support for vertex colors (**Enhancement** - P5)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1557/head:pull/1557` \
`$ git checkout pull/1557`

Update a local copy of the PR: \
`$ git checkout pull/1557` \
`$ git pull https://git.openjdk.org/jfx.git pull/1557/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1557`

View PR using the GUI difftool: \
`$ git pr show -t 1557`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1557.diff">https://git.openjdk.org/jfx/pull/1557.diff</a>

</details>
