### PR TITLE
8342627: Create Eclipse project files for jdk.jsobject

### DIFF
--- a/modules/jdk.jsobject/.classpath
+++ b/modules/jdk.jsobject/.classpath
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" path="src/main/java"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/5">
+		<attributes>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/modules/jdk.jsobject/.project
+++ b/modules/jdk.jsobject/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>jsobject</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/modules/jdk.jsobject/.settings/org.eclipse.core.resources.prefs
+++ b/modules/jdk.jsobject/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8


### PR DESCRIPTION
Added eclipse project files.

The project is named `jsobject` instead of jdk.jsobject, similarly to how the other projects are named "base", "controls", ... instead of their full module names.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342627](https://bugs.openjdk.org/browse/JDK-8342627): Create Eclipse project files for jdk.jsobject (**Bug** - P4)


### Reviewers
 * [John Hendrikx](https://openjdk.org/census#jhendrikx) (@hjohn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1621/head:pull/1621` \
`$ git checkout pull/1621`

Update a local copy of the PR: \
`$ git checkout pull/1621` \
`$ git pull https://git.openjdk.org/jfx.git pull/1621/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1621`

View PR using the GUI difftool: \
`$ git pr show -t 1621`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1621.diff">https://git.openjdk.org/jfx/pull/1621.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1621#issuecomment-2451011876)
</details>
