### PR TITLE
8340982: [win] Dead key followed by Space generates two characters instead of one

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/win/ViewContainer.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/win/ViewContainer.cpp
@@ -669,9 +669,14 @@ void ViewContainer::HandleViewTypedEvent(HWND hwnd, UINT msg, WPARAM wParam, LPA
             wChar = (jchar)out[0];
 
             if (res == 3) {
-                // The character cannot be accented, so we send a TYPED event
-                // for the dead key itself first.
-                SendViewTypedEvent(1, (jchar)m_deadKeyWParam);
+                // The character cannot be accented. If it's a Space
+                // we send out the dead key only. Otherwise we send
+                // out the dead key followed by the character.
+                if (wChar == 0x20) {
+                    wChar = m_deadKeyWParam;
+                } else {
+                    SendViewTypedEvent(1, (jchar)m_deadKeyWParam);
+                }
             }
         } else {
             // Folding failed. Use the untranslated original character then


### PR DESCRIPTION
The standard across all platforms is:

- A dead key followed by a composable character generates the composed character. For example, a circumflex dead key followed by an 'e' should generate 'ê'.
- A dead key followed by a character that can't compose with it generates a spacing character followed by the non-composable character. On Windows US International a circumflex dead key followed by a 'q' generates '^q'. The spacing character corresponding to the dead key varies based on the OS and layout.
- An exception is SPACE. On all platforms a dead key followed by SPACE should generate just the spacing version of the dead key but *not* a space character. Users rely on this shortcut to quickly access the character 'hidden' by the dead key.

The Windows glass code didn't implement the Space exception. This PR fixes that.

On Windows the US  US International layout. Shift+6 is the dead key for a circumflex diacritic if you want to test out the combinations mentioned above.

For some reason Windows 11 hides this setting well. To install a US International layout:
- Go to Settings > Time & Language > Language & Region.
- In the entry for English click on the three dots to the far right and select 'Language Options'. 
- Scroll down until you see 'Installed keyboards' and select 'Add a keyboard'.
- From the list select "United States - International".
To actually use the layout look to the right of the Task Bar and you should see a button for choosing the layout (it will contain the word "ENG").

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8340982](https://bugs.openjdk.org/browse/JDK-8340982): [win] Dead key followed by Space generates two characters instead of one (**Bug** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [John Hendrikx](https://openjdk.org/census#jhendrikx) (@hjohn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1584/head:pull/1584` \
`$ git checkout pull/1584`

Update a local copy of the PR: \
`$ git checkout pull/1584` \
`$ git pull https://git.openjdk.org/jfx.git pull/1584/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1584`

View PR using the GUI difftool: \
`$ git pr show -t 1584`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1584.diff">https://git.openjdk.org/jfx/pull/1584.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1584#issuecomment-2379428095)