### PR TITLE
8333374: Cannot invoke "com.sun.prism.RTTexture.contentsUseful()" because "this.txt" is null 

### DIFF
--- a/modules/javafx.web/src/main/java/com/sun/javafx/webkit/prism/RTImage.java
+++ b/modules/javafx.web/src/main/java/com/sun/javafx/webkit/prism/RTImage.java
@@ -115,6 +115,10 @@ final class RTImage extends PrismImage implements ResourceFactoryListener {
                     (int) Math.ceil(width * pixelScale),
                     (int) Math.ceil(height * pixelScale),
                     Texture.WrapMode.CLAMP_NOT_NEEDED);
+            if (txt == null) {
+                log.fine("RTImage::getTexture : return null because rt texture not allocated");
+                return null;
+            }
             txt.contentsUseful();
             txt.makePermanent();
             if (registeredWithFactory == null || registeredWithFactory.get() != f) {

--- a/modules/javafx.web/src/main/java/com/sun/javafx/webkit/prism/WCGraphicsPrismContext.java
+++ b/modules/javafx.web/src/main/java/com/sun/javafx/webkit/prism/WCGraphicsPrismContext.java
@@ -146,6 +146,11 @@ class WCGraphicsPrismContext extends WCGraphicsContext {
                     ? l.getGraphics()
                     : baseGraphics;
 
+            if (cachedGraphics == null) {
+                log.fine("getGraphics failed - couldn't acquire cachedGraphics");
+                return null;
+            }
+
             ResourceFactory rf = cachedGraphics.getResourceFactory();
             if (!rf.isDisposed()) {
                 state.apply(cachedGraphics);


### PR DESCRIPTION
Contrary to issue description, the problem was not because we referenced a texture after it was freed, but we referenced an RTT that we just tried to allocate and failed to do so because of lack of space in Prism's vram pool. In case of attached `WebViewAnimationTest.java` test app, the problem exists because WebView tries to allocate a new RTT for newly opened WebView scene and the Prism pool does not have 16MB needed while previous WebView is still being displayed. Only after the old WebView is disposed of, then the RTT allocation can proceed and WebView can continue as normal.

I looked around and did not find other solution than adding the null-checks to silence the NPE being thrown. NPE was originally in `RTImage.java`, however after adding a null check there triggered another NPE in `WCGraphicsPrismContext.java`, so I also added another null check there. Upper layers of web module seem to handle those just fine, the NPEs disappeared after that and the test still works properly once the pool gets enough room to display.

All of our tests run fine with this change (I do not expect any major regressions, as this happens only with a very limited memory pool scenario - it was extremely hard and time consuming to trigger this bug on the test app with default 512MB pool limit). For the test app, it might take a couple frames until the old WebView is disposed of and there is enough room for new WebView's RTT in the pool, after that the scene renders properly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8333374](https://bugs.openjdk.org/browse/JDK-8333374): Cannot invoke "com.sun.prism.RTTexture.contentsUseful()" because "this.txt" is null (**Bug** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Jose Pereda](https://openjdk.org/census#jpereda) (@jperedadnr - **Reviewer**)
 * [Hima Bindu Meda](https://openjdk.org/census#hmeda) (@HimaBinduMeda - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1590/head:pull/1590` \
`$ git checkout pull/1590`

Update a local copy of the PR: \
`$ git checkout pull/1590` \
`$ git pull https://git.openjdk.org/jfx.git pull/1590/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1590`

View PR using the GUI difftool: \
`$ git pr show -t 1590`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1590.diff">https://git.openjdk.org/jfx/pull/1590.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1590#issuecomment-2390967879)