### PR TITLE
8340850: Wrong bug ID listed as reason for skipping SwingNodePlatformExitCrashTest

### DIFF
--- a/tests/system/src/test/java/test/robot/javafx/embed/swing/SwingNodePlatformExitCrashTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/embed/swing/SwingNodePlatformExitCrashTest.java
@@ -36,7 +36,7 @@ import test.util.Util;
 public class SwingNodePlatformExitCrashTest extends SwingNodeBase {
 
     @Test
-    @Disabled("JDK-8190329")
+    @Disabled("JDK-8340849")
     public void testPlatformExitBeforeShowHoldEDT() throws InvocationTargetException, InterruptedException {
         myApp.createAndShowStage();
         CountDownLatch latch = new CountDownLatch(1);


### PR DESCRIPTION
SwingNodePlatformExitCrashTest lists [JDK-8190329](https://bugs.openjdk.org/browse/JDK-8190329) as the reason it is skipped. However, the correct bug ID is the newly filed [JDK-8340849](https://bugs.openjdk.org/browse/JDK-8340849)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340850](https://bugs.openjdk.org/browse/JDK-8340850): Wrong bug ID listed as reason for skipping SwingNodePlatformExitCrashTest (**Bug** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1603/head:pull/1603` \
`$ git checkout pull/1603`

Update a local copy of the PR: \
`$ git checkout pull/1603` \
`$ git pull https://git.openjdk.org/jfx.git pull/1603/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1603`

View PR using the GUI difftool: \
`$ git pr show -t 1603`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1603.diff">https://git.openjdk.org/jfx/pull/1603.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1603#issuecomment-2418810440)