### PR TITLE
8341440: ScrollPane: no immediate effect changing fitWidth/fitHeight

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ScrollPane.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ScrollPane.java
@@ -354,8 +354,6 @@ public class ScrollPane extends Control {
      * If true and if the contained node is a Resizable, then the node will be
      * kept resized to match the width of the ScrollPane's viewport. If the
      * contained node is not a Resizable, this value is ignored.
-     *
-     * @defaultValue false
      */
     private BooleanProperty fitToWidth;
     public final void setFitToWidth(boolean value) {
@@ -393,8 +391,6 @@ public class ScrollPane extends Control {
      * If true and if the contained node is a Resizable, then the node will be
      * kept resized to match the height of the ScrollPane's viewport. If the
      * contained node is not a Resizable, this value is ignored.
-     *
-     * @defaultValue false
      */
     private BooleanProperty fitToHeight;
     public final void setFitToHeight(boolean value) {

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ScrollPane.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ScrollPane.java
@@ -354,6 +354,8 @@ public class ScrollPane extends Control {
      * If true and if the contained node is a Resizable, then the node will be
      * kept resized to match the width of the ScrollPane's viewport. If the
      * contained node is not a Resizable, this value is ignored.
+     *
+     * @defaultValue false
      */
     private BooleanProperty fitToWidth;
     public final void setFitToWidth(boolean value) {
@@ -391,6 +393,8 @@ public class ScrollPane extends Control {
      * If true and if the contained node is a Resizable, then the node will be
      * kept resized to match the height of the ScrollPane's viewport. If the
      * contained node is not a Resizable, this value is ignored.
+     *
+     * @defaultValue false
      */
     private BooleanProperty fitToHeight;
     public final void setFitToHeight(boolean value) {

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ScrollPaneSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ScrollPaneSkin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -294,6 +294,7 @@ public class ScrollPaneSkin extends SkinBase<ScrollPane> {
             () -> {
                 getSkinnable().requestLayout();
                 viewRect.requestLayout();
+                viewContent.requestLayout();
             },
             control.fitToWidthProperty(),
             control.fitToHeightProperty()

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/ScrollPaneSkinTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/ScrollPaneSkinTest.java
@@ -144,6 +144,67 @@ public class ScrollPaneSkinTest {
         assertTrue(originalValue < scrollPane.getVvalue());
     }
 
+    @Test
+    public void fitToHeight() {
+        StackPane content = new StackPane();
+        content.setPrefWidth(100);
+        content.setPrefHeight(100);
+
+        scrollPane.setContent(content);
+        scrollPane.setPrefWidth(200);
+        scrollPane.setPrefHeight(200);
+        scrollPane.setFitToHeight(false);
+
+        Scene scene = new Scene(new Group(), 400, 400);
+        ((Group) scene.getRoot()).getChildren().clear();
+        ((Group) scene.getRoot()).getChildren().add(scrollPane);
+        Stage stage = new Stage();
+        stage.setScene(scene);
+        stage.show();
+
+        assertTrue(content.getHeight() == 100);
+
+        scrollPane.setFitToHeight(true);
+        Toolkit.getToolkit().firePulse();
+
+        assertTrue(content.getHeight() > 150);
+
+        scrollPane.setFitToHeight(false);
+        Toolkit.getToolkit().firePulse();
+
+        assertTrue(content.getHeight() == 100);
+    }
+
+    @Test
+    public void fitToWidth() {
+        StackPane content = new StackPane();
+        content.setPrefWidth(100);
+        content.setPrefHeight(100);
+
+        scrollPane.setContent(content);
+        scrollPane.setPrefWidth(200);
+        scrollPane.setPrefHeight(200);
+        scrollPane.setFitToWidth(false);
+
+        Scene scene = new Scene(new Group(), 400, 400);
+        ((Group) scene.getRoot()).getChildren().clear();
+        ((Group) scene.getRoot()).getChildren().add(scrollPane);
+        Stage stage = new Stage();
+        stage.setScene(scene);
+        stage.show();
+
+        assertTrue(content.getWidth() == 100);
+
+        scrollPane.setFitToWidth(true);
+        Toolkit.getToolkit().firePulse();
+
+        assertTrue(content.getWidth() > 150);
+
+        scrollPane.setFitToWidth(false);
+        Toolkit.getToolkit().firePulse();
+
+        assertTrue(content.getWidth() == 100);
+    }
 
     boolean continueTest;
     class myPane extends Pane {


### PR DESCRIPTION
- fixed the issue
- added unit tests
- clarified default value of `ScrollPane.fitWidth` and `ScrollPane.fitHeight` properties

No CSR is needed as it is a minor clarification.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341440](https://bugs.openjdk.org/browse/JDK-8341440): ScrollPane: no immediate effect changing fitWidth/fitHeight (**Bug** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [John Hendrikx](https://openjdk.org/census#jhendrikx) (@hjohn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1597/head:pull/1597` \
`$ git checkout pull/1597`

Update a local copy of the PR: \
`$ git checkout pull/1597` \
`$ git pull https://git.openjdk.org/jfx.git pull/1597/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1597`

View PR using the GUI difftool: \
`$ git pr show -t 1597`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1597.diff">https://git.openjdk.org/jfx/pull/1597.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1597#issuecomment-2405763899)