### PR TITLE
8339550: Enable javac lint options for tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -573,7 +573,9 @@ def defaultToolLintOptions = ""
 defineProperty("TOOL_LINT", defaultToolLintOptions)
 ext.IS_TOOL_LINT = TOOL_LINT != ""
 
-def defaultTestLintOptions = ""
+def defaultTestLintOptions =
+        "-options" + "," +
+        "removal"
 defineProperty("TEST_LINT", defaultTestLintOptions)
 ext.IS_TEST_LINT = TEST_LINT != ""
 
@@ -583,7 +585,7 @@ ext.IS_JAVAC_WERROR = Boolean.parseBoolean(JAVAC_WERROR)
 defineProperty("TOOL_JAVAC_WERROR", "false")
 ext.IS_TOOL_JAVAC_WERROR = Boolean.parseBoolean(TOOL_JAVAC_WERROR)
 
-defineProperty("TEST_JAVAC_WERROR", "false")
+defineProperty("TEST_JAVAC_WERROR", "true")
 ext.IS_TEST_JAVAC_WERROR = Boolean.parseBoolean(TEST_JAVAC_WERROR)
 
 // Doclint options (all enabled by default)
@@ -2121,7 +2123,7 @@ allprojects {
         testImplementation group: "org.junit.jupiter", name: "junit-jupiter-api", version: "5.8.1"
         testImplementation group: "org.junit.jupiter", name: "junit-jupiter-params", version: "5.8.1"
         testImplementation group: "org.opentest4j", name: "opentest4j", version: "1.2.0"
-        testRuntimeOnly group: "org.apiguardian", name: "apiguardian-api", version: "1.1.2"
+        testImplementation group: "org.apiguardian", name: "apiguardian-api", version: "1.1.2"
         testRuntimeOnly group: "org.junit.jupiter", name: "junit-jupiter-engine", version: "5.8.1"
         testRuntimeOnly group: "org.junit.platform", name: "junit-platform-commons", version: "1.8.1"
         testRuntimeOnly group: "org.junit.platform", name: "junit-platform-engine", version: "1.8.1"

--- a/modules/javafx.base/src/shims/java/javafx/util/converter/NumberStringConverterShim.java
+++ b/modules/javafx.base/src/shims/java/javafx/util/converter/NumberStringConverterShim.java
@@ -34,6 +34,7 @@ public class NumberStringConverterShim {
         return nsc.numberFormat;
     }
 
+    @SuppressWarnings("removal")
     public static NumberFormat getNumberFormat(NumberStringConverter nsc) {
         return nsc.getNumberFormat();
     }

--- a/modules/javafx.web/src/test/java/test/javafx/scene/web/FileReaderTest.java
+++ b/modules/javafx.web/src/test/java/test/javafx/scene/web/FileReaderTest.java
@@ -226,7 +226,7 @@ public class FileReaderTest extends TestBase {
             final byte[] expectedArrayBuffer = in.readAllBytes();
             submit(() -> {
                 final JSObject obj = (JSObject) getEngine().executeScript("new Uint8Array(window.result)");
-                assertEquals(String.format("%s length must be equal in both Java & JavaScript", fileList),
+                assertEquals(String.format("%s length must be equal in both Java & JavaScript", fileList[0]),
                                        expectedArrayBuffer.length, obj.getMember("length"));
                 for (int i = 0; i < expectedArrayBuffer.length; i++) {
                     assertEquals("Unexpected file content received", expectedArrayBuffer[i], ((Number)(obj.getSlot(i))).byteValue());

--- a/tests/system/src/test/java/test/robot/javafx/scene/RobotTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/RobotTest.java
@@ -444,7 +444,7 @@ public class RobotTest {
     public void testMousePressThrowsNPEForNullArgument() {
         Util.runAndWait(() -> {
             try {
-                robot.mousePress(null);
+                robot.mousePress((MouseButton[])null);
             } catch (NullPointerException e) {
                 return;
             }
@@ -466,7 +466,7 @@ public class RobotTest {
     public void testMouseReleaseThrowsNPEForNullArgument() {
         Util.runAndWait(() -> {
             try {
-                robot.mouseRelease(null);
+                robot.mouseRelease((MouseButton[])null);
             } catch (NullPointerException e) {
                 return;
             }
@@ -488,7 +488,7 @@ public class RobotTest {
     public void testMouseClickThrowsNPEForNullArgument() {
         Util.runAndWait(() -> {
             try {
-                robot.mouseClick(null);
+                robot.mouseClick((MouseButton[])null);
             } catch (NullPointerException e) {
                 return;
             }


### PR DESCRIPTION
This PR enables the `removal` lint option, along with `-Werror`, for compiling shims and test classes. In order to do that, I had to also do the following:

* Disable the `options` lint warning as is done for the `javafx.swing` module, and for the same reason: using `-source NN -release NN` produces a warning that we know about and don't care to see (and will fail the build with `-Werror`)
* Change the `apiguardian` dependency from `testRuntimeOnly` to `testImplementation`, since it needs to be a compile-time dependency to avoid many compile-time warnings for a missing annotation
* Add a missing `@SuppressWarnings("removal")` in one place
* Fix the varargs warnings filed in [JDK-8338340](https://bugs.openjdk.org/browse/JDK-8338340)

I tested locally and with our CI test system. The GHA build passes.

/issue add JDK-8338340

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8339550](https://bugs.openjdk.org/browse/JDK-8339550): Enable javac lint options for tests (**Bug** - P4)
 * [JDK-8338340](https://bugs.openjdk.org/browse/JDK-8338340): [TestBug] fix varargs parameter type warnings (**Bug** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Marius Hanl](https://openjdk.org/census#mhanl) (@Maran23 - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1565/head:pull/1565` \
`$ git checkout pull/1565`

Update a local copy of the PR: \
`$ git checkout pull/1565` \
`$ git pull https://git.openjdk.org/jfx.git pull/1565/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1565`

View PR using the GUI difftool: \
`$ git pr show -t 1565`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1565.diff">https://git.openjdk.org/jfx/pull/1565.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1565#issuecomment-2349159307)