### PR TITLE
Added an ApplicationMenu class to the javafx.application package

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Application.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Application.java
@@ -170,6 +170,24 @@ public abstract class Application {
     }
 
     /**
+     * Installs a handler to show a custom About window for the application. The default
+     * implementation does nothing.
+     *
+     * @param handler - the handler to respond to the About menu item being selected
+     */
+    public void setAboutHandler(Runnable handler) {
+    }
+
+    /**
+     * Installs a handler to show a custom Settings window for the application. The default
+     * implementation does nothing.
+     *
+     * @param handler - the handler to respond to the Settings menu item being selected
+     */
+    public void setSettingsHandler(Runnable handler) {
+    }
+
+    /**
      * Gets the name for the application.  The application name may
      * be used to identify the application in the user interface or
      * as part of the platform specific path used to store application

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacApplication.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacApplication.java
@@ -112,6 +112,8 @@ final class MacApplication extends Application implements InvokeLaterDispatcher.
     }
 
     private Menu appleMenu;
+    private Runnable aboutHandler;
+    private Runnable settingsHandler;
 
     native void _runLoop(ClassLoader classLoader, Runnable launchable,
                          boolean isTaskbarApplication);
@@ -230,8 +232,46 @@ final class MacApplication extends Application implements InvokeLaterDispatcher.
     native private void _hideOtherApplications();
     native private void _unhideAllApplications();
 
-    public void installAppleMenu(MenuBar menubar) {
-        this.appleMenu = createMenu("Apple");
+    @Override
+    public void setAboutHandler(Runnable handler) {
+      aboutHandler = handler;
+      rebuildAppleMenu();
+    }
+
+    @Override
+    public void setSettingsHandler(Runnable handler) {
+      settingsHandler = handler;
+      rebuildAppleMenu();
+    }
+
+    private void rebuildAppleMenu() {
+        for (int index = this.appleMenu.getItems().size() - 1; index >= 0; index--) {
+            this.appleMenu.remove(index);
+        }
+
+        if (null != aboutHandler) {
+            MenuItem aboutMenu = createMenuItem("About " + getName(), new MenuItem.Callback() {
+                @Override public void action() {
+                    aboutHandler.run();
+                }
+                @Override public void validate() {
+                }
+            });
+            this.appleMenu.add(aboutMenu);
+            this.appleMenu.add(MenuItem.Separator);
+        }
+
+        if (null != settingsHandler) {
+            MenuItem aboutMenu = createMenuItem("Settings...", new MenuItem.Callback() {
+                @Override public void action() {
+                    settingsHandler.run();
+                }
+                @Override public void validate() {
+                }
+            }, ',', KeyEvent.MODIFIER_COMMAND);
+            this.appleMenu.add(aboutMenu);
+            this.appleMenu.add(MenuItem.Separator);
+        }
 
         MenuItem hideMenu = createMenuItem("Hide " + getName(), new MenuItem.Callback() {
             @Override public void action() {
@@ -273,6 +313,12 @@ final class MacApplication extends Application implements InvokeLaterDispatcher.
             }
         }, 'q', KeyEvent.MODIFIER_COMMAND);
         this.appleMenu.add(quitMenu);
+    }
+
+    public void installAppleMenu(MenuBar menubar) {
+        this.appleMenu = createMenu("Apple");
+
+        rebuildAppleMenu();
 
         menubar.add(this.appleMenu);
     }

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/application/PlatformImpl.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/application/PlatformImpl.java
@@ -139,6 +139,28 @@ public class PlatformImpl {
     }
 
     /**
+     * Installs a handler to show a custom About window for your application.
+     * <p>
+     * Setting the handler to null reverts it to the default behavior.
+     *
+     * @param handler - the handler to respond to the About menu item being selected
+     */
+    public static void setAboutHandler(Runnable handler) {
+        com.sun.glass.ui.Application.GetApplication().setAboutHandler(handler);
+    }
+
+    /**
+     * Installs a handler to show a custom Settings window for your application.
+     * <p>
+     * Setting the handler to null reverts it to the default behavior.
+     *
+     * @param handler - the handler to respond to the Settings menu item being selected
+     */
+    public static void setSettingsHandler(Runnable handler) {
+        com.sun.glass.ui.Application.GetApplication().setSettingsHandler(handler);
+    }
+
+    /**
      * Sets the name of the this application based on the Application class.
      * This method is called by the launcher, and is not
      * called from the FX Application Thread, so we need to do it in a runLater.
@@ -1001,6 +1023,8 @@ public class PlatformImpl {
                     return Toolkit.getToolkit().isSupported(feature);
                 }
                 return hasPointer;
+            case APPLICATION_MENU:
+                return PlatformUtil.isMac();
             default:
                 return Toolkit.getToolkit().isSupported(feature);
         }

--- a/modules/javafx.graphics/src/main/java/javafx/application/Application.java
+++ b/modules/javafx.graphics/src/main/java/javafx/application/Application.java
@@ -372,6 +372,32 @@ public abstract class Application {
     public void stop() throws Exception {
     }
 
+    private ApplicationMenu applicationMenu = null;
+
+    /**
+     * Gets the ApplicationMenu for this application. This provides
+     * the ability to interact with the platform provided application menu.
+     *
+     * @return the ApplicationMenu
+     *
+     * @throws java.lang.UnsupportedOperationException if
+     * javafx.application.ConditionalFeature.APPLICATION_MENU is not supported on this platform
+     *
+     * @since JavaFX 24.0
+     */
+    public final ApplicationMenu getApplicationMenu() {
+        if (!PlatformImpl.isSupported(ConditionalFeature.APPLICATION_MENU)) {
+            throw new UnsupportedOperationException("ConditionalFeature.APPLICATION_MENU is not"
+                    + " supported on this platform");
+        }
+        synchronized (this) {
+            if (applicationMenu == null) {
+                applicationMenu = new ApplicationMenu();
+            }
+            return applicationMenu;
+        }
+    }
+
     private HostServices hostServices = null;
 
     /**

--- a/modules/javafx.graphics/src/main/java/javafx/application/ApplicationMenu.java
+++ b/modules/javafx.graphics/src/main/java/javafx/application/ApplicationMenu.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package javafx.application;
+
+import com.sun.javafx.application.PlatformImpl;
+
+/**
+ * Application menu class that provides support for interacting with the platform provided
+ * application menu. This is currently only supported on macOS.
+ *
+ * @author David Kopp
+ *
+ * @since JavaFX 24.0
+ */
+public final class ApplicationMenu
+{
+    ApplicationMenu() {
+    }
+
+    /**
+     * Installs a handler to show a custom About window for your application.
+     * <p>
+     * Setting the handler to null reverts it to the default behavior.
+     *
+     * @param handler - the handler to respond to the About menu item being selected
+     */
+    public void setAboutHandler(Runnable handler) {
+        PlatformImpl.setAboutHandler(handler);
+    }
+
+    /**
+     * Installs a handler to show a custom Settings window for your application.
+     * <p>
+     * Setting the handler to null reverts it to the default behavior.
+     *
+     * @param handler - the handler to respond to the Settings menu item being selected
+     */
+    public void setSettingsHandler(Runnable handler) {
+        PlatformImpl.setSettingsHandler(handler);
+    }
+}

--- a/modules/javafx.graphics/src/main/java/javafx/application/ConditionalFeature.java
+++ b/modules/javafx.graphics/src/main/java/javafx/application/ConditionalFeature.java
@@ -216,6 +216,14 @@ public enum ConditionalFeature {
      * true.
      * @since JavaFX 8.0
      */
-    INPUT_POINTER
+    INPUT_POINTER,
+
+    /**
+     * Indicates whether or this platform supports the concept of an application menu.
+     * <p>
+     * This is currently only supported on macOS.
+     * @since JavaFX 24.0
+     */
+    APPLICATION_MENU
 
 }


### PR DESCRIPTION
Added an ApplicationMenu class that provides support for adding About and Settings menu items and handlers to JavaFX applications running on macOS. This provides similar functionality to java.awt.Desktop's setAboutHandler and setPreferencesHandler methods.

A new enumeration value, APPLICATION_MENU, had been added to ConditionalFeature, and a new method called getAboutHandler has been added to javafx.application.Application.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1622/head:pull/1622` \
`$ git checkout pull/1622`

Update a local copy of the PR: \
`$ git checkout pull/1622` \
`$ git pull https://git.openjdk.org/jfx.git pull/1622/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1622`

View PR using the GUI difftool: \
`$ git pr show -t 1622`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1622.diff">https://git.openjdk.org/jfx/pull/1622.diff</a>

</details>
