### PR TITLE
JDK-8340852 ScrollPane should not consume navigation keys when it doesn't have direct focus

### DIFF
--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/ScrollPaneBehavior.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/ScrollPaneBehavior.java
@@ -28,6 +28,9 @@ package com.sun.javafx.scene.control.behavior;
 import javafx.scene.control.ScrollBar;
 import javafx.scene.control.ScrollPane;
 import com.sun.javafx.scene.control.inputmap.InputMap;
+import com.sun.javafx.scene.control.inputmap.KeyBinding;
+
+import javafx.scene.input.KeyEvent;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.control.skin.ScrollPaneSkin;
 
@@ -71,18 +74,18 @@ public class ScrollPaneBehavior extends BehaviorBase<ScrollPane> {
 
         // scrollpane-specific mappings for key and mouse input
         addDefaultMapping(inputMap,
-            new InputMap.KeyMapping(LEFT, e -> rtl(scrollPane, this::horizontalUnitIncrement, this::horizontalUnitDecrement)),
-            new InputMap.KeyMapping(RIGHT, e -> rtl(scrollPane, this::horizontalUnitDecrement, this::horizontalUnitIncrement)),
+            new InputMap.KeyMapping(new KeyBinding(LEFT), e -> rtl(scrollPane, this::horizontalUnitIncrement, this::horizontalUnitDecrement), this::isNotFocused),
+            new InputMap.KeyMapping(new KeyBinding(RIGHT), e -> rtl(scrollPane, this::horizontalUnitDecrement, this::horizontalUnitIncrement), this::isNotFocused),
 
-            new InputMap.KeyMapping(UP, e -> verticalUnitDecrement()),
-            new InputMap.KeyMapping(DOWN, e -> verticalUnitIncrement()),
+            new InputMap.KeyMapping(new KeyBinding(UP), e -> verticalUnitDecrement(), this::isNotFocused),
+            new InputMap.KeyMapping(new KeyBinding(DOWN), e -> verticalUnitIncrement(), this::isNotFocused),
 
-            new InputMap.KeyMapping(PAGE_UP, e -> verticalPageDecrement()),
-            new InputMap.KeyMapping(PAGE_DOWN, e -> verticalPageIncrement()),
-            new InputMap.KeyMapping(SPACE, e -> verticalPageIncrement()),
+            new InputMap.KeyMapping(new KeyBinding(PAGE_UP), e -> verticalPageDecrement(), this::isNotFocused),
+            new InputMap.KeyMapping(new KeyBinding(PAGE_DOWN), e -> verticalPageIncrement(), this::isNotFocused),
+            new InputMap.KeyMapping(new KeyBinding(SPACE), e -> verticalPageIncrement(), this::isNotFocused),
 
-            new InputMap.KeyMapping(HOME, e -> verticalHome()),
-            new InputMap.KeyMapping(END, e -> verticalEnd()),
+            new InputMap.KeyMapping(new KeyBinding(HOME), e -> verticalHome(), this::isNotFocused),
+            new InputMap.KeyMapping(new KeyBinding(END), e -> verticalEnd(), this::isNotFocused),
 
             new InputMap.MouseMapping(MouseEvent.MOUSE_PRESSED, this::mousePressed)
         );
@@ -143,6 +146,9 @@ public class ScrollPaneBehavior extends BehaviorBase<ScrollPane> {
         return Optional.ofNullable(((ScrollPaneSkin)getNode().getSkin()).getHorizontalScrollBar());
     }
 
+    private boolean isNotFocused(KeyEvent keyEvent) {
+        return !getNode().isFocused();
+    }
 
     /***************************************************************************
      *                                                                         *


### PR DESCRIPTION
This change modifies `ScrollPaneBehavior` to only consume keys that are targetted at it.  As `KeyEvent`s are in almost all cases only intended for the targetted node (as visually that's where the user expects the keyboard input to go, as per normal UI rules) consuming key events that bubble up is simply incorrect.  When the `ScrollPane` is focused directly (it has the focused border) then it is fine for it to respond to all kinds of keys.

In FX controls normally there is no need to check if a `Control` is focused (although they probably should **all** do this) as they do not have children that could have received the Key Events involved, and Key Events are always sent to the focused Node.  When `ScrollPane` was developed this was not taken into account, leading to it consuming keys not intended for it.

This fixes several unexpected problems for custom control builders.  A custom control normally benefits from standard navigation out of the box (TAB/shift+TAB) and directional keys.  However, this breaks down as soon as this custom control is positioned within a `ScrollPane`, which is very surprising behavior and not at all expected.  This makes it harder than needed for custom control developers to get the standard navigation for the directional keys, as they would have to specifically capture those keys before they reach the `ScrollPane` and trigger the correct navigation action themselves (for which as of this writing there is no public API).

The same goes for all the other keys captured by `ScrollPane` when it does not have focus, although not as critical as the UP/DOWN/LEFT/RIGHT keys.
