### PR TITLE
8341010: TriangleMesh.vertexFormat Property default value is wrong

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/scene/shape/TriangleMesh.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/shape/TriangleMesh.java
@@ -212,7 +212,7 @@ public class TriangleMesh extends Mesh {
 
     public final ObjectProperty<VertexFormat> vertexFormatProperty() {
         if (vertexFormat == null) {
-            vertexFormat = new SimpleObjectProperty<>(TriangleMesh.this, "vertexFormat") {
+            vertexFormat = new SimpleObjectProperty<>(TriangleMesh.this, "vertexFormat", VertexFormat.POINT_TEXCOORD) {
 
                 @Override
                 protected void invalidated() {

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/shape/TriangleMeshTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/shape/TriangleMeshTest.java
@@ -26,6 +26,7 @@ package test.javafx.scene.shape;
 
 import java.util.Arrays;
 import javafx.scene.shape.TriangleMesh;
+import javafx.scene.shape.VertexFormat;
 
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -456,6 +457,14 @@ public class TriangleMeshTest {
         assertEquals(2, triMesh.getTexCoordElementSize());
         // 3 point indices and 3 texCoord indices per triangle
         assertEquals(6, triMesh.getFaceElementSize());
+    }
+
+    @Test
+    public void testVertexFormatProperty() {
+        TriangleMesh triMesh = new TriangleMesh();
+        VertexFormat vf1 = triMesh.getVertexFormat();
+        VertexFormat vf2 = triMesh.vertexFormatProperty().get();
+        assertEquals(vf1, vf2);
     }
 
     TriangleMesh buildTriangleMesh(int subDivX, int subDivY) {


### PR DESCRIPTION
Fixing the wrong TriangleMesh.vertexFormat property. TriangleMesh.getVertexFormat() and TriangleMesh.vertexProperty().get() initially returned different values, which are now fixed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341010](https://bugs.openjdk.org/browse/JDK-8341010): TriangleMesh.vertexFormat Property default value is wrong (**Bug** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1581/head:pull/1581` \
`$ git checkout pull/1581`

Update a local copy of the PR: \
`$ git checkout pull/1581` \
`$ git pull https://git.openjdk.org/jfx.git pull/1581/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1581`

View PR using the GUI difftool: \
`$ git pr show -t 1581`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1581.diff">https://git.openjdk.org/jfx/pull/1581.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1581#issuecomment-2376577239)