### PR TITLE
8342460: Remove calls to doPrivileged in javafx.web

### DIFF
--- a/modules/javafx.web/src/main/java/com/sun/javafx/webkit/UIClientImpl.java
+++ b/modules/javafx.web/src/main/java/com/sun/javafx/webkit/UIClientImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,9 +41,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.nio.ByteBuffer;
-import java.security.AccessControlContext;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -111,31 +108,20 @@ public final class UIClientImpl implements UIClient {
         return accessor.getEngine();
     }
 
-    @SuppressWarnings("removal")
-    private AccessControlContext getAccessContext() {
-        return accessor.getPage().getAccessControlContext();
-    }
-
     @Override public WebPage createPage(
             boolean menu, boolean status, boolean toolbar, boolean resizable) {
         final WebEngine w = getWebEngine();
         if (w != null && w.getCreatePopupHandler() != null) {
             final PopupFeatures pf =
                     new PopupFeatures(menu, status, toolbar, resizable);
-            @SuppressWarnings("removal")
-            WebEngine popup = AccessController.doPrivileged(
-                    (PrivilegedAction<WebEngine>) () -> w.getCreatePopupHandler().call(pf), getAccessContext());
+            WebEngine popup = w.getCreatePopupHandler().call(pf);
             return Accessor.getPageFor(popup);
         }
         return null;
     }
 
-    @SuppressWarnings("removal")
     private void dispatchWebEvent(final EventHandler handler, final WebEvent ev) {
-        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-            handler.handle(ev);
-            return null;
-        }, getAccessContext());
+        handler.handle(ev);
     }
 
     private void notifyVisibilityChanged(boolean visible) {
@@ -197,23 +183,19 @@ public final class UIClientImpl implements UIClient {
         }
     }
 
-    @SuppressWarnings("removal")
     @Override public boolean confirm(final String text) {
         final WebEngine w = getWebEngine();
         if (w != null && w.getConfirmHandler() != null) {
-            return AccessController.doPrivileged(
-                    (PrivilegedAction<Boolean>) () -> w.getConfirmHandler().call(text), getAccessContext());
+            return w.getConfirmHandler().call(text);
         }
         return false;
     }
 
-    @SuppressWarnings("removal")
     @Override public String prompt(String text, String defaultValue) {
         final WebEngine w = getWebEngine();
         if (w != null && w.getPromptHandler() != null) {
             final PromptData data = new PromptData(text, defaultValue);
-            return AccessController.doPrivileged(
-                    (PrivilegedAction<String>) () -> w.getPromptHandler().call(data), getAccessContext());
+            return w.getPromptHandler().call(data);
         }
         return "";
     }

--- a/modules/javafx.web/src/main/java/com/sun/javafx/webkit/WebPageClientImpl.java
+++ b/modules/javafx.web/src/main/java/com/sun/javafx/webkit/WebPageClientImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,8 +27,6 @@ package com.sun.javafx.webkit;
 
 import com.sun.javafx.scene.NodeHelper;
 import java.lang.ref.WeakReference;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 
 import com.sun.javafx.scene.traversal.Direction;
 import com.sun.javafx.scene.traversal.TraversalMethod;
@@ -50,10 +48,8 @@ import com.sun.webkit.graphics.WCPoint;
 import com.sun.webkit.graphics.WCRectangle;
 
 public final class WebPageClientImpl implements WebPageClient<WebView> {
-    @SuppressWarnings("removal")
-    private static final boolean backBufferSupported = Boolean.valueOf(
-        AccessController.doPrivileged((PrivilegedAction<String>) () -> System.getProperty(
-            "com.sun.webkit.pagebackbuffer", "true")));
+    private static final boolean backBufferSupported =
+        Boolean.valueOf(System.getProperty("com.sun.webkit.pagebackbuffer", "true"));
     private static WebConsoleListener consoleListener = null;
     private final Accessor accessor;
 

--- a/modules/javafx.web/src/main/java/com/sun/javafx/webkit/prism/WCGraphicsPrismContext.java
+++ b/modules/javafx.web/src/main/java/com/sun/javafx/webkit/prism/WCGraphicsPrismContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,8 +53,6 @@ import com.sun.webkit.graphics.*;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -81,10 +79,8 @@ class WCGraphicsPrismContext extends WCGraphicsContext {
 
     private final static PlatformLogger log =
             PlatformLogger.getLogger(WCGraphicsPrismContext.class.getName());
-    @SuppressWarnings("removal")
-    private final static boolean DEBUG_DRAW_CLIP_SHAPE = Boolean.valueOf(
-            AccessController.doPrivileged((PrivilegedAction<String>) () ->
-            System.getProperty("com.sun.webkit.debugDrawClipShape", "false")));
+    private final static boolean DEBUG_DRAW_CLIP_SHAPE =
+        Boolean.valueOf(System.getProperty("com.sun.webkit.debugDrawClipShape", "false"));
 
     Graphics baseGraphics;
     private BaseTransform baseTransform;

--- a/modules/javafx.web/src/main/java/com/sun/webkit/Disposer.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/Disposer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,6 @@ package com.sun.webkit;
 
 import java.lang.ref.ReferenceQueue;
 import java.lang.ref.WeakReference;
-import java.security.PrivilegedAction;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
@@ -59,24 +58,20 @@ public final class Disposer implements Runnable {
             new HashSet<>();
 
     static {
-        @SuppressWarnings("removal")
-        var dummy = java.security.AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-            /*
-             * The thread must be a member of a thread group
-             * which will not get GCed before VM exit.
-             * Make its parent the top-level thread group.
-             */
-            ThreadGroup tg = Thread.currentThread().getThreadGroup();
-            for (ThreadGroup tgn = tg;
-                    tgn != null;
-                    tg = tgn, tgn = tg.getParent());
+        /*
+         * The thread must be a member of a thread group
+         * which will not get GCed before VM exit.
+         * Make its parent the top-level thread group.
+         */
+        ThreadGroup tg = Thread.currentThread().getThreadGroup();
+        for (ThreadGroup tgn = tg;
+                tgn != null;
+                tg = tgn, tgn = tg.getParent());
 
-            Thread t = new Thread(tg, disposerInstance, "Disposer");
-            t.setDaemon(true);
-            t.setPriority(Thread.MAX_PRIORITY);
-            t.start();
-            return null;
-        });
+        Thread t = new Thread(tg, disposerInstance, "Disposer");
+        t.setDaemon(true);
+        t.setPriority(Thread.MAX_PRIORITY);
+        t.start();
     }
 
     /**

--- a/modules/javafx.web/src/main/java/com/sun/webkit/MethodHelper.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/MethodHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,18 +28,13 @@ package com.sun.webkit;
 import com.sun.javafx.reflect.MethodUtil;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import com.sun.javafx.reflect.ReflectUtil;
 
 /**
  * Utility class to wrap method invocation.
  */
 public class MethodHelper {
-    @SuppressWarnings("removal")
-    private static final boolean logAccessErrors
-            = AccessController.doPrivileged((PrivilegedAction<Boolean>) ()
-                    -> Boolean.getBoolean("sun.reflect.debugModuleAccessChecks"));
+    private static final boolean logAccessErrors = Boolean.getBoolean("sun.reflect.debugModuleAccessChecks");
 
     private static final Module trampolineModule = MethodUtil.getTrampolineModule();
 

--- a/modules/javafx.web/src/main/java/com/sun/webkit/Timer.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/Timer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,9 +25,6 @@
 
 package com.sun.webkit;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-
 public class Timer {
     private static Timer instance;
     private static Mode mode;
@@ -42,12 +39,9 @@ public class Timer {
         SEPARATE_THREAD
     }
 
-    @SuppressWarnings("removal")
     public synchronized static Mode getMode() {
         if (mode == null) {
-            mode = Boolean.valueOf(AccessController.doPrivileged(
-                    (PrivilegedAction<String>) () -> System.getProperty(
-                            "com.sun.webkit.platformticks", "true"))) ? Mode.PLATFORM_TICKS : Mode.SEPARATE_THREAD;
+            mode = Boolean.valueOf(System.getProperty("com.sun.webkit.platformticks", "true")) ? Mode.PLATFORM_TICKS : Mode.SEPARATE_THREAD;
         }
         return mode;
     }

--- a/modules/javafx.web/src/main/java/com/sun/webkit/Utilities.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/Utilities.java
@@ -116,6 +116,11 @@ public abstract class Utilities {
             });
         }
 
-        return MethodHelper.invoke(method, instance, args);
+        try {
+            return MethodHelper.invoke(method, instance, args);
+        } catch (InvocationTargetException ex) {
+            Throwable cause = ex.getCause();
+            throw cause != null ? cause : ex;
+        }
     }
 }

--- a/modules/javafx.web/src/main/java/com/sun/webkit/Utilities.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/Utilities.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,9 +28,6 @@ package com.sun.webkit;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.security.AccessControlContext;
-import java.security.AccessController;
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
 import java.util.List;
 import java.util.Set;
 
@@ -119,17 +116,6 @@ public abstract class Utilities {
             });
         }
 
-        try {
-            return AccessController.doPrivileged((PrivilegedExceptionAction<Object>)
-                    () -> MethodHelper.invoke(method, instance, args), acc);
-        } catch (PrivilegedActionException ex) {
-            Throwable cause = ex.getCause();
-            if (cause == null)
-                cause = ex;
-            else if (cause instanceof InvocationTargetException
-                && cause.getCause() != null)
-                cause = cause.getCause();
-            throw cause;
-        }
+        return MethodHelper.invoke(method, instance, args);
     }
 }

--- a/modules/javafx.web/src/main/java/com/sun/webkit/WebPage.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/WebPage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,9 +45,6 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.security.AccessControlContext;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -103,10 +100,6 @@ public final class WebPage {
     // List of created frames
     private final Set<Long> frames = new HashSet<>();
 
-    // The access control context associated with this object
-    @SuppressWarnings("removal")
-    private final AccessControlContext accessControlContext;
-
     // Maps load request identifiers to URLs
     private final Map<Integer, String> requestURLs =
             new HashMap<>();
@@ -134,48 +127,42 @@ public final class WebPage {
     private int updateContentCycleID;
 
     static {
-        @SuppressWarnings("removal")
-        var dummy = AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-            NativeLibLoader.loadLibrary("jfxwebkit");
-            log.finer("jfxwebkit loaded");
+        NativeLibLoader.loadLibrary("jfxwebkit");
+        log.finer("jfxwebkit loaded");
 
-            if (CookieHandler.getDefault() == null) {
-                boolean setDefault = Boolean.valueOf(System.getProperty(
-                        "com.sun.webkit.setDefaultCookieHandler",
-                        "true"));
-                if (setDefault) {
-                    CookieHandler.setDefault(new CookieManager());
-                }
+        if (CookieHandler.getDefault() == null) {
+            boolean setDefault = Boolean.valueOf(System.getProperty(
+                    "com.sun.webkit.setDefaultCookieHandler",
+                    "true"));
+            if (setDefault) {
+                CookieHandler.setDefault(new CookieManager());
             }
+        }
 
-            final boolean useJIT = Boolean.valueOf(System.getProperty(
-                    "com.sun.webkit.useJIT", "true"));
-            final boolean useDFGJIT = Boolean.valueOf(System.getProperty(
-                    "com.sun.webkit.useDFGJIT", "false"));
+        final boolean useJIT = Boolean.valueOf(System.getProperty(
+                "com.sun.webkit.useJIT", "true"));
+        final boolean useDFGJIT = Boolean.valueOf(System.getProperty(
+                "com.sun.webkit.useDFGJIT", "false"));
 
-            // TODO: Enable CSS3D by default once it is stabilized.
-            boolean useCSS3D = Boolean.valueOf(System.getProperty(
-                    "com.sun.webkit.useCSS3D", "false"));
-            useCSS3D = useCSS3D && Platform.isSupported(ConditionalFeature.SCENE3D);
+        // TODO: Enable CSS3D by default once it is stabilized.
+        boolean useCSS3D = Boolean.valueOf(System.getProperty(
+                "com.sun.webkit.useCSS3D", "false"));
+        useCSS3D = useCSS3D && Platform.isSupported(ConditionalFeature.SCENE3D);
 
-            // Initialize WTF, WebCore and JavaScriptCore.
-            twkInitWebCore(useJIT, useDFGJIT, useCSS3D);
+        // Initialize WTF, WebCore and JavaScriptCore.
+        twkInitWebCore(useJIT, useDFGJIT, useCSS3D);
 
-            // Inform the native webkit code when either the JVM or the
-            // JavaFX runtime is being shutdown
-            final Runnable shutdownHook = () -> {
-                synchronized(WebPage.class) {
-                    MainThread.twkSetShutdown(true);
-                }
-            };
+        // Inform the native webkit code when either the JVM or the
+        // JavaFX runtime is being shutdown
+        final Runnable shutdownHook = () -> {
+            synchronized(WebPage.class) {
+                MainThread.twkSetShutdown(true);
+            }
+        };
 
-            // Register shutdown hook with the Java runtime and the Toolkit
-            Toolkit.getToolkit().addShutdownHook(shutdownHook);
-            Runtime.getRuntime().addShutdownHook(new Thread(shutdownHook));
-
-            return null;
-        });
-
+        // Register shutdown hook with the Java runtime and the Toolkit
+        Toolkit.getToolkit().addShutdownHook(shutdownHook);
+        Runtime.getRuntime().addShutdownHook(new Thread(shutdownHook));
     }
 
     private static boolean firstWebPageCreated = false;
@@ -210,10 +197,6 @@ public final class WebPage {
             this.scrollbarTheme = null;
         }
 
-        @SuppressWarnings("removal")
-        AccessControlContext tmpAcc = AccessController.getContext();
-        accessControlContext = tmpAcc;
-
         hostWindow = new WCFrameView(this);
         pPage = twkCreatePage(editable);
 
@@ -239,16 +222,6 @@ public final class WebPage {
     // Called from the native code
     private WCWidget getHostWindow() {
         return hostWindow;
-    }
-
-    /**
-     * Returns the access control context associated with this object.
-     * May be called on any thread.
-     * @return the access control context associated with this object
-     */
-    @SuppressWarnings("removal")
-    public AccessControlContext getAccessControlContext() {
-        return accessControlContext;
     }
 
     static boolean lockPage() {

--- a/modules/javafx.web/src/main/java/com/sun/webkit/network/CookieJar.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/network/CookieJar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,8 +29,6 @@ import java.io.IOException;
 import java.net.CookieHandler;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -42,9 +40,7 @@ final class CookieJar {
     }
 
     private static void fwkPut(String url, String cookie) {
-        @SuppressWarnings("removal")
-        CookieHandler handler =
-            AccessController.doPrivileged((PrivilegedAction<CookieHandler>) CookieHandler::getDefault);
+        CookieHandler handler = CookieHandler.getDefault();
         if (handler != null) {
             URI uri = null;
             try {
@@ -66,9 +62,7 @@ final class CookieJar {
     }
 
     private static String fwkGet(String url, boolean includeHttpOnlyCookies) {
-        @SuppressWarnings("removal")
-        CookieHandler handler =
-            AccessController.doPrivileged((PrivilegedAction<CookieHandler>) CookieHandler::getDefault);
+        CookieHandler handler = CookieHandler.getDefault();
         if (handler != null) {
             URI uri = null;
             try {

--- a/modules/javafx.web/src/main/java/com/sun/webkit/network/NetworkContext.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/network/NetworkContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,8 +28,6 @@ package com.sun.webkit.network;
 import static com.sun.webkit.network.URLs.newURL;
 
 import java.net.MalformedURLException;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.Arrays;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadFactory;
@@ -92,14 +90,10 @@ final class NetworkContext {
                 new URLLoaderThreadFactory());
         threadPool.allowCoreThreadTimeOut(true);
 
-        @SuppressWarnings("removal")
-        boolean tmp = AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> {
-            // Use HTTP2 by default on JDK 12 or later
-            final var version = Runtime.Version.parse(System.getProperty("java.version"));
-            final String defaultUseHTTP2 = version.feature() >= 12 ? "true" : "false";
-            return Boolean.valueOf(System.getProperty("com.sun.webkit.useHTTP2Loader", defaultUseHTTP2));
-        });
-        useHTTP2Loader = tmp;
+        // Use HTTP2 by default on JDK 12 or later
+        final var version = Runtime.Version.parse(System.getProperty("java.version"));
+        final String defaultUseHTTP2 = version.feature() >= 12 ? "true" : "false";
+        useHTTP2Loader = Boolean.valueOf(System.getProperty("com.sun.webkit.useHTTP2Loader", defaultUseHTTP2));
     }
 
     /**
@@ -218,9 +212,7 @@ final class NetworkContext {
         // Our implementation employs HttpURLConnection for all
         // HTTP exchanges, so return the value of the "http.maxConnections"
         // system property.
-        @SuppressWarnings("removal")
-        int propValue = AccessController.doPrivileged(
-                (PrivilegedAction<Integer>) () -> Integer.getInteger("http.maxConnections", -1));
+        int propValue = Integer.getInteger("http.maxConnections", -1);
 
         if (useHTTP2Loader) {
             return propValue >= 0 ? propValue : DEFAULT_HTTP2_MAX_CONNECTIONS;
@@ -235,13 +227,6 @@ final class NetworkContext {
         private final ThreadGroup group;
         private final AtomicInteger index = new AtomicInteger(1);
 
-        // Need to assert the modifyThread and modifyThreadGroup permission when
-        // creating the thread from the URLLoaderThreadFactory, so we can
-        // create the thread with the desired ThreadGroup.
-        // Note that this is needed when running with a security manager
-        private static final Permission modifyThreadGroupPerm = new RuntimePermission("modifyThreadGroup");
-        private static final Permission modifyThreadPerm = new RuntimePermission("modifyThread");
-
         private URLLoaderThreadFactory() {
             @SuppressWarnings("removal")
             SecurityManager sm = System.getSecurityManager();
@@ -249,22 +234,14 @@ final class NetworkContext {
                     : Thread.currentThread().getThreadGroup();
         }
 
-        @SuppressWarnings("removal")
         @Override
         public Thread newThread(Runnable r) {
-            // Assert the modifyThread and modifyThreadGroup permissions
-            return
-                AccessController.doPrivileged((PrivilegedAction<Thread>) () -> {
-                    Thread t = new Thread(group, r,
-                            "URL-Loader-" + index.getAndIncrement());
-                    t.setDaemon(true);
-                    if (t.getPriority() != Thread.NORM_PRIORITY) {
-                        t.setPriority(Thread.NORM_PRIORITY);
-                    }
-                    return t;
-                },
-                null,
-                modifyThreadGroupPerm, modifyThreadPerm);
+            Thread t = new Thread(group, r, "URL-Loader-" + index.getAndIncrement());
+            t.setDaemon(true);
+            if (t.getPriority() != Thread.NORM_PRIORITY) {
+                t.setPriority(Thread.NORM_PRIORITY);
+            }
+            return t;
         }
     }
 }

--- a/modules/javafx.web/src/main/java/com/sun/webkit/network/SocketStreamHandle.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/network/SocketStreamHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,8 +43,6 @@ import java.net.SocketException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.UnknownHostException;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.List;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadFactory;
@@ -101,7 +99,6 @@ final class SocketStreamHandle {
         return ssh;
     }
 
-    @SuppressWarnings("removal")
     private void run() {
         if (webPage == null) {
             logger.finest("{0} is not associated with any web "
@@ -114,13 +111,7 @@ final class SocketStreamHandle {
             didClose();
             return;
         }
-        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-            doRun();
-            return null;
-        }, webPage.getAccessControlContext());
-    }
 
-    private void doRun() {
         Throwable error = null;
         String errorDescription = null;
         try {
@@ -209,9 +200,7 @@ final class SocketStreamHandle {
         boolean success = false;
         IOException lastException = null;
         boolean triedDirectConnection = false;
-        @SuppressWarnings("removal")
-        ProxySelector proxySelector = AccessController.doPrivileged(
-                (PrivilegedAction<ProxySelector>) () -> ProxySelector.getDefault());
+        ProxySelector proxySelector = ProxySelector.getDefault();
         if (proxySelector != null) {
             URI uri;
             try {

--- a/modules/javafx.web/src/main/java/com/sun/webkit/network/URLLoader.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/network/URLLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,9 +51,6 @@ import java.net.URLConnection;
 import java.net.URLDecoder;
 import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
-import java.security.AccessControlException;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -122,20 +119,8 @@ final class URLLoader extends URLLoaderBase implements Runnable {
     /**
      * {@inheritDoc}
      */
-    @SuppressWarnings("removal")
     @Override
     public void run() {
-        // Run the loader in the page's access control context
-        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-            doRun();
-            return null;
-        }, webPage.getAccessControlContext());
-    }
-
-    /**
-     * Executes this loader.
-     */
-    private void doRun() {
         Throwable error = null;
         int errorCode = 0;
         try {
@@ -186,9 +171,6 @@ final class URLLoader extends URLLoaderBase implements Runnable {
         } catch (MalformedURLException ex) {
             error = ex;
             errorCode = LoadListenerClient.MALFORMED_URL;
-        } catch (@SuppressWarnings("removal") AccessControlException ex) {
-            error = ex;
-            errorCode = LoadListenerClient.PERMISSION_DENIED;
         } catch (UnknownHostException ex) {
             error = ex;
             errorCode = LoadListenerClient.UNKNOWN_HOST;

--- a/modules/javafx.web/src/main/java/com/sun/webkit/network/URLs.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/network/URLs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,12 +26,8 @@
 package com.sun.webkit.network;
 
 import java.net.MalformedURLException;
-import java.net.NetPermission;
 import java.net.URL;
 import java.net.URLStreamHandler;
-import java.security.AccessController;
-import java.security.Permission;
-import java.security.PrivilegedAction;
 import java.util.Map;
 
 /**
@@ -46,9 +42,6 @@ public final class URLs {
     private static final Map<String,URLStreamHandler> HANDLER_MAP = Map.of(
         "about", new com.sun.webkit.network.about.Handler(),
         "data", new com.sun.webkit.network.data.Handler());
-
-    private static final Permission streamHandlerPermission =
-        new NetPermission("specifyStreamHandler");
 
     /**
      * The private default constructor. Ensures non-instantiability.
@@ -96,25 +89,7 @@ public final class URLs {
 
             if (handler == null) throw ex;
 
-            try {
-                // We should be able to specify one of our stream handlers for the URL
-                // when running with a security manager
-                @SuppressWarnings("removal")
-                URL result = AccessController.doPrivileged((PrivilegedAction<URL>) () -> {
-                    try {
-                        return new URL(context, spec, handler);
-                    } catch (MalformedURLException muex) {
-                        throw new RuntimeException(muex);
-                    }
-                }, null, streamHandlerPermission);
-                return result;
-
-            } catch (RuntimeException re) {
-                if (re.getCause() instanceof MalformedURLException) {
-                    throw (MalformedURLException)re.getCause();
-                }
-                throw re;
-            }
+            return new URL(context, spec, handler);
         }
     }
 }

--- a/modules/javafx.web/src/main/java/javafx/scene/web/HTMLEditorSkin.java
+++ b/modules/javafx.web/src/main/java/javafx/scene/web/HTMLEditorSkin.java
@@ -828,6 +828,7 @@ public class HTMLEditorSkin extends SkinBase<HTMLEditor> {
 
         Image icon = new Image(HTMLEditorSkin.class.getResource(iconName).toString());
         ((StyleableProperty)button.graphicProperty()).applyStyle(null, new ImageView(icon));
+//      button.setGraphic(new ImageView(icon));
         button.setTooltip(new Tooltip(tooltipText));
 
         button.setOnAction(event -> {
@@ -851,6 +852,7 @@ public class HTMLEditorSkin extends SkinBase<HTMLEditor> {
 
         Image icon = new Image(HTMLEditorSkin.class.getResource(iconName).toString());
         ((StyleableProperty)toggleButton.graphicProperty()).applyStyle(null, new ImageView(icon));
+//      toggleButton.setGraphic(new ImageView(icon));
 
         toggleButton.setTooltip(new Tooltip(tooltipText));
 

--- a/modules/javafx.web/src/main/java/javafx/scene/web/HTMLEditorSkin.java
+++ b/modules/javafx.web/src/main/java/javafx/scene/web/HTMLEditorSkin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -71,10 +71,6 @@ import com.sun.javafx.scene.control.skin.FXVK;
 import com.sun.javafx.scene.web.behavior.HTMLEditorBehavior;
 import com.sun.webkit.WebPage;
 import com.sun.javafx.webkit.Accessor;
-
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -830,9 +826,7 @@ public class HTMLEditorSkin extends SkinBase<HTMLEditor> {
         button.getStyleClass().add(styleClass);
         toolbar.getItems().add(button);
 
-        @SuppressWarnings("removal")
-        Image icon = AccessController.doPrivileged((PrivilegedAction<Image>) () -> new Image(HTMLEditorSkin.class.getResource(iconName).toString()));
-//        button.setGraphic(new ImageView(icon));
+        Image icon = new Image(HTMLEditorSkin.class.getResource(iconName).toString());
         ((StyleableProperty)button.graphicProperty()).applyStyle(null, new ImageView(icon));
         button.setTooltip(new Tooltip(tooltipText));
 
@@ -855,10 +849,8 @@ public class HTMLEditorSkin extends SkinBase<HTMLEditor> {
             toggleButton.setToggleGroup(toggleGroup);
         }
 
-        @SuppressWarnings("removal")
-        Image icon = AccessController.doPrivileged((PrivilegedAction<Image>) () -> new Image(HTMLEditorSkin.class.getResource(iconName).toString()));
+        Image icon = new Image(HTMLEditorSkin.class.getResource(iconName).toString());
         ((StyleableProperty)toggleButton.graphicProperty()).applyStyle(null, new ImageView(icon));
-//        toggleButton.setGraphic(new ImageView(icon));
 
         toggleButton.setTooltip(new Tooltip(tooltipText));
 

--- a/modules/javafx.web/src/main/java/javafx/scene/web/WebEngine.java
+++ b/modules/javafx.web/src/main/java/javafx/scene/web/WebEngine.java
@@ -1569,8 +1569,6 @@ final public class WebEngine {
             this.engine = new WeakReference<>(engine);
         }
 
-
-        @SuppressWarnings("removal")
         @Override
         public boolean sendMessageToFrontend(final String message) {
             boolean result = false;

--- a/modules/javafx.web/src/main/java/javafx/scene/web/WebEngine.java
+++ b/modules/javafx.web/src/main/java/javafx/scene/web/WebEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -66,8 +66,6 @@ import java.net.URLConnection;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.PosixFilePermissions;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
@@ -1581,10 +1579,7 @@ final public class WebEngine {
                 final Callback<String,Void> messageCallback =
                         webEngine.debugger.messageCallback;
                 if (messageCallback != null) {
-                    AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-                        messageCallback.call(message);
-                        return null;
-                    }, webEngine.page.getAccessControlContext());
+                    messageCallback.call(message);
                     result = true;
                 }
             }


### PR DESCRIPTION
Removes `doPrivileged` calls in the javafx.web module, excluding the code in `{android,ios}`.

/reviewers 2

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8342460](https://bugs.openjdk.org/browse/JDK-8342460): Remove calls to doPrivileged in javafx.web (**Bug** - P3)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1620/head:pull/1620` \
`$ git checkout pull/1620`

Update a local copy of the PR: \
`$ git checkout pull/1620` \
`$ git pull https://git.openjdk.org/jfx.git pull/1620/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1620`

View PR using the GUI difftool: \
`$ git pr show -t 1620`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1620.diff">https://git.openjdk.org/jfx/pull/1620.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1620#issuecomment-2451012773)
</details>
