### PR TITLE
8183521: Unable to type characters with tilde with swiss german keyboard layout

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/win/ViewContainer.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/win/ViewContainer.cpp
@@ -547,8 +547,8 @@ void ViewContainer::HandleViewDeadKeyEvent(HWND hwnd, UINT msg, WPARAM wParam, L
     }
 
     // Since we handle dead keys ourselves, reset the keyboard dead key status (if any)
-    static BYTE kbState[256];
-    ::GetKeyboardState(kbState);
+    static BYTE kbState[256] = {};
+    kbState[VK_SPACE] = 0x80;
     WORD ignored;
     ::ToAsciiEx(VK_SPACE, ::MapVirtualKey(VK_SPACE, 0),
             kbState, &ignored, 0, m_kbLayout);

--- a/modules/javafx.graphics/src/main/native-glass/win/ViewContainer.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/win/ViewContainer.cpp
@@ -547,7 +547,7 @@ void ViewContainer::HandleViewDeadKeyEvent(HWND hwnd, UINT msg, WPARAM wParam, L
     }
 
     // Since we handle dead keys ourselves, reset the keyboard dead key status (if any)
-    static BYTE kbState[256] = {};
+    BYTE kbState[256] = {};
     kbState[VK_SPACE] = 0x80;
     WORD ignored;
     ::ToAsciiEx(VK_SPACE, ::MapVirtualKey(VK_SPACE, 0),


### PR DESCRIPTION
The glass code on Windows does its own dead key processing so at certain points it must clear the dead key state that the OS is maintaining. It does this by simulating a SPACE key press but this only works reliably if the SPACE key is pressed without any modifiers.

Currently the code is picking up the current modifier state of the keyboard. If the dead key is invoked using AltGr the code is trying to clear the dead key state using AltGr+Space. This does nothing. The fix is to ignore the current keyboard state and pretend the only key being held down is Space.

I haven't figured out a way of providing automated tests for dead keys. There's no way to detect whether the correct keyboard layout is active or to force the correct layout to be active.

To test this you'll need to install the correct layout. On Windows 11 go to Settings > Time & language > Language & region. Click on the three dots to the far right of the English entry (or whatever language you're using) and select “Language options”. Scroll down until you find “Add a keyboard”. From that button scroll through all the many, many layouts until you find “Swiss German”. Once you’ve added the keyboard you should see a button on the far right of the task bar to select the layout. The dead key for this bug is where the =/+ key is on the standard US keyboard, top row to the left of Backspace.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8183521](https://bugs.openjdk.org/browse/JDK-8183521): Unable to type characters with tilde with swiss german keyboard layout (**Bug** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1585/head:pull/1585` \
`$ git checkout pull/1585`

Update a local copy of the PR: \
`$ git checkout pull/1585` \
`$ git pull https://git.openjdk.org/jfx.git pull/1585/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1585`

View PR using the GUI difftool: \
`$ git pr show -t 1585`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1585.diff">https://git.openjdk.org/jfx/pull/1585.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1585#issuecomment-2383675911)