### PR TITLE
8339513: [TestBug] Convert fxml tests to JUnit 5

### DIFF
--- a/modules/javafx.fxml/src/test/java/test/com/sun/javafx/fxml/builder/ProxyBuilderTest.java
+++ b/modules/javafx.fxml/src/test/java/test/com/sun/javafx/fxml/builder/ProxyBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,9 +31,14 @@ import javafx.beans.NamedArg;
 import javafx.scene.paint.Color;
 import javafx.scene.paint.Paint;
 import javafx.stage.StageStyle;
-import org.junit.Test;
-import static org.junit.Assert.*;
-import org.junit.Ignore;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Disabled;
 
 public class ProxyBuilderTest {
 
@@ -97,7 +102,7 @@ public class ProxyBuilderTest {
     }
 
     @Test
-    @Ignore
+    @Disabled
     public void testImmutableTwoConstructorsWithSameArgNames() {
         ProxyBuilder pb = new ProxyBuilder(ImmutableClass.class);
         pb.put("a", 123);

--- a/modules/javafx.fxml/src/test/java/test/javafx/fxml/AlertTest.java
+++ b/modules/javafx.fxml/src/test/java/test/javafx/fxml/AlertTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,8 +28,8 @@ package test.javafx.fxml;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.control.Alert;
 import javafx.scene.control.ButtonType;
-import static org.junit.Assert.assertArrayEquals;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import org.junit.jupiter.api.Test;
 
 public class AlertTest {
 

--- a/modules/javafx.fxml/src/test/java/test/javafx/fxml/CompareVersionsTest.java
+++ b/modules/javafx.fxml/src/test/java/test/javafx/fxml/CompareVersionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,9 +26,9 @@
 package test.javafx.fxml;
 
 import javafx.fxml.FXMLLoaderShim;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CompareVersionsTest {
     @Test

--- a/modules/javafx.fxml/src/test/java/test/javafx/fxml/FXMLLoaderTest_FieldInjectionTest.java
+++ b/modules/javafx.fxml/src/test/java/test/javafx/fxml/FXMLLoaderTest_FieldInjectionTest.java
@@ -1,6 +1,5 @@
-package test.javafx.fxml;
 /*
- * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,17 +23,19 @@ package test.javafx.fxml;
  * questions.
  */
 
+package test.javafx.fxml;
+
 import javafx.scene.Node;
 import javafx.scene.Parent;
 import javafx.scene.shape.Rectangle;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import javafx.fxml.FXML;
 import javafx.fxml.FXMLLoader;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class FXMLLoaderTest_FieldInjectionTest {
 

--- a/modules/javafx.fxml/src/test/java/test/javafx/fxml/FXMLLoader_BuilderTest.java
+++ b/modules/javafx.fxml/src/test/java/test/javafx/fxml/FXMLLoader_BuilderTest.java
@@ -1,6 +1,5 @@
-package test.javafx.fxml;
 /*
- * Copyright (c) 2011, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,11 +22,12 @@ package test.javafx.fxml;
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+package test.javafx.fxml;
 
 import javafx.scene.shape.TriangleMesh;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 import java.io.IOException;
 import javafx.fxml.FXMLLoader;

--- a/modules/javafx.fxml/src/test/java/test/javafx/fxml/FXMLLoader_EventsTest.java
+++ b/modules/javafx.fxml/src/test/java/test/javafx/fxml/FXMLLoader_EventsTest.java
@@ -1,18 +1,5 @@
-package test.javafx.fxml;
-
-import javafx.beans.value.ChangeListener;
-import javafx.beans.value.ObservableValue;
-import javafx.util.Callback;
-import org.junit.Test;
-
-import java.io.IOException;
-import javafx.fxml.FXMLLoader;
-import javafx.fxml.LoadException;
-
-import static org.junit.Assert.*;
-
 /*
- * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +22,23 @@ import static org.junit.Assert.*;
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
+package test.javafx.fxml;
+
+import javafx.beans.value.ChangeListener;
+import javafx.beans.value.ObservableValue;
+import javafx.util.Callback;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import javafx.fxml.FXMLLoader;
+import javafx.fxml.LoadException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 public class FXMLLoader_EventsTest {
     @Test
     public void testListEvents() throws Exception {
@@ -201,10 +205,12 @@ public class FXMLLoader_EventsTest {
     }
 
 
-    @Test(expected = LoadException.class)
+    @Test
     public void testPropertyEvents_testExpressionHandler_NA() throws IOException {
-        FXMLLoader fxmlLoader = new FXMLLoader(getClass().getResource("property_events_test_expression_na.fxml"));
-        fxmlLoader.load();
+        assertThrows(LoadException.class, () -> {
+            FXMLLoader fxmlLoader = new FXMLLoader(getClass().getResource("property_events_test_expression_na.fxml"));
+            fxmlLoader.load();
+        });
     }
 
     @Test

--- a/modules/javafx.fxml/src/test/java/test/javafx/fxml/FXMLLoader_ExpressionTest.java
+++ b/modules/javafx.fxml/src/test/java/test/javafx/fxml/FXMLLoader_ExpressionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,7 @@ package test.javafx.fxml;
 import com.sun.javafx.fxml.expression.Expression;
 import com.sun.javafx.fxml.expression.KeyPath;
 import javafx.collections.ObservableList;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -37,7 +37,7 @@ import javafx.fxml.FXMLLoader;
 import static com.sun.javafx.fxml.expression.Expression.*;
 import static com.sun.javafx.fxml.expression.Expression.set;
 import static com.sun.javafx.fxml.expression.Expression.valueOf;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class FXMLLoader_ExpressionTest {
 

--- a/modules/javafx.fxml/src/test/java/test/javafx/fxml/FXMLLoader_ScriptTest.java
+++ b/modules/javafx.fxml/src/test/java/test/javafx/fxml/FXMLLoader_ScriptTest.java
@@ -1,6 +1,5 @@
-package test.javafx.fxml;
 /*
- * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,9 +22,10 @@ package test.javafx.fxml;
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+package test.javafx.fxml;
 
 import com.sun.javafx.fxml.FXMLLoaderHelper;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -34,8 +34,11 @@ import javafx.fxml.LoadListener;
 import javax.script.ScriptEngineManager;
 import javax.script.ScriptEngine;
 
-import static org.junit.Assert.*;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class FXMLLoader_ScriptTest {
     @Test

--- a/modules/javafx.fxml/src/test/java/test/javafx/fxml/RT_15524Test.java
+++ b/modules/javafx.fxml/src/test/java/test/javafx/fxml/RT_15524Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,9 +28,10 @@ package test.javafx.fxml;
 import java.io.IOException;
 import java.util.Arrays;
 import javafx.fxml.FXMLLoader;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class RT_15524Test {
     @Test

--- a/modules/javafx.fxml/src/test/java/test/javafx/fxml/RT_16724Test.java
+++ b/modules/javafx.fxml/src/test/java/test/javafx/fxml/RT_16724Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@ package test.javafx.fxml;
 
 import java.io.IOException;
 import javafx.fxml.FXMLLoader;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class RT_16724Test {
     @Test

--- a/modules/javafx.fxml/src/test/java/test/javafx/fxml/RT_16815Test.java
+++ b/modules/javafx.fxml/src/test/java/test/javafx/fxml/RT_16815Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,9 +28,9 @@ package test.javafx.fxml;
 import java.io.IOException;
 import java.util.ResourceBundle;
 import javafx.fxml.FXMLLoader;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class RT_16815Test {
     @Test

--- a/modules/javafx.fxml/src/test/java/test/javafx/fxml/RT_16977Test.java
+++ b/modules/javafx.fxml/src/test/java/test/javafx/fxml/RT_16977Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,9 +26,9 @@
 package test.javafx.fxml;
 
 import javafx.fxml.FXMLLoader;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class RT_16977Test {
     @Test

--- a/modules/javafx.fxml/src/test/java/test/javafx/fxml/RT_18218Test.java
+++ b/modules/javafx.fxml/src/test/java/test/javafx/fxml/RT_18218Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,9 +30,10 @@ import java.io.IOException;
 import java.util.Map;
 import javafx.fxml.FXMLLoader;
 import javafx.fxml.LoadListener;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class RT_18218Test {
     @Test

--- a/modules/javafx.fxml/src/test/java/test/javafx/fxml/RT_18933Test.java
+++ b/modules/javafx.fxml/src/test/java/test/javafx/fxml/RT_18933Test.java
@@ -35,7 +35,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public class RT_18933Test {
     @Test
     public void testDefaultListProperty() throws IOException {
-            assertThrows(LoadException.class, () -> { FXMLLoader fxmlLoader = new FXMLLoader(getClass().getResource("rt_18933.fxml"));
+        assertThrows(LoadException.class, () -> {
+            FXMLLoader fxmlLoader = new FXMLLoader(getClass().getResource("rt_18933.fxml"));
             fxmlLoader.load();
         });
     }

--- a/modules/javafx.fxml/src/test/java/test/javafx/fxml/RT_18933Test.java
+++ b/modules/javafx.fxml/src/test/java/test/javafx/fxml/RT_18933Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,12 +28,15 @@ package test.javafx.fxml;
 import java.io.IOException;
 import javafx.fxml.FXMLLoader;
 import javafx.fxml.LoadException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class RT_18933Test {
-    @Test(expected=LoadException.class)
+    @Test
     public void testDefaultListProperty() throws IOException {
-        FXMLLoader fxmlLoader = new FXMLLoader(getClass().getResource("rt_18933.fxml"));
-        fxmlLoader.load();
+            assertThrows(LoadException.class, () -> { FXMLLoader fxmlLoader = new FXMLLoader(getClass().getResource("rt_18933.fxml"));
+            fxmlLoader.load();
+        });
     }
 }

--- a/modules/javafx.fxml/src/test/java/test/javafx/fxml/RT_19008Test.java
+++ b/modules/javafx.fxml/src/test/java/test/javafx/fxml/RT_19008Test.java
@@ -34,7 +34,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public class RT_19008Test {
     @Test
     public void testMissingResource() throws IOException {
-        assertThrows(NullPointerException.class, () -> {FXMLLoader.load(getClass().getResource("rt_19008.fxml"));
+        assertThrows(NullPointerException.class, () -> {
+            FXMLLoader.load(getClass().getResource("rt_19008.fxml"));
         });
     }
 }

--- a/modules/javafx.fxml/src/test/java/test/javafx/fxml/RT_19008Test.java
+++ b/modules/javafx.fxml/src/test/java/test/javafx/fxml/RT_19008Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,11 +27,14 @@ package test.javafx.fxml;
 
 import java.io.IOException;
 import javafx.fxml.FXMLLoader;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class RT_19008Test {
-    @Test(expected=NullPointerException.class)
+    @Test
     public void testMissingResource() throws IOException {
-        FXMLLoader.load(getClass().getResource("rt_19008.fxml"));
+        assertThrows(NullPointerException.class, () -> {FXMLLoader.load(getClass().getResource("rt_19008.fxml"));
+        });
     }
 }

--- a/modules/javafx.fxml/src/test/java/test/javafx/fxml/RT_19112Test.java
+++ b/modules/javafx.fxml/src/test/java/test/javafx/fxml/RT_19112Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,9 +27,9 @@ package test.javafx.fxml;
 
 import java.io.IOException;
 import javafx.fxml.FXMLLoader;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class RT_19112Test {
     @Test

--- a/modules/javafx.fxml/src/test/java/test/javafx/fxml/RT_19139Test.java
+++ b/modules/javafx.fxml/src/test/java/test/javafx/fxml/RT_19139Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,9 +28,9 @@ package test.javafx.fxml;
 import java.io.IOException;
 import java.util.Arrays;
 import javafx.fxml.FXMLLoader;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class RT_19139Test {
     @Test

--- a/modules/javafx.fxml/src/test/java/test/javafx/fxml/RT_19228Test.java
+++ b/modules/javafx.fxml/src/test/java/test/javafx/fxml/RT_19228Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,9 +27,9 @@ package test.javafx.fxml;
 
 import java.io.IOException;
 import javafx.fxml.FXMLLoader;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class RT_19228Test {
     @Test

--- a/modules/javafx.fxml/src/test/java/test/javafx/fxml/RT_19329Test.java
+++ b/modules/javafx.fxml/src/test/java/test/javafx/fxml/RT_19329Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,11 +27,13 @@ package test.javafx.fxml;
 
 import java.io.IOException;
 import javafx.fxml.FXMLLoader;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class RT_19329Test {
-    @Test(expected=IOException.class)
+    @Test
     public void testIncludeException() throws IOException {
-        FXMLLoader.load(getClass().getResource("rt_19329.fxml"));
+        assertThrows(IOException.class, () -> { FXMLLoader.load(getClass().getResource("rt_19329.fxml")); });
     }
 }

--- a/modules/javafx.fxml/src/test/java/test/javafx/fxml/RT_19329Test.java
+++ b/modules/javafx.fxml/src/test/java/test/javafx/fxml/RT_19329Test.java
@@ -34,6 +34,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public class RT_19329Test {
     @Test
     public void testIncludeException() throws IOException {
-        assertThrows(IOException.class, () -> { FXMLLoader.load(getClass().getResource("rt_19329.fxml")); });
+        assertThrows(IOException.class, () -> {
+            FXMLLoader.load(getClass().getResource("rt_19329.fxml"));
+        });
     }
 }

--- a/modules/javafx.fxml/src/test/java/test/javafx/fxml/RT_19870Test.java
+++ b/modules/javafx.fxml/src/test/java/test/javafx/fxml/RT_19870Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,9 +25,9 @@
 
 package test.javafx.fxml;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class RT_19870Test {
     @Test

--- a/modules/javafx.fxml/src/test/java/test/javafx/fxml/RT_20082Test.java
+++ b/modules/javafx.fxml/src/test/java/test/javafx/fxml/RT_20082Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,9 +27,9 @@ package test.javafx.fxml;
 
 import java.io.IOException;
 import javafx.fxml.FXMLLoader;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class RT_20082Test {
     @Test

--- a/modules/javafx.fxml/src/test/java/test/javafx/fxml/RT_20471Test.java
+++ b/modules/javafx.fxml/src/test/java/test/javafx/fxml/RT_20471Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,9 +29,10 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.ResourceBundle;
 import javafx.fxml.FXMLLoader;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class RT_20471Test {
     @Test

--- a/modules/javafx.fxml/src/test/java/test/javafx/fxml/RT_22971Test.java
+++ b/modules/javafx.fxml/src/test/java/test/javafx/fxml/RT_22971Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,9 +28,9 @@ package test.javafx.fxml;
 import java.io.IOException;
 import java.net.URL;
 import javafx.fxml.FXMLLoader;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class RT_22971Test {
     @Test

--- a/modules/javafx.fxml/src/test/java/test/javafx/fxml/RT_23519Test.java
+++ b/modules/javafx.fxml/src/test/java/test/javafx/fxml/RT_23519Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,9 +28,9 @@ package test.javafx.fxml;
 import java.io.IOException;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.control.Button;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class RT_23519Test {
 

--- a/modules/javafx.fxml/src/test/java/test/javafx/fxml/RT_24380Test.java
+++ b/modules/javafx.fxml/src/test/java/test/javafx/fxml/RT_24380Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,7 @@ package test.javafx.fxml;
 import java.io.IOException;
 import javafx.fxml.FXMLLoader;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class RT_24380Test {
     @Test

--- a/modules/javafx.fxml/src/test/java/test/javafx/fxml/RT_25494_Cycle_DetectionTest.java
+++ b/modules/javafx.fxml/src/test/java/test/javafx/fxml/RT_25494_Cycle_DetectionTest.java
@@ -34,16 +34,22 @@ public class RT_25494_Cycle_DetectionTest {
 
     @Test
     public void test_dummy_cycle() throws Exception {
-        assertThrows(IOException.class, () -> {FXMLLoader.load(RT_25494_Cycle_DetectionTest.class.getResource("dummy-cycle.fxml")); });
+        assertThrows(IOException.class, () -> {
+            FXMLLoader.load(RT_25494_Cycle_DetectionTest.class.getResource("dummy-cycle.fxml"));
+        });
     }
 
     @Test
     public void test_one_2_one_cycle() throws Exception {
-        assertThrows(IOException.class, () -> {FXMLLoader.load(RT_25494_Cycle_DetectionTest.class.getResource("one-2-one-cycle.fxml")); });
+        assertThrows(IOException.class, () -> {
+            FXMLLoader.load(RT_25494_Cycle_DetectionTest.class.getResource("one-2-one-cycle.fxml"));
+        });
     }
 
     @Test
     public void test_cycle() throws Exception {
-        assertThrows(IOException.class, () -> {FXMLLoader.load(RT_25494_Cycle_DetectionTest.class.getResource("cycle.fxml")); });
+        assertThrows(IOException.class, () -> {
+            FXMLLoader.load(RT_25494_Cycle_DetectionTest.class.getResource("cycle.fxml"));
+        });
     }
 }

--- a/modules/javafx.fxml/src/test/java/test/javafx/fxml/RT_25494_Cycle_DetectionTest.java
+++ b/modules/javafx.fxml/src/test/java/test/javafx/fxml/RT_25494_Cycle_DetectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,22 +27,23 @@ package test.javafx.fxml;
 
 import java.io.IOException;
 import javafx.fxml.FXMLLoader;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class RT_25494_Cycle_DetectionTest {
 
-    @Test(expected=IOException.class)
+    @Test
     public void test_dummy_cycle() throws Exception {
-        FXMLLoader.load(RT_25494_Cycle_DetectionTest.class.getResource("dummy-cycle.fxml"));
+        assertThrows(IOException.class, () -> {FXMLLoader.load(RT_25494_Cycle_DetectionTest.class.getResource("dummy-cycle.fxml")); });
     }
 
-    @Test(expected=IOException.class)
+    @Test
     public void test_one_2_one_cycle() throws Exception {
-        FXMLLoader.load(RT_25494_Cycle_DetectionTest.class.getResource("one-2-one-cycle.fxml"));
+        assertThrows(IOException.class, () -> {FXMLLoader.load(RT_25494_Cycle_DetectionTest.class.getResource("one-2-one-cycle.fxml")); });
     }
 
-    @Test(expected=IOException.class)
+    @Test
     public void test_cycle() throws Exception {
-        FXMLLoader.load(RT_25494_Cycle_DetectionTest.class.getResource("cycle.fxml"));
+        assertThrows(IOException.class, () -> {FXMLLoader.load(RT_25494_Cycle_DetectionTest.class.getResource("cycle.fxml")); });
     }
 }

--- a/modules/javafx.fxml/src/test/java/test/javafx/fxml/RT_26449Test.java
+++ b/modules/javafx.fxml/src/test/java/test/javafx/fxml/RT_26449Test.java
@@ -35,7 +35,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public class RT_26449Test {
     @Test
     public void testRootNotSet() throws IOException {
-        assertThrows(LoadException.class, () -> {FXMLLoader fxmlLoader = new FXMLLoader(getClass().getResource("rt_26449.fxml"));
-        fxmlLoader.load(); });
+        assertThrows(LoadException.class, () -> {
+            FXMLLoader fxmlLoader = new FXMLLoader(getClass().getResource("rt_26449.fxml"));
+            fxmlLoader.load();
+        });
     }
 }

--- a/modules/javafx.fxml/src/test/java/test/javafx/fxml/RT_26449Test.java
+++ b/modules/javafx.fxml/src/test/java/test/javafx/fxml/RT_26449Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,12 +29,13 @@ import java.io.IOException;
 import javafx.fxml.FXMLLoader;
 import javafx.fxml.LoadException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class RT_26449Test {
-    @Test(expected=LoadException.class)
+    @Test
     public void testRootNotSet() throws IOException {
-        FXMLLoader fxmlLoader = new FXMLLoader(getClass().getResource("rt_26449.fxml"));
-        fxmlLoader.load();
+        assertThrows(LoadException.class, () -> {FXMLLoader fxmlLoader = new FXMLLoader(getClass().getResource("rt_26449.fxml"));
+        fxmlLoader.load(); });
     }
 }

--- a/modules/javafx.fxml/src/test/java/test/javafx/fxml/RT_27529Test.java
+++ b/modules/javafx.fxml/src/test/java/test/javafx/fxml/RT_27529Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,9 +30,10 @@ import java.net.URL;
 import java.util.Arrays;
 import java.util.ResourceBundle;
 import javafx.fxml.FXMLLoader;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class RT_27529Test {
 

--- a/modules/javafx.fxml/src/test/java/test/javafx/fxml/RT_34146Test.java
+++ b/modules/javafx.fxml/src/test/java/test/javafx/fxml/RT_34146Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,8 +28,8 @@ package test.javafx.fxml;
 import java.io.IOException;
 import javafx.fxml.FXML;
 import javafx.fxml.FXMLLoader;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public final class RT_34146Test {
     @Test
@@ -43,7 +43,7 @@ public final class RT_34146Test {
         final Widget widget = fxmlLoader.<Widget>load();
         widget.fire();
 
-        Assert.assertTrue(concreteController.getActionHandlerCalled());
+        assertTrue(concreteController.getActionHandlerCalled());
     }
 
     private static abstract class AbstractController {

--- a/modules/javafx.fxml/src/test/java/test/javafx/fxml/RT_36633Test.java
+++ b/modules/javafx.fxml/src/test/java/test/javafx/fxml/RT_36633Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,9 +34,9 @@ import javafx.scene.control.TabPane;
 import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableView;
 import javafx.scene.layout.VBox;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class RT_36633Test {
     @Test public void test_rt36633_tableColumn() throws Exception {

--- a/modules/javafx.fxml/src/test/java/test/javafx/fxml/RT_40335Test.java
+++ b/modules/javafx.fxml/src/test/java/test/javafx/fxml/RT_40335Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,9 +29,9 @@ import javafx.fxml.FXMLLoader;
 import javafx.scene.control.Button;
 import javafx.scene.control.Spinner;
 import javafx.scene.layout.VBox;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class RT_40335Test {
     @Test public void test_rt_40335() throws Exception {


### PR DESCRIPTION
This converts FXML module tests to junit5.

All changes are trivial API replacements from junit4 to junit5.
There are no parameterized tests in this module.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339513](https://bugs.openjdk.org/browse/JDK-8339513): [TestBug] Convert fxml tests to JUnit 5 (**Enhancement** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Marius Hanl](https://openjdk.org/census#mhanl) (@Maran23 - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1564/head:pull/1564` \
`$ git checkout pull/1564`

Update a local copy of the PR: \
`$ git checkout pull/1564` \
`$ git pull https://git.openjdk.org/jfx.git pull/1564/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1564`

View PR using the GUI difftool: \
`$ git pr show -t 1564`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1564.diff">https://git.openjdk.org/jfx/pull/1564.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1564#issuecomment-2348645429)