### PR TITLE
8340849: [macos] Crash when creating a child window of a JavaFX window after Platform::exit

### DIFF
--- a/modules/javafx.swing/src/main/java/javafx/embed/swing/SwingNode.java
+++ b/modules/javafx.swing/src/main/java/javafx/embed/swing/SwingNode.java
@@ -387,7 +387,7 @@ public class SwingNode extends Node {
             swNodeIOP.setContent(lwFrame, swNodeIOP.createSwingNodeContent(content, this));
             swNodeIOP.setVisible(lwFrame, true);
 
-            rec = swNodeIOP.createSwingNodeDisposer(lwFrame);
+            rec = swNodeIOP.createSwingNodeDisposer(lwFrame, swNodeIOP);
             disposerRecRef = Disposer.addRecord(this, rec);
 
             if (getScene() != null) {

--- a/tests/system/src/test/java/test/robot/javafx/embed/swing/SwingNodePlatformExitCrashTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/embed/swing/SwingNodePlatformExitCrashTest.java
@@ -29,6 +29,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.concurrent.CountDownLatch;
 import javax.swing.SwingUtilities;
 import javafx.application.Platform;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import test.util.Util;
@@ -36,7 +37,6 @@ import test.util.Util;
 public class SwingNodePlatformExitCrashTest extends SwingNodeBase {
 
     @Test
-    @Disabled("JDK-8340849")
     public void testPlatformExitBeforeShowHoldEDT() throws InvocationTargetException, InterruptedException {
         myApp.createAndShowStage();
         CountDownLatch latch = new CountDownLatch(1);
@@ -50,5 +50,11 @@ public class SwingNodePlatformExitCrashTest extends SwingNodeBase {
         testAbove(false);
         runWaitSleep(()-> Platform.exit());
         myApp.disposeDialog();
+    }
+
+    @AfterAll
+    public static void teardownOnce() {
+        // No-op as Toolkit shutdown is already done in Platform.exit
+        // and calling superclass teardownOnce will cause hang
     }
 }


### PR DESCRIPTION
When AWT toolkit is started first for it to own the "NSApplication" and then FX toolkit is started and shutdown by calling `Platform.exit` and then Swing Dialog is tried to be created, then it is seen that the application crashes as the AWT dialog tries to create the underlying Window as a child window of the FX window (as can be seen [here](https://github.com/openjdk/jdk/blob/9f6211bcf1b46e4bfba2d128d9eb8457bc0cde51/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPlatformWindow.java#L738-L743) )
Since the underlying window handle is already invalid, it crashes.

The fix is made to register shutdown hook when FX toolkit is shutting down so as to notify JLightweightFrame about the invalid window handle when FX toolkit is shutdown and SwingNode disposer is called.

The regression test is modified to override tearDownOnce as the test method shuts down the JavaFX runtime using `Platform.exit`, then the `teardownOnce `method in the superclass  calls `Util.shutdown`, which times out waiting for a runnable to run, which it never will since the toolkit is already shutdown

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issues
 * [JDK-8340849](https://bugs.openjdk.org/browse/JDK-8340849): [macos] Crash when creating a child window of a JavaFX window after Platform::exit (**Bug** - P3)
 * [JDK-8340442](https://bugs.openjdk.org/browse/JDK-8340442): Enable SwingNodePlatformExitCrashTest after JDK-8340849 is fixed (**Bug** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Lukasz Kostyra](https://openjdk.org/census#lkostyra) (@lukostyra - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1614/head:pull/1614` \
`$ git checkout pull/1614`

Update a local copy of the PR: \
`$ git checkout pull/1614` \
`$ git pull https://git.openjdk.org/jfx.git pull/1614/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1614`

View PR using the GUI difftool: \
`$ git pr show -t 1614`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1614.diff">https://git.openjdk.org/jfx/pull/1614.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1614#issuecomment-2441858967)