### PR TITLE
8340005: Eliminate native access calls from javafx.swing

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Application.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Application.java
@@ -811,4 +811,13 @@ public abstract class Application {
      * and if so, emits a warning.
      */
     public void checkPlatformPreferencesSupport() {}
+
+    private static native void _overrideNativeWindowHandle(Class lwFrameWrapperClass,
+                                                           Object frame,
+                                                           long handle, Runnable closeWindow);
+
+    public static void overrideNativeWindowHandle(Class lwFrameWrapperClass, Object frame,
+                                                  long handle, Runnable closeWindow) {
+        _overrideNativeWindowHandle(lwFrameWrapperClass, frame, handle, closeWindow);
+    }
 }

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/application/PlatformImpl.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/application/PlatformImpl.java
@@ -1060,4 +1060,5 @@ public class PlatformImpl {
             setAccessibilityTheme(null);
         }
     }
+
 }

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/application/PlatformImpl.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/application/PlatformImpl.java
@@ -1061,4 +1061,12 @@ public class PlatformImpl {
         }
     }
 
+    private static native void _overrideNativeWindowHandle(Class lwFrameWrapperClass,
+                                                           Object frame,
+                                                           long handle, Runnable closeWindow);
+
+    public static void overrideNativeWindowHandle(Class lwFrameWrapperClass, Object frame,
+                                                  long handle, Runnable closeWindow) {
+        _overrideNativeWindowHandle(lwFrameWrapperClass, frame, handle, closeWindow);
+    }
 }

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/application/PlatformImpl.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/application/PlatformImpl.java
@@ -1060,13 +1060,4 @@ public class PlatformImpl {
             setAccessibilityTheme(null);
         }
     }
-
-    private static native void _overrideNativeWindowHandle(Class lwFrameWrapperClass,
-                                                           Object frame,
-                                                           long handle, Runnable closeWindow);
-
-    public static void overrideNativeWindowHandle(Class lwFrameWrapperClass, Object frame,
-                                                  long handle, Runnable closeWindow) {
-        _overrideNativeWindowHandle(lwFrameWrapperClass, frame, handle, closeWindow);
-    }
 }

--- a/modules/javafx.graphics/src/main/native-prism/SwingInterop.c
+++ b/modules/javafx.graphics/src/main/native-prism/SwingInterop.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,12 +26,12 @@
 #include <jni.h>
 
 /*
- * Class com_sun_javafx_embed_swing_newimpl_SwingNodeInteropN
+ * Class com_sun_javafx_application_PlatformImpl
  * Method: overrideNativeWindowHandle
  * Signature (Ljava/lang/Class;JLjava/lang/Runnable)Ljdk.swing.interop.LightweightFrameWrapper;
  */
 JNIEXPORT void JNICALL
-Java_com_sun_javafx_embed_swing_newimpl_SwingNodeInteropN_overrideNativeWindowHandle(
+Java_com_sun_javafx_application_PlatformImpl__1overrideNativeWindowHandle(
  JNIEnv *env, jclass cls, jclass lwFrameClass, jobject lwFrame, jlong id, jobject runnable) {
 
     jmethodID cons;

--- a/modules/javafx.graphics/src/main/native-prism/SwingInterop.c
+++ b/modules/javafx.graphics/src/main/native-prism/SwingInterop.c
@@ -24,14 +24,15 @@
  */
 
 #include <jni.h>
+#include "com_sun_glass_ui_Application.h"
 
 /*
- * Class com_sun_javafx_application_PlatformImpl
- * Method: overrideNativeWindowHandle
- * Signature (Ljava/lang/Class;JLjava/lang/Runnable)Ljdk.swing.interop.LightweightFrameWrapper;
+ * Class com_sun_glass_ui_Application
+ * Method: _overrideNativeWindowHandle
+ * Signature (Ljava/lang/Class;Ljava/lang/Object;JLjava/lang/Runnable;)V
  */
 JNIEXPORT void JNICALL
-Java_com_sun_javafx_application_PlatformImpl__1overrideNativeWindowHandle(
+Java_com_sun_glass_ui_Application__1overrideNativeWindowHandle(
  JNIEnv *env, jclass cls, jclass lwFrameClass, jobject lwFrame, jlong id, jobject runnable) {
 
     jmethodID cons;

--- a/modules/javafx.swing/src/main/java/com/sun/javafx/embed/swing/newimpl/SwingNodeInteropN.java
+++ b/modules/javafx.swing/src/main/java/com/sun/javafx/embed/swing/newimpl/SwingNodeInteropN.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
 package com.sun.javafx.embed.swing.newimpl;
 
 import com.sun.javafx.PlatformUtil;
+import com.sun.javafx.application.PlatformImpl;
 import com.sun.javafx.embed.swing.DisposerRecord;
 import com.sun.javafx.embed.swing.FXDnD;
 import com.sun.javafx.embed.swing.SwingCursors;
@@ -65,9 +66,7 @@ public class SwingNodeInteropN {
      */
     private static OptionalMethod<LightweightFrameWrapper> jlfNotifyDisplayChanged;
     private static Class lwFrameWrapperClass = null;
-    private static native void overrideNativeWindowHandle(Class lwFrameWrapperClass,
-                                  LightweightFrameWrapper lwFrame, long handle,
-                                                    Runnable closeWindow);
+
     static {
         jlfNotifyDisplayChanged = new OptionalMethod<>(LightweightFrameWrapper.class,
                 "notifyDisplayChanged", Double.TYPE, Double.TYPE);
@@ -125,8 +124,9 @@ public class SwingNodeInteropN {
 
     public void overrideNativeWindowHandle(Object frame, long handle, Runnable closeWindow) {
         LightweightFrameWrapper lwFrame = (LightweightFrameWrapper)frame;
-        overrideNativeWindowHandle(lwFrameWrapperClass, lwFrame, handle, closeWindow);
+        PlatformImpl.overrideNativeWindowHandle(lwFrameWrapperClass, lwFrame, handle, closeWindow);
     }
+
 
     public void notifyDisplayChanged(Object frame, double scaleX, double scaleY) {
         LightweightFrameWrapper lwFrame = (LightweightFrameWrapper)frame;

--- a/modules/javafx.swing/src/main/java/com/sun/javafx/embed/swing/newimpl/SwingNodeInteropN.java
+++ b/modules/javafx.swing/src/main/java/com/sun/javafx/embed/swing/newimpl/SwingNodeInteropN.java
@@ -25,8 +25,8 @@
 
 package com.sun.javafx.embed.swing.newimpl;
 
+import com.sun.glass.ui.Application;
 import com.sun.javafx.PlatformUtil;
-import com.sun.javafx.application.PlatformImpl;
 import com.sun.javafx.embed.swing.DisposerRecord;
 import com.sun.javafx.embed.swing.FXDnD;
 import com.sun.javafx.embed.swing.SwingCursors;
@@ -124,9 +124,8 @@ public class SwingNodeInteropN {
 
     public void overrideNativeWindowHandle(Object frame, long handle, Runnable closeWindow) {
         LightweightFrameWrapper lwFrame = (LightweightFrameWrapper)frame;
-        PlatformImpl.overrideNativeWindowHandle(lwFrameWrapperClass, lwFrame, handle, closeWindow);
+        Application.overrideNativeWindowHandle(lwFrameWrapperClass, lwFrame, handle, closeWindow);
     }
-
 
     public void notifyDisplayChanged(Object frame, double scaleX, double scaleY) {
         LightweightFrameWrapper lwFrame = (LightweightFrameWrapper)frame;


### PR DESCRIPTION
While implementing [JDK-8339517](https://bugs.openjdk.org/browse/JDK-8339517) to eliminate native access warnings by passing "--enable-native-access" for the three JavaFX modules with native code (javafx.graphics, javafx.media, and javafx.web), it was found  that the Swing interop code in javafx.swing calls a JNI method defined in one of the native graphics libraries (prism-common) directly

This means that even after [JDK-8339517](https://bugs.openjdk.org/browse/JDK-8339517) is fixed, we still get native access warnings when running any test that uses SwingNode.

This fixes the native access warning by making javafx.graphics module call the native JNI and Swing-interop calls the static utility method in javafx.graphics, in this case defined in PlatformImpl

All test.javafx.embed.swing SwingNode tests are running ok without any native warning

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8340005](https://bugs.openjdk.org/browse/JDK-8340005): Eliminate native access calls from javafx.swing (**Bug** - P3)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1600/head:pull/1600` \
`$ git checkout pull/1600`

Update a local copy of the PR: \
`$ git checkout pull/1600` \
`$ git pull https://git.openjdk.org/jfx.git pull/1600/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1600`

View PR using the GUI difftool: \
`$ git pr show -t 1600`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1600.diff">https://git.openjdk.org/jfx/pull/1600.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1600#issuecomment-2412798528)