### PR TITLE
8340980: Cannot build on Windows ARM

### DIFF
--- a/buildSrc/genVSproperties.bat
+++ b/buildSrc/genVSproperties.bat
@@ -23,7 +23,7 @@ REM questions.
 
 setlocal ENABLEDELAYEDEXPANSION
 
-REM Windows bat file that runs vcvars64.bat for Visual Studio
+REM Windows bat file that runs vcvarsall.bat for Visual Studio
 REM and echoes out a property file with the values of the environment
 REM variables we want, e.g. PATH, INCLUDE, LIB, and LIBPATH.
 
@@ -68,7 +68,7 @@ if not "%VSCOMNTOOLS%"=="" (
 if "%VSTOOLSDIR%"=="" exit
 if not exist "%VSTOOLSDIR%" exit
 
-call "%VSTOOLSDIR%\vcvars64.bat" > NUL
+call "%VSTOOLSDIR%\vcvarsall.bat" %VCARCH% > NUL
 
 REM Set legacy MSVCDIR variable in case some Makefiles still need it
 if "%MSVCDIR%"=="" set MSVCDIR=%VCINSTALLDIR%


### PR DESCRIPTION
Restored some behavior in genVSproperties that enabled ARM builds and cross-compilation on Windows. Verified that I can build on ARM but have no way of testing other architectures.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340980](https://bugs.openjdk.org/browse/JDK-8340980): Cannot build on Windows ARM (**Bug** - P3)


### Reviewers
 * [Joeri Sykora](https://openjdk.org/census#sykora) (@tiainen - Author)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1580/head:pull/1580` \
`$ git checkout pull/1580`

Update a local copy of the PR: \
`$ git checkout pull/1580` \
`$ git pull https://git.openjdk.org/jfx.git pull/1580/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1580`

View PR using the GUI difftool: \
`$ git pr show -t 1580`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1580.diff">https://git.openjdk.org/jfx/pull/1580.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1580#issuecomment-2375583244)