### PR TITLE
8340829: Generated API docs should clearly identify EA builds

### DIFF
--- a/UPDATING-VERSION.md
+++ b/UPDATING-VERSION.md
@@ -18,8 +18,6 @@ feature version number from `N` to `N+1`:
 
 ```
     jfx.release.major.version
-    javadoc.title
-    javadoc.header
 ```
 
 * In

--- a/build.gradle
+++ b/build.gradle
@@ -4434,16 +4434,18 @@ task javadoc(type: Javadoc, dependsOn: createMSPfile) {
     String draftMsg = IS_MILESTONE_FCS ? "" : "<br><b>DRAFT ${RELEASE_VERSION_LONG}</b>"
     String javadocTitleImpl = javadocTitle
             .replaceAll("@JAVADOC_VERSION@", jfxReleaseMajorVersion)
-            .replaceAll("@DRAFT_UNLESS_FCS@", draftMsg)
     String javadocHeaderImpl = javadocHeader
             .replaceAll("@JAVADOC_VERSION@", jfxReleaseMajorVersion)
             .replaceAll("@DRAFT_UNLESS_FCS@", draftMsg)
     String javadocBottomImpl = javadocBottom
-            .replaceAll("@JAVADOC_VERSION@", jfxReleaseMajorVersion)
             .replaceAll("@DRAFT_UNLESS_FCS@", draftMsg)
+            .replaceAll("@FULL_VERSION@", RELEASE_VERSION_LONG)
     options.windowTitle(javadocTitleImpl)
     options.header(javadocHeaderImpl)
     options.bottom(javadocBottomImpl)
+    if (!IS_MILESTONE_FCS) {
+        options.addStringOption("top").setValue(javadocTop)
+    }
 
     options.locale("en");
     if (JDK_DOCS_LINK != "") {

--- a/build.gradle
+++ b/build.gradle
@@ -4431,9 +4431,20 @@ task javadoc(type: Javadoc, dependsOn: createMSPfile) {
     options.addStringOption("Xmaxwarns").setValue("1000")
     options.addStringOption("Xmaxerrs").setValue("1000")
 
-    options.windowTitle("${javadocTitle}")
-    options.header("${javadocHeader}")
-    options.bottom("${javadocBottom}")
+    String draftMsg = IS_MILESTONE_FCS ? "" : "<br><b>DRAFT ${RELEASE_VERSION_LONG}</b>"
+    String javadocTitleImpl = javadocTitle
+            .replaceAll("@JAVADOC_VERSION@", jfxReleaseMajorVersion)
+            .replaceAll("@DRAFT_UNLESS_FCS@", draftMsg)
+    String javadocHeaderImpl = javadocHeader
+            .replaceAll("@JAVADOC_VERSION@", jfxReleaseMajorVersion)
+            .replaceAll("@DRAFT_UNLESS_FCS@", draftMsg)
+    String javadocBottomImpl = javadocBottom
+            .replaceAll("@JAVADOC_VERSION@", jfxReleaseMajorVersion)
+            .replaceAll("@DRAFT_UNLESS_FCS@", draftMsg)
+    options.windowTitle(javadocTitleImpl)
+    options.header(javadocHeaderImpl)
+    options.bottom(javadocBottomImpl)
+
     options.locale("en");
     if (JDK_DOCS_LINK != "") {
         options.linksOffline(JDK_DOCS, JDK_DOCS_LINK);

--- a/build.properties
+++ b/build.properties
@@ -54,10 +54,11 @@ jfx.release.patch.version=0
 #
 ##############################################################################
 
-javadoc.bottom=<small><a href="http://bugreport.java.com/bugreport/">Report a bug or suggest an enhancement</a><br> Copyright &copy; 2008, 2024, Oracle and/or its affiliates. All rights reserved.@DRAFT_UNLESS_FCS@</small>
+javadoc.bottom=<small><a href="http://bugreport.java.com/bugreport/">Report a bug or suggest an enhancement</a><br> Copyright &copy; 2008, 2024, Oracle and/or its affiliates. All rights reserved.@DRAFT_UNLESS_FCS@<!-- Version @FULL_VERSION@ --></small>
 
 javadoc.title=JavaFX @JAVADOC_VERSION@
-javadoc.header=JavaFX&nbsp;@JAVADOC_VERSION@@DRAFT_UNLESS_FCS@
+javadoc.header=<div><strong>JavaFX @JAVADOC_VERSION@@DRAFT_UNLESS_FCS@</strong></div>
+javadoc.top=<div style="padding: 6px; text-align: center; font-size: 80%;">This specification is not final and is subject to change. Use is subject to license terms.</div>
 
 ##############################################################################
 #

--- a/build.properties
+++ b/build.properties
@@ -54,10 +54,10 @@ jfx.release.patch.version=0
 #
 ##############################################################################
 
-javadoc.bottom=<small><a href="http://bugreport.java.com/bugreport/">Report a bug or suggest an enhancement</a><br> Copyright &copy; 2008, 2024, Oracle and/or its affiliates. All rights reserved.</small>
+javadoc.bottom=<small><a href="http://bugreport.java.com/bugreport/">Report a bug or suggest an enhancement</a><br> Copyright &copy; 2008, 2024, Oracle and/or its affiliates. All rights reserved.@DRAFT_UNLESS_FCS@</small>
 
-javadoc.title=JavaFX 24
-javadoc.header=JavaFX&nbsp;24
+javadoc.title=JavaFX @JAVADOC_VERSION@
+javadoc.header=JavaFX&nbsp;@JAVADOC_VERSION@@DRAFT_UNLESS_FCS@
 
 ##############################################################################
 #


### PR DESCRIPTION
This PR modifies the header and footer of the javadoc-generated API docs to add "DRAFT $VER-ea+$BLD" to clearly identify an ea build of the docs, and also to make it clear which build number the docs refer to. This matches was the JDK does. For GA builds, there will be no change to what we generate today. Since I had to add logic to filter the javadoc properties defined in `build.javadoc` to add the DRAFT message if not a GA build, I also changed the properties to not hard-code the major version of JavaFX, thus reducing the duplication.

I ran three builds to test this, an ordinary developer build, an EA build, and a GA build as follows:

#### Developer build

Command line:
```
gradle javadoc
```

Generated docs: https://cr.openjdk.org/~kcr/8340829/javadoc-internal/

#### EA build

Command line:
```
gradle -PPROMOTED_BUILD_NUMBER=98 -PHUDSON_BUILD_NUMBER=1234 -PHUDSON_JOB_NAME=jfx-dev javadoc
```

Generated docs: https://cr.openjdk.org/~kcr/8340829/javadoc-ea/

#### GA build

Command line:
```
gradle -PMILESTONE_FCS=true -PPROMOTED_BUILD_NUMBER=99 -PHUDSON_BUILD_NUMBER=4321 -PHUDSON_JOB_NAME=jfx-dev javadoc
```

Generated docs: https://cr.openjdk.org/~kcr/8340829/javadoc-fcs/

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340829](https://bugs.openjdk.org/browse/JDK-8340829): Generated API docs should clearly identify EA builds (**Bug** - P3)


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - no project role)
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1583/head:pull/1583` \
`$ git checkout pull/1583`

Update a local copy of the PR: \
`$ git checkout pull/1583` \
`$ git pull https://git.openjdk.org/jfx.git pull/1583/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1583`

View PR using the GUI difftool: \
`$ git pr show -t 1583`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1583.diff">https://git.openjdk.org/jfx/pull/1583.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1583#issuecomment-2377984471)