### PR TITLE
8342917: GHA: Intermittent build failure on Linux while downloading ant

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -76,9 +76,9 @@ jobs:
       BOOT_JDK_VERSION: "23"
       BOOT_JDK_FILENAME: "jdk-23_linux-x64_bin.tar.gz"
       BOOT_JDK_URL: "https://download.oracle.com/java/23/archive/jdk-23_linux-x64_bin.tar.gz"
-      ANT_DIR: "apache-ant-1.10.5"
-      ANT_FILENAME: "apache-ant-1.10.5.tar.gz"
-      ANT_URL: "https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.5-bin.tar.gz"
+      # ANT_DIR: "apache-ant-1.10.5"
+      # ANT_FILENAME: "apache-ant-1.10.5.tar.gz"
+      # ANT_URL: "https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.5-bin.tar.gz"
 
     steps:
       - name: Checkout the source
@@ -90,11 +90,11 @@ jobs:
         run: |
           set -x
           sudo apt-get update
-          sudo apt-get install libgl1-mesa-dev libx11-dev libxxf86vm-dev libxt-dev pkg-config libgtk2.0-dev libgtk-3-dev libxtst-dev gcc-13 g++-13
+          sudo apt-get install ant libgl1-mesa-dev libx11-dev libxxf86vm-dev libxt-dev pkg-config libgtk2.0-dev libgtk-3-dev libxtst-dev gcc-13 g++-13
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 100 --slave /usr/bin/g++ g++ /usr/bin/g++-13
           mkdir -p "${HOME}/build-tools"
-          wget -O "${HOME}/build-tools/${ANT_FILENAME}" "${ANT_URL}"
-          tar -zxf "${HOME}/build-tools/${ANT_FILENAME}" -C "${HOME}/build-tools"
+          # wget -O "${HOME}/build-tools/${ANT_FILENAME}" "${ANT_URL}"
+          # tar -zxf "${HOME}/build-tools/${ANT_FILENAME}" -C "${HOME}/build-tools"
 
 # FIXME: enable cache for boot JDK
 #      - name: Restore boot JDK from cache
@@ -118,9 +118,9 @@ jobs:
           set -x
           export JAVA_HOME="${HOME}/bootjdk/jdk-${BOOT_JDK_VERSION}"
           echo "JAVA_HOME=${JAVA_HOME}" >> "${GITHUB_ENV}"
-          export ANT_HOME="${HOME}/build-tools/${ANT_DIR}"
-          echo "ANT_HOME=${ANT_HOME}" >> "${GITHUB_ENV}"
-          export PATH="$JAVA_HOME/bin:$ANT_HOME/bin:$PATH"
+          # export ANT_HOME="${HOME}/build-tools/${ANT_DIR}"
+          # echo "ANT_HOME=${ANT_HOME}" >> "${GITHUB_ENV}"
+          # export PATH="$JAVA_HOME/bin:$ANT_HOME/bin:$PATH"
           env | sort
           which java
           java -version
@@ -132,7 +132,8 @@ jobs:
         working-directory: jfx
         run: |
           set -x
-          export PATH="$JAVA_HOME/bin:$ANT_HOME/bin:$PATH"
+          # export PATH="$JAVA_HOME/bin:$ANT_HOME/bin:$PATH"
+          export PATH="$JAVA_HOME/bin:$PATH"
           bash gradlew -version
           bash gradlew --info all
 
@@ -140,7 +141,8 @@ jobs:
         working-directory: jfx
         run: |
           set -x
-          export PATH="$JAVA_HOME/bin:$ANT_HOME/bin:$PATH"
+          # export PATH="$JAVA_HOME/bin:$ANT_HOME/bin:$PATH"
+          export PATH="$JAVA_HOME/bin:$PATH"
           bash gradlew --info --continue -PTEST_ONLY=true test -x :web:test
 
 

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -121,6 +121,7 @@ jobs:
           # export ANT_HOME="${HOME}/build-tools/${ANT_DIR}"
           # echo "ANT_HOME=${ANT_HOME}" >> "${GITHUB_ENV}"
           # export PATH="$JAVA_HOME/bin:$ANT_HOME/bin:$PATH"
+          export PATH="$JAVA_HOME/bin:$PATH"
           env | sort
           which java
           java -version


### PR DESCRIPTION
We are getting frequent intermittent failures downloading `ant` on Linux. The fix is to use the package manager to install ant rather than downloading it from `apache.org`.

This only impacts GHA test builds, so the only verification needed for this fix is that the GHA build passes on all platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342917](https://bugs.openjdk.org/browse/JDK-8342917): GHA: Intermittent build failure on Linux while downloading ant (**Bug** - P4)


### Reviewers
 * [Johan Vos](https://openjdk.org/census#jvos) (@johanvos - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1623/head:pull/1623` \
`$ git checkout pull/1623`

Update a local copy of the PR: \
`$ git checkout pull/1623` \
`$ git pull https://git.openjdk.org/jfx.git pull/1623/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1623`

View PR using the GUI difftool: \
`$ git pr show -t 1623`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1623.diff">https://git.openjdk.org/jfx/pull/1623.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1623#issuecomment-2455367633)
</details>
