### PR TITLE
8341514: Add reducedMotion and reducedTransparency preferences

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Application.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Application.java
@@ -27,6 +27,7 @@ package com.sun.glass.ui;
 import com.sun.glass.events.KeyEvent;
 import com.sun.glass.ui.CommonDialogs.ExtensionFilter;
 import com.sun.glass.ui.CommonDialogs.FileChooserResult;
+import com.sun.javafx.application.preferences.PreferenceMapping;
 
 import java.io.File;
 import java.nio.ByteBuffer;
@@ -771,22 +772,25 @@ public abstract class Application {
     }
 
     /**
-     * Returns a map of platform-specific keys to platform-independent keys defined by JavaFX.
+     * Returns a map of platform-specific keys to platform-independent keys defined by JavaFX, including a
+     * function that maps the platform-specific value to the platform-independent value.
      * <p>
      * For example, the platform-specific key "Windows.UIColor.Foreground" is mapped to the key "foregroundColor",
      * which makes it easier to write shared code without depending on platform-specific details.
      * <p>
-     * The following platform-independent keys are currently supported, which correspond to the names of color
+     * The following platform-independent keys are currently supported, which correspond to the names of
      * properties on the {@link com.sun.javafx.application.preferences.PreferenceProperties} class:
      * <ul>
      *     <li>foregroundColor
      *     <li>backgroundColor
      *     <li>accentColor
+     *     <li>reducedMotion
+     *     <li>reducedTransparency
      * </ul>
      *
      * @return a map of platform-specific keys to well-known keys
      */
-    public Map<String, String> getPlatformKeyMappings() {
+    public Map<String, PreferenceMapping<?>> getPlatformKeyMappings() {
         return Map.of();
     }
 

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/gtk/GtkApplication.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/gtk/GtkApplication.java
@@ -36,6 +36,7 @@ import com.sun.glass.ui.Size;
 import com.sun.glass.ui.Timer;
 import com.sun.glass.ui.View;
 import com.sun.glass.ui.Window;
+import com.sun.javafx.application.preferences.PreferenceMapping;
 import com.sun.javafx.util.Logging;
 import com.sun.glass.utils.NativeLibLoader;
 import com.sun.prism.impl.PrismSettings;
@@ -472,10 +473,12 @@ final class GtkApplication extends Application implements
     public native Map<String, Object> getPlatformPreferences();
 
     @Override
-    public Map<String, String> getPlatformKeyMappings() {
+    public Map<String, PreferenceMapping<?>> getPlatformKeyMappings() {
         return Map.of(
-            "GTK.theme_fg_color", "foregroundColor",
-            "GTK.theme_bg_color", "backgroundColor"
+            "GTK.theme_fg_color", new PreferenceMapping<>("foregroundColor", Color.class),
+            "GTK.theme_bg_color", new PreferenceMapping<>("backgroundColor", Color.class),
+            "GTK.theme_selected_bg_color", new PreferenceMapping<>("accentColor", Color.class),
+            "GTK.enable_animations", new PreferenceMapping<>("reducedMotion", Boolean.class, b -> !b)
         );
     }
 
@@ -501,7 +504,8 @@ final class GtkApplication extends Application implements
             Map.entry("GTK.unfocused_borders", Color.class),
             Map.entry("GTK.warning_color", Color.class),
             Map.entry("GTK.error_color", Color.class),
-            Map.entry("GTK.success_color", Color.class)
+            Map.entry("GTK.success_color", Color.class),
+            Map.entry("GTK.enable_animations", Boolean.class)
         );
     }
 }

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacApplication.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacApplication.java
@@ -28,6 +28,7 @@ import com.sun.glass.events.KeyEvent;
 import com.sun.glass.ui.*;
 import com.sun.glass.ui.CommonDialogs.ExtensionFilter;
 import com.sun.glass.ui.CommonDialogs.FileChooserResult;
+import com.sun.javafx.application.preferences.PreferenceMapping;
 import com.sun.javafx.util.Logging;
 import javafx.scene.paint.Color;
 
@@ -439,11 +440,13 @@ final class MacApplication extends Application implements InvokeLaterDispatcher.
     public native Map<String, Object> getPlatformPreferences();
 
     @Override
-    public Map<String, String> getPlatformKeyMappings() {
+    public Map<String, PreferenceMapping<?>> getPlatformKeyMappings() {
         return Map.of(
-            "macOS.NSColor.textColor", "foregroundColor",
-            "macOS.NSColor.textBackgroundColor", "backgroundColor",
-            "macOS.NSColor.controlAccentColor", "accentColor"
+            "macOS.NSColor.textColor", new PreferenceMapping<>("foregroundColor", Color.class),
+            "macOS.NSColor.textBackgroundColor", new PreferenceMapping<>("backgroundColor", Color.class),
+            "macOS.NSColor.controlAccentColor", new PreferenceMapping<>("accentColor", Color.class),
+            "macOS.NSWorkspace.accessibilityDisplayShouldReduceMotion", new PreferenceMapping<>("reducedMotion", Boolean.class),
+            "macOS.NSWorkspace.accessibilityDisplayShouldReduceTransparency", new PreferenceMapping<>("reducedTransparency", Boolean.class)
         );
     }
 
@@ -496,7 +499,9 @@ final class MacApplication extends Application implements InvokeLaterDispatcher.
             Map.entry("macOS.NSColor.systemPurpleColor", Color.class),
             Map.entry("macOS.NSColor.systemRedColor", Color.class),
             Map.entry("macOS.NSColor.systemTealColor", Color.class),
-            Map.entry("macOS.NSColor.systemYellowColor", Color.class)
+            Map.entry("macOS.NSColor.systemYellowColor", Color.class),
+            Map.entry("macOS.NSWorkspace.accessibilityDisplayShouldReduceMotion", Boolean.class),
+            Map.entry("macOS.NSWorkspace.accessibilityDisplayShouldReduceTransparency", Boolean.class)
         );
     }
 

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinApplication.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinApplication.java
@@ -27,6 +27,7 @@ package com.sun.glass.ui.win;
 import com.sun.glass.ui.*;
 import com.sun.glass.ui.CommonDialogs.ExtensionFilter;
 import com.sun.glass.ui.CommonDialogs.FileChooserResult;
+import com.sun.javafx.application.preferences.PreferenceMapping;
 import com.sun.prism.impl.PrismSettings;
 import com.sun.javafx.tk.Toolkit;
 import javafx.scene.paint.Color;
@@ -374,11 +375,13 @@ final class WinApplication extends Application implements InvokeLaterDispatcher.
 
     // This list needs to be kept in sync with PlatformSupport.cpp in the Glass toolkit for Windows.
     @Override
-    public Map<String, String> getPlatformKeyMappings() {
+    public Map<String, PreferenceMapping<?>> getPlatformKeyMappings() {
         return Map.of(
-            "Windows.UIColor.Foreground", "foregroundColor",
-            "Windows.UIColor.Background", "backgroundColor",
-            "Windows.UIColor.Accent", "accentColor"
+            "Windows.UIColor.Foreground", new PreferenceMapping<>("foregroundColor", Color.class),
+            "Windows.UIColor.Background", new PreferenceMapping<>("backgroundColor", Color.class),
+            "Windows.UIColor.Accent", new PreferenceMapping<>("accentColor", Color.class),
+            "Windows.UISettings.AdvancedEffectsEnabled", new PreferenceMapping<>("reducedTransparency", Boolean.class, b -> !b),
+            "Windows.SPI.ClientAreaAnimation", new PreferenceMapping<>("reducedMotion", Boolean.class, b -> !b)
         );
     }
 
@@ -388,6 +391,7 @@ final class WinApplication extends Application implements InvokeLaterDispatcher.
         return Map.ofEntries(
             Map.entry("Windows.SPI.HighContrast", Boolean.class),
             Map.entry("Windows.SPI.HighContrastColorScheme", String.class),
+            Map.entry("Windows.SPI.ClientAreaAnimation", Boolean.class),
             Map.entry("Windows.SysColor.COLOR_3DFACE", Color.class),
             Map.entry("Windows.SysColor.COLOR_BTNTEXT", Color.class),
             Map.entry("Windows.SysColor.COLOR_GRAYTEXT", Color.class),
@@ -404,7 +408,8 @@ final class WinApplication extends Application implements InvokeLaterDispatcher.
             Map.entry("Windows.UIColor.Accent", Color.class),
             Map.entry("Windows.UIColor.AccentLight1", Color.class),
             Map.entry("Windows.UIColor.AccentLight2", Color.class),
-            Map.entry("Windows.UIColor.AccentLight3", Color.class)
+            Map.entry("Windows.UIColor.AccentLight3", Color.class),
+            Map.entry("Windows.UISettings.AdvancedEffectsEnabled", Boolean.class)
         );
     }
 }

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/application/PlatformImpl.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/application/PlatformImpl.java
@@ -28,6 +28,7 @@ package com.sun.javafx.application;
 import static com.sun.javafx.FXPermissions.CREATE_TRANSPARENT_WINDOW_PERMISSION;
 import com.sun.javafx.PlatformUtil;
 import com.sun.javafx.application.preferences.PlatformPreferences;
+import com.sun.javafx.application.preferences.PreferenceMapping;
 import com.sun.javafx.css.StyleManager;
 import com.sun.javafx.tk.TKListener;
 import com.sun.javafx.tk.TKStage;
@@ -1013,7 +1014,7 @@ public class PlatformImpl {
      * @param preferences the initial set of platform preferences
      */
     public static void initPreferences(Map<String, Class<?>> platformKeys,
-                                       Map<String, String> platformKeyMappings,
+                                       Map<String, PreferenceMapping<?>> platformKeyMappings,
                                        Map<String, Object> preferences) {
         platformPreferences = new PlatformPreferences(platformKeys, platformKeyMappings);
         platformPreferences.update(preferences);

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/application/preferences/PlatformPreferences.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/application/preferences/PlatformPreferences.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@ import com.sun.javafx.binding.MapExpressionHelper;
 import javafx.application.ColorScheme;
 import javafx.application.Platform;
 import javafx.beans.InvalidationListener;
+import javafx.beans.property.ReadOnlyBooleanProperty;
 import javafx.beans.property.ReadOnlyObjectProperty;
 import javafx.collections.MapChangeListener;
 import javafx.scene.paint.Color;
@@ -63,7 +64,7 @@ public class PlatformPreferences extends AbstractMap<String, Object> implements 
      * Contains mappings from platform-specific keys to well-known keys, which are used
      * in the implementation of the property-based API in {@link PreferenceProperties}.
      */
-    private final Map<String, String> platformKeyMappings;
+    private final Map<String, PreferenceMapping<?>> platformKeyMappings;
 
     /**
      * Contains the current set of effective preferences, i.e. the set of preferences that
@@ -86,7 +87,8 @@ public class PlatformPreferences extends AbstractMap<String, Object> implements 
      * @throws NullPointerException if {@code platformKeys} or {@code platformKeyMappings} is {@code null} or
      *                              contains {@code null} keys or values
      */
-    public PlatformPreferences(Map<String, Class<?>> platformKeys, Map<String, String> platformKeyMappings) {
+    public PlatformPreferences(Map<String, Class<?>> platformKeys,
+                               Map<String, PreferenceMapping<?>> platformKeyMappings) {
         this.platformKeys = Map.copyOf(platformKeys);
         this.platformKeyMappings = Map.copyOf(platformKeyMappings);
     }
@@ -199,6 +201,26 @@ public class PlatformPreferences extends AbstractMap<String, Object> implements 
     @Override
     public Optional<Color> getColor(String key) {
         return getValue(key, Color.class);
+    }
+
+    @Override
+    public ReadOnlyBooleanProperty reducedMotionProperty() {
+        return properties.reducedMotionProperty();
+    }
+
+    @Override
+    public boolean isReducedMotion() {
+        return properties.isReducedMotion();
+    }
+
+    @Override
+    public ReadOnlyBooleanProperty reducedTransparencyProperty() {
+        return properties.reducedTransparencyProperty();
+    }
+
+    @Override
+    public boolean isReducedTransparency() {
+        return properties.isReducedTransparency();
     }
 
     @Override

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/application/preferences/PlatformPreferences.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/application/preferences/PlatformPreferences.java
@@ -51,7 +51,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
  * When the operating system signals that a preference has changed, the mappings are updated
  * by calling the {@link #update(Map)} method.
  */
-public class PlatformPreferences extends AbstractMap<String, Object> implements Platform.Preferences {
+public final class PlatformPreferences extends AbstractMap<String, Object> implements Platform.Preferences {
 
     /**
      * Contains mappings from platform-specific keys to their types. This information is

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/application/preferences/PreferenceMapping.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/application/preferences/PreferenceMapping.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.sun.javafx.application.preferences;
+
+import com.sun.javafx.util.Logging;
+import java.util.Objects;
+import java.util.function.Function;
+
+/**
+ * A mapping from platform-specific keys to platform-independent keys defined by JavaFX, including a
+ * function that maps the platform-specific value to the platform-independent value.
+ */
+public record PreferenceMapping<T>(String keyName, Class<T> valueType, Function<T, T> valueMapper) {
+
+    public PreferenceMapping {
+        Objects.requireNonNull(keyName, "keyName cannot be null");
+        Objects.requireNonNull(valueType, "valueType cannot be null");
+        Objects.requireNonNull(valueMapper, "valueMapper cannot be null");
+    }
+
+    public PreferenceMapping(String keyName, Class<T> valueType) {
+        this(keyName, valueType, Function.identity());
+    }
+
+    @SuppressWarnings("unchecked")
+    public T map(Object value) {
+        if (valueType.isInstance(value)) {
+            return valueMapper.apply((T)value);
+        }
+
+        if (value != null) {
+            Logging.getJavaFXLogger().warning(
+                "Unexpected value of " + keyName + " platform preference, " +
+                "using default value instead (expected = " + valueType.getName() +
+                ", actual = " + value.getClass().getName() + ")");
+        }
+
+        return null;
+    }
+}

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/application/preferences/PreferenceProperties.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/application/preferences/PreferenceProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,8 @@ import com.sun.javafx.util.Utils;
 import javafx.application.ColorScheme;
 import javafx.beans.InvalidationListener;
 import javafx.beans.property.Property;
+import javafx.beans.property.ReadOnlyBooleanProperty;
+import javafx.beans.property.ReadOnlyBooleanWrapper;
 import javafx.beans.property.ReadOnlyObjectProperty;
 import javafx.beans.property.ReadOnlyObjectPropertyBase;
 import javafx.beans.property.ReadOnlyObjectWrapper;
@@ -43,15 +45,50 @@ import java.util.Objects;
  */
 final class PreferenceProperties {
 
-    private final ColorProperty backgroundColor = new ColorProperty("backgroundColor", Color.WHITE);
-    private final ColorProperty foregroundColor = new ColorProperty("foregroundColor", Color.BLACK);
-    private final ColorProperty accentColor = new ColorProperty("accentColor", Color.rgb(21, 126, 251));
-    private final List<ColorProperty> allColors = List.of(backgroundColor, foregroundColor, accentColor);
+    private final DeferredProperty<Color> backgroundColor = new DeferredProperty<>("backgroundColor", Color.WHITE);
+    private final DeferredProperty<Color> foregroundColor = new DeferredProperty<>("foregroundColor", Color.BLACK);
+    private final DeferredProperty<Color> accentColor = new DeferredProperty<>("accentColor", Color.rgb(21, 126, 251));
+    private final List<DeferredProperty<Color>> allColors = List.of(backgroundColor, foregroundColor, accentColor);
     private final ColorSchemeProperty colorScheme = new ColorSchemeProperty();
+    private final DeferredProperty<Boolean> reducedMotion = new DeferredProperty<>("reducedMotion", false);
+    private final DeferredProperty<Boolean> reducedTransparency = new DeferredProperty<>("reducedTransparency", false);
+    private final List<DeferredProperty<Boolean>> allFlags = List.of(reducedMotion, reducedTransparency);
+    private final ReadOnlyBooleanWrapper reducedMotionFlag;
+    private final ReadOnlyBooleanWrapper reducedTransparencyFlag;
     private final Object bean;
 
     PreferenceProperties(Object bean) {
         this.bean = bean;
+
+        reducedMotionFlag = new ReadOnlyBooleanWrapper(bean, reducedMotion.getName());
+        reducedMotionFlag.bind(reducedMotion);
+
+        reducedTransparencyFlag = new ReadOnlyBooleanWrapper(bean, reducedTransparency.getName());
+        reducedTransparencyFlag.bind(reducedTransparency);
+    }
+
+    public ReadOnlyBooleanProperty reducedMotionProperty() {
+        return reducedMotionFlag.getReadOnlyProperty();
+    }
+
+    public boolean isReducedMotion() {
+        return reducedMotion.get();
+    }
+
+    public void setReducedMotion(boolean value) {
+        reducedMotion.setValueOverride(value);
+    }
+
+    public ReadOnlyBooleanProperty reducedTransparencyProperty() {
+        return reducedTransparencyFlag.getReadOnlyProperty();
+    }
+
+    public boolean isReducedTransparency() {
+        return reducedTransparency.get();
+    }
+
+    public void setReducedTransparency(boolean value) {
+        reducedTransparency.setValueOverride(value);
     }
 
     public ReadOnlyObjectProperty<ColorScheme> colorSchemeProperty() {
@@ -102,14 +139,23 @@ final class PreferenceProperties {
         accentColor.setValueOverride(color);
     }
 
-    public void update(Map<String, ChangedValue> changedPreferences, Map<String, String> platformKeyMappings) {
+    public void update(Map<String, ChangedValue> changedPreferences,
+                       Map<String, PreferenceMapping<?>> platformKeyMappings) {
+        outerLoop:
         for (Map.Entry<String, ChangedValue> entry : changedPreferences.entrySet()) {
-            String key = platformKeyMappings.get(entry.getKey());
-            if (key != null) {
-                for (ColorProperty colorProperty : allColors) {
-                    if (colorProperty.getName().equals(key)) {
-                        updateColorProperty(colorProperty, entry.getValue().newValue());
-                        break;
+            PreferenceMapping<?> mapping = platformKeyMappings.get(entry.getKey());
+            if (mapping != null) {
+                for (DeferredProperty<Color> color : allColors) {
+                    if (color.getName().equals(mapping.keyName())) {
+                        updateDeferredProperty(color, Color.class, entry.getValue().newValue());
+                        continue outerLoop;
+                    }
+                }
+
+                for (DeferredProperty<Boolean> flag : allFlags) {
+                    if (flag.getName().equals(mapping.keyName())) {
+                        updateDeferredProperty(flag, Boolean.class, mapping.map(entry.getValue().newValue()));
+                        continue outerLoop;
                     }
                 }
             }
@@ -118,44 +164,45 @@ final class PreferenceProperties {
         fireValueChangedIfNecessary();
     }
 
-    private void updateColorProperty(ColorProperty property, Object value) {
-        if (value instanceof Color color) {
-            property.setValue(color);
+    @SuppressWarnings("unchecked")
+    private <T> void updateDeferredProperty(DeferredProperty<T> property, Class<T> valueType, Object value) {
+        if (valueType.isInstance(value)) {
+            property.setValue((T)value);
         } else {
             if (value != null) {
                 Logging.getJavaFXLogger().warning(
                     "Unexpected value of " + property.getName() + " platform preference, " +
-                    "using default value instead (expected = " + Color.class.getName() +
+                    "using default value instead (expected = " + valueType.getName() +
                     ", actual = " + value.getClass().getName() + ")");
             }
 
-            // Setting a ColorProperty to 'null' restores its platform value or default value.
+            // Setting a DeferredProperty to 'null' restores its platform value or default value.
             property.setValue(null);
         }
     }
 
     private void fireValueChangedIfNecessary() {
-        for (ColorProperty colorProperty : allColors) {
+        for (DeferredProperty<Color> colorProperty : allColors) {
             colorProperty.fireValueChangedIfNecessary();
         }
     }
 
     /**
-     * ColorProperty implements a deferred notification mechanism, where change notifications
-     * are only fired after changes of all color properties have been applied.
-     * This ensures that observers will never see a transient state where two color properties
+     * DeferredProperty implements a deferred notification mechanism, where change notifications
+     * are only fired after changes to all properties have been applied.
+     * This ensures that observers will never see a transient state where two properties
      * are inconsistent (for example, both foreground and background could be the same color
      * when going from light to dark mode).
      */
-    private final class ColorProperty extends ReadOnlyObjectPropertyBase<Color> {
+    private final class DeferredProperty<T> extends ReadOnlyObjectPropertyBase<T> {
         private final String name;
-        private final Color defaultValue;
-        private Color overrideValue;
-        private Color platformValue;
-        private Color effectiveValue;
-        private Color lastEffectiveValue;
+        private final T defaultValue;
+        private T overrideValue;
+        private T platformValue;
+        private T effectiveValue;
+        private T lastEffectiveValue;
 
-        ColorProperty(String name, Color initialValue) {
+        DeferredProperty(String name, T initialValue) {
             this.name = name;
             this.defaultValue = initialValue;
             this.platformValue = initialValue;
@@ -174,20 +221,20 @@ final class PreferenceProperties {
         }
 
         @Override
-        public Color get() {
+        public T get() {
             return effectiveValue;
         }
 
         /**
-         * Only called by {@link #updateColorProperty}, this method doesn't fire a change notification.
-         * Change notifications are fired after the new values of all color properties have been set.
+         * Only called by {@link #updateDeferredProperty}, this method doesn't fire a change notification.
+         * Change notifications are fired after the new values of all deferred properties have been set.
          */
-        public void setValue(Color value) {
+        public void setValue(T value) {
             this.platformValue = value;
             updateEffectiveValue();
         }
 
-        public void setValueOverride(Color value) {
+        public void setValueOverride(T value) {
             this.overrideValue = value;
             updateEffectiveValue();
             fireValueChangedEvent();

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/application/preferences/PreferenceProperties.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/application/preferences/PreferenceProperties.java
@@ -208,18 +208,18 @@ final class PreferenceProperties {
             fireValueChangedEvent();
         }
 
+        public void fireValueChangedIfNecessary() {
+            if (!Objects.equals(lastEffectiveValue, effectiveValue)) {
+                lastEffectiveValue = effectiveValue;
+                fireValueChangedEvent();
+            }
+        }
+
         private void updateEffectiveValue() {
             // Choose the first non-null value in this order: overrideValue, platformValue, defaultValue.
             effectiveValue = Objects.requireNonNullElse(
                 overrideValue != null ? overrideValue : platformValue,
                 defaultValue);
-        }
-
-        void fireValueChangedIfNecessary() {
-            if (!Objects.equals(lastEffectiveValue, effectiveValue)) {
-                lastEffectiveValue = effectiveValue;
-                fireValueChangedEvent();
-            }
         }
     }
 

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/application/preferences/PreferenceProperties.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/application/preferences/PreferenceProperties.java
@@ -189,7 +189,7 @@ final class PreferenceProperties {
 
     /**
      * DeferredProperty implements a deferred notification mechanism, where change notifications
-     * are only fired after changes to all properties have been applied.
+     * are only fired after changes of all properties have been applied.
      * This ensures that observers will never see a transient state where two properties
      * are inconsistent (for example, both foreground and background could be the same color
      * when going from light to dark mode).

--- a/modules/javafx.graphics/src/main/java/javafx/application/Platform.java
+++ b/modules/javafx.graphics/src/main/java/javafx/application/Platform.java
@@ -583,7 +583,8 @@ public final class Platform {
      *
      * @since 22
      */
-    public interface Preferences extends ObservableMap<String, Object> {
+    public sealed interface Preferences extends ObservableMap<String, Object>
+            permits com.sun.javafx.application.preferences.PlatformPreferences {
 
         /**
          * Specifies whether applications should minimize the amount of non-essential animations,

--- a/modules/javafx.graphics/src/main/java/javafx/application/Platform.java
+++ b/modules/javafx.graphics/src/main/java/javafx/application/Platform.java
@@ -478,6 +478,7 @@ public final class Platform {
      *     <tbody>
      *         <tr><td>{@code Windows.SPI.HighContrast}</td><td>{@link Boolean}</td></tr>
      *         <tr><td>{@code Windows.SPI.HighContrastColorScheme}</td><td>{@link String}</td></tr>
+     *         <tr><td>{@code Windows.SPI.ClientAreaAnimation}</td><td>{@link Boolean}</td></tr>
      *         <tr><td>{@code Windows.SysColor.COLOR_3DFACE}</td><td>{@link Color}</td></tr>
      *         <tr><td>{@code Windows.SysColor.COLOR_BTNTEXT}</td><td>{@link Color}</td></tr>
      *         <tr><td>{@code Windows.SysColor.COLOR_GRAYTEXT}</td><td>{@link Color}</td></tr>
@@ -495,6 +496,7 @@ public final class Platform {
      *         <tr><td>{@code Windows.UIColor.AccentLight1}</td><td>{@link Color}</td></tr>
      *         <tr><td>{@code Windows.UIColor.AccentLight2}</td><td>{@link Color}</td></tr>
      *         <tr><td>{@code Windows.UIColor.AccentLight3}</td><td>{@link Color}</td></tr>
+     *         <tr><td>{@code Windows.UISettings.AdvancedEffectsEnabled}</td><td>{@link Boolean}</td></tr>
      *         <tr></tr>
      *     </tbody>
      * </table>
@@ -547,6 +549,8 @@ public final class Platform {
      *         <tr><td>{@code macOS.NSColor.systemRedColor}</td><td>{@link Color}</td></tr>
      *         <tr><td>{@code macOS.NSColor.systemTealColor}</td><td>{@link Color}</td></tr>
      *         <tr><td>{@code macOS.NSColor.systemYellowColor}</td><td>{@link Color}</td></tr>
+     *         <tr><td>{@code macOS.NSWorkspace.accessibilityDisplayShouldReduceMotion}</td><td>{@link Boolean}</td></tr>
+     *         <tr><td>{@code macOS.NSWorkspace.accessibilityDisplayShouldReduceTransparency}</td><td>{@link Boolean}</td></tr>
      *         <tr></tr>
      *     </tbody>
      * </table>
@@ -572,6 +576,7 @@ public final class Platform {
      *         <tr><td>{@code GTK.warning_color}</td><td>{@link Color}</td></tr>
      *         <tr><td>{@code GTK.error_color}</td><td>{@link Color}</td></tr>
      *         <tr><td>{@code GTK.success_color}</td><td>{@link Color}</td></tr>
+     *         <tr><td>{@code GTK.enable_animations}</td><td>{@link Boolean}</td></tr>
      *         <tr></tr>
      *     </tbody>
      * </table>
@@ -579,6 +584,34 @@ public final class Platform {
      * @since 22
      */
     public interface Preferences extends ObservableMap<String, Object> {
+
+        /**
+         * Specifies whether applications should minimize the amount of non-essential animations,
+         * reducing discomfort for users who experience motion sickness or vertigo.
+         * <p>
+         * If the platform does not report this preference, this property defaults to {@code false}.
+         *
+         * @return the {@code reducedMotion} property
+         * @defaultValue {@link false}
+         * @since 24
+         */
+        ReadOnlyBooleanProperty reducedMotionProperty();
+
+        boolean isReducedMotion();
+
+        /**
+         * Specifies whether applications should minimize the amount of transparent or translucent
+         * layer effects, which can help to increase contrast and readability for some users.
+         * <p>
+         * If the platform does not report this preference, this property defaults to {@code false}.
+         *
+         * @return the {@code reducedTransparency} property
+         * @defaultValue {@link false}
+         * @since 24
+         */
+        ReadOnlyBooleanProperty reducedTransparencyProperty();
+
+        boolean isReducedTransparency();
 
         /**
          * The platform color scheme, which specifies whether applications should prefer light text on

--- a/modules/javafx.graphics/src/main/java/javafx/application/Platform.java
+++ b/modules/javafx.graphics/src/main/java/javafx/application/Platform.java
@@ -592,7 +592,7 @@ public final class Platform {
          * If the platform does not report this preference, this property defaults to {@code false}.
          *
          * @return the {@code reducedMotion} property
-         * @defaultValue {@link false}
+         * @defaultValue {@code false}
          * @since 24
          */
         ReadOnlyBooleanProperty reducedMotionProperty();
@@ -606,7 +606,7 @@ public final class Platform {
          * If the platform does not report this preference, this property defaults to {@code false}.
          *
          * @return the {@code reducedTransparency} property
-         * @defaultValue {@link false}
+         * @defaultValue {@code false}
          * @since 24
          */
         ReadOnlyBooleanProperty reducedTransparencyProperty();

--- a/modules/javafx.graphics/src/main/native-glass/gtk/GlassApplication.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/GlassApplication.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -200,8 +200,10 @@ JNIEXPORT void JNICALL Java_com_sun_glass_ui_gtk_GtkApplication__1init
 
     GtkSettings* settings = gtk_settings_get_default();
     if (settings != NULL) {
-        g_signal_connect(G_OBJECT(settings), "notify::gtk-theme-name",
-                         G_CALLBACK(call_update_preferences), NULL);
+        for (const auto& setting : PlatformSupport::observedSettings) {
+            g_signal_connect_after(G_OBJECT(settings), setting,
+                                   G_CALLBACK(call_update_preferences), NULL);
+        }
     }
 }
 

--- a/modules/javafx.graphics/src/main/native-glass/gtk/PlatformSupport.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/PlatformSupport.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,6 +60,17 @@ namespace
         env->CallObjectMethod(preferences, jMapPut, prefKey, prefValue);
         CHECK_JNI_EXCEPTION(env);
     }
+
+    void putBoolean(JNIEnv* env, jobject preferences, const char* name, bool value) {
+        jobject prefKey = env->NewStringUTF(name);
+        if (EXCEPTION_OCCURED(env) || prefKey == NULL) return;
+
+        jobject prefValue = env->GetStaticObjectField(jBooleanCls, value ? jBooleanTRUE : jBooleanFALSE);
+        if (EXCEPTION_OCCURED(env) || prefValue == NULL) return;
+
+        env->CallObjectMethod(preferences, jMapPut, prefKey, prefValue);
+        CHECK_JNI_EXCEPTION(env);
+    }
 }
 
 PlatformSupport::PlatformSupport(JNIEnv* env, jobject application)
@@ -105,6 +116,11 @@ jobject PlatformSupport::collectPreferences() const {
         gchar* themeName;
         g_object_get(settings, "gtk-theme-name", &themeName, NULL);
         putString(env, prefs, "GTK.theme_name", themeName);
+        g_free(themeName);
+
+        gboolean enableAnimations = true;
+        g_object_get(settings, "gtk-enable-animations", &enableAnimations, NULL);
+        putBoolean(env, prefs, "GTK.enable_animations", enableAnimations);
     }
 
     return prefs;

--- a/modules/javafx.graphics/src/main/native-glass/gtk/PlatformSupport.h
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/PlatformSupport.h
@@ -30,6 +30,11 @@
 class PlatformSupport final
 {
 public:
+    static constexpr const char* observedSettings[] = {
+        "notify::gtk-theme-name",
+        "notify::gtk-enable-animations"
+    };
+
     PlatformSupport(JNIEnv*, jobject);
     ~PlatformSupport();
     PlatformSupport(PlatformSupport const&) = delete;

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
@@ -245,6 +245,12 @@ jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved)
                                                                          name:@"AppleColorPreferencesChangedNotification"
                                                                          object:nil];
 
+                        [[[NSWorkspace sharedWorkspace] notificationCenter]
+                            addObserver:self
+                            selector:@selector(platformPreferencesDidChange)
+                            name:NSWorkspaceAccessibilityDisplayOptionsDidChangeNotification
+                            object:nil];
+
                         // localMonitor = [NSEvent addLocalMonitorForEventsMatchingMask: NSRightMouseDownMask
                         //                                                      handler:^(NSEvent *incomingEvent) {
                         //                                                          NSEvent *result = incomingEvent;

--- a/modules/javafx.graphics/src/main/native-glass/mac/PlatformSupport.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/PlatformSupport.m
@@ -106,6 +106,16 @@ static jobject currentPreferences = nil;
     [PlatformSupport queryNSColors:preferences];
     [NSAppearance setCurrentAppearance:lastAppearance];
 
+    bool reduceMotion = [[NSWorkspace sharedWorkspace] accessibilityDisplayShouldReduceMotion];
+    [PlatformSupport putBoolean:preferences
+                     key:"macOS.NSWorkspace.accessibilityDisplayShouldReduceMotion"
+                     value:reduceMotion];
+
+    bool reduceTransparency = [[NSWorkspace sharedWorkspace] accessibilityDisplayShouldReduceTransparency];
+    [PlatformSupport putBoolean:preferences
+                     key:"macOS.NSWorkspace.accessibilityDisplayShouldReduceTransparency"
+                     value:reduceTransparency];
+
     return preferences;
 }
 
@@ -220,6 +230,19 @@ static jobject currentPreferences = nil;
     }
 
     (*env)->DeleteLocalRef(env, newPreferences);
+}
+
++ (void)putBoolean:(jobject)preferences key:(const char*)key value:(bool)value {
+    GET_MAIN_JENV;
+
+    jobject prefKey = (*env)->NewStringUTF(env, key);
+    GLASS_CHECK_NONNULL_EXCEPTION_RETURN(env, prefKey);
+
+    jobject prefValue = (*env)->GetStaticObjectField(env, jBooleanClass, value ? jBooleanTRUE : jBooleanFALSE);
+    GLASS_CHECK_NONNULL_EXCEPTION_RETURN(env, prefValue);
+
+    (*env)->CallObjectMethod(env, preferences, jMapPutMethod, prefKey, prefValue);
+    GLASS_CHECK_EXCEPTION(env);
 }
 
 + (void)putString:(jobject)preferences key:(const char*)key value:(const char*)value {

--- a/modules/javafx.graphics/src/main/native-glass/mac/PlatformSupport.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/PlatformSupport.m
@@ -106,15 +106,13 @@ static jobject currentPreferences = nil;
     [PlatformSupport queryNSColors:preferences];
     [NSAppearance setCurrentAppearance:lastAppearance];
 
-    bool reduceMotion = [[NSWorkspace sharedWorkspace] accessibilityDisplayShouldReduceMotion];
     [PlatformSupport putBoolean:preferences
                      key:"macOS.NSWorkspace.accessibilityDisplayShouldReduceMotion"
-                     value:reduceMotion];
+                     value:[[NSWorkspace sharedWorkspace] accessibilityDisplayShouldReduceMotion]];
 
-    bool reduceTransparency = [[NSWorkspace sharedWorkspace] accessibilityDisplayShouldReduceTransparency];
     [PlatformSupport putBoolean:preferences
                      key:"macOS.NSWorkspace.accessibilityDisplayShouldReduceTransparency"
-                     value:reduceTransparency];
+                     value:[[NSWorkspace sharedWorkspace] accessibilityDisplayShouldReduceTransparency]];
 
     return preferences;
 }

--- a/modules/javafx.graphics/src/main/native-glass/win/GlassApplication.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/win/GlassApplication.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -168,11 +168,10 @@ LRESULT GlassApplication::WindowProc(UINT msg, WPARAM wParam, LPARAM lParam)
             }
             break;
         case WM_SETTINGCHANGE:
-            if (((UINT)wParam == SPI_GETHIGHCONTRAST ||
-                    lParam != NULL && wcscmp(LPCWSTR(lParam), L"ImmersiveColorSet") == 0) &&
-                    m_platformSupport.updatePreferences(m_grefThis)) {
+            if (m_platformSupport.settingChanged(m_grefThis, wParam, lParam)) {
                 return 0;
             }
+
             if ((UINT)wParam != SPI_SETWORKAREA) {
                 break;
             }

--- a/modules/javafx.graphics/src/main/native-glass/win/GlassApplication.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/win/GlassApplication.cpp
@@ -168,7 +168,7 @@ LRESULT GlassApplication::WindowProc(UINT msg, WPARAM wParam, LPARAM lParam)
             }
             break;
         case WM_SETTINGCHANGE:
-            if (m_platformSupport.settingChanged(m_grefThis, wParam, lParam)) {
+            if (m_platformSupport.onSettingChanged(m_grefThis, wParam, lParam)) {
                 return 0;
             }
 

--- a/modules/javafx.graphics/src/main/native-glass/win/PlatformSupport.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/win/PlatformSupport.cpp
@@ -87,9 +87,9 @@ jobject PlatformSupport::collectPreferences() const
     jobject prefs = env->NewObject(javaClasses.HashMap, javaIDs.HashMap.init);
     if (CheckAndClearException(env)) return NULL;
 
-    queryHighContrastScheme(prefs);
+    querySystemParameters(prefs);
     querySystemColors(prefs);
-    queryUIColors(prefs);
+    queryUISettings(prefs);
     return prefs;
 }
 
@@ -124,7 +124,22 @@ bool PlatformSupport::updatePreferences(jobject application) const
     return false;
 }
 
-void PlatformSupport::queryHighContrastScheme(jobject properties) const
+bool PlatformSupport::settingChanged(jobject application, WPARAM wParam, LPARAM lParam) const
+{
+    switch ((UINT)wParam) {
+        case SPI_SETHIGHCONTRAST:
+        case SPI_SETCLIENTAREAANIMATION:
+            return updatePreferences(application);
+    }
+
+    if (lParam != NULL && wcscmp(LPCWSTR(lParam), L"ImmersiveColorSet") == 0) {
+        return updatePreferences(application);
+    }
+
+    return false;
+}
+
+void PlatformSupport::querySystemParameters(jobject properties) const
 {
     HIGHCONTRAST contrastInfo;
     contrastInfo.cbSize = sizeof(HIGHCONTRAST);
@@ -138,6 +153,10 @@ void PlatformSupport::queryHighContrastScheme(jobject properties) const
         putBoolean(properties, "Windows.SPI.HighContrast", false);
         putString(properties, "Windows.SPI.HighContrastColorScheme", (const char*)NULL);
     }
+
+    BOOL value;
+    ::SystemParametersInfo(SPI_GETCLIENTAREAANIMATION, 0, &value, 0);
+    putBoolean(properties, "Windows.SPI.ClientAreaAnimation", value);
 }
 
 void PlatformSupport::querySystemColors(jobject properties) const
@@ -153,17 +172,25 @@ void PlatformSupport::querySystemColors(jobject properties) const
     putColor(properties, "Windows.SysColor.COLOR_WINDOWTEXT", GetSysColor(COLOR_WINDOWTEXT));
 }
 
-void PlatformSupport::queryUIColors(jobject properties) const
+void PlatformSupport::queryUISettings(jobject properties) const
 {
     if (!isRoActivationSupported()) {
         return;
     }
 
+    ComPtr<IUISettings> settings;
+
     try {
-        ComPtr<IUISettings> settings;
         RO_CHECKED("RoActivateInstance",
                    RoActivateInstance(hstring("Windows.UI.ViewManagement.UISettings"), (IInspectable**)&settings));
+    } catch (RoException const&) {
+        // If an activation exception occurs, it probably means that we're on a Windows system
+        // that doesn't support the UISettings API. This is not a problem, it simply means that
+        // we don't report the UISettings properties back to the JavaFX application.
+        return;
+    }
 
+    try {
         ComPtr<IUISettings3> settings3;
         RO_CHECKED("IUISettings::QueryInterface<IUISettings3>",
                    settings->QueryInterface<IUISettings3>(&settings3));
@@ -192,9 +219,18 @@ void PlatformSupport::queryUIColors(jobject properties) const
         putColor(properties, "Windows.UIColor.AccentLight2", accentLight2);
         putColor(properties, "Windows.UIColor.AccentLight3", accentLight3);
     } catch (RoException const&) {
-        // If an activation exception occurs, it probably means that we're on a Windows system
-        // that doesn't support the UISettings API. This is not a problem, it simply means that
-        // we don't report the UISettings properties back to the JavaFX application.
+        return;
+    }
+
+    try {
+        ComPtr<IUISettings4> settings4;
+        RO_CHECKED("IUISettings::QueryInterface<IUISettings4>",
+                   settings->QueryInterface<IUISettings4>(&settings4));
+
+        unsigned char value;
+        settings4->get_AdvancedEffectsEnabled(&value);
+        putBoolean(properties, "Windows.UISettings.AdvancedEffectsEnabled", value);
+    } catch (RoException const&) {
         return;
     }
 }

--- a/modules/javafx.graphics/src/main/native-glass/win/PlatformSupport.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/win/PlatformSupport.cpp
@@ -124,7 +124,7 @@ bool PlatformSupport::updatePreferences(jobject application) const
     return false;
 }
 
-bool PlatformSupport::settingChanged(jobject application, WPARAM wParam, LPARAM lParam) const
+bool PlatformSupport::onSettingChanged(jobject application, WPARAM wParam, LPARAM lParam) const
 {
     switch ((UINT)wParam) {
         case SPI_SETHIGHCONTRAST:

--- a/modules/javafx.graphics/src/main/native-glass/win/PlatformSupport.h
+++ b/modules/javafx.graphics/src/main/native-glass/win/PlatformSupport.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,6 +48,11 @@ public:
      */
     bool updatePreferences(jobject application) const;
 
+    /**
+     * Handles the WM_SETTINGCHANGE message.
+    */
+    bool settingChanged(jobject application, WPARAM, LPARAM) const;
+
 private:
     JNIEnv* env;
     bool initialized;
@@ -63,8 +68,8 @@ private:
     } javaClasses;
 
     void querySystemColors(jobject properties) const;
-    void queryHighContrastScheme(jobject properties) const;
-    void queryUIColors(jobject properties) const;
+    void querySystemParameters(jobject properties) const;
+    void queryUISettings(jobject properties) const;
 
     void putString(jobject properties, const char* key, const char* value) const;
     void putString(jobject properties, const char* key, const wchar_t* value) const;

--- a/modules/javafx.graphics/src/main/native-glass/win/PlatformSupport.h
+++ b/modules/javafx.graphics/src/main/native-glass/win/PlatformSupport.h
@@ -51,7 +51,7 @@ public:
     /**
      * Handles the WM_SETTINGCHANGE message.
     */
-    bool settingChanged(jobject application, WPARAM, LPARAM) const;
+    bool onSettingChanged(jobject application, WPARAM, LPARAM) const;
 
 private:
     JNIEnv* env;

--- a/modules/javafx.graphics/src/test/java/test/com/sun/javafx/application/preferences/PlatformPreferencesTest.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/javafx/application/preferences/PlatformPreferencesTest.java
@@ -332,39 +332,37 @@ public class PlatformPreferencesTest {
 
     @Test
     void testReducedMotionProperty() {
-        var observer = new MockMapObserver<String, Object>();
-        prefs.addListener(observer);
+        var trace = new ArrayList<Boolean>();
+        prefs.reducedMotionProperty().addListener((observable, ov, nv) -> trace.add(nv));
 
         assertFalse(prefs.isReducedMotion());
         prefs.update(Map.of("test.reducedMotion", true));
 
+        assertEquals(1, trace.size());
+        assertEquals(Boolean.TRUE, trace.get(0));
         assertTrue(prefs.isReducedMotion());
-        assertEquals(1, observer.getCallsNumber());
-        observer.assertAdded(0, tup("test.reducedMotion", true));
-        observer.clear();
 
         prefs.update(new HashMap<>() {{ put("test.reducedMotion", null); }});
-        assertEquals(1, observer.getCallsNumber());
-        observer.assertRemoved(0, tup("test.reducedMotion", true));
+        assertEquals(2, trace.size());
+        assertEquals(Boolean.FALSE, trace.get(1));
         assertFalse(prefs.isReducedMotion());
     }
 
     @Test
     void testReducedTransparencyPropertyWithInverseMapping() {
-        var observer = new MockMapObserver<String, Object>();
-        prefs.addListener(observer);
+        var trace = new ArrayList<Boolean>();
+        prefs.reducedTransparencyProperty().addListener((observable, ov, nv) -> trace.add(nv));
 
         assertFalse(prefs.isReducedTransparency());
         prefs.update(Map.of("test.enableTransparency", false));
 
+        assertEquals(1, trace.size());
+        assertEquals(Boolean.TRUE, trace.get(0));
         assertTrue(prefs.isReducedTransparency());
-        assertEquals(1, observer.getCallsNumber());
-        observer.assertAdded(0, tup("test.enableTransparency", false));
-        observer.clear();
 
         prefs.update(new HashMap<>() {{ put("test.enableTransparency", null); }});
-        assertEquals(1, observer.getCallsNumber());
-        observer.assertRemoved(0, tup("test.enableTransparency", false));
-        assertFalse(prefs.isReducedMotion());
+        assertEquals(2, trace.size());
+        assertEquals(Boolean.FALSE, trace.get(1));
+        assertFalse(prefs.isReducedTransparency());
     }
 }

--- a/tests/manual/events/PlatformPreferencesChangedTest.java
+++ b/tests/manual/events/PlatformPreferencesChangedTest.java
@@ -64,6 +64,8 @@ public class PlatformPreferencesChangedTest extends Application {
         var foregroundColorLabel = new Label();
         var accentColorLabel = new Label();
         var colorSchemeLabel = new Label();
+        var reducedMotionLabel = new Label();
+        var reducedTransparencyLabel = new Label();
 
         Runnable updateColorProperties = () -> {
             var preferences = Platform.getPreferences();
@@ -71,6 +73,8 @@ public class PlatformPreferencesChangedTest extends Application {
             foregroundColorLabel.setText(preferences.getForegroundColor().toString());
             accentColorLabel.setText(preferences.getAccentColor().toString());
             colorSchemeLabel.setText(preferences.getColorScheme().toString());
+            reducedMotionLabel.setText(Boolean.toString(preferences.isReducedMotion()));
+            reducedTransparencyLabel.setText(Boolean.toString(preferences.isReducedTransparency()));
         };
 
         var box = new VBox();
@@ -87,7 +91,9 @@ public class PlatformPreferencesChangedTest extends Application {
                 new HBox(new BoldLabel("    backgroundColor: "), backgroundColorLabel),
                 new HBox(new BoldLabel("    foregroundColor: "), foregroundColorLabel),
                 new HBox(new BoldLabel("    accentColor: "), accentColorLabel),
-                new HBox(new BoldLabel("    colorScheme: "), colorSchemeLabel)),
+                new HBox(new BoldLabel("    colorScheme: "), colorSchemeLabel),
+                new HBox(new BoldLabel("    reducedMotion: "), reducedMotionLabel),
+                new HBox(new BoldLabel("    reducedTransparency: "), reducedTransparencyLabel)),
             new Label("4. Click \"Pass\" if the changes were correctly reported, otherwise click \"Fail\"."),
             new HBox(5, passButton, failButton, clearButton)
         ));


### PR DESCRIPTION
This PR adds the `Platform.Preferences.reducedMotion` and `Platform.Preferences.reducedTransparency` accessibility preferences:
```java
interface Preferences {
    /**
     * Specifies whether applications should minimize the amount of non-essential animations,
     * reducing discomfort for users who experience motion sickness or vertigo.
     * <p>
     * If the platform does not report this preference, this property defaults to {@code false}.
     *
     * @return the {@code reducedMotion} property
     * @defaultValue {@code false}
     * @since 24
     */
    ReadOnlyBooleanProperty reducedMotionProperty();

    /**
     * Specifies whether applications should minimize the amount of transparent or translucent
     * layer effects, which can help to increase contrast and readability for some users.
     * <p>
     * If the platform does not report this preference, this property defaults to {@code false}.
     *
     * @return the {@code reducedTransparency} property
     * @defaultValue {@code false}
     * @since 24
     */
    ReadOnlyBooleanProperty reducedTransparencyProperty();

    ...
}
```

On Windows, these preferences correspond to "Transparency effects" and "Animation effects" in the system settings:
<img src="https://github.com/user-attachments/assets/b286850d-ebbc-444c-9c09-5380f97d0e91" width="400" >

On macOS, these preferences correspond to "Reduce motion" and "Reduce transparency" in the system settings:
<img src="https://github.com/user-attachments/assets/4c7b92f8-0cd9-4d1f-91df-40cb449f91ff" width="400" >

On Linux, the `reducedMotion` preference corresponds to `gtk-enable-animations`. On my Ubuntu 24.04 system, GTK3 does not pick up the "Settings / Accessibility / Reduce Animations" system setting, and therefore GTK always reports `gtk-enable-animations == true`. Changing the preference requires manually editing `etc/gtk-3.0/settings.ini`. The `reducedTransparency` preference has no corresponding GTK setting.

/reviewers 2
/csr

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8341667](https://bugs.openjdk.org/browse/JDK-8341667) to be approved
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issues
 * [JDK-8341514](https://bugs.openjdk.org/browse/JDK-8341514): Add reducedMotion and reducedTransparency preferences (**Enhancement** - P4)
 * [JDK-8341667](https://bugs.openjdk.org/browse/JDK-8341667): Add reducedMotion and reducedTransparency preferences (**CSR**)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1592/head:pull/1592` \
`$ git checkout pull/1592`

Update a local copy of the PR: \
`$ git checkout pull/1592` \
`$ git pull https://git.openjdk.org/jfx.git pull/1592/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1592`

View PR using the GUI difftool: \
`$ git pr show -t 1592`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1592.diff">https://git.openjdk.org/jfx/pull/1592.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1592#issuecomment-2394910311)