### PR TITLE
Remove redundant `this` keyword

### DIFF
--- a/modules/javafx.base/src/main/java/javafx/util/Pair.java
+++ b/modules/javafx.base/src/main/java/javafx/util/Pair.java
@@ -49,7 +49,7 @@ public class Pair<K, V> implements Serializable {
     public K getKey() { return key; }
 
     /**
-     * Value of this this <code>Pair</code>.
+     * Value of this <code>Pair</code>.
      */
     private V value;
 


### PR DESCRIPTION
In the codebase, there is a redundant use of the `this` keyword. Specifically, the code snippet `this this` is not valid Java code. The `this` keyword is used to refer to the current object instance. However, in this case, it is not clear what the intention is.

To fix this issue, I have removed the redundant use of the `this` keyword.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1573/head:pull/1573` \
`$ git checkout pull/1573`

Update a local copy of the PR: \
`$ git checkout pull/1573` \
`$ git pull https://git.openjdk.org/jfx.git pull/1573/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1573`

View PR using the GUI difftool: \
`$ git pr show -t 1573`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1573.diff">https://git.openjdk.org/jfx/pull/1573.diff</a>

</details>
