### PR TITLE
8341372: BackgroundPosition, BorderImage, BorderStroke, CornerRadii should be final

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/Background.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/Background.java
@@ -144,7 +144,7 @@ public final class Background implements Interpolatable<Background> {
      * @interpolationType <a href="../../animation/Interpolatable.html#pairwise">pairwise</a>
      */
     public final List<BackgroundFill> getFills() { return fills; }
-    final List<BackgroundFill> fills;
+    private final List<BackgroundFill> fills;
 
     /**
      * The list of BackgroundImages which together define the image portion
@@ -155,7 +155,7 @@ public final class Background implements Interpolatable<Background> {
      * @interpolationType <a href="../../animation/Interpolatable.html#pairwise">pairwise</a>
      */
     public final List<BackgroundImage> getImages() { return images; }
-    final List<BackgroundImage> images;
+    private final List<BackgroundImage> images;
 
     /**
      * The outsets of this Background. This represents the largest
@@ -169,7 +169,7 @@ public final class Background implements Interpolatable<Background> {
      * @interpolationType the intermediate value is derived from {@link #getFills() fills}
      */
     public final Insets getOutsets() { return outsets; }
-    final Insets outsets;
+    private final Insets outsets;
 
     /**
      * Gets whether the background is empty. It is empty if there are no fills or images.
@@ -185,18 +185,17 @@ public final class Background implements Interpolatable<Background> {
     private final boolean hasOpaqueFill;
 
     /**
-     * Package-private immutable fields referring to the opaque insets
-     * of this Background.
+     * The opaque insets of this Background.
      */
     private final double opaqueFillTop, opaqueFillRight, opaqueFillBottom, opaqueFillLeft;
-    final boolean hasPercentageBasedOpaqueFills;
+    private final boolean hasPercentageBasedOpaqueFills;
 
     /**
      * True if there are any fills that are in some way based on the size of the region.
      * For example, if a CornerRadii on the fill is percentage based in either or both
      * dimensions.
      */
-    final boolean hasPercentageBasedFills;
+    private final boolean hasPercentageBasedFills;
 
     /**
      * The cached hash code computation for the Background. One very big
@@ -314,7 +313,7 @@ public final class Background implements Interpolatable<Background> {
             // The common case is to NOT have percent based radii
             final boolean b = fill.getRadii().hasPercentBasedRadii;
             hasPercentFillRadii |= b;
-            if (fill.fill.isOpaque()) {
+            if (fill.getFill().isOpaque()) {
                 opaqueFill = true;
                 if (b) {
                     hasPercentOpaqueInsets = true;
@@ -452,7 +451,7 @@ public final class Background implements Interpolatable<Background> {
                     final double fillBottom = fillInsets.getBottom();
                     final double fillLeft = fillInsets.getLeft();
 
-                    if (fill.fill.isOpaque()) {
+                    if (fill.getFill().isOpaque()) {
                         // Some possible configurations:
                         //     (a) rect1 is completely contained by rect2
                         //     (b) rect2 is completely contained by rect1
@@ -532,7 +531,7 @@ public final class Background implements Interpolatable<Background> {
             if (bi.opaque == null) {
                 // If the image is not yet loaded, just skip it
                 // Note: Unit test wants this to be com.sun.javafx.tk.PlatformImage, not com.sun.prism.Image
-                final com.sun.javafx.tk.PlatformImage platformImage = acc.getImageProperty(bi.image).get();
+                final com.sun.javafx.tk.PlatformImage platformImage = acc.getImageProperty(bi.getImage()).get();
                 if (platformImage == null) continue;
 
                 // The image has been loaded, so update the opaque flag
@@ -547,9 +546,9 @@ public final class Background implements Interpolatable<Background> {
             // and we know whether it is opaque or not. Of course, we only care about processing
             // opaque images.
             if (bi.opaque) {
-                if (bi.size.cover ||
-                        (bi.size.height == BackgroundSize.AUTO && bi.size.width == BackgroundSize.AUTO &&
-                        bi.size.widthAsPercentage && bi.size.heightAsPercentage)) {
+                if (bi.size.isCover() ||
+                        (bi.size.getHeight() == BackgroundSize.AUTO && bi.size.getWidth() == BackgroundSize.AUTO &&
+                        bi.size.isWidthAsPercentage() && bi.size.isHeightAsPercentage())) {
                     // If the size mode is "cover" or AUTO, AUTO, and percentage based, then we're done -- we can simply
                     // accumulate insets of "0"
                     opaqueRegionTop = Double.isNaN(opaqueRegionTop) ? 0 : Math.min(0, opaqueRegionTop);
@@ -585,16 +584,16 @@ public final class Background implements Interpolatable<Background> {
 
                     // We know that one or the other dimension is not filled, so we have to compute the right
                     // width / height. This is basically a big copy/paste from NGRegion! Blah!
-                    final double w = bi.size.widthAsPercentage ? bi.size.width * width : bi.size.width;
-                    final double h = bi.size.heightAsPercentage ? bi.size.height * height : bi.size.height;
-                    final double imgUnscaledWidth = bi.image.getWidth();
-                    final double imgUnscaledHeight = bi.image.getHeight();
+                    final double w = bi.size.isWidthAsPercentage() ? bi.size.getWidth() * width : bi.size.getWidth();
+                    final double h = bi.size.isHeightAsPercentage() ? bi.size.getHeight() * height : bi.size.getHeight();
+                    final double imgUnscaledWidth = bi.getImage().getWidth();
+                    final double imgUnscaledHeight = bi.getImage().getHeight();
 
                     // Now figure out the width and height of each tile to be drawn. The actual image
                     // dimensions may be one thing, but we need to figure out what the size of the image
                     // in the destination is going to be.
                     final double tileWidth, tileHeight;
-                    if (bi.size.contain) {
+                    if (bi.size.isContain()) {
                         // In the case of "contain", we compute the destination size based on the largest
                         // possible scale such that the aspect ratio is maintained, yet one side of the
                         // region is completely filled.
@@ -603,7 +602,7 @@ public final class Background implements Interpolatable<Background> {
                         final double scale = Math.min(scaleX, scaleY);
                         tileWidth = Math.ceil(scale * imgUnscaledWidth);
                         tileHeight = Math.ceil(scale * imgUnscaledHeight);
-                    } else if (bi.size.width >= 0 && bi.size.height >= 0) {
+                    } else if (bi.size.getWidth() >= 0 && bi.size.getHeight() >= 0) {
                         // The width and height have been expressly defined. Note that AUTO is -1,
                         // and all other negative values are disallowed, so by checking >= 0, we
                         // are essentially saying "if neither is AUTO"

--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/BackgroundFill.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/BackgroundFill.java
@@ -53,7 +53,7 @@ public final class BackgroundFill implements Interpolatable<BackgroundFill> {
      * @interpolationType see {@link Paint}
      */
     public final Paint getFill() { return fill; }
-    final Paint fill;
+    private final Paint fill;
 
     /**
      * The Radii to use for representing the four radii of the
@@ -65,7 +65,7 @@ public final class BackgroundFill implements Interpolatable<BackgroundFill> {
      * @interpolationType <a href="../../animation/Interpolatable.html#default">default</a>
      */
     public final CornerRadii getRadii() { return radii; }
-    final CornerRadii radii;
+    private final CornerRadii radii;
 
     /**
      * The Insets to use for this fill. Each inset indicates at what
@@ -78,7 +78,7 @@ public final class BackgroundFill implements Interpolatable<BackgroundFill> {
      * @interpolationType <a href="../../animation/Interpolatable.html#default">default</a>
      */
     public final Insets getInsets() { return insets; }
-    final Insets insets;
+    private final Insets insets;
 
     /**
      * A cached hash for improved performance on subsequent hash or

--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/BackgroundImage.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/BackgroundImage.java
@@ -59,7 +59,7 @@ public final class BackgroundImage implements Interpolatable<BackgroundImage> {
      * @interpolationType <a href="../../animation/Interpolatable.html#discrete">discrete</a>
      */
     public final Image getImage() { return image; }
-    final Image image;
+    private final Image image;
 
     /**
      * Indicates in what manner (if at all) the background image

--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/BackgroundPosition.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/BackgroundPosition.java
@@ -76,7 +76,7 @@ public final class BackgroundPosition implements Interpolatable<BackgroundPositi
      * @interpolationType <a href="../../animation/Interpolatable.html#discrete">discrete</a>
      */
     public final Side getHorizontalSide() { return horizontalSide; }
-    final Side horizontalSide;
+    private final Side horizontalSide;
 
     /**
      * The side along the vertical axis to which the BackgroundImage is
@@ -85,7 +85,7 @@ public final class BackgroundPosition implements Interpolatable<BackgroundPositi
      * @interpolationType <a href="../../animation/Interpolatable.html#discrete">discrete</a>
      */
     public final Side getVerticalSide() { return verticalSide; }
-    final Side verticalSide;
+    private final Side verticalSide;
 
     /**
      * The value indicating the position of the BackgroundImage relative
@@ -102,7 +102,7 @@ public final class BackgroundPosition implements Interpolatable<BackgroundPositi
      *                    otherwise <a href="../../animation/Interpolatable.html#linear">linear</a>
      */
     public final double getHorizontalPosition() { return horizontalPosition; }
-    final double horizontalPosition;
+    private final double horizontalPosition;
 
     /**
      * The value indicating the position of the BackgroundImage relative
@@ -118,7 +118,7 @@ public final class BackgroundPosition implements Interpolatable<BackgroundPositi
      *                    otherwise <a href="../../animation/Interpolatable.html#linear">linear</a>
      */
     public final double getVerticalPosition() { return verticalPosition; }
-    final double verticalPosition;
+    private final double verticalPosition;
 
     /**
      * Specifies whether the {@link #getHorizontalPosition() horizontalPosition} should
@@ -128,7 +128,7 @@ public final class BackgroundPosition implements Interpolatable<BackgroundPositi
      * @interpolationType <a href="../../animation/Interpolatable.html#discrete">discrete</a>
      */
     public final boolean isHorizontalAsPercentage() { return horizontalAsPercentage; }
-    final boolean horizontalAsPercentage;
+    private final boolean horizontalAsPercentage;
 
     /**
      * Specifies whether the {@link #getVerticalPosition() verticalPosition} should
@@ -138,7 +138,7 @@ public final class BackgroundPosition implements Interpolatable<BackgroundPositi
      * @interpolationType <a href="../../animation/Interpolatable.html#discrete">discrete</a>
      */
     public final boolean isVerticalAsPercentage() { return verticalAsPercentage; }
-    final boolean verticalAsPercentage;
+    private final boolean verticalAsPercentage;
 
     /**
      * A cached has code value.

--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/BackgroundPosition.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/BackgroundPosition.java
@@ -52,7 +52,7 @@ import java.util.Objects;
  * the Region's right edge.
  * @since JavaFX 8.0
  */
-public class BackgroundPosition implements Interpolatable<BackgroundPosition> {
+public final class BackgroundPosition implements Interpolatable<BackgroundPosition> {
     /**
      * The default BackgroundPosition for any BackgroundImage. The default
      * is to have no insets and to be defined as 0% and 0%. That is, the

--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/BackgroundSize.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/BackgroundSize.java
@@ -95,7 +95,7 @@ public final class BackgroundSize implements Interpolatable<BackgroundSize> {
      *                    <a href="../../animation/Interpolatable.html#linear">linear</a>
      */
     public final double getWidth() { return width; }
-    final double width;
+    private final double width;
 
     /**
      * The height of the area within the Region where the associated BackgroundImage should
@@ -112,7 +112,7 @@ public final class BackgroundSize implements Interpolatable<BackgroundSize> {
      *                    <a href="../../animation/Interpolatable.html#linear">linear</a>
      */
     public final double getHeight() { return height; }
-    final double height;
+    private final double height;
 
     /**
      * Specifies whether the value contained in {@code width} should be interpreted
@@ -122,7 +122,7 @@ public final class BackgroundSize implements Interpolatable<BackgroundSize> {
      * @interpolationType <a href="../../animation/Interpolatable.html#discrete">discrete</a>
      */
     public final boolean isWidthAsPercentage() { return widthAsPercentage; }
-    final boolean widthAsPercentage;
+    private final boolean widthAsPercentage;
 
     /**
      * Specifies whether the value contained in {@code height} should be interpreted
@@ -132,7 +132,7 @@ public final class BackgroundSize implements Interpolatable<BackgroundSize> {
      * @interpolationType <a href="../../animation/Interpolatable.html#discrete">discrete</a>
      */
     public final boolean isHeightAsPercentage() { return heightAsPercentage; }
-    final boolean heightAsPercentage;
+    private final boolean heightAsPercentage;
 
     /**
      * If true, scale the image, while preserving its intrinsic aspect ratio (if any), to the
@@ -143,7 +143,7 @@ public final class BackgroundSize implements Interpolatable<BackgroundSize> {
      * @interpolationType <a href="../../animation/Interpolatable.html#discrete">discrete</a>
      */
     public final boolean isContain() { return contain; }
-    final boolean contain;
+    private final boolean contain;
 
     /**
      * If true, scale the image, while preserving its intrinsic aspect ratio (if any), to the
@@ -154,7 +154,7 @@ public final class BackgroundSize implements Interpolatable<BackgroundSize> {
      * @interpolationType <a href="../../animation/Interpolatable.html#discrete">discrete</a>
      */
     public final boolean isCover() { return cover; }
-    final boolean cover;
+    private final boolean cover;
 
     /**
      * A cached hash code value

--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/Border.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/Border.java
@@ -172,7 +172,7 @@ public final class Border implements Interpolatable<Border> {
      * @interpolationType <a href="../../animation/Interpolatable.html#pairwise">pairwise</a>
      */
     public final List<BorderStroke> getStrokes() { return strokes; }
-    final List<BorderStroke> strokes;
+    private final List<BorderStroke> strokes;
 
     /**
      * The list of BorderImages which together define the images to use
@@ -189,7 +189,7 @@ public final class Border implements Interpolatable<Border> {
      * @interpolationType <a href="../../animation/Interpolatable.html#pairwise">pairwise</a>
      */
     public final List<BorderImage> getImages() { return images; }
-    final List<BorderImage> images;
+    private final List<BorderImage> images;
 
     /**
      * The outsets of the border define the outer-most edge of the border to be drawn.
@@ -198,7 +198,7 @@ public final class Border implements Interpolatable<Border> {
      * border to be drawn
      */
     public final Insets getOutsets() { return outsets; }
-    final Insets outsets;
+    private final Insets outsets;
 
     /**
      * The insets define the distance from the edge of the Region to the inner-most edge
@@ -208,7 +208,7 @@ public final class Border implements Interpolatable<Border> {
      * inner-most edge of the border
      */
     public final Insets getInsets() { return insets; }
-    final Insets insets;
+    private final Insets insets;
 
     /**
      * Gets whether the Border is empty. It is empty if there are no strokes or images.

--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/BorderImage.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/BorderImage.java
@@ -61,7 +61,7 @@ public final class BorderImage implements Interpolatable<BorderImage> {
      * @interpolationType <a href="../../animation/Interpolatable.html#discrete">discrete</a>
      */
     public final Image getImage() { return image; }
-    final Image image;
+    private final Image image;
 
     /**
      * Indicates in what manner (if at all) the border image
@@ -73,7 +73,7 @@ public final class BorderImage implements Interpolatable<BorderImage> {
      * @interpolationType <a href="../../animation/Interpolatable.html#discrete">discrete</a>
      */
     public final BorderRepeat getRepeatX() { return repeatX; }
-    final BorderRepeat repeatX;
+    private final BorderRepeat repeatX;
 
     /**
      * Indicates in what manner (if at all) the border image
@@ -85,7 +85,7 @@ public final class BorderImage implements Interpolatable<BorderImage> {
      * @interpolationType <a href="../../animation/Interpolatable.html#discrete">discrete</a>
      */
     public final BorderRepeat getRepeatY() { return repeatY; }
-    final BorderRepeat repeatY;
+    private final BorderRepeat repeatY;
 
     /**
      * The widths of the border on each side. These can be defined
@@ -97,7 +97,7 @@ public final class BorderImage implements Interpolatable<BorderImage> {
      * @interpolationType <a href="../../animation/Interpolatable.html#default">default</a>
      */
     public final BorderWidths getWidths() { return widths; }
-    final BorderWidths widths;
+    private final BorderWidths widths;
 
     /**
      * Defines the slices of the image. JavaFX uses a 4-slice scheme where
@@ -119,7 +119,7 @@ public final class BorderImage implements Interpolatable<BorderImage> {
      * @see <a href="http://www.w3.org/TR/css3-background/#the-border-image-slice">border-image-slice</a>
      */
     public final BorderWidths getSlices() { return slices; }
-    final BorderWidths slices;
+    private final BorderWidths slices;
 
     /**
      * Specifies whether or not the center patch (as defined by the left, right, top, and bottom slices)
@@ -129,7 +129,7 @@ public final class BorderImage implements Interpolatable<BorderImage> {
      * @interpolationType <a href="../../animation/Interpolatable.html#discrete">discrete</a>
      */
     public final boolean isFilled() { return filled; }
-    final boolean filled;
+    private final boolean filled;
 
     /**
      * The insets of the BorderImage define where the border should be positioned
@@ -139,7 +139,7 @@ public final class BorderImage implements Interpolatable<BorderImage> {
      * @interpolationType <a href="../../animation/Interpolatable.html#default">default</a>
      */
     public final Insets getInsets() { return insets; }
-    final Insets insets;
+    private final Insets insets;
 
     // These two are used by Border to compute the insets and outsets of the border
     final Insets innerEdge;

--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/BorderImage.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/BorderImage.java
@@ -50,7 +50,7 @@ import java.util.Objects;
  * When applied to a Region with a defined shape, a BorderImage is ignored.
  * @since JavaFX 8.0
  */
-public class BorderImage implements Interpolatable<BorderImage> {
+public final class BorderImage implements Interpolatable<BorderImage> {
     /**
      * The image to be used. This will never be null. If this
      * image fails to load, then the entire BorderImage will

--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/BorderStroke.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/BorderStroke.java
@@ -48,7 +48,7 @@ import java.util.Objects;
  *
  * @since JavaFX 8.0
  */
-public class BorderStroke implements Interpolatable<BorderStroke> {
+public final class BorderStroke implements Interpolatable<BorderStroke> {
     /**
      * The default insets when "thin" is specified.
      */

--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/BorderStroke.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/BorderStroke.java
@@ -78,7 +78,7 @@ public final class BorderStroke implements Interpolatable<BorderStroke> {
      * @interpolationType see {@link Paint}
      */
     public final Paint getTopStroke() { return topStroke; }
-    final Paint topStroke;
+    private final Paint topStroke;
     // TODO: The spec says the default color is "currentColor", which appears to mean
     // by default the color is "inherit". So we should file a JIRA on this so that
     // we use inherit. But first I'd like a performance analysis.
@@ -92,7 +92,7 @@ public final class BorderStroke implements Interpolatable<BorderStroke> {
      * @interpolationType see {@link Paint}
      */
     public final Paint getRightStroke() { return rightStroke; }
-    final Paint rightStroke;
+    private final Paint rightStroke;
 
     /**
      * Defines the fill of bottom side of this border. If {@code null}, then the
@@ -103,7 +103,7 @@ public final class BorderStroke implements Interpolatable<BorderStroke> {
      * @interpolationType see {@link Paint}
      */
     public final Paint getBottomStroke() { return bottomStroke; }
-    final Paint bottomStroke;
+    private final Paint bottomStroke;
 
     /**
      * Defines the fill of left side of this border. If {@code null}, then the
@@ -114,7 +114,7 @@ public final class BorderStroke implements Interpolatable<BorderStroke> {
      * @interpolationType see {@link Paint}
      */
     public final Paint getLeftStroke() { return leftStroke; }
-    final Paint leftStroke;
+    private final Paint leftStroke;
 
     /**
      * Defines the style of top side of this border.
@@ -124,7 +124,7 @@ public final class BorderStroke implements Interpolatable<BorderStroke> {
      * @interpolationType <a href="../../animation/Interpolatable.html#discrete">discrete</a>
      */
     public final BorderStrokeStyle getTopStyle() { return topStyle; }
-    final BorderStrokeStyle topStyle;
+    private final BorderStrokeStyle topStyle;
 
     /**
      * Defines the style of right side of this border. If {@code null}, then
@@ -135,7 +135,7 @@ public final class BorderStroke implements Interpolatable<BorderStroke> {
      * @interpolationType <a href="../../animation/Interpolatable.html#discrete">discrete</a>
      */
     public final BorderStrokeStyle getRightStyle() { return rightStyle; }
-    final BorderStrokeStyle rightStyle;
+    private final BorderStrokeStyle rightStyle;
 
     /**
      * Defines the style of bottom side of this border. If {@code null}, then
@@ -147,7 +147,7 @@ public final class BorderStroke implements Interpolatable<BorderStroke> {
      * @interpolationType <a href="../../animation/Interpolatable.html#discrete">discrete</a>
      */
     public final BorderStrokeStyle getBottomStyle() { return bottomStyle; }
-    final BorderStrokeStyle bottomStyle;
+    private final BorderStrokeStyle bottomStyle;
 
     /**
      * Defines the style of left side of this border. If {@code null}, then
@@ -159,7 +159,7 @@ public final class BorderStroke implements Interpolatable<BorderStroke> {
      * @interpolationType <a href="../../animation/Interpolatable.html#discrete">discrete</a>
      */
     public final BorderStrokeStyle getLeftStyle() { return leftStyle; }
-    final BorderStrokeStyle leftStyle;
+    private final BorderStrokeStyle leftStyle;
 
     /**
      * Defines the thickness of each side of the {@code BorderStroke}. This will never
@@ -169,7 +169,7 @@ public final class BorderStroke implements Interpolatable<BorderStroke> {
      * @interpolationType <a href="../../animation/Interpolatable.html#default">default</a>
      */
     public final BorderWidths getWidths() { return widths; }
-    final BorderWidths widths;
+    private final BorderWidths widths;
 
     /**
      * Defines the insets of each side of the {@code BorderStroke}. This will never
@@ -179,7 +179,7 @@ public final class BorderStroke implements Interpolatable<BorderStroke> {
      * @interpolationType <a href="../../animation/Interpolatable.html#default">default</a>
      */
     public final Insets getInsets() { return insets; }
-    final Insets insets;
+    private final Insets insets;
 
     // These two are used by Border to compute the insets and outsets of the border
     final Insets innerEdge;
@@ -233,9 +233,9 @@ public final class BorderStroke implements Interpolatable<BorderStroke> {
         // widths, you get 0 instead of whatever was specified. See 4.3 of the CSS Spec.
 
         // Strokes can only differ in width
-        strokeUniform = this.widths.left == this.widths.top &&
-                        this.widths.left == this.widths.right &&
-                        this.widths.left == this.widths.bottom;
+        strokeUniform = this.widths.getLeft() == this.widths.getTop() &&
+                        this.widths.getLeft() == this.widths.getRight() &&
+                        this.widths.getLeft() == this.widths.getBottom();
 
         // Since insets are empty, don't have to worry about it
         innerEdge = new Insets(
@@ -307,9 +307,9 @@ public final class BorderStroke implements Interpolatable<BorderStroke> {
                 this.leftStroke.equals(this.rightStroke) &&
                 this.leftStroke.equals(this.bottomStroke);
         final boolean widthsSame =
-                this.widths.left == this.widths.top &&
-                this.widths.left == this.widths.right &&
-                this.widths.left == this.widths.bottom;
+                this.widths.getLeft() == this.widths.getTop() &&
+                this.widths.getLeft() == this.widths.getRight() &&
+                this.widths.getLeft() == this.widths.getBottom();
         final boolean stylesSame =
                 this.leftStyle.equals(this.topStyle) &&
                 this.leftStyle.equals(this.rightStyle) &&

--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/BorderWidths.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/BorderWidths.java
@@ -82,7 +82,7 @@ public final class BorderWidths implements Interpolatable<BorderWidths> {
      *                    <a href="../../animation/Interpolatable.html#discrete">discrete</a> otherwise
      */
     public final double getTop() { return top; }
-    final double top;
+    private final double top;
 
     /**
      * The non-negative value (with the exception of {@link #AUTO}) indicating the border
@@ -97,7 +97,7 @@ public final class BorderWidths implements Interpolatable<BorderWidths> {
      *                    <a href="../../animation/Interpolatable.html#discrete">discrete</a> otherwise
      */
     public final double getRight() { return right; }
-    final double right;
+    private final double right;
 
     /**
      * The non-negative value (with the exception of {@link #AUTO}) indicating the border
@@ -112,7 +112,7 @@ public final class BorderWidths implements Interpolatable<BorderWidths> {
      *                    <a href="../../animation/Interpolatable.html#discrete">discrete</a> otherwise
      */
     public final double getBottom() { return bottom; }
-    final double bottom;
+    private final double bottom;
 
     /**
      * The non-negative value (with the exception of {@link #AUTO}) indicating the border
@@ -127,7 +127,7 @@ public final class BorderWidths implements Interpolatable<BorderWidths> {
      *                    <a href="../../animation/Interpolatable.html#discrete">discrete</a> otherwise
      */
     public final double getLeft() { return left; }
-    final double left;
+    private final double left;
 
     /**
      * Specifies whether the {@link #getTop() top} property should be interpreted as a percentage ({@code true})
@@ -137,7 +137,7 @@ public final class BorderWidths implements Interpolatable<BorderWidths> {
      * @interpolationType <a href="../../animation/Interpolatable.html#discrete">discrete</a>
      */
     public final boolean isTopAsPercentage() { return topAsPercentage; }
-    final boolean topAsPercentage;
+    private final boolean topAsPercentage;
 
     /**
      * Specifies whether the {@link #getRight() right} property should be interpreted as a percentage ({@code true})
@@ -147,7 +147,7 @@ public final class BorderWidths implements Interpolatable<BorderWidths> {
      * @interpolationType <a href="../../animation/Interpolatable.html#discrete">discrete</a>
      */
     public final boolean isRightAsPercentage() { return rightAsPercentage; }
-    final boolean rightAsPercentage;
+    private final boolean rightAsPercentage;
 
     /**
      * Specifies whether the {@link #getBottom() bottom} property should be interpreted as a percentage ({@code true})
@@ -157,7 +157,7 @@ public final class BorderWidths implements Interpolatable<BorderWidths> {
      * @interpolationType <a href="../../animation/Interpolatable.html#discrete">discrete</a>
      */
     public final boolean isBottomAsPercentage() { return bottomAsPercentage; }
-    final boolean bottomAsPercentage;
+    private final boolean bottomAsPercentage;
 
     /**
      * Specifies whether the {@link #getLeft() left} property should be interpreted as a percentage ({@code true})
@@ -167,7 +167,7 @@ public final class BorderWidths implements Interpolatable<BorderWidths> {
      * @interpolationType <a href="../../animation/Interpolatable.html#discrete">discrete</a>
      */
     public final boolean isLeftAsPercentage() { return leftAsPercentage; }
-    final boolean leftAsPercentage;
+    private final boolean leftAsPercentage;
 
     /**
      * A cached hash code for faster secondary usage. It is expected

--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/CornerRadii.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/CornerRadii.java
@@ -217,7 +217,7 @@ public final class CornerRadii implements Interpolatable<CornerRadii> {
      * @return if true each corner radius is uniformly percentage-based, otherwise not
      */
     public final boolean isUniform() { return uniform; }
-    final boolean uniform;
+    private final boolean uniform;
 
     /**
      * The cached hash code.

--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/CornerRadii.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/CornerRadii.java
@@ -39,7 +39,7 @@ import java.util.Objects;
  *
  * @since JavaFX 8.0
  */
-public class CornerRadii implements Interpolatable<CornerRadii> {
+public final class CornerRadii implements Interpolatable<CornerRadii> {
     /**
      * A CornerRadii which is entirely empty, indicating squared corners.
      * This is the default value for a BorderStroke's radii.
@@ -58,7 +58,7 @@ public class CornerRadii implements Interpolatable<CornerRadii> {
      *                    <a href="../../animation/Interpolatable.html#discrete">discrete</a> otherwise
      */
     public final double getTopLeftHorizontalRadius() { return topLeftHorizontalRadius; }
-    private double topLeftHorizontalRadius;
+    private final double topLeftHorizontalRadius;
 
     /**
      * The length of the vertical radii of the top-left corner.
@@ -69,7 +69,7 @@ public class CornerRadii implements Interpolatable<CornerRadii> {
      *                    <a href="../../animation/Interpolatable.html#discrete">discrete</a> otherwise
      */
     public final double getTopLeftVerticalRadius() { return topLeftVerticalRadius; }
-    private double topLeftVerticalRadius;
+    private final double topLeftVerticalRadius;
 
     /**
      * The length of the vertical radii of the top-right corner.
@@ -80,7 +80,7 @@ public class CornerRadii implements Interpolatable<CornerRadii> {
      *                    <a href="../../animation/Interpolatable.html#discrete">discrete</a> otherwise
      */
     public final double getTopRightVerticalRadius() { return topRightVerticalRadius; }
-    private double topRightVerticalRadius;
+    private final double topRightVerticalRadius;
 
     /**
      * The length of the horizontal radii of the top-right corner.
@@ -91,7 +91,7 @@ public class CornerRadii implements Interpolatable<CornerRadii> {
      *                    <a href="../../animation/Interpolatable.html#discrete">discrete</a> otherwise
      */
     public final double getTopRightHorizontalRadius() { return topRightHorizontalRadius; }
-    private double topRightHorizontalRadius;
+    private final double topRightHorizontalRadius;
 
     /**
      * The length of the horizontal radii of the bottom-right corner.
@@ -102,7 +102,7 @@ public class CornerRadii implements Interpolatable<CornerRadii> {
      *                    <a href="../../animation/Interpolatable.html#discrete">discrete</a> otherwise
      */
     public final double getBottomRightHorizontalRadius() { return bottomRightHorizontalRadius; }
-    private double bottomRightHorizontalRadius;
+    private final double bottomRightHorizontalRadius;
 
     /**
      * The length of the vertical radii of the bottom-right corner.
@@ -113,7 +113,7 @@ public class CornerRadii implements Interpolatable<CornerRadii> {
      *                    <a href="../../animation/Interpolatable.html#discrete">discrete</a> otherwise
      */
     public final double getBottomRightVerticalRadius() { return bottomRightVerticalRadius; }
-    private double bottomRightVerticalRadius;
+    private final double bottomRightVerticalRadius;
 
     /**
      * The length of the vertical radii of the bottom-left corner.
@@ -124,7 +124,7 @@ public class CornerRadii implements Interpolatable<CornerRadii> {
      *                    <a href="../../animation/Interpolatable.html#discrete">discrete</a> otherwise
      */
     public final double getBottomLeftVerticalRadius() { return bottomLeftVerticalRadius; }
-    private double bottomLeftVerticalRadius;
+    private final double bottomLeftVerticalRadius;
 
     /**
      * The length of the horizontal radii of the bottom-left corner.
@@ -135,7 +135,7 @@ public class CornerRadii implements Interpolatable<CornerRadii> {
      *                    <a href="../../animation/Interpolatable.html#discrete">discrete</a> otherwise
      */
     public final double getBottomLeftHorizontalRadius() { return bottomLeftHorizontalRadius; }
-    private double bottomLeftHorizontalRadius;
+    private final double bottomLeftHorizontalRadius;
 
     /**
      * Indicates whether {@code topLeftHorizontalRadius} is interpreted as a value or a percentage.

--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/Region.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/Region.java
@@ -726,7 +726,7 @@ public class Region extends Parent {
                 // we can repaint the region.
                 if (b != null) {
                     for (BackgroundImage i : b.getImages()) {
-                        final Image image = i.image;
+                        final Image image = i.getImage();
                         final Toolkit.ImageAccessor acc = Toolkit.getImageAccessor();
                         if (acc.isAnimation(image) || image.getProgress() < 1) {
                             addImageListener(image);
@@ -737,7 +737,7 @@ public class Region extends Parent {
                 // And we must remove this listener from any old images
                 if (old != null) {
                     for (BackgroundImage i : old.getImages()) {
-                        removeImageListener(i.image);
+                        removeImageListener(i.getImage());
                     }
                 }
 
@@ -785,7 +785,7 @@ public class Region extends Parent {
                 // we can repaint the region.
                 if (b != null) {
                     for (BorderImage i : b.getImages()) {
-                        final Image image = i.image;
+                        final Image image = i.getImage();
                         final Toolkit.ImageAccessor acc = Toolkit.getImageAccessor();
                         if (acc.isAnimation(image) || image.getProgress() < 1) {
                             addImageListener(image);
@@ -796,7 +796,7 @@ public class Region extends Parent {
                 // And we must remove this listener from any old images
                 if (old != null) {
                     for (BorderImage i : old.getImages()) {
-                        removeImageListener(i.image);
+                        removeImageListener(i.getImage());
                     }
                 }
 
@@ -3229,7 +3229,7 @@ public class Region extends Parent {
                 }
 
                 final StrokeType type = bss.getType();
-                double sw = Math.max(bs.getWidths().top, 0d);
+                double sw = Math.max(bs.getWidths().getTop(), 0d);
                 StrokeLineCap cap = bss.getLineCap();
                 StrokeLineJoin join = bss.getLineJoin();
                 float miterlimit = (float) Math.max(bss.getMiterLimit(), 1d);


### PR DESCRIPTION
Backgrounds and borders are comprised of immutable and final types. The following types are marked with the `final` modifier:

* Background
* BackgroundFill
* BackgroundImage
* BackgroundSize
* Border
* BorderWidths

The following types are not marked with the `final` modifier:

* BackgroundPosition
* BorderImage
* BorderStroke
* CornerRadii

This is probably just an oversight, as there is no value in allowing a subsection of these types to be extended.

/reviewers 2
/csr

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change requires CSR request [JDK-8341434](https://bugs.openjdk.org/browse/JDK-8341434) to be approved
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issues
 * [JDK-8341372](https://bugs.openjdk.org/browse/JDK-8341372): BackgroundPosition, BorderImage, BorderStroke, CornerRadii should be final (**Enhancement** - P4)
 * [JDK-8341434](https://bugs.openjdk.org/browse/JDK-8341434): BackgroundPosition, BorderImage, BorderStroke, CornerRadii should be final (**CSR**)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [John Hendrikx](https://openjdk.org/census#jhendrikx) (@hjohn - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1587/head:pull/1587` \
`$ git checkout pull/1587`

Update a local copy of the PR: \
`$ git checkout pull/1587` \
`$ git pull https://git.openjdk.org/jfx.git pull/1587/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1587`

View PR using the GUI difftool: \
`$ git pr show -t 1587`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1587.diff">https://git.openjdk.org/jfx/pull/1587.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1587#issuecomment-2387139929)