### PR TITLE
8297072: Provide gradle option to test a previously built SDK

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2001,6 +2001,9 @@ task createTestArgfiles {
     // an empty task we can add to as needed
 }
 
+task createRunArgFiles {
+    // an empty task we can add to as needed
+}
 
 /*****************************************************************************
 *        Project definitions (dependencies, etc)                             *
@@ -4520,7 +4523,7 @@ task sdk() {
         gradle.taskGraph.whenReady { taskGraph ->
             taskGraph.allTasks.each { task ->
                 if (!isTestTask(task) && !task.name.equals("verifyJava") &&
-                    !task.name.equals("validateSourceSets")) {
+                    !task.name.equals("validateSourceSets") && !task.name.contains("buildRunArgs")) {
                     task.enabled = false
                 }
             }
@@ -5084,7 +5087,7 @@ compileTargets { t ->
     // ============================================================
 
     def standaloneSdkDirName = "${platformPrefix}sdk"
-    def standaloneSdkDir = "${rootProject.buildDir}/${standaloneSdkDirName}"
+    def standaloneSdkDir = "${TEST_SDK_PATH}/${standaloneSdkDirName}"
     def standaloneLibDir = "${standaloneSdkDir}/lib"
     def libDest=targetProperties.libDest
     def standaloneNativeDir = "${standaloneSdkDir}/${libDest}"
@@ -5242,6 +5245,7 @@ compileTargets { t ->
             }
         }
     }
+    createRunArgFiles.dependsOn(buildRunArgsTask)
     buildModules.dependsOn(buildRunArgsTask)
 
     def isWindows = IS_WINDOWS && t.name == "win";

--- a/build.gradle
+++ b/build.gradle
@@ -729,6 +729,24 @@ def buildSdkForTest = Boolean.parseBoolean(BUILD_SDK_FOR_TEST)
 defineProperty("TEST_ONLY", "false")
 ext.IS_TEST_ONLY = Boolean.parseBoolean(TEST_ONLY) || !buildSdkForTest
 
+ext.IS_TEST_JAVAFX_SDK = false
+if (hasProperty("TEST_JAVAFX_SDK_PATH")) {
+    if (!IS_TEST_ONLY) {
+        fail("TEST_ONLY must be set true when using an external TEST_JAVAFX_SDK_PATH for running tests: include -PTEST_ONLY=true")
+    }
+    def sdkShimsPath = file("${TEST_JAVAFX_SDK_PATH}")
+    def sdkPath = file("${TEST_JAVAFX_SDK_PATH}/sdk")
+    def shimsPath = file("${TEST_JAVAFX_SDK_PATH}/shims")
+    if (!sdkShimsPath.exists() || !sdkShimsPath.isDirectory() ||
+             !sdkPath.exists() || !sdkPath.isDirectory() ||
+           !shimsPath.exists() || !shimsPath.isDirectory()) {
+        fail("The provided TEST_JAVAFX_SDK_PATH=${TEST_JAVAFX_SDK_PATH} is invalid")
+    }
+    ext.IS_TEST_JAVAFX_SDK = true
+} else {
+    defineProperty("TEST_JAVAFX_SDK_PATH", "${rootProject.buildDir}")
+}
+
 // Make sure JDK_HOME/bin/java exists
 if (!file(JAVA).exists()) throw new Exception("Missing or incorrect path to 'java': '$JAVA'. Perhaps bad JDK_HOME? $JDK_HOME")
 if (!file(JAVAC).exists()) throw new Exception("Missing or incorrect path to 'javac': '$JAVAC'. Perhaps bad JDK_HOME? $JDK_HOME")
@@ -982,7 +1000,7 @@ List<String> computeLibraryPath(boolean working) {
     } else {
         def platformPrefix = ""
         def standaloneSdkDirName = "${platformPrefix}sdk"
-        def standaloneSdkDir = "${rootProject.buildDir}/${standaloneSdkDirName}"
+        def standaloneSdkDir = "${TEST_JAVAFX_SDK_PATH}/${standaloneSdkDirName}"
         def modulesLibName = IS_WINDOWS ? "bin" : "lib"
         def modulesLibsDir = "${standaloneSdkDir}/${modulesLibName}"
         lp << cygpath("${modulesLibsDir}")
@@ -1019,9 +1037,9 @@ List<String> computePatchModuleArgs(List<String> deps, boolean test, boolean inc
                 String moduleName = proj.ext.moduleName
                 File dir;
                 if (test && proj.sourceSets.hasProperty('shims')) {
-                    dir = file("${rootProject.buildDir}/shims/${moduleName}")
+                    dir = file("${TEST_JAVAFX_SDK_PATH}/shims/${moduleName}")
                 } else {
-                    dir = file("${rootProject.buildDir}/sdk/lib/${moduleName}.jar")
+                    dir = file("${TEST_JAVAFX_SDK_PATH}/sdk/lib/${moduleName}.jar")
                 }
                 if (mp == null) {
                     mp = dir.path
@@ -2283,6 +2301,13 @@ project(":base") {
     addMavenPublication(project, [])
 
     addValidateSourceSets(project, sourceSets)
+
+    test {
+        if (IS_TEST_JAVAFX_SDK) {
+            logger.info "Skipping VersionInfoTest when TEST_JAVAFX_SDK_PATH is set."
+            exclude("test/com/sun/javafx/runtime/VersionInfoTest*");
+        }
+    }
 }
 
 // The graphics module is needed for any graphical JavaFX application. It requires
@@ -2694,7 +2719,7 @@ project(":graphics") {
     processResources.dependsOn processDecoraShaders, processPrismShaders
 
     test {
-        def cssDir = file("$buildDir/classes/java/main/${moduleName}/javafx")
+        def cssDir = file("${TEST_JAVAFX_SDK_PATH}/shims/${moduleName}/javafx")
         jvmArgs enableNativeGraphics
         jvmArgs "-Djavafx.toolkit=test.com.sun.javafx.pgstub.StubToolkit",
             "-DCSS_META_DATA_TEST_DIR=$cssDir"
@@ -2783,7 +2808,7 @@ project(":controls") {
     }
 
     test {
-        def cssDir = file("$buildDir/classes/java/main/${moduleName}/javafx")
+        def cssDir = file("${TEST_JAVAFX_SDK_PATH}/shims/${moduleName}/javafx")
         jvmArgs enableNativeGraphics
         jvmArgs "-Djavafx.toolkit=test.com.sun.javafx.pgstub.StubToolkit",
             "-DCSS_META_DATA_TEST_DIR=$cssDir"
@@ -5650,6 +5675,34 @@ compileTargets { t ->
     }
     jdkZip.dependsOn(zipTask)
 
+    def buildSdkDir = "${rootProject.buildDir}/sdk"
+    def buildShimsDir = "${rootProject.buildDir}/shims"
+    def sdkShimZipTask = project.task("sdkShimsZip$t.capital", type: Zip, group: "Build",
+            dependsOn: [shims] ) {
+
+        def sdkShimsBundle = "${platformPrefix}javafx-sdk-shims.zip"
+
+        doFirst() {
+            file("${rootProject.buildDir}/${sdkShimsBundle}").delete()
+        }
+
+        if (IS_WINDOWS && IS_USE_CYGWIN) {
+            dirPermissions { unix(0755) }
+            filePermissions { unix(0755) }
+        }
+
+        archiveFileName = sdkShimsBundle
+        destinationDirectory = file("${rootProject.buildDir}")
+        includeEmptyDirs = false
+        from ("${buildSdkDir}") {
+            into "sdk"
+        }
+        from ("${buildShimsDir}") {
+            into "shims"
+        }
+    }
+    jdkZip.dependsOn(sdkShimZipTask)
+
     Task testArgFiles = task("createTestArgfiles${t.capital}") {
 
         File testRunArgsFile = new File(rootProject.buildDir, TESTRUNARGSFILE)
@@ -5724,9 +5777,9 @@ compileTargets { t ->
                         modnames << project.ext.moduleName
                         File dir;
                         if (project.sourceSets.hasProperty('shims')) {
-                           dir = new File(rootProject.buildDir, "shims/${project.ext.moduleName}")
+                           dir = new File(TEST_JAVAFX_SDK_PATH, "shims/${project.ext.moduleName}")
                         } else {
-                           dir = new File(rootProject.buildDir, "sdk/lib/${project.ext.moduleName}.jar")
+                           dir = new File(TEST_JAVAFX_SDK_PATH, "sdk/lib/${project.ext.moduleName}.jar")
                         }
 
                         def dstModuleDir = cygpath(dir.path)
@@ -5737,7 +5790,7 @@ compileTargets { t ->
                         "    permission java.security.AllPermission;\n" +
                         "};\n"
 
-                        dir = new File(rootProject.buildDir, "sdk/lib/${project.ext.moduleName}.jar")
+                        dir = new File(TEST_JAVAFX_SDK_PATH, "sdk/lib/${project.ext.moduleName}.jar")
                         themod = dir.toURI()
                         runJavaPolicyFile <<  "grant codeBase \"${themod}\" {\n" +
                         "    permission java.security.AllPermission;\n" +

--- a/build.gradle
+++ b/build.gradle
@@ -729,22 +729,22 @@ def buildSdkForTest = Boolean.parseBoolean(BUILD_SDK_FOR_TEST)
 defineProperty("TEST_ONLY", "false")
 ext.IS_TEST_ONLY = Boolean.parseBoolean(TEST_ONLY) || !buildSdkForTest
 
-ext.IS_TEST_JAVAFX_SDK = false
-if (hasProperty("TEST_JAVAFX_SDK_PATH")) {
+ext.IS_TEST_SDK = false
+if (hasProperty("TEST_SDK_PATH")) {
     if (!IS_TEST_ONLY) {
-        fail("TEST_ONLY must be set true when using an external TEST_JAVAFX_SDK_PATH for running tests: include -PTEST_ONLY=true")
+        fail("TEST_ONLY must be set to true when using an external TEST_SDK_PATH for running tests: include -PTEST_ONLY=true")
     }
-    def sdkShimsPath = file("${TEST_JAVAFX_SDK_PATH}")
-    def sdkPath = file("${TEST_JAVAFX_SDK_PATH}/sdk")
-    def shimsPath = file("${TEST_JAVAFX_SDK_PATH}/shims")
+    def sdkShimsPath = file("${TEST_SDK_PATH}")
+    def sdkPath = file("${TEST_SDK_PATH}/sdk")
+    def shimsPath = file("${TEST_SDK_PATH}/shims")
     if (!sdkShimsPath.exists() || !sdkShimsPath.isDirectory() ||
              !sdkPath.exists() || !sdkPath.isDirectory() ||
            !shimsPath.exists() || !shimsPath.isDirectory()) {
-        fail("The provided TEST_JAVAFX_SDK_PATH=${TEST_JAVAFX_SDK_PATH} is invalid")
+        fail("The provided TEST_SDK_PATH=${TEST_SDK_PATH} is invalid")
     }
-    ext.IS_TEST_JAVAFX_SDK = true
+    ext.IS_TEST_SDK = true
 } else {
-    defineProperty("TEST_JAVAFX_SDK_PATH", "${rootProject.buildDir}")
+    defineProperty("TEST_SDK_PATH", "${rootProject.buildDir}")
 }
 
 // Make sure JDK_HOME/bin/java exists
@@ -1000,7 +1000,7 @@ List<String> computeLibraryPath(boolean working) {
     } else {
         def platformPrefix = ""
         def standaloneSdkDirName = "${platformPrefix}sdk"
-        def standaloneSdkDir = "${TEST_JAVAFX_SDK_PATH}/${standaloneSdkDirName}"
+        def standaloneSdkDir = "${TEST_SDK_PATH}/${standaloneSdkDirName}"
         def modulesLibName = IS_WINDOWS ? "bin" : "lib"
         def modulesLibsDir = "${standaloneSdkDir}/${modulesLibName}"
         lp << cygpath("${modulesLibsDir}")
@@ -1037,9 +1037,9 @@ List<String> computePatchModuleArgs(List<String> deps, boolean test, boolean inc
                 String moduleName = proj.ext.moduleName
                 File dir;
                 if (test && proj.sourceSets.hasProperty('shims')) {
-                    dir = file("${TEST_JAVAFX_SDK_PATH}/shims/${moduleName}")
+                    dir = file("${TEST_SDK_PATH}/shims/${moduleName}")
                 } else {
-                    dir = file("${TEST_JAVAFX_SDK_PATH}/sdk/lib/${moduleName}.jar")
+                    dir = file("${TEST_SDK_PATH}/sdk/lib/${moduleName}.jar")
                 }
                 if (mp == null) {
                     mp = dir.path
@@ -2303,8 +2303,8 @@ project(":base") {
     addValidateSourceSets(project, sourceSets)
 
     test {
-        if (IS_TEST_JAVAFX_SDK) {
-            logger.info "Skipping VersionInfoTest when TEST_JAVAFX_SDK_PATH is set."
+        if (IS_TEST_SDK) {
+            logger.info "Skipping VersionInfoTest when TEST_SDK_PATH is set."
             exclude("test/com/sun/javafx/runtime/VersionInfoTest*");
         }
     }
@@ -2719,7 +2719,7 @@ project(":graphics") {
     processResources.dependsOn processDecoraShaders, processPrismShaders
 
     test {
-        def cssDir = file("${TEST_JAVAFX_SDK_PATH}/shims/${moduleName}/javafx")
+        def cssDir = file("${TEST_SDK_PATH}/shims/${moduleName}/javafx")
         jvmArgs enableNativeGraphics
         jvmArgs "-Djavafx.toolkit=test.com.sun.javafx.pgstub.StubToolkit",
             "-DCSS_META_DATA_TEST_DIR=$cssDir"
@@ -2808,7 +2808,7 @@ project(":controls") {
     }
 
     test {
-        def cssDir = file("${TEST_JAVAFX_SDK_PATH}/shims/${moduleName}/javafx")
+        def cssDir = file("${TEST_SDK_PATH}/shims/${moduleName}/javafx")
         jvmArgs enableNativeGraphics
         jvmArgs "-Djavafx.toolkit=test.com.sun.javafx.pgstub.StubToolkit",
             "-DCSS_META_DATA_TEST_DIR=$cssDir"
@@ -5777,9 +5777,9 @@ compileTargets { t ->
                         modnames << project.ext.moduleName
                         File dir;
                         if (project.sourceSets.hasProperty('shims')) {
-                           dir = new File(TEST_JAVAFX_SDK_PATH, "shims/${project.ext.moduleName}")
+                           dir = new File(TEST_SDK_PATH, "shims/${project.ext.moduleName}")
                         } else {
-                           dir = new File(TEST_JAVAFX_SDK_PATH, "sdk/lib/${project.ext.moduleName}.jar")
+                           dir = new File(TEST_SDK_PATH, "sdk/lib/${project.ext.moduleName}.jar")
                         }
 
                         def dstModuleDir = cygpath(dir.path)
@@ -5790,7 +5790,7 @@ compileTargets { t ->
                         "    permission java.security.AllPermission;\n" +
                         "};\n"
 
-                        dir = new File(TEST_JAVAFX_SDK_PATH, "sdk/lib/${project.ext.moduleName}.jar")
+                        dir = new File(TEST_SDK_PATH, "sdk/lib/${project.ext.moduleName}.jar")
                         themod = dir.toURI()
                         runJavaPolicyFile <<  "grant codeBase \"${themod}\" {\n" +
                         "    permission java.security.AllPermission;\n" +

--- a/build.gradle
+++ b/build.gradle
@@ -2959,6 +2959,10 @@ project(":swt") {
             "--add-exports=javafx.graphics/com.sun.javafx.tk=ALL-UNNAMED",
             ])
 
+    compileTestJava {
+        if (IS_TEST_SDK) enabled = false
+    }
+
     test {
         //enabled = IS_FULL_TEST && IS_SWT_TEST
         enabled = false // FIXME: JIGSAW -- support this with modules


### PR DESCRIPTION
#### Requirement:
We want to be able to test a JavaFX SDK built somewhere else other than on current machine or current repo on same machine. Which means we should be able to run the unit and system tests with a different JavaFX SDK.

#### Change:
##### Run tests using a specified JavaFX SDK:
- Introduce a property `TEST_JAVAFX_SDK_PATH` that points to the JavaFX SDK which was built elsewhere.
- Modify the paths generated by build.gradle to point to the path sepcified by `TEST_JAVAFX_SDK_PATH`
- When a `TEST_JAVAFX_SDK_PATH` is specified `-PTEST_ONLY=true` must also be specified.

##### Generate the JavaFX SDK bundle
- Generate the minimal JavaFX SDK bundle that is required to run the tests: We require content of the _build/sdk_ and _build/shims_ directories to achieve the same.


#### Verification:
##### With a single machine:
1. Create two local copies JavaFX repo, [repo1, repo2]
2. Build sdk and shims in repo1. `gradle sdk shims`
3. In repo2, run different tests as,
> gradle -PTEST_ONLY=true -PTEST_JAVAFX_SDK_PATH=**repo1/build**  :base:test <any tests>
4. In repo1 run `gradle all`
5. `javafx-sdk-shims.zip` file would be created under repo1/build. unzip it any `unzip-path` on machine
6. In repo2, run the tests by providing the `unzip-path` as TEST_JAVAFX_SDK_PATH
> gradle -PTEST_ONLY=true -PTEST_JAVAFX_SDK_PATH=**unzip-path**  :base:test <any tests>

##### With 2 machines.
1. Run `gradle all` on a machine1
2. Move build/javafx-sdk-shims.zip to machine2 and unzip to any `unzip-path`
3. Run the tests by providing the `unzip-path` as TEST_JAVAFX_SDK_PATH
> gradle -PTEST_ONLY=true -PTEST_JAVAFX_SDK_PATH=**unzip-path**  :base:test <any tests>


#### Additional changes:
Additionally we observed that three unit tests failed because they access a specific path. A path that would no exists when JavaFX SDK is not built.
1. Controls test: test.javafx.scene.control.ControlTest.testRT18097
It required path: modules/javafx.controls/build/classes/java/main/javafx.controls/javafx
It is fixed by change on line 2811

2. Graphics test: test.javafx.css.CssMetaDataTest.testRT18097
It required path: modules/javafx.graphics/build/classes/java/main/javafx.graphics/javafx
It is fixed by change on line 2722

3. Base test: test.com.sun.javafx.runtime.VersionInfoTest
It required path: build/module-lib/javafx.properties
VersionInfoTest is specific to the local build of JavaFX. So, It can be safely excluded when TEST_JAVAFX_SDK_PATH is specified.
It is fixed by change on line 2304 to 2310

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8297072](https://bugs.openjdk.org/browse/JDK-8297072): Provide gradle option to test a previously built SDK (**Enhancement** - P3)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Lukasz Kostyra](https://openjdk.org/census#lkostyra) (@lukostyra - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1577/head:pull/1577` \
`$ git checkout pull/1577`

Update a local copy of the PR: \
`$ git checkout pull/1577` \
`$ git pull https://git.openjdk.org/jfx.git pull/1577/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1577`

View PR using the GUI difftool: \
`$ git pr show -t 1577`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1577.diff">https://git.openjdk.org/jfx/pull/1577.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1577#issuecomment-2368704878)