### PR TITLE
8341920: Intermittent WebKit build failure on Windows generating PDB files in 619.1

### DIFF
--- a/modules/javafx.web/src/main/native/Source/cmake/OptionsMSVC.cmake
+++ b/modules/javafx.web/src/main/native/Source/cmake/OptionsMSVC.cmake
@@ -117,16 +117,14 @@ if (NOT COMPILER_IS_CLANG_CL)
     )
 endif ()
 
-if (NOT WTF_CPU_X86)
-    if (PORT STREQUAL "Java")
+if (PORT STREQUAL "Java")
     # Suppress creation of pdb files for Release builds
     # FIXME: Need to re-enable the flag for Debug builds
     #add_compile_options(/Zi /GS)
 
-    else()
+else()
     # Create pdb files for debugging purposes, also for Release builds
     add_compile_options(/Zi /GS)
-    endif()
 endif()
 
 # Disable ICF (identical code folding) optimization,

--- a/modules/javafx.web/src/main/native/Source/cmake/OptionsMSVC.cmake
+++ b/modules/javafx.web/src/main/native/Source/cmake/OptionsMSVC.cmake
@@ -117,8 +117,17 @@ if (NOT COMPILER_IS_CLANG_CL)
     )
 endif ()
 
-# Create pdb files for debugging purposes, also for Release builds
-add_compile_options(/Zi /GS)
+if (NOT WTF_CPU_X86)
+    if (PORT STREQUAL "Java")
+    # Suppress creation of pdb files for Release builds
+    # FIXME: Need to re-enable the flag for Debug builds
+    #add_compile_options(/Zi /GS)
+
+    else()
+    # Create pdb files for debugging purposes, also for Release builds
+    add_compile_options(/Zi /GS)
+    endif()
+endif()
 
 # Disable ICF (identical code folding) optimization,
 # as it makes it unsafe to pointer-compare functions with identical definitions.


### PR DESCRIPTION
Disabled the pdb file generation in order to resolve the build failure.
Sanity testing looks fine. Verified build on windows, mac and linux.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341920](https://bugs.openjdk.org/browse/JDK-8341920): Intermittent WebKit build failure on Windows generating PDB files in 619.1 (**Bug** - P2)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Joeri Sykora](https://openjdk.org/census#sykora) (@tiainen - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1599/head:pull/1599` \
`$ git checkout pull/1599`

Update a local copy of the PR: \
`$ git checkout pull/1599` \
`$ git pull https://git.openjdk.org/jfx.git pull/1599/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1599`

View PR using the GUI difftool: \
`$ git pr show -t 1599`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1599.diff">https://git.openjdk.org/jfx/pull/1599.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1599#issuecomment-2407841870)