### PR TITLE
8342456: Remove calls to doPrivileged in javafx.graphics/other

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/application/LauncherImpl.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/application/LauncherImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,8 +39,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.URL;
 import java.net.URLClassLoader;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.text.Normalizer;
 import java.util.ArrayList;
 import java.util.LinkedList;
@@ -91,9 +89,7 @@ public class LauncherImpl {
     private static final boolean trace = false;
 
     // set system property javafx.verbose to true to make the launcher noisy
-    @SuppressWarnings("removal")
-    private static final boolean verbose = AccessController.doPrivileged((PrivilegedAction<Boolean>) () ->
-        Boolean.getBoolean("javafx.verbose"));
+    private static final boolean verbose = Boolean.getBoolean("javafx.verbose");
 
     private static final String MF_MAIN_CLASS = "Main-Class";
     private static final String MF_JAVAFX_MAIN = "JavaFX-Application-Class";
@@ -146,9 +142,7 @@ public class LauncherImpl {
         Class<? extends Preloader> preloaderClass = savedPreloaderClass;
 
         if (preloaderClass == null) {
-            @SuppressWarnings("removal")
-            String preloaderByProperty = AccessController.doPrivileged((PrivilegedAction<String>) () ->
-                    System.getProperty("javafx.preloader"));
+            String preloaderByProperty = System.getProperty("javafx.preloader");
             if (preloaderByProperty != null) {
                 try {
                     preloaderClass = (Class<? extends Preloader>) Class.forName(preloaderByProperty,

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/application/PlatformImpl.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/application/PlatformImpl.java
@@ -39,9 +39,6 @@ import com.sun.javafx.util.ModuleHelper;
 import java.lang.module.ModuleDescriptor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.security.AccessControlContext;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -105,15 +102,9 @@ public class PlatformImpl {
     private static BooleanProperty accessibilityActive = new SimpleBooleanProperty();
     private static CountDownLatch allNestedLoopsExitedLatch = new CountDownLatch(1);
 
-    @SuppressWarnings("removal")
-    private static final boolean verbose
-            = AccessController.doPrivileged((PrivilegedAction<Boolean>) () ->
-                Boolean.getBoolean("javafx.verbose"));
+    private static final boolean verbose = Boolean.getBoolean("javafx.verbose");
 
-    @SuppressWarnings("removal")
-    private static final boolean DEBUG
-            = AccessController.doPrivileged((PrivilegedAction<Boolean>) ()
-                    -> Boolean.getBoolean("com.sun.javafx.application.debug"));
+    private static final boolean DEBUG = Boolean.getBoolean("com.sun.javafx.application.debug");
 
     // Internal permission used by FXCanvas (SWT interop)
     private static final FXPermission FXCANVAS_PERMISSION =
@@ -218,52 +209,48 @@ public class PlatformImpl {
             Logging.getJavaFXLogger().warning(warningStr);
         }
 
-        @SuppressWarnings("removal")
-        var dummy = AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-            applicationType = System.getProperty("com.sun.javafx.application.type");
-            if (applicationType == null) applicationType = "";
+        applicationType = System.getProperty("com.sun.javafx.application.type");
+        if (applicationType == null) applicationType = "";
 
-            contextual2DNavigation = Boolean.getBoolean(
-                    "com.sun.javafx.isContextual2DNavigation");
-            String s = System.getProperty("com.sun.javafx.twoLevelFocus");
-            if (s != null) {
-                hasTwoLevelFocus = Boolean.valueOf(s);
+        contextual2DNavigation = Boolean.getBoolean(
+                "com.sun.javafx.isContextual2DNavigation");
+        String s = System.getProperty("com.sun.javafx.twoLevelFocus");
+        if (s != null) {
+            hasTwoLevelFocus = Boolean.valueOf(s);
+        }
+        s = System.getProperty("com.sun.javafx.virtualKeyboard");
+        if (s != null) {
+            if (s.equalsIgnoreCase("none")) {
+                hasVirtualKeyboard = false;
+            } else if (s.equalsIgnoreCase("javafx")) {
+                hasVirtualKeyboard = true;
+            } else if (s.equalsIgnoreCase("native")) {
+                hasVirtualKeyboard = true;
             }
-            s = System.getProperty("com.sun.javafx.virtualKeyboard");
-            if (s != null) {
-                if (s.equalsIgnoreCase("none")) {
-                    hasVirtualKeyboard = false;
-                } else if (s.equalsIgnoreCase("javafx")) {
-                    hasVirtualKeyboard = true;
-                } else if (s.equalsIgnoreCase("native")) {
-                    hasVirtualKeyboard = true;
+        }
+        s = System.getProperty("com.sun.javafx.touch");
+        if (s != null) {
+            hasTouch = Boolean.valueOf(s);
+        }
+        s = System.getProperty("com.sun.javafx.multiTouch");
+        if (s != null) {
+            hasMultiTouch = Boolean.valueOf(s);
+        }
+        s = System.getProperty("com.sun.javafx.pointer");
+        if (s != null) {
+            hasPointer = Boolean.valueOf(s);
+        }
+        s = System.getProperty("javafx.embed.singleThread");
+        if (s != null) {
+            isThreadMerged = Boolean.valueOf(s);
+            if (isThreadMerged && !isSupported(ConditionalFeature.SWING)) {
+                isThreadMerged = false;
+                if (verbose) {
+                    System.err.println(
+                    "WARNING: javafx.embed.singleThread ignored (javafx.swing module not found)");
                 }
             }
-            s = System.getProperty("com.sun.javafx.touch");
-            if (s != null) {
-                hasTouch = Boolean.valueOf(s);
-            }
-            s = System.getProperty("com.sun.javafx.multiTouch");
-            if (s != null) {
-                hasMultiTouch = Boolean.valueOf(s);
-            }
-            s = System.getProperty("com.sun.javafx.pointer");
-            if (s != null) {
-                hasPointer = Boolean.valueOf(s);
-            }
-            s = System.getProperty("javafx.embed.singleThread");
-            if (s != null) {
-                isThreadMerged = Boolean.valueOf(s);
-                if (isThreadMerged && !isSupported(ConditionalFeature.SWING)) {
-                    isThreadMerged = false;
-                    if (verbose) {
-                        System.err.println(
-                        "WARNING: javafx.embed.singleThread ignored (javafx.swing module not found)");
-                    }
-                }
-            }
-            return null;
-        });
+        }
 
         if (DEBUG) {
             System.err.println("PlatformImpl::startup : applicationType = "
@@ -274,11 +261,7 @@ public class PlatformImpl {
         }
 
         if (!taskbarApplication) {
-            @SuppressWarnings("removal")
-            var dummy2 = AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-                System.setProperty("glass.taskbarApplication", "false");
-                return null;
-            });
+            System.setProperty("glass.taskbarApplication", "false");
         }
 
         // Create Toolkit listener and register it with the Toolkit.
@@ -315,9 +298,7 @@ public class PlatformImpl {
         // Read the javafx.embed.eventProc system property and store
         // it in an entry in the glass Application device details map
         final String eventProcProperty = "javafx.embed.eventProc";
-        @SuppressWarnings("removal")
-        final long eventProc = AccessController.doPrivileged((PrivilegedAction<Long>) () ->
-                Long.getLong(eventProcProperty, 0));
+        final long eventProc = Long.getLong(eventProcProperty, 0);
         if (eventProc != 0L) {
             // Set the value for the javafx.embed.eventProc
             // key in the glass Application map
@@ -376,9 +357,7 @@ public class PlatformImpl {
                 !f.getClassName().startsWith("javafx.application.")
                         && !f.getClassName().startsWith("com.sun.javafx.application.");
 
-        @SuppressWarnings("removal")
-        final StackWalker walker = AccessController.doPrivileged((PrivilegedAction<StackWalker>) () ->
-                StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE));
+        final StackWalker walker = StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE);
         Optional<StackWalker.StackFrame> frame = walker.walk(
                 s -> s.filter(classFilter).findFirst());
 
@@ -456,16 +435,10 @@ public class PlatformImpl {
                 return;
             }
 
-            @SuppressWarnings("removal")
-            final AccessControlContext acc = AccessController.getContext();
             // Don't catch exceptions, they are handled by Toolkit.defer()
             Toolkit.getToolkit().defer(() -> {
                 try {
-                    @SuppressWarnings("removal")
-                    var dummy = AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-                        r.run();
-                        return null;
-                    }, acc);
+                    r.run();
                 } finally {
                     pendingRunnables.decrementAndGet();
                     checkIdle();
@@ -756,9 +729,7 @@ public class PlatformImpl {
     private static void _setAccessibilityTheme(String platformTheme) {
 
         // check to see if there is an override to enable a high-contrast theme
-        @SuppressWarnings("removal")
-        final String userTheme = AccessController.doPrivileged(
-                (PrivilegedAction<String>) () -> System.getProperty("com.sun.javafx.highContrastTheme"));
+        final String userTheme = System.getProperty("com.sun.javafx.highContrastTheme");
 
         if (isCaspian()) {
             if (platformTheme != null || userTheme != null) {
@@ -804,9 +775,7 @@ public class PlatformImpl {
     private static void _setPlatformUserAgentStylesheet(String stylesheetUrl) {
         isModena = isCaspian = false;
         // check for command line override
-        @SuppressWarnings("removal")
-        final String overrideStylesheetUrl = AccessController.doPrivileged(
-                (PrivilegedAction<String>) () -> System.getProperty("javafx.userAgentStylesheetUrl"));
+        final String overrideStylesheetUrl = System.getProperty("javafx.userAgentStylesheetUrl");
 
         if (overrideStylesheetUrl != null) {
             stylesheetUrl = overrideStylesheetUrl;
@@ -886,28 +855,16 @@ public class PlatformImpl {
             uaStylesheets.add(accessibilityTheme);
         }
 
-        @SuppressWarnings("removal")
-        var dummy = AccessController.doPrivileged((PrivilegedAction) () -> {
-            StyleManager.getInstance().setUserAgentStylesheets(uaStylesheets);
-            return null;
-        });
-
+        StyleManager.getInstance().setUserAgentStylesheets(uaStylesheets);
     }
 
-    @SuppressWarnings("removal")
     public static void addNoTransparencyStylesheetToScene(final Scene scene) {
         if (PlatformImpl.isCaspian()) {
-            AccessController.doPrivileged((PrivilegedAction) () -> {
-                StyleManager.getInstance().addUserAgentStylesheet(scene,
-                        "com/sun/javafx/scene/control/skin/caspian/caspian-no-transparency.css");
-                return null;
-            });
+            StyleManager.getInstance().addUserAgentStylesheet(scene,
+                    "com/sun/javafx/scene/control/skin/caspian/caspian-no-transparency.css");
         } else if (PlatformImpl.isModena()) {
-            AccessController.doPrivileged((PrivilegedAction) () -> {
-                StyleManager.getInstance().addUserAgentStylesheet(scene,
-                        "com/sun/javafx/scene/control/skin/modena/modena-no-transparency.css");
-                return null;
-            });
+            StyleManager.getInstance().addUserAgentStylesheet(scene,
+                    "com/sun/javafx/scene/control/skin/modena/modena-no-transparency.css");
         }
     }
 
@@ -929,15 +886,10 @@ public class PlatformImpl {
                     isMediaSupported = checkForClass(
                             "javafx.scene.media.MediaView");
                     if (isMediaSupported && PlatformUtil.isEmbedded()) {
-                        @SuppressWarnings("removal")
-                        var dummy = AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-                            String s = System.getProperty(
-                                    "com.sun.javafx.experimental.embedded.media",
-                                    "false");
-                            isMediaSupported = Boolean.valueOf(s);
-                            return null;
-
-                        });
+                        String s = System.getProperty(
+                                "com.sun.javafx.experimental.embedded.media",
+                                "false");
+                        isMediaSupported = Boolean.valueOf(s);
                     }
                 }
                 return isMediaSupported;
@@ -945,15 +897,10 @@ public class PlatformImpl {
                 if (isWebSupported == null) {
                     isWebSupported = checkForClass("javafx.scene.web.WebView");
                     if (isWebSupported && PlatformUtil.isEmbedded()) {
-                        @SuppressWarnings("removal")
-                        var dummy = AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-                            String s = System.getProperty(
-                                    "com.sun.javafx.experimental.embedded.web",
-                                    "false");
-                            isWebSupported = Boolean.valueOf(s);
-                            return null;
-
-                        });
+                        String s = System.getProperty(
+                                "com.sun.javafx.experimental.embedded.web",
+                                "false");
+                        isWebSupported = Boolean.valueOf(s);
                     }
                 }
                 return isWebSupported;

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/AndroidFontFinder.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/AndroidFontFinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,6 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -63,11 +61,7 @@ class AndroidFontFinder {
     final static String systemFontsDir = "/system/fonts";
 
     static {
-        @SuppressWarnings("removal")
-        var dummy = AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-            NativeLibLoader.loadLibrary("javafx_font");
-            return null;
-        });
+        NativeLibLoader.loadLibrary("javafx_font");
     }
 
     public static String getSystemFont() {

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/DFontDecoder.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/DFontDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,18 +26,12 @@
 package com.sun.javafx.font;
 
 import java.io.IOException;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 
 import com.sun.glass.utils.NativeLibLoader;
 
 class DFontDecoder extends FontFileWriter {
     static {
-        @SuppressWarnings("removal")
-        var dummy = AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-            NativeLibLoader.loadLibrary("javafx_font");
-            return null;
-        });
+        NativeLibLoader.loadLibrary("javafx_font");
     }
     private native static long createCTFont(String fontName);
     private native static void releaseCTFont(long font);

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/Disposer.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/Disposer.java
@@ -59,6 +59,7 @@ public class Disposer implements Runnable {
         for (ThreadGroup tgn = tg;
             tgn != null;
             tg = tgn, tgn = tg.getParent());
+
         Thread t = new Thread(tg, disposerInstance, "Prism Font Disposer");
         t.setContextClassLoader(null);
         t.setDaemon(true);

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/Disposer.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/Disposer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,29 +52,18 @@ public class Disposer implements Runnable {
         disposerInstance = new Disposer();
 
         ThreadGroup tg = Thread.currentThread().getThreadGroup();
-        @SuppressWarnings("removal")
-        var dummy = java.security.AccessController.doPrivileged(
-            new java.security.PrivilegedAction() {
-                @Override
-                public Object run() {
-                    /* The thread must be a member of a thread group
-                     * which will not get GCed before VM exit.
-                     * Make its parent the top-level thread group.
-                     */
-                    ThreadGroup tg = Thread.currentThread().getThreadGroup();
-                    for (ThreadGroup tgn = tg;
-                         tgn != null;
-                         tg = tgn, tgn = tg.getParent());
-                    Thread t =
-                        new Thread(tg, disposerInstance, "Prism Font Disposer");
-                    t.setContextClassLoader(null);
-                    t.setDaemon(true);
-                    t.setPriority(Thread.MAX_PRIORITY);
-                    t.start();
-                    return null;
-                }
-            }
-        );
+        /* The thread must be a member of a thread group
+         * which will not get GCed before VM exit.
+         * Make its parent the top-level thread group.
+         */
+        for (ThreadGroup tgn = tg;
+            tgn != null;
+            tg = tgn, tgn = tg.getParent());
+        Thread t = new Thread(tg, disposerInstance, "Prism Font Disposer");
+        t.setContextClassLoader(null);
+        t.setDaemon(true);
+        t.setPriority(Thread.MAX_PRIORITY);
+        t.start();
     }
 
     /**

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/FontConfigManager.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/FontConfigManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,8 +28,6 @@ package com.sun.javafx.font;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -44,18 +42,12 @@ public class FontConfigManager {
     static boolean useEmbeddedFontSupport = false;
 
     static {
-        @SuppressWarnings("removal")
-        var dummy = AccessController.doPrivileged(
-                (PrivilegedAction<Void>) () -> {
-                    String dbg = System.getProperty("prism.debugfonts", "");
-                    debugFonts = "true".equals(dbg);
-                    String ufc = System.getProperty("prism.useFontConfig", "true");
-                    useFontConfig = "true".equals(ufc);
-                    String emb = System.getProperty("prism.embeddedfonts", "");
-                    useEmbeddedFontSupport = "true".equals(emb);
-                    return null;
-                }
-        );
+        String dbg = System.getProperty("prism.debugfonts", "");
+        debugFonts = "true".equals(dbg);
+        String ufc = System.getProperty("prism.useFontConfig", "true");
+        useFontConfig = "true".equals(ufc);
+        String emb = System.getProperty("prism.embeddedfonts", "");
+        useEmbeddedFontSupport = "true".equals(emb);
     }
 
     /* These next three classes are just data structures.
@@ -348,13 +340,7 @@ public class FontConfigManager {
         private static boolean fontDirFromJRE = false;
 
         static {
-            @SuppressWarnings("removal")
-            var dummy = AccessController.doPrivileged(
-                    (PrivilegedAction<Void>) () -> {
-                        initEmbeddedFonts();
-                    return null;
-                    }
-            );
+            initEmbeddedFonts();
         }
 
         private static void initEmbeddedFonts() {
@@ -399,11 +385,8 @@ public class FontConfigManager {
         }
 
 
-        @SuppressWarnings("removal")
         private static boolean exists(final File f) {
-            return AccessController.doPrivileged(
-                    (PrivilegedAction<Boolean>) () -> f.exists()
-            );
+            return f.exists();
         }
 
         // this mapping is used in the embedded world when
@@ -544,24 +527,18 @@ public class FontConfigManager {
              Locale locale)
         {
             final Properties props = new Properties();
-            @SuppressWarnings("removal")
-            var dummy = AccessController.doPrivileged(
-                    (PrivilegedAction<Void>) () -> {
-                        try {
-                            String lFile = fontDir+"/allfonts.properties";
-                            FileInputStream fis = new FileInputStream(lFile);
-                            props.load(fis);
-                            fis.close();
-                        } catch (IOException ioe) {
-                            props.clear();
-                            if (debugFonts) {
-                                System.err.println(ioe);
-                                System.err.println("Fall back to opening the files");
-                            }
-                        }
-                        return null;
-                    }
-            );
+            try {
+                String lFile = fontDir+"/allfonts.properties";
+                FileInputStream fis = new FileInputStream(lFile);
+                props.load(fis);
+                fis.close();
+            } catch (IOException ioe) {
+                props.clear();
+                if (debugFonts) {
+                    System.err.println(ioe);
+                    System.err.println("Fall back to opening the files");
+                }
+            }
 
             if (!props.isEmpty()) {
                 int maxFont = Integer.MAX_VALUE;

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/FontFileReader.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/FontFileReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,9 +28,6 @@ package com.sun.javafx.font;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.RandomAccessFile;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-import java.security.PrivilegedActionException;
 
 /*
  * Utility class to read font files.
@@ -52,22 +49,15 @@ class FontFileReader implements FontConstants {
      * Opens the file.
      * @return returns true if the file opened, false if the file was opened
      *  already or if it failed to open the file.
-     * @throws PrivilegedActionException
      */
-    @SuppressWarnings("removal")
-    public synchronized boolean openFile() throws PrivilegedActionException {
+    public synchronized boolean openFile() {
         if (raFile != null) {
             return false;
         }
-        raFile = AccessController.doPrivileged(
-                (PrivilegedAction<RandomAccessFile>) () -> {
-                    try {
-                        return new RandomAccessFile(filename, "r");
-                    } catch (FileNotFoundException fnfe) {
-                        return null;
-                    }
-                }
-        );
+        try {
+            raFile = new RandomAccessFile(filename, "r");
+        } catch (FileNotFoundException fnfe) {
+        }
         if (raFile != null) {
             try {
                 filesize = raFile.length();

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/FontFileWriter.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/FontFileWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,9 +29,6 @@ import java.io.File;
 import java.io.RandomAccessFile;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.security.AccessController;
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Semaphore;
@@ -80,26 +77,19 @@ class FontFileWriter implements FontConstants {
         return file;
     }
 
-    @SuppressWarnings("removal")
-    public File openFile() throws PrivilegedActionException {
+    public File openFile() throws IOException {
         pos = 0;
         writtenBytes = 0;
-        file = AccessController.doPrivileged(
-                (PrivilegedExceptionAction<File>) () -> {
-                    try {
-                        return Files.createTempFile("+JXF", ".tmp").toFile();
-                    } catch (IOException e) {
-                        // don't reveal temporary directory location
-                        throw new IOException("Unable to create temporary file");
-                    }
-                }
-        );
+        try {
+            file = Files.createTempFile("+JXF", ".tmp").toFile();
+        } catch (IOException e) {
+            // don't reveal temporary directory location
+            throw new IOException("Unable to create temporary file");
+        }
         if (tracker != null) {
             tracker.add(file);
         }
-        raFile = AccessController.doPrivileged(
-                (PrivilegedExceptionAction<RandomAccessFile>) () -> new RandomAccessFile(file, "rw")
-        );
+        raFile = new RandomAccessFile(file, "rw");
         if (tracker != null) {
             tracker.set(file, raFile);
         }
@@ -124,7 +114,6 @@ class FontFileWriter implements FontConstants {
         }
     }
 
-    @SuppressWarnings("removal")
     public void deleteFile() {
         if (file != null) {
             if (tracker != null) {
@@ -135,12 +124,7 @@ class FontFileWriter implements FontConstants {
             } catch (Exception e) {
             }
             try {
-                AccessController.doPrivileged(
-                        (PrivilegedExceptionAction<Void>) () -> {
-                            file.delete();
-                            return null;
-                        }
-                );
+                file.delete();
                 if (PrismFontFactory.debugFonts) {
                     System.err.println("Temp file delete: " + file.getPath());
                 }
@@ -342,19 +326,13 @@ class FontFileWriter implements FontConstants {
             private static HashMap<File, RandomAccessFile> files = new HashMap<>();
 
             private static Thread t = null;
-            @SuppressWarnings("removal")
             static void init() {
                 if (t == null) {
                     // Add a shutdown hook to remove the temp file.
-                    java.security.AccessController.doPrivileged(
-                            (java.security.PrivilegedAction) () -> {
-                                t = new Thread(() -> {
-                                    runHooks();
-                                });
-                                Runtime.getRuntime().addShutdownHook(t);
-                                return null;
-                            }
-                    );
+                    t = new Thread(() -> {
+                        runHooks();
+                    });
+                    Runtime.getRuntime().addShutdownHook(t);
                 }
             }
 

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/MacFontFinder.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/MacFontFinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,6 @@
 
 package com.sun.javafx.font;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Locale;
@@ -36,13 +34,7 @@ import com.sun.glass.utils.NativeLibLoader;
 public class MacFontFinder {
 
     static {
-        @SuppressWarnings("removal")
-        var dummy = AccessController.doPrivileged(
-                (PrivilegedAction<Void>) () -> {
-                    NativeLibLoader.loadLibrary("javafx_font");
-                    return null;
-                }
-        );
+        NativeLibLoader.loadLibrary("javafx_font");
     }
 
     private static final int SystemFontType = 2; /*kCTFontSystemFontType*/

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/PrismFontFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/PrismFontFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,9 +25,6 @@
 
 package com.sun.javafx.font;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-import java.security.PrivilegedExceptionAction;
 import java.io.File;
 import java.io.FilenameFilter;
 import java.io.InputStream;
@@ -91,68 +88,61 @@ public abstract class PrismFontFactory implements FontFactory {
         isEmbedded = PlatformUtil.isEmbedded();
         int[] tempCacheLayoutSize = {0x10000};
 
-        @SuppressWarnings("removal")
-        boolean tmp = AccessController.doPrivileged(
-                (PrivilegedAction<Boolean>) () -> {
-                    NativeLibLoader.loadLibrary("javafx_font");
-                    String dbg = System.getProperty("prism.debugfonts", "");
-                    boolean debug = "true".equals(dbg);
-                    jreFontDir = getJDKFontDir();
-                    String s = System.getProperty("com.sun.javafx.fontSize");
-                    systemFontSize = -1f;
-                    if (s != null) {
-                        try {
-                            systemFontSize = Float.parseFloat(s);
-                        } catch (NumberFormatException nfe) {
-                            System.err.println("Cannot parse font size '"
-                                    + s + "'");
-                        }
-                    }
-                    s = System.getProperty("prism.subpixeltext", "on");
-                    if (s.indexOf("on") != -1 || s.indexOf("true") != -1) {
-                        subPixelMode = SUB_PIXEL_ON;
-                    }
-                    if (s.indexOf("native") != -1) {
-                        subPixelMode |= SUB_PIXEL_NATIVE | SUB_PIXEL_ON;
-                    }
-                    if (s.indexOf("vertical") != -1) {
-                        subPixelMode |= SUB_PIXEL_Y | SUB_PIXEL_NATIVE | SUB_PIXEL_ON;
-                    }
+        NativeLibLoader.loadLibrary("javafx_font");
+        String dbg = System.getProperty("prism.debugfonts", "");
+        debugFonts = "true".equals(dbg);
+        jreFontDir = getJDKFontDir();
+        String s = System.getProperty("com.sun.javafx.fontSize");
+        systemFontSize = -1f;
+        if (s != null) {
+            try {
+                systemFontSize = Float.parseFloat(s);
+            } catch (NumberFormatException nfe) {
+                System.err.println("Cannot parse font size '"
+                        + s + "'");
+            }
+        }
+        s = System.getProperty("prism.subpixeltext", "on");
+        if (s.indexOf("on") != -1 || s.indexOf("true") != -1) {
+            subPixelMode = SUB_PIXEL_ON;
+        }
+        if (s.indexOf("native") != -1) {
+            subPixelMode |= SUB_PIXEL_NATIVE | SUB_PIXEL_ON;
+        }
+        if (s.indexOf("vertical") != -1) {
+            subPixelMode |= SUB_PIXEL_Y | SUB_PIXEL_NATIVE | SUB_PIXEL_ON;
+        }
 
-                    s = System.getProperty("prism.fontSizeLimit");
-                    if (s != null) {
-                        try {
-                            fontSizeLimit = Float.parseFloat(s);
-                            if (fontSizeLimit <= 0) {
-                                fontSizeLimit = Float.POSITIVE_INFINITY;
-                            }
-                        } catch (NumberFormatException nfe) {
-                            System.err.println("Cannot parse fontSizeLimit '" + s + "'");
-                        }
-                    }
-
-                    boolean lcdTextOff = isMacOSX || isIOS || isAndroid || isEmbedded;
-                    String defLCDProp = lcdTextOff ? "false" : "true";
-                    String lcdProp = System.getProperty("prism.lcdtext", defLCDProp);
-                    lcdEnabled = lcdProp.equals("true");
-
-                    s = System.getProperty("prism.cacheLayoutSize");
-                    if (s != null) {
-                        try {
-                            tempCacheLayoutSize[0] = Integer.parseInt(s);
-                            if (tempCacheLayoutSize[0] < 0) {
-                                tempCacheLayoutSize[0] = 0;
-                            }
-                        } catch (NumberFormatException nfe) {
-                            System.err.println("Cannot parse cache layout size '"
-                                    + s + "'");
-                        }
-                    }
-
-                    return debug;
+        s = System.getProperty("prism.fontSizeLimit");
+        if (s != null) {
+            try {
+                fontSizeLimit = Float.parseFloat(s);
+                if (fontSizeLimit <= 0) {
+                    fontSizeLimit = Float.POSITIVE_INFINITY;
                 }
-        );
-        debugFonts = tmp;
+            } catch (NumberFormatException nfe) {
+                System.err.println("Cannot parse fontSizeLimit '" + s + "'");
+            }
+        }
+
+        boolean lcdTextOff = isMacOSX || isIOS || isAndroid || isEmbedded;
+        String defLCDProp = lcdTextOff ? "false" : "true";
+        String lcdProp = System.getProperty("prism.lcdtext", defLCDProp);
+        lcdEnabled = lcdProp.equals("true");
+
+        s = System.getProperty("prism.cacheLayoutSize");
+        if (s != null) {
+            try {
+                tempCacheLayoutSize[0] = Integer.parseInt(s);
+                if (tempCacheLayoutSize[0] < 0) {
+                    tempCacheLayoutSize[0] = 0;
+                }
+            } catch (NumberFormatException nfe) {
+                System.err.println("Cannot parse cache layout size '"
+                        + s + "'");
+            }
+        }
+
         cacheLayoutSize = tempCacheLayoutSize[0];
     }
 
@@ -1163,24 +1153,18 @@ public abstract class PrismFontFactory implements FontFactory {
             return sysFontDir+"\\"+filename;
         }
 
-        @SuppressWarnings("removal")
-        String path = AccessController.doPrivileged(
-            new PrivilegedAction<String>() {
-                @Override
-                public String run() {
-                    File f = new File(sysFontDir+"\\"+filename);
-                    if (f.exists()) {
-                        return f.getAbsolutePath();
-                    }
-                    else {
-                        return userFontDir+"\\"+filename;
-                    }
-                }
-            });
+        String path;
+        f = new File(sysFontDir+"\\"+filename);
+        if (f.exists()) {
+            path = f.getAbsolutePath();
+        }
+        else {
+            path = userFontDir+"\\"+filename;
+        }
 
-            if (path != null) {
-                return path;
-            }
+        if (path != null) {
+            return path;
+        }
         return null; //  shouldn't happen.
     }
 
@@ -1363,22 +1347,17 @@ public abstract class PrismFontFactory implements FontFactory {
                     }
                 }
             };
-            @SuppressWarnings("removal")
-            var dummy = java.security.AccessController.doPrivileged(
-                    (PrivilegedAction<Object>) () -> {
-                        /* The thread must be a member of a thread group
-                         * which will not get GCed before VM exit.
-                         * Make its parent the top-level thread group.
-                         */
-                        ThreadGroup tg = Thread.currentThread().getThreadGroup();
-                        for (ThreadGroup tgn = tg;
-                             tgn != null; tg = tgn, tgn = tg.getParent());
-                        fileCloser = new Thread(tg, fileCloserRunnable);
-                        fileCloser.setContextClassLoader(null);
-                        Runtime.getRuntime().addShutdownHook(fileCloser);
-                        return null;
-                    }
-            );
+
+            /* The thread must be a member of a thread group
+             * which will not get GCed before VM exit.
+             * Make its parent the top-level thread group.
+             */
+            ThreadGroup tg = Thread.currentThread().getThreadGroup();
+            for (ThreadGroup tgn = tg;
+                    tgn != null; tg = tgn, tgn = tg.getParent());
+            fileCloser = new Thread(tg, fileCloserRunnable);
+            fileCloser.setContextClassLoader(null);
+            Runtime.getRuntime().addShutdownHook(fileCloser);
         }
     }
 
@@ -1844,11 +1823,7 @@ public abstract class PrismFontFactory implements FontFactory {
         final File dir = new File(fontDir);
         String[] files = null;
         try {
-            @SuppressWarnings("removal")
-            String[] tmp = AccessController.doPrivileged(
-                    (PrivilegedExceptionAction<String[]>) () -> dir.list(TTFilter.getInstance())
-            );
-            files = tmp;
+            files = dir.list(TTFilter.getInstance());
         } catch (Exception e) {
         }
 

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/PrismFontFile.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/PrismFontFile.java
@@ -134,10 +134,12 @@ public abstract class PrismFontFile implements FontResource, FontConstants {
                     */
                 isCopy = isDecoded = false;
             } catch (Exception e) {
-            } finally {
-                if (PrismFontFactory.debugFonts) {
-                    System.err.println("Temp file deleted: " + filename);
-                }
+            }
+
+            // TODO: In case of failure this will print "temp file not deleted" and then
+            // "temp file deleted" right after, might be worth ironing out.
+            if (PrismFontFactory.debugFonts) {
+                System.err.println("Temp file deleted: " + filename);
             }
         }
     }
@@ -245,9 +247,9 @@ public abstract class PrismFontFile implements FontResource, FontConstants {
                     if (PrismFontFactory.debugFonts) {
                         e.printStackTrace();
                     }
-                } finally {
-                    fileName = null;
                 }
+
+                fileName = null;
             }
         }
     }

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/PrismFontFile.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/PrismFontFile.java
@@ -29,8 +29,6 @@ package com.sun.javafx.font;
 import java.lang.ref.WeakReference;
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -114,37 +112,32 @@ public abstract class PrismFontFile implements FontResource, FontConstants {
 
     /* This is called only for fonts where a temp file was created
      */
-    @SuppressWarnings("removal")
     protected synchronized void disposeOnShutdown() {
         if (isCopy || isDecoded) {
-            AccessController.doPrivileged(
-                    (PrivilegedAction<Void>) () -> {
-                        try {
-                            /* Although there is likely no harm in calling
-                             * delete on a file > once, we want to refrain
-                             * from deleting it until the shutdown hook
-                             * code in subclasses has had an opportunity
-                             * to clean up native accesses on the resource.
-                             */
-                            if (decFileRefCount() > 0) {
-                                return null;
-                            }
-                            boolean delOK = (new File(filename)).delete();
-                            if (!delOK && PrismFontFactory.debugFonts) {
-                                 System.err.println("Temp file not deleted : "
-                                                    + filename);
-                            }
-                            /* Embedded fonts (copy) can also be decoded.
-                             * Set both flags to false to avoid double deletes.
-                             */
-                            isCopy = isDecoded = false;
-                        } catch (Exception e) {
-                        }
-                        return null;
-                    }
-            );
-            if (PrismFontFactory.debugFonts) {
-                System.err.println("Temp file deleted: " + filename);
+            try {
+                /* Although there is likely no harm in calling
+                 * delete on a file > once, we want to refrain
+                 * from deleting it until the shutdown hook
+                 * code in subclasses has had an opportunity
+                 * to clean up native accesses on the resource.
+                 */
+                if (decFileRefCount() > 0) {
+                    return;
+                }
+                boolean delOK = (new File(filename)).delete();
+                if (!delOK && PrismFontFactory.debugFonts) {
+                        System.err.println("Temp file not deleted : "
+                                        + filename);
+                }
+                /* Embedded fonts (copy) can also be decoded.
+                    * Set both flags to false to avoid double deletes.
+                    */
+                isCopy = isDecoded = false;
+            } catch (Exception e) {
+            } finally {
+                if (PrismFontFactory.debugFonts) {
+                    System.err.println("Temp file deleted: " + filename);
+                }
             }
         }
     }
@@ -220,46 +213,41 @@ public abstract class PrismFontFile implements FontResource, FontConstants {
         }
 
         @Override
-        @SuppressWarnings("removal")
         public synchronized void dispose() {
             if (fileName != null) {
-                AccessController.doPrivileged(
-                        (PrivilegedAction<Void>) () -> {
-                            try {
-                                if (refCounter != null &&
-                                    refCounter.decrement() > 0)
-                                {
-                                    return null;
-                                }
-                                File file = new File(fileName);
-                                int size = (int)file.length();
-                                file.delete();
-                                // decrement tracker only after
-                                // successful deletion.
-                                if (isTracked) {
-                                    FontFileWriter.FontTracker.
-                                        getTracker().subBytes(size);
-                                }
-                                if (factory != null && refKey != null) {
-                                    Object o = refKey.get();
-                                    if (o == null) {
-                                        factory.removeTmpFont(refKey);
-                                        factory = null;
-                                        refKey = null;
-                                    }
-                                }
-                                if (PrismFontFactory.debugFonts) {
-                                    System.err.println("FileDisposer=" + fileName);
-                                }
-                            } catch (Exception e) {
-                                if (PrismFontFactory.debugFonts) {
-                                    e.printStackTrace();
-                                }
-                            }
-                            return null;
+                try {
+                    if (refCounter != null &&
+                        refCounter.decrement() > 0)
+                    {
+                        return;
+                    }
+                    File file = new File(fileName);
+                    int size = (int)file.length();
+                    file.delete();
+                    // decrement tracker only after
+                    // successful deletion.
+                    if (isTracked) {
+                        FontFileWriter.FontTracker.
+                            getTracker().subBytes(size);
+                    }
+                    if (factory != null && refKey != null) {
+                        Object o = refKey.get();
+                        if (o == null) {
+                            factory.removeTmpFont(refKey);
+                            factory = null;
+                            refKey = null;
                         }
-                );
-                fileName = null;
+                    }
+                    if (PrismFontFactory.debugFonts) {
+                        System.err.println("FileDisposer=" + fileName);
+                    }
+                } catch (Exception e) {
+                    if (PrismFontFactory.debugFonts) {
+                        e.printStackTrace();
+                    }
+                } finally {
+                    fileName = null;
+                }
             }
         }
     }

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/coretext/OS.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/coretext/OS.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,19 +26,13 @@
 package com.sun.javafx.font.coretext;
 
 import java.nio.ByteOrder;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 
 import com.sun.glass.utils.NativeLibLoader;
 import com.sun.javafx.geom.Path2D;
 
 class OS {
     static {
-        @SuppressWarnings("removal")
-        var dummy = AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-            NativeLibLoader.loadLibrary("javafx_font");
-            return null;
-        });
+        NativeLibLoader.loadLibrary("javafx_font");
     }
 
     static final int kCFURLPOSIXPathStyle = 0;

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/directwrite/OS.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/directwrite/OS.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,19 +25,12 @@
 
 package com.sun.javafx.font.directwrite;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-
 import com.sun.glass.utils.NativeLibLoader;
 import com.sun.javafx.geom.Path2D;
 
 class OS {
     static {
-        @SuppressWarnings("removal")
-        var dummy = AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-            NativeLibLoader.loadLibrary("javafx_font");
-            return null;
-        });
+        NativeLibLoader.loadLibrary("javafx_font");
     }
 
     static final int S_OK = 0x0;

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/freetype/OSFreetype.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/freetype/OSFreetype.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,19 +25,13 @@
 
 package com.sun.javafx.font.freetype;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import com.sun.glass.utils.NativeLibLoader;
 import com.sun.javafx.geom.Path2D;
 
 class OSFreetype {
 
     static {
-        @SuppressWarnings("removal")
-        var dummy = AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-            NativeLibLoader.loadLibrary("javafx_font_freetype");
-            return null;
-        });
+        NativeLibLoader.loadLibrary("javafx_font_freetype");
     }
 
     /* Freetype */

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/freetype/OSPango.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/freetype/OSPango.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,18 +25,12 @@
 
 package com.sun.javafx.font.freetype;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import com.sun.glass.utils.NativeLibLoader;
 
 class OSPango {
 
     static {
-        @SuppressWarnings("removal")
-        var dummy = AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-            NativeLibLoader.loadLibrary("javafx_font_pango");
-            return null;
-        });
+        NativeLibLoader.loadLibrary("javafx_font_pango");
     }
 
     /* Pango */

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/iio/ios/IosImageLoader.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/iio/ios/IosImageLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,8 +36,6 @@ import com.sun.javafx.iio.common.ImageTools;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 
 import java.util.Map;
 
@@ -109,11 +107,7 @@ public class IosImageLoader extends ImageLoaderImpl {
 
 
     static {
-        @SuppressWarnings("removal")
-        var dummy = AccessController.doPrivileged((PrivilegedAction<Object>) () -> {
-            NativeLibLoader.loadLibrary("nativeiio");
-            return null;
-        });
+        NativeLibLoader.loadLibrary("nativeiio");
 
         COLOR_SPACE_MAPPING = Map.of(
             GRAY,              ImageType.GRAY,

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/iio/jpeg/JPEGImageLoader.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/iio/jpeg/JPEGImageLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,8 +34,6 @@ import com.sun.javafx.iio.common.ImageTools;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 
 public class JPEGImageLoader extends ImageLoaderImpl {
 
@@ -103,11 +101,8 @@ public class JPEGImageLoader extends ImageLoaderImpl {
     private native boolean decompressIndirect(long structPointer, boolean reportProgress, byte[] array) throws IOException;
 
     static {
-        @SuppressWarnings("removal")
-        var dummy = AccessController.doPrivileged((PrivilegedAction<Object>) () -> {
-            NativeLibLoader.loadLibrary("javafx_iio");
-            return null;
-        });
+        NativeLibLoader.loadLibrary("javafx_iio");
+
         initJPEGMethodIDs(InputStream.class);
     }
 

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/util/ModuleHelper.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/util/ModuleHelper.java
@@ -33,11 +33,9 @@ public class ModuleHelper {
     private static final Method addReadsMethod;
     private static final Method addExportsMethod;
 
-    private static final boolean verbose;
+    private static final boolean verbose = Boolean.getBoolean("javafx.verbose");
 
     static {
-        verbose = Boolean.getBoolean("javafx.verbose");
-
         if (verbose) {
             System.err.println("" + ModuleHelper.class.getName() + " : <clinit>");
         }

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/util/ModuleHelper.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/util/ModuleHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,8 +27,6 @@ package com.sun.javafx.util;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 
 public class ModuleHelper {
     private static final Method getModuleMethod;
@@ -38,10 +36,7 @@ public class ModuleHelper {
     private static final boolean verbose;
 
     static {
-        @SuppressWarnings("removal")
-        boolean tmp = AccessController.doPrivileged((PrivilegedAction<Boolean>) () ->
-                Boolean.getBoolean("javafx.verbose"));
-        verbose = tmp;
+        verbose = Boolean.getBoolean("javafx.verbose");
 
         if (verbose) {
             System.err.println("" + ModuleHelper.class.getName() + " : <clinit>");

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/util/Utils.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/util/Utils.java
@@ -25,8 +25,6 @@
 
 package com.sun.javafx.util;
 
-import static com.sun.javafx.FXPermissions.ACCESS_WINDOW_LIST_PERMISSION;
-
 import javafx.application.Platform;
 import javafx.geometry.BoundingBox;
 import javafx.geometry.Bounds;
@@ -680,7 +678,6 @@ public class Utils {
     }
 
     public static boolean hasFullScreenStage(final Screen screen) {
-        @SuppressWarnings("removal")
         final List<Window> allWindows = Window.getWindows();
 
         for (final Window window : allWindows) {

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/util/Utils.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/util/Utils.java
@@ -45,8 +45,6 @@ import javafx.stage.Window;
 import java.math.BigDecimal;
 import java.util.List;
 import com.sun.javafx.PlatformUtil;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import com.sun.glass.utils.NativeLibLoader;
 import com.sun.prism.impl.PrismSettings;
 
@@ -683,10 +681,7 @@ public class Utils {
 
     public static boolean hasFullScreenStage(final Screen screen) {
         @SuppressWarnings("removal")
-        final List<Window> allWindows = AccessController.doPrivileged(
-                (PrivilegedAction<List<Window>>) () -> Window.getWindows(),
-                null,
-                ACCESS_WINDOW_LIST_PERMISSION);
+        final List<Window> allWindows = Window.getWindows();
 
         for (final Window window : allWindows) {
             if (window instanceof Stage) {
@@ -995,20 +990,16 @@ public class Utils {
         return new String(dst, 0, dstIndex);
     }
 
-    @SuppressWarnings("removal")
     public static synchronized void loadNativeSwingLibrary() {
-        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-            String libName = "prism_common";
+        String libName = "prism_common";
 
-            if (PrismSettings.verbose) {
-                System.out.println("Loading Prism common native library ...");
-            }
-            NativeLibLoader.loadLibrary(libName);
-            if (PrismSettings.verbose) {
-                System.out.println("\tsucceeded.");
-            }
-            return null;
-        });
+        if (PrismSettings.verbose) {
+            System.out.println("Loading Prism common native library ...");
+        }
+        NativeLibLoader.loadLibrary(libName);
+        if (PrismSettings.verbose) {
+            System.out.println("\tsucceeded.");
+        }
     }
 
     /**

--- a/modules/javafx.graphics/src/main/java/com/sun/marlin/DMarlinRenderingEngine.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/marlin/DMarlinRenderingEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,14 +25,12 @@
 
 package com.sun.marlin;
 
-import java.security.AccessController;
 import static com.sun.marlin.MarlinUtils.logInfo;
 import com.sun.util.reentrant.ReentrantContextProvider;
 import com.sun.util.reentrant.ReentrantContextProviderCLQ;
 import com.sun.util.reentrant.ReentrantContextProviderTL;
 import com.sun.javafx.geom.PathIterator;
 import com.sun.prism.BasicStroke;
-import java.security.PrivilegedAction;
 
 /**
  * Marlin RendererEngine implementation (derived from Pisces)
@@ -74,12 +72,8 @@ public final class DMarlinRenderingEngine implements MarlinConst
         USE_THREAD_LOCAL = MarlinProperties.isUseThreadLocal();
 
         // Soft reference by default:
-        @SuppressWarnings("removal")
-        final String refType = AccessController.doPrivileged(
-            (PrivilegedAction<String>) () -> {
-                String value = System.getProperty("prism.marlin.useRef");
-                return (value == null) ? "soft" : value;
-            });
+        String value = System.getProperty("prism.marlin.useRef");
+        final String refType = (value == null) ? "soft" : value;
         switch (refType) {
             default:
             case "soft":

--- a/modules/javafx.graphics/src/main/java/com/sun/marlin/MarlinProperties.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/marlin/MarlinProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,9 +25,7 @@
 
 package com.sun.marlin;
 
-import java.security.AccessController;
 import static com.sun.marlin.MarlinUtils.logInfo;
-import java.security.PrivilegedAction;
 
 public final class MarlinProperties {
 
@@ -268,30 +266,20 @@ public final class MarlinProperties {
     }
 
     // system property utilities
-    @SuppressWarnings("removal")
     static String getString(final String key, final String def) {
-        return AccessController.doPrivileged(
-            (PrivilegedAction<String>) () -> {
-                String value = System.getProperty(key);
-                return (value == null) ? def : value;
-            });
+        String value = System.getProperty(key);
+        return (value == null) ? def : value;
     }
 
-    @SuppressWarnings("removal")
     static boolean getBoolean(final String key, final String def) {
-        return Boolean.valueOf(AccessController.doPrivileged(
-            (PrivilegedAction<String>) () -> {
-                String value = System.getProperty(key);
-                return (value == null) ? def : value;
-            }));
+        String value = System.getProperty(key);
+        return Boolean.valueOf((value == null) ? def : value);
     }
 
     static int getInteger(final String key, final int def,
                                  final int min, final int max)
     {
-        @SuppressWarnings("removal")
-        final String property = AccessController.doPrivileged(
-                    (PrivilegedAction<String>) () -> System.getProperty(key));
+        final String property = System.getProperty(key);
 
         int value = def;
         if (property != null) {
@@ -320,9 +308,7 @@ public final class MarlinProperties {
                                    final double min, final double max)
     {
         double value = def;
-        @SuppressWarnings("removal")
-        final String property = AccessController.doPrivileged(
-                    (PrivilegedAction<String>) () -> System.getProperty(key));
+        final String property = System.getProperty(key);
 
         if (property != null) {
             try {

--- a/modules/javafx.graphics/src/main/java/com/sun/marlin/OffHeapArray.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/marlin/OffHeapArray.java
@@ -27,8 +27,6 @@ package com.sun.marlin;
 
 import static com.sun.marlin.MarlinConst.LOG_UNSAFE_MALLOC;
 import java.lang.reflect.Field;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import sun.misc.Unsafe;
 
 /**
@@ -45,22 +43,13 @@ final class OffHeapArray  {
     static final int SIZE_INT;
 
     static {
-        @SuppressWarnings("removal")
-        Unsafe tmp = AccessController.doPrivileged(new PrivilegedAction<Unsafe>() {
-            @Override
-            public Unsafe run() {
-                Unsafe ref = null;
-                try {
-                    final Field field = Unsafe.class.getDeclaredField("theUnsafe");
-                    field.setAccessible(true);
-                    ref = (Unsafe) field.get(null);
-                } catch (Exception e) {
-                    throw new InternalError("Unable to get sun.misc.Unsafe instance", e);
-                }
-                return ref;
-            }
-        });
-        UNSAFE = tmp;
+        try {
+            final Field field = Unsafe.class.getDeclaredField("theUnsafe");
+            field.setAccessible(true);
+            UNSAFE = (Unsafe) field.get(null);
+        } catch (Exception e) {
+            throw new InternalError("Unable to get sun.misc.Unsafe instance", e);
+        }
 
         SIZE_INT = Unsafe.ARRAY_INT_INDEX_SCALE;
     }

--- a/modules/javafx.graphics/src/main/java/com/sun/marlin/RendererStats.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/marlin/RendererStats.java
@@ -25,8 +25,6 @@
 
 package com.sun.marlin;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.ConcurrentLinkedQueue;

--- a/modules/javafx.graphics/src/main/java/com/sun/marlin/RendererStats.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/marlin/RendererStats.java
@@ -356,35 +356,29 @@ public final class RendererStats implements MarlinConst {
         private final ConcurrentLinkedQueue<RendererStats> allStats
             = new ConcurrentLinkedQueue<>();
 
-        @SuppressWarnings("removal")
         private RendererStatsHolder() {
-            AccessController.doPrivileged(
-                (PrivilegedAction<Void>) () -> {
-                    final Thread hook = new Thread(
-                        MarlinUtils.getRootThreadGroup(),
-                        new Runnable() {
-                            @Override
-                            public void run() {
-                                dump();
-                            }
-                        },
-                        "MarlinStatsHook"
-                    );
-                    hook.setContextClassLoader(null);
-                    Runtime.getRuntime().addShutdownHook(hook);
-
-                    if (USE_DUMP_THREAD) {
-                        final Timer statTimer = new Timer("RendererStats");
-                        statTimer.scheduleAtFixedRate(new TimerTask() {
-                            @Override
-                            public void run() {
-                                dump();
-                            }
-                        }, DUMP_INTERVAL, DUMP_INTERVAL);
+            final Thread hook = new Thread(
+                MarlinUtils.getRootThreadGroup(),
+                new Runnable() {
+                    @Override
+                    public void run() {
+                        dump();
                     }
-                    return null;
-                }
+                },
+                "MarlinStatsHook"
             );
+            hook.setContextClassLoader(null);
+            Runtime.getRuntime().addShutdownHook(hook);
+
+            if (USE_DUMP_THREAD) {
+                final Timer statTimer = new Timer("RendererStats");
+                statTimer.scheduleAtFixedRate(new TimerTask() {
+                    @Override
+                    public void run() {
+                        dump();
+                    }
+                }, DUMP_INTERVAL, DUMP_INTERVAL);
+            }
         }
 
         void add(final Object parent, final RendererStats stats) {

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DPipeline.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DPipeline.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,8 +31,6 @@ import com.sun.prism.GraphicsPipeline;
 import com.sun.prism.ResourceFactory;
 import com.sun.prism.impl.PrismSettings;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.List;
 
 public final class D3DPipeline extends GraphicsPipeline {
@@ -45,19 +43,14 @@ public final class D3DPipeline extends GraphicsPipeline {
     private static boolean d3dInitialized;
 
     static {
-
-        @SuppressWarnings("removal")
-        boolean tmp = AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> {
-            if (PrismSettings.verbose) {
-                System.out.println("Loading D3D native library ...");
-            }
-            NativeLibLoader.loadLibrary("prism_d3d");
-            if (PrismSettings.verbose) {
-                System.out.println("\tsucceeded.");
-            }
-            return Boolean.valueOf(nInit(PrismSettings.class, true));
-        });
-        d3dEnabled = tmp;
+        if (PrismSettings.verbose) {
+            System.out.println("Loading D3D native library ...");
+        }
+        NativeLibLoader.loadLibrary("prism_d3d");
+        if (PrismSettings.verbose) {
+            System.out.println("\tsucceeded.");
+        }
+        d3dEnabled = nInit(PrismSettings.class, true);
 
         if (PrismSettings.verbose) {
             System.out.println("Direct3D initialization " + (d3dEnabled ? "succeeded" : "failed"));

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DResourceFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DResourceFactory.java
@@ -33,8 +33,6 @@ import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.FloatBuffer;
 import java.nio.IntBuffer;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.LinkedList;
 import java.util.ListIterator;
 import java.util.Map;
@@ -452,11 +450,7 @@ class D3DResourceFactory extends BaseShaderFactory {
             throw new IllegalArgumentException("Shader name must be non-null");
         }
         try {
-            @SuppressWarnings("removal")
-            InputStream stream = AccessController.doPrivileged(
-                    (PrivilegedAction<InputStream>) () -> D3DResourceFactory.class.
-                           getResourceAsStream("hlsl/" + name + ".obj")
-            );
+            InputStream stream = D3DResourceFactory.class.getResourceAsStream("hlsl/" + name + ".obj");
             Class klass = Class.forName("com.sun.prism.shader." + name + "_Loader");
             Method m = klass.getMethod("loadShader",
                 new Class[] { ShaderFactory.class, String.class, InputStream.class });

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2Pipeline.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2Pipeline.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,8 +32,6 @@ import com.sun.prism.ResourceFactory;
 import com.sun.prism.impl.PrismSettings;
 import com.sun.javafx.PlatformUtil;
 import java.util.List;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.HashMap;
 
 public class ES2Pipeline extends GraphicsPipeline {
@@ -48,24 +46,20 @@ public class ES2Pipeline extends GraphicsPipeline {
     private static boolean isEglfb = false;
 
     static {
-        @SuppressWarnings("removal")
-        var dummy = AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-            String libName = "prism_es2";
+        String libName = "prism_es2";
 
-            String eglType = PlatformUtil.getEmbeddedType();
-            if ("monocle".equals(eglType)) {
-                isEglfb = true;
-                libName = "prism_es2_monocle";
-            }
-            if (PrismSettings.verbose) {
-                System.out.println("Loading ES2 native library ... " + libName);
-            }
-            NativeLibLoader.loadLibrary(libName);
-            if (PrismSettings.verbose) {
-                System.out.println("\tsucceeded.");
-            }
-            return null;
-        });
+        String eglType = PlatformUtil.getEmbeddedType();
+        if ("monocle".equals(eglType)) {
+            isEglfb = true;
+            libName = "prism_es2_monocle";
+        }
+        if (PrismSettings.verbose) {
+            System.out.println("Loading ES2 native library ... " + libName);
+        }
+        NativeLibLoader.loadLibrary(libName);
+        if (PrismSettings.verbose) {
+            System.out.println("\tsucceeded.");
+        }
 
         // Initialize the prism-es2 pipe and a handler of it
         glFactory = GLFactory.getFactory();

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/es2/GLFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/es2/GLFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,8 +27,6 @@ package com.sun.prism.es2;
 
 import com.sun.prism.impl.PrismSettings;
 import com.sun.javafx.PlatformUtil;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.HashMap;
 
 abstract class GLFactory {
@@ -82,32 +80,19 @@ abstract class GLFactory {
         if (PrismSettings.verbose) {
             System.out.println("GLFactory using " + factoryClassName);
         }
-        @SuppressWarnings("removal")
-        GLFactory tmp = factoryClassName == null ? null :
-            AccessController.doPrivileged(new FactoryLoader(factoryClassName));
-        platformFactory = tmp;
-    }
 
-    private static class FactoryLoader implements PrivilegedAction<GLFactory> {
-        private final String factoryClassName;
-        FactoryLoader(String factoryClassName) {
-            this.factoryClassName = factoryClassName;
+        GLFactory factory = null;
+        try {
+            factory = (factoryClassName == null) ? null :
+                (GLFactory)Class.forName(factoryClassName).getDeclaredConstructor().newInstance();
+        } catch (Throwable t) {
+            System.err.println("GLFactory.static - Platform: "
+                    + System.getProperty("os.name")
+                    + " - not available: "
+                    + factoryClassName);
+            t.printStackTrace();
         }
-
-        @Override
-        public GLFactory run() {
-            GLFactory factory = null;
-            try {
-                factory = (GLFactory) Class.forName(factoryClassName).getDeclaredConstructor().newInstance();
-            } catch (Throwable t) {
-                System.err.println("GLFactory.static - Platform: "
-                        + System.getProperty("os.name")
-                        + " - not available: "
-                        + factoryClassName);
-                t.printStackTrace();
-            }
-            return factory;
-        }
+        platformFactory = factory;
     }
 
     /**

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/es2/GLPixelFormat.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/es2/GLPixelFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,8 +26,6 @@
 package com.sun.prism.es2;
 
 import java.lang.annotation.Native;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 
 class GLPixelFormat {
     final private Attributes attributes;
@@ -37,12 +35,8 @@ class GLPixelFormat {
     private static int defaultBufferSize;
 
     static {
-        @SuppressWarnings("removal")
-        var dummy = AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-           defaultDepthSize = Integer.getInteger("prism.glDepthSize", 24);
-           defaultBufferSize = Integer.getInteger("prism.glBufferSize", 32);
-            return null;
-        });
+        defaultDepthSize = Integer.getInteger("prism.glDepthSize", 24);
+        defaultBufferSize = Integer.getInteger("prism.glBufferSize", 32);
     }
 
     GLPixelFormat(long nativeScreen, Attributes attributes) {

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/es2/GLPixelFormat.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/es2/GLPixelFormat.java
@@ -31,13 +31,8 @@ class GLPixelFormat {
     final private Attributes attributes;
     final private long nativeScreen;
     private long nativePFInfo;
-    private static int defaultDepthSize;
-    private static int defaultBufferSize;
-
-    static {
-        defaultDepthSize = Integer.getInteger("prism.glDepthSize", 24);
-        defaultBufferSize = Integer.getInteger("prism.glBufferSize", 32);
-    }
+    final private static int defaultDepthSize = Integer.getInteger("prism.glDepthSize", 24);
+    final private static int defaultBufferSize = Integer.getInteger("prism.glBufferSize", 32);
 
     GLPixelFormat(long nativeScreen, Attributes attributes) {
         this.nativeScreen = nativeScreen;

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/es2/MonocleGLDrawable.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/es2/MonocleGLDrawable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,14 +27,10 @@ package com.sun.prism.es2;
 
 import com.sun.glass.ui.monocle.AcceleratedScreen;
 import com.sun.prism.paint.Color;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 
 class MonocleGLDrawable extends GLDrawable {
 
-    @SuppressWarnings("removal")
-    private static final boolean transparentFramebuffer =
-            AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> Boolean.getBoolean("com.sun.javafx.transparentFramebuffer"));
+    private static final boolean transparentFramebuffer = Boolean.getBoolean("com.sun.javafx.transparentFramebuffer");
 
     AcceleratedScreen accScreen;
 

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/impl/BufferUtil.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/impl/BufferUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,8 +31,6 @@ import java.nio.DoubleBuffer;
 import java.nio.FloatBuffer;
 import java.nio.IntBuffer;
 import java.nio.ShortBuffer;
-import java.security.AccessController;
-import java.security.PrivilegedExceptionAction;
 
 /**
  * Utility routines for dealing with direct buffers.
@@ -57,13 +55,11 @@ public class BufferUtil {
     private BufferUtil() {
     }
 
-    @SuppressWarnings("removal")
     public static void nativeOrder(ByteBuffer buf) {
         if (!isCDCFP) {
             try {
                 if (byteOrderClass == null) {
-                    byteOrderClass = (Class) AccessController.doPrivileged(
-                            (PrivilegedExceptionAction) () -> Class.forName("java.nio.ByteOrder", true, null));
+                    byteOrderClass = Class.forName("java.nio.ByteOrder", true, null);
                     orderMethod = ByteBuffer.class.getMethod("order", new Class[]{byteOrderClass});
                     Method nativeOrderMethod = byteOrderClass.getMethod("nativeOrder", (Class[])null);
                     nativeOrderObject = nativeOrderMethod.invoke(null, (Object[])null);

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/impl/PrismSettings.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/impl/PrismSettings.java
@@ -25,8 +25,6 @@
 
 package com.sun.prism.impl;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.List;
 import java.util.Properties;
 import java.util.StringTokenizer;
@@ -112,10 +110,7 @@ public final class PrismSettings {
     }
 
     static {
-        @SuppressWarnings("removal")
-        final Properties systemProperties =
-                (Properties) AccessController.doPrivileged(
-                        (PrivilegedAction) () -> System.getProperties());
+        final Properties systemProperties = System.getProperties();
 
         /* Vsync */
         isVsyncEnabled  = getBoolean(systemProperties, "prism.vsync", true)

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/impl/ps/BaseShaderGraphics.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/impl/ps/BaseShaderGraphics.java
@@ -25,8 +25,6 @@
 
 package com.sun.prism.impl.ps;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import com.sun.javafx.font.FontResource;
 import com.sun.javafx.font.FontStrike;
 import com.sun.javafx.font.Metrics;
@@ -534,8 +532,7 @@ public abstract class BaseShaderGraphics
 
     private static final float FRINGE_FACTOR;
     static {
-        @SuppressWarnings("removal")
-        String v = (String) AccessController.doPrivileged((PrivilegedAction) () -> System.getProperty("prism.primshaderpad"));
+        String v = System.getProperty("prism.primshaderpad");
         if (v == null) {
             FRINGE_FACTOR = -0.5f;
         } else {

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/j2d/J2DFontFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/j2d/J2DFontFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,8 +28,6 @@ package com.sun.prism.j2d;
 import java.lang.reflect.Method;
 import java.lang.reflect.InvocationTargetException;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.awt.Font;
 import java.io.File;
 import java.io.FileInputStream;
@@ -132,28 +130,23 @@ final class J2DFontFactory implements FontFactory {
      * printing begins, so grabs a copy of the file holding an
      * embedded font to 2D on first use.
      */
-    @SuppressWarnings("removal")
     public static void registerFont(final FontResource fr) {
-
-        AccessController.doPrivileged((PrivilegedAction<Object>) () -> {
-            InputStream stream = null;
-            try {
-                File file = new File(fr.getFileName());
-                stream = new FileInputStream(file);
-                Font font = Font.createFont(Font.TRUETYPE_FONT, stream);
-                fr.setPeer(font);
-            } catch (Exception e) {
-                e.printStackTrace();
-            } finally {
-                if (stream != null) {
-                    try {
-                        stream.close();
-                    } catch (Exception e2) {
-                    }
+        InputStream stream = null;
+        try {
+            File file = new File(fr.getFileName());
+            stream = new FileInputStream(file);
+            Font font = Font.createFont(Font.TRUETYPE_FONT, stream);
+            fr.setPeer(font);
+        } catch (Exception e) {
+            e.printStackTrace();
+        } finally {
+            if (stream != null) {
+                try {
+                    stream.close();
+                } catch (Exception e2) {
                 }
             }
-            return null;
-        });
+        }
     }
 
     @Override
@@ -176,20 +169,13 @@ final class J2DFontFactory implements FontFactory {
         // REMIND: this needs to be upgraded to use JDK9 createFont
         // which can handle a collection.
         final FontResource fr = fonts[0].getFontResource();
-        @SuppressWarnings("removal")
-        var dummy = AccessController.doPrivileged(new PrivilegedAction<Object>() {
-            @Override
-            public Object run() {
-                try {
-                    File file = new File(fr.getFileName());
-                    Font font = Font.createFont(Font.TRUETYPE_FONT, file);
-                    fr.setPeer(font);
-                } catch (Exception e) {
-                    e.printStackTrace();
-                }
-                return null;
-            }
-        });
+        try {
+            File file = new File(fr.getFileName());
+            Font font = Font.createFont(Font.TRUETYPE_FONT, file);
+            fr.setPeer(font);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
         return fonts;
     }
 
@@ -208,35 +194,29 @@ final class J2DFontFactory implements FontFactory {
         }
         synchronized (J2DFontFactory.class) {
             if (!compositeFontMethodsInitialized) {
-                @SuppressWarnings("removal")
-                var dummy = AccessController.doPrivileged(
-                        (PrivilegedAction<Void>) () -> {
-                            compositeFontMethodsInitialized = true;
-                            Class<?> fontMgrCls;
-                            try {
-                                // JDK7
-                                fontMgrCls = Class.forName(
-                                        "sun.font.FontUtilities", true, null);
-                            } catch (ClassNotFoundException cnfe) {
-                                try {
-                                    // JDK5/6
-                                    fontMgrCls = Class.forName(
-                                       "sun.font.FontManager", true, null);
-                                } catch (ClassNotFoundException cnfe2) {
-                                    return null;
-                                }
-                            }
+                compositeFontMethodsInitialized = true;
+                Class<?> fontMgrCls;
+                try {
+                    // JDK7
+                    fontMgrCls = Class.forName(
+                            "sun.font.FontUtilities", true, null);
+                } catch (ClassNotFoundException cnfe) {
+                    try {
+                        // JDK5/6
+                        fontMgrCls = Class.forName(
+                            "sun.font.FontManager", true, null);
+                    } catch (ClassNotFoundException cnfe2) {
+                        return null;
+                    }
+                }
 
-                            try {
-                                getCompositeFontUIResource =
-                                    fontMgrCls.getMethod(
-                                    "getCompositeFontUIResource",
-                                    Font.class);
-                            } catch (NoSuchMethodException nsme) {
-                            }
-                            return null;
-                        }
-                );
+                try {
+                    getCompositeFontUIResource =
+                        fontMgrCls.getMethod(
+                        "getCompositeFontUIResource",
+                        Font.class);
+                } catch (NoSuchMethodException nsme) {
+                }
             }
         }
 

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/j2d/print/J2DPrinterJob.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/j2d/print/J2DPrinterJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -89,25 +89,19 @@ import com.sun.prism.impl.PrismSettings;
 import com.sun.prism.j2d.PrismPrintGraphics;
 
 import java.lang.reflect.Constructor;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 
 public class J2DPrinterJob implements PrinterJobImpl {
 
     static {
-        @SuppressWarnings("removal")
-        var dummy = AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-            String libName = "prism_common";
+        String libName = "prism_common";
 
-            if (PrismSettings.verbose) {
-                System.out.println("Loading Prism common native library ...");
-            }
-            NativeLibLoader.loadLibrary(libName);
-            if (PrismSettings.verbose) {
-                System.out.println("\tsucceeded.");
-            }
-            return null;
-        });
+        if (PrismSettings.verbose) {
+            System.out.println("Loading Prism common native library ...");
+        }
+        NativeLibLoader.loadLibrary(libName);
+        if (PrismSettings.verbose) {
+            System.out.println("\tsucceeded.");
+        }
     }
 
     javafx.print.PrinterJob fxPrinterJob;
@@ -120,28 +114,23 @@ public class J2DPrinterJob implements PrinterJobImpl {
     private volatile Object elo = null;
 
     private static Class onTopClass = null;
-    @SuppressWarnings("removal")
     PrintRequestAttribute getAlwaysOnTop(final long id) {
-        return AccessController.doPrivileged(
-            (PrivilegedAction<PrintRequestAttribute>) () -> {
-
-            PrintRequestAttribute alwaysOnTop = null;
-            try {
-                if (onTopClass == null) {
-                    onTopClass =
-                        Class.forName("javax.print.attribute.standard.DialogOwner");
-                }
-                if (id == 0) {
-                    Constructor<PrintRequestAttribute>
-                         cons = onTopClass.getConstructor();
-                    alwaysOnTop = cons.newInstance();
-                } else {
-                    alwaysOnTop = getAlwaysOnTop(onTopClass, id);
-                }
-            } catch (Throwable t) {
+        PrintRequestAttribute alwaysOnTop = null;
+        try {
+            if (onTopClass == null) {
+                onTopClass =
+                    Class.forName("javax.print.attribute.standard.DialogOwner");
             }
-            return alwaysOnTop;
-        });
+            if (id == 0) {
+                Constructor<PrintRequestAttribute>
+                        cons = onTopClass.getConstructor();
+                alwaysOnTop = cons.newInstance();
+            } else {
+                alwaysOnTop = getAlwaysOnTop(onTopClass, id);
+            }
+        } catch (Throwable t) {
+        }
+        return alwaysOnTop;
     }
 
     private static native

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/sw/SWPipeline.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/sw/SWPipeline.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,19 +30,13 @@ import com.sun.glass.utils.NativeLibLoader;
 import com.sun.prism.GraphicsPipeline;
 import com.sun.prism.ResourceFactory;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.List;
 import java.util.HashMap;
 
 public final class SWPipeline extends GraphicsPipeline {
 
     static {
-        @SuppressWarnings("removal")
-        var dummy = AccessController.doPrivileged((PrivilegedAction<Object>) () -> {
-            NativeLibLoader.loadLibrary("prism_sw");
-            return null;
-        });
+        NativeLibLoader.loadLibrary("prism_sw");
     }
 
     @Override public boolean init() {

--- a/modules/javafx.graphics/src/main/java/com/sun/scenario/effect/ImageData.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/scenario/effect/ImageData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,6 @@
 
 package com.sun.scenario.effect;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.HashSet;
 import java.util.Iterator;
 import com.sun.javafx.geom.Rectangle;
@@ -47,25 +45,21 @@ public class ImageData {
     private static HashSet<ImageData> alldatas;
 
     static {
-        @SuppressWarnings("removal")
-        var dummy = AccessController.doPrivileged((PrivilegedAction) () -> {
-            if (System.getProperty("decora.showleaks") != null) {
-                alldatas = new HashSet<>();
-                Runtime.getRuntime().addShutdownHook(new Thread() {
-                    @Override
-                    public void run() {
-                        Iterator<ImageData> datas = alldatas.iterator();
-                        while (datas.hasNext()) {
-                            ImageData id = datas.next();
-                            Rectangle r = id.getUntransformedBounds();
-                            System.out.println("id["+r.width+"x"+r.height+", refcount="+id.refcount+"] leaked from:");
-                            id.fromwhere.printStackTrace(System.out);
-                        }
+        if (System.getProperty("decora.showleaks") != null) {
+            alldatas = new HashSet<>();
+            Runtime.getRuntime().addShutdownHook(new Thread() {
+                @Override
+                public void run() {
+                    Iterator<ImageData> datas = alldatas.iterator();
+                    while (datas.hasNext()) {
+                        ImageData id = datas.next();
+                        Rectangle r = id.getUntransformedBounds();
+                        System.out.println("id["+r.width+"x"+r.height+", refcount="+id.refcount+"] leaked from:");
+                        id.fromwhere.printStackTrace(System.out);
                     }
-                });
-            }
-            return null;
-        });
+                }
+            });
+        }
     }
 
     private ImageData sharedOwner;

--- a/modules/javafx.graphics/src/main/java/com/sun/scenario/effect/impl/BufferUtil.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/scenario/effect/impl/BufferUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,8 +31,6 @@ import java.nio.DoubleBuffer;
 import java.nio.FloatBuffer;
 import java.nio.IntBuffer;
 import java.nio.ShortBuffer;
-import java.security.AccessController;
-import java.security.PrivilegedExceptionAction;
 
 /**
  * Utility routines for dealing with direct buffers.
@@ -57,13 +55,11 @@ public class BufferUtil {
     private BufferUtil() {
     }
 
-    @SuppressWarnings("removal")
     public static void nativeOrder(ByteBuffer buf) {
         if (!isCDCFP) {
             try {
                 if (byteOrderClass == null) {
-                    byteOrderClass = (Class) AccessController.doPrivileged(
-                            (PrivilegedExceptionAction) () -> Class.forName("java.nio.ByteOrder", true, null));
+                    byteOrderClass = Class.forName("java.nio.ByteOrder", true, null);
                     orderMethod = ByteBuffer.class.getMethod("order", new Class[]{byteOrderClass});
                     Method nativeOrderMethod = byteOrderClass.getMethod("nativeOrder", (Class[])null);
                     nativeOrderObject = nativeOrderMethod.invoke(null, (Object[])null);

--- a/modules/javafx.graphics/src/main/java/com/sun/scenario/effect/impl/ImagePool.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/scenario/effect/impl/ImagePool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,8 +26,6 @@
 package com.sun.scenario.effect.impl;
 
 import java.lang.ref.SoftReference;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -48,17 +46,13 @@ public class ImagePool {
     static long pixelsAccessed;
 
     static {
-        @SuppressWarnings("removal")
-        var dummy = AccessController.doPrivileged((PrivilegedAction) () -> {
-            if (System.getProperty("decora.showstats") != null) {
-                Runtime.getRuntime().addShutdownHook(new Thread() {
-                    @Override public void run() {
-                        printStats();
-                    }
-                });
-            }
-            return null;
-        });
+        if (System.getProperty("decora.showstats") != null) {
+            Runtime.getRuntime().addShutdownHook(new Thread() {
+                @Override public void run() {
+                    printStats();
+                }
+            });
+        }
     }
 
     static void printStats() {

--- a/modules/javafx.graphics/src/main/java/com/sun/scenario/effect/impl/Renderer.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/scenario/effect/impl/Renderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,6 @@
 
 package com.sun.scenario.effect.impl;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -92,9 +90,7 @@ public abstract class Renderer {
         Collections.synchronizedMap(new HashMap<String, EffectPeer>(5));
     private final ImagePool imagePool;
 
-    @SuppressWarnings("removal")
-    protected static final boolean verbose = AccessController.doPrivileged(
-            (PrivilegedAction<Boolean>) () -> Boolean.getBoolean("decora.verbose"));
+    protected static final boolean verbose = Boolean.getBoolean("decora.verbose");
 
     protected Renderer() {
         this.imagePool = new ImagePool();

--- a/modules/javafx.graphics/src/main/java/com/sun/scenario/effect/impl/RendererFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/scenario/effect/impl/RendererFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,8 +26,6 @@
 package com.sun.scenario.effect.impl;
 
 import java.lang.reflect.Method;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import com.sun.javafx.PlatformUtil;
 import com.sun.scenario.effect.FilterContext;
 
@@ -179,40 +177,37 @@ class RendererFactory {
         return r;
     }
 
-    @SuppressWarnings("removal")
     static Renderer createRenderer(final FilterContext fctx) {
-        return AccessController.doPrivileged((PrivilegedAction<Renderer>) () -> {
-            Renderer r = null;
-            // Class.getSimpleName is not available on CDC
-            String klassName = fctx.getClass().getName();
-            String simpleName = klassName.substring(klassName.lastIndexOf(".") + 1);
+        Renderer r = null;
+        // Class.getSimpleName is not available on CDC
+        String klassName = fctx.getClass().getName();
+        String simpleName = klassName.substring(klassName.lastIndexOf(".") + 1);
 
-            if (simpleName.equals("PrFilterContext") && tryPrism) {
-                r = createPrismRenderer(fctx);
-            }
-            // check to see whether one of the hardware accelerated
-            // Java 2D pipelines is in use and exposes the necessary
-            // "resource sharing layer" APIs (only in Sun's JDK 6u10 and above)
-            if (r == null && tryRSL && isRSLAvailable(fctx)) {
-                // try locating an RSLRenderer (need to use reflection in case
-                // certain RSL backend classes are not available;
-                // this step will trigger lazy downloading of impl jars
-                // via JNLP, if not already available)
-                r = createRSLRenderer(fctx);
-            }
-            if (r == null && tryJOGL) {
-                // next try the JOGL renderer
-                r = createJOGLRenderer(fctx);
-            }
-            if (r == null && trySIMD) {
-                // next try the SSE renderer
-                r = getSSERenderer();
-            }
-            if (r == null) {
-                // otherwise, fall back on the Java/CPU renderer
-                r = getJavaRenderer(fctx);
-            }
-            return r;
-        });
+        if (simpleName.equals("PrFilterContext") && tryPrism) {
+            r = createPrismRenderer(fctx);
+        }
+        // check to see whether one of the hardware accelerated
+        // Java 2D pipelines is in use and exposes the necessary
+        // "resource sharing layer" APIs (only in Sun's JDK 6u10 and above)
+        if (r == null && tryRSL && isRSLAvailable(fctx)) {
+            // try locating an RSLRenderer (need to use reflection in case
+            // certain RSL backend classes are not available;
+            // this step will trigger lazy downloading of impl jars
+            // via JNLP, if not already available)
+            r = createRSLRenderer(fctx);
+        }
+        if (r == null && tryJOGL) {
+            // next try the JOGL renderer
+            r = createJOGLRenderer(fctx);
+        }
+        if (r == null && trySIMD) {
+            // next try the SSE renderer
+            r = getSSERenderer();
+        }
+        if (r == null) {
+            // otherwise, fall back on the Java/CPU renderer
+            r = getJavaRenderer(fctx);
+        }
+        return r;
     }
 }

--- a/modules/javafx.graphics/src/main/java/com/sun/scenario/effect/impl/state/LinearConvolveRenderState.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/scenario/effect/impl/state/LinearConvolveRenderState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,8 +33,6 @@ import com.sun.scenario.effect.ImageData;
 import com.sun.scenario.effect.impl.EffectPeer;
 import com.sun.scenario.effect.impl.Renderer;
 import java.nio.FloatBuffer;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 
 /**
  * The {@code LinearConvolveRenderState} object manages the strategies of
@@ -71,10 +69,7 @@ public abstract class LinearConvolveRenderState implements RenderState {
          * The default value is set to 64 if platform is an embedded system and 128 otherwise.
          */
         final int defSize = PlatformUtil.isEmbedded() ? 64 : MAX_COMPILED_KERNEL_SIZE;
-        @SuppressWarnings("removal")
-        int size = AccessController.doPrivileged(
-                (PrivilegedAction<Integer>) () -> Integer.getInteger(
-                        "decora.maxLinearConvolveKernelSize", defSize));
+        int size = Integer.getInteger("decora.maxLinearConvolveKernelSize", defSize);
         if (size > MAX_COMPILED_KERNEL_SIZE) {
             System.out.println("Clamping maxLinearConvolveKernelSize to "
                     + MAX_COMPILED_KERNEL_SIZE);

--- a/modules/javafx.graphics/src/main/java/com/sun/scenario/effect/impl/sw/sse/SSERendererDelegate.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/scenario/effect/impl/sw/sse/SSERendererDelegate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,6 @@
 
 package com.sun.scenario.effect.impl.sw.sse;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import com.sun.glass.utils.NativeLibLoader;
 import com.sun.scenario.effect.Effect.AccelType;
 import com.sun.scenario.effect.impl.Renderer;
@@ -37,11 +35,7 @@ public class SSERendererDelegate implements RendererDelegate {
     public static native boolean isSupported();
 
     static {
-        @SuppressWarnings("removal")
-        var dummy = AccessController.doPrivileged((PrivilegedAction) () -> {
-            NativeLibLoader.loadLibrary("decora_sse");
-            return null;
-        });
+        NativeLibLoader.loadLibrary("decora_sse");
     }
 
     public SSERendererDelegate() {

--- a/modules/javafx.graphics/src/main/java/javafx/animation/Animation.java
+++ b/modules/javafx.graphics/src/main/java/javafx/animation/Animation.java
@@ -52,10 +52,6 @@ import com.sun.scenario.animation.AbstractPrimaryTimer;
 import com.sun.scenario.animation.shared.ClipEnvelope;
 import com.sun.scenario.animation.shared.PulseReceiver;
 
-import java.security.AccessControlContext;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-
 /**
  * The class {@code Animation} provides the core functionality of all animations
  * used in the JavaFX runtime.
@@ -152,20 +148,11 @@ public abstract class Animation {
     private boolean paused = false;
     private final AbstractPrimaryTimer timer;
 
-    // Access control context, captured whenever we add this pulse receiver to
-    // the PrimaryTimer (which is called when an animation is played or resumed)
-    @SuppressWarnings("removal")
-    private AccessControlContext accessCtrlCtx = null;
-
     private long now() {
         return TickCalculation.fromNano(timer.nanos());
     }
 
-    @SuppressWarnings("removal")
     private void addPulseReceiver() {
-        // Capture the Access Control Context to be used during the animation pulse
-        accessCtrlCtx = AccessController.getContext();
-
         timer.addPulseReceiver(pulseReceiver);
     }
 
@@ -194,20 +181,13 @@ public abstract class Animation {
 
     // package private only for the sake of testing
     final PulseReceiver pulseReceiver = new PulseReceiver() {
-        @SuppressWarnings("removal")
         @Override public void timePulse(long now) {
             final long elapsedTime = now - startTime;
             if (elapsedTime < 0) {
                 return;
             }
-            if (accessCtrlCtx == null) {
-                throw new IllegalStateException("Error: AccessControlContext not captured");
-            }
 
-            AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-                doTimePulse(elapsedTime);
-                return null;
-            }, accessCtrlCtx);
+            doTimePulse(elapsedTime);
         }
     };
 

--- a/modules/javafx.graphics/src/main/java/javafx/animation/AnimationTimer.java
+++ b/modules/javafx.graphics/src/main/java/javafx/animation/AnimationTimer.java
@@ -29,9 +29,6 @@ import com.sun.javafx.tk.Toolkit;
 import com.sun.javafx.util.Utils;
 import com.sun.scenario.animation.AbstractPrimaryTimer;
 import com.sun.scenario.animation.shared.TimerReceiver;
-import java.security.AccessControlContext;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 
 /**
  * The class {@code AnimationTimer} allows to create a timer, that is called in
@@ -50,26 +47,14 @@ import java.security.PrivilegedAction;
 public abstract class AnimationTimer {
 
     private class AnimationTimerReceiver implements TimerReceiver {
-        @SuppressWarnings("removal")
         @Override public void handle(final long now) {
-            if (accessCtrlCtx == null) {
-                throw new IllegalStateException("Error: AccessControlContext not captured");
-            }
-
-            AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-                AnimationTimer.this.handle(now);
-                return null;
-            }, accessCtrlCtx);
+            AnimationTimer.this.handle(now);
         }
     }
 
     private final AbstractPrimaryTimer timer;
     private final AnimationTimerReceiver timerReceiver = new AnimationTimerReceiver();
     private boolean active;
-
-    // Access control context, captured in start()
-    @SuppressWarnings("removal")
-    private AccessControlContext accessCtrlCtx = null;
 
     /**
      * Creates a new timer.
@@ -113,11 +98,8 @@ public abstract class AnimationTimer {
      *
      * @see #start()
      */
-    @SuppressWarnings("removal")
     private void startImpl() {
         if (!active) {
-            // Capture the Access Control Context to be used during the animation pulse
-            accessCtrlCtx = AccessController.getContext();
             timer.addAnimationTimer(timerReceiver);
             active = true;
         }

--- a/modules/javafx.graphics/src/main/java/javafx/application/Preloader.java
+++ b/modules/javafx.graphics/src/main/java/javafx/application/Preloader.java
@@ -103,13 +103,7 @@ package javafx.application;
  */
 public abstract class Preloader extends Application {
 
-    // Too bad this isn't already available in a Java core class
-    private static final String lineSeparator;
-
-    static {
-        String prop = System.getProperty("line.separator");
-        lineSeparator = prop != null ? prop : "\n";
-    }
+    private static final String lineSeparator = System.lineSeparator();
 
     /**
      * Constructor for subclasses to call.

--- a/modules/javafx.graphics/src/main/java/javafx/application/Preloader.java
+++ b/modules/javafx.graphics/src/main/java/javafx/application/Preloader.java
@@ -25,9 +25,6 @@
 
 package javafx.application;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-
 /**
  * Class that is extended to define an optional preloader for a
  * JavaFX Application.
@@ -110,8 +107,7 @@ public abstract class Preloader extends Application {
     private static final String lineSeparator;
 
     static {
-        @SuppressWarnings("removal")
-        String prop = AccessController.doPrivileged((PrivilegedAction<String>) () -> System.getProperty("line.separator"));
+        String prop = System.getProperty("line.separator");
         lineSeparator = prop != null ? prop : "\n";
     }
 

--- a/modules/javafx.graphics/src/main/java/javafx/concurrent/Service.java
+++ b/modules/javafx.graphics/src/main/java/javafx/concurrent/Service.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,9 +43,6 @@ import javafx.event.EventDispatchChain;
 import javafx.event.EventHandler;
 import javafx.event.EventTarget;
 import javafx.event.EventType;
-import java.security.AccessController;
-import java.security.AccessControlContext;
-import java.security.PrivilegedAction;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Executor;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -164,9 +161,7 @@ public abstract class Service<V> implements Worker<V>, EventTarget {
         }
     };
 
-    // Addition of doPrivileged added due to RT-19580
-    @SuppressWarnings("removal")
-    private static final ThreadGroup THREAD_GROUP = AccessController.doPrivileged((PrivilegedAction<ThreadGroup>) () -> new ThreadGroup("javafx concurrent thread pool"));
+    private static final ThreadGroup THREAD_GROUP = new ThreadGroup("javafx concurrent thread pool");
     private static final Thread.UncaughtExceptionHandler UNCAUGHT_HANDLER = (thread, throwable) -> {
         // Ignore IllegalMonitorStateException which could be thrown from the ThreadPoolExecutor in certain cases when there are
         // asynchronous tasks. These exceptions generally do not cause loss of functionality.
@@ -175,15 +170,13 @@ public abstract class Service<V> implements Worker<V>, EventTarget {
         }
     };
 
-    // Addition of doPrivileged added due to RT-19580
-    @SuppressWarnings("removal")
-    private static final ThreadFactory THREAD_FACTORY = run -> AccessController.doPrivileged((PrivilegedAction<Thread>) () -> {
+    private static final ThreadFactory THREAD_FACTORY = run -> {
         final Thread th = new Thread(THREAD_GROUP, run);
         th.setUncaughtExceptionHandler(UNCAUGHT_HANDLER);
         th.setPriority(Thread.MIN_PRIORITY);
         th.setDaemon(true);
         return th;
-    });
+    };
 
     private static final ThreadPoolExecutor EXECUTOR = new ThreadPoolExecutor(
             2, THREAD_POOL_SIZE,
@@ -715,15 +708,10 @@ public abstract class Service<V> implements Worker<V>, EventTarget {
      * @param task a non-null task to execute
      * @since JavaFX 2.1
      */
-    @SuppressWarnings("removal")
     protected void executeTask(final Task<V> task) {
-        final AccessControlContext acc = AccessController.getContext();
         final Executor e = getExecutor() != null ? getExecutor() : EXECUTOR;
         e.execute(() -> {
-            AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-                task.run();
-                return null;
-            }, acc);
+            task.run();
         });
     }
 

--- a/modules/javafx.graphics/src/main/java/javafx/concurrent/Task.java
+++ b/modules/javafx.graphics/src/main/java/javafx/concurrent/Task.java
@@ -25,9 +25,6 @@
 
 package javafx.concurrent;
 
-import java.security.AccessController;
-import java.security.Permission;
-import java.security.PrivilegedAction;
 import javafx.application.Platform;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.DoubleProperty;
@@ -1001,20 +998,10 @@ public abstract class Task<V> extends FutureTask<V> implements Worker<V>, EventT
         return cancel(true);
     }
 
-    // Need to assert the modifyThread permission so an app can cancel
-    // a task that it created (the default executor for the service runs in
-    // its own thread group)
-    // Note that this is needed when running with a security manager.
-    private static final Permission modifyThreadPerm = new RuntimePermission("modifyThread");
-
     @Override public boolean cancel(boolean mayInterruptIfRunning) {
         // Delegate to the super implementation to actually attempt to cancel this thing
         // Assert the modifyThread permission
-        @SuppressWarnings("removal")
-        boolean flag = AccessController.doPrivileged(
-            (PrivilegedAction<Boolean>) () -> super.cancel(mayInterruptIfRunning),
-            null,
-            modifyThreadPerm);
+        boolean flag = super.cancel(mayInterruptIfRunning);
 
         // If cancel succeeded (according to the semantics of the Future cancel method),
         // then we need to make sure the State flag is set appropriately

--- a/modules/javafx.graphics/src/main/java/javafx/css/converter/URLConverter.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/converter/URLConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,10 +36,7 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.security.AccessController;
 import java.security.CodeSource;
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
 import java.security.ProtectionDomain;
 
 /**
@@ -196,15 +193,12 @@ public final class URLConverter extends StyleConverter<ParsedValue[], String> {
 
             // check whether the path is file from our runtime jar
             try {
-                @SuppressWarnings("removal")
-                final URL rtJarURL = AccessController.doPrivileged((PrivilegedExceptionAction<URL>) () -> {
-                    // getProtectionDomain either throws a SecurityException or returns a non-null value
-                    final ProtectionDomain protectionDomain = Application.class.getProtectionDomain();
-                    // If we're running with a SecurityManager, then the ProtectionDomain will have a CodeSource
-                    final CodeSource codeSource = protectionDomain.getCodeSource();
-                    // The CodeSource location will be our runtime jar
-                    return codeSource.getLocation();
-                });
+                // getProtectionDomain either throws a SecurityException or returns a non-null value
+                final ProtectionDomain protectionDomain = Application.class.getProtectionDomain();
+                // If we're running with a SecurityManager, then the ProtectionDomain will have a CodeSource
+                final CodeSource codeSource = protectionDomain.getCodeSource();
+                // The CodeSource location will be our runtime jar
+                final URL rtJarURL = codeSource.getLocation();
 
                 final URI rtJarURI = rtJarURL.toURI();
 
@@ -237,7 +231,7 @@ public final class URLConverter extends StyleConverter<ParsedValue[], String> {
                 URI resolved = new URI(scheme, rtJarUserInfo, rtJarHost, rtJarPort, rtJarPath, null, null);
                 return resolved.toURL();
 
-            } catch (URISyntaxException | MalformedURLException | PrivilegedActionException ignored) {
+            } catch (URISyntaxException | MalformedURLException ignored) {
                 // Allow this method to return null so the caller will try to further resolve the path.
                 // If nothing else, an error message will result when the converted URL is consumed.
             }

--- a/modules/javafx.graphics/src/main/java/javafx/scene/PropertyHelper.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/PropertyHelper.java
@@ -27,8 +27,7 @@ package javafx.scene;
 
 class PropertyHelper {
 
-    // Function to return whether a system property is set to true. Note that
-    // this runs within a doPrivilege block so this function must be package-private.
+    // Function to return whether a system property is set to true.
     static boolean getBooleanProperty(final String propName) {
         try {
             String propVal = System.getProperty(propName);

--- a/modules/javafx.graphics/src/main/java/javafx/scene/PropertyHelper.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/PropertyHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,21 +25,14 @@
 
 package javafx.scene;
 
-import java.security.AccessController;
-
 class PropertyHelper {
 
     // Function to return whether a system property is set to true. Note that
     // this runs within a doPrivilege block so this function must be package-private.
     static boolean getBooleanProperty(final String propName) {
         try {
-            @SuppressWarnings("removal")
-            boolean answer =
-                AccessController.doPrivileged((java.security.PrivilegedAction<Boolean>) () -> {
-                        String propVal = System.getProperty(propName);
-                        return "true".equals(propVal.toLowerCase());
-                    });
-            return answer;
+            String propVal = System.getProperty(propName);
+            return "true".equals(propVal.toLowerCase());
         } catch (Exception any) {
         }
         return false;

--- a/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
@@ -1408,7 +1408,6 @@ public class Scene implements EventTarget {
     private static List<Runnable> snapshotRunnableListB;
     private static List<Runnable> snapshotRunnableList;
 
-    @SuppressWarnings("removal")
     static void addSnapshotRunnable(final Runnable runnable) {
         Toolkit.getToolkit().checkFxUserThread();
 
@@ -1442,9 +1441,7 @@ public class Scene implements EventTarget {
             Toolkit.getToolkit().addPostSceneTkPulseListener(snapshotPulseListener);
         }
 
-        snapshotRunnableList.add(() -> {
-            runnable.run();
-        });
+        snapshotRunnableList.add(runnable);
         Toolkit.getToolkit().requestNextPulse();
     }
 

--- a/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
@@ -90,7 +90,6 @@ import com.sun.javafx.logging.PlatformLogger.Level;
 import java.io.File;
 import java.security.AccessControlContext;
 import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.*;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Stream;
@@ -1443,12 +1442,8 @@ public class Scene implements EventTarget {
             Toolkit.getToolkit().addPostSceneTkPulseListener(snapshotPulseListener);
         }
 
-        final AccessControlContext acc = AccessController.getContext();
         snapshotRunnableList.add(() -> {
-            AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-                runnable.run();
-                return null;
-            }, acc);
+            runnable.run();
         });
         Toolkit.getToolkit().requestNextPulse();
     }
@@ -6244,10 +6239,8 @@ public class Scene implements EventTarget {
      *                                                                         *
      **************************************************************************/
 
-    @SuppressWarnings("removal")
     private static final NodeOrientation defaultNodeOrientation =
-        AccessController.doPrivileged(
-                (PrivilegedAction<Boolean>) () -> Boolean.getBoolean("javafx.scene.nodeOrientation.RTL")) ? NodeOrientation.RIGHT_TO_LEFT : NodeOrientation.INHERIT;
+        Boolean.getBoolean("javafx.scene.nodeOrientation.RTL") ? NodeOrientation.RIGHT_TO_LEFT : NodeOrientation.INHERIT;
 
     /**
      * Node orientation describes the flow of visual data within a node.


### PR DESCRIPTION
This PR removes uses of `AccessControler.doPrivileged()` from `javafx.graphics` package. All uses of `doPrivileged()` were removed _excluding_ `com.sun.javafx.tk` and `com.sun.ui.glass` subpackages - those are handled by [JDK-8342453](https://bugs.openjdk.org/browse/JDK-8342453) (already completed) and [JDK-8342454](https://bugs.openjdk.org/browse/JDK-8342454) respectively.

Most of these changes are fairly straightforward and follow the standard replacement from `AccessController.doPrivileged(LAMBDA)` to just simply `LAMBDA` with a couple exceptions:

- `StyleManager.java` where `loadStylesheet()` followed two steps - attempting straightforward stylesheet load via `loadStylesheetUnPrivileged()` and in case of `AccessControlException` retrying the load via `AccessController.doPrivileged` with read-only access to stylesheet JAR. Now that `doPrivileged` is deprecated and not used anymore, `loadStylesheetUnPrivileged()` was always successful and the fallback became essentially dead code. Fallback was removed and `loadStylesheetUnPrivileged()` was renamed to `loadStylesheet()`.
- `Scene.java` integrates with `com.sun.javafx.tk` so only straightforward `doPrivileged()` calls were removed - `AccessControlContext` remained, as it needs to be removed from both tk and Scene via a follow-up ([JDK-8342993](https://bugs.openjdk.org/browse/JDK-8342993))

Building graphics module now produces less warnings than before this change with no new warning messages (all warnings refer to the use of `Unsafe` which is out of scope of this change).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8342456](https://bugs.openjdk.org/browse/JDK-8342456): Remove calls to doPrivileged in javafx.graphics/other (**Bug** - P3)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1619/head:pull/1619` \
`$ git checkout pull/1619`

Update a local copy of the PR: \
`$ git checkout pull/1619` \
`$ git pull https://git.openjdk.org/jfx.git pull/1619/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1619`

View PR using the GUI difftool: \
`$ git pr show -t 1619`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1619.diff">https://git.openjdk.org/jfx/pull/1619.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1619#issuecomment-2449913787)
</details>
