### PR TITLE
8343630: Pass AccessControlContext to/from WebKit as opaque object

### DIFF
--- a/modules/javafx.web/src/main/java/com/sun/webkit/Utilities.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/Utilities.java
@@ -96,8 +96,10 @@ public abstract class Utilities {
     private static Object fwkInvokeWithContext(final Method method,
                                                final Object instance,
                                                final Object[] args,
-                                               AccessControlContext acc)
+                                               Object accObj)
             throws Throwable {
+
+        AccessControlContext acc = (AccessControlContext) accObj;
 
         final Class<?> clazz = method.getDeclaringClass();
         if (clazz.equals(java.lang.Class.class)) {

--- a/modules/javafx.web/src/main/java/com/sun/webkit/dom/JSObject.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/dom/JSObject.java
@@ -28,7 +28,6 @@ package com.sun.webkit.dom;
 import com.sun.webkit.Disposer;
 import com.sun.webkit.DisposerRecord;
 import com.sun.webkit.Invoker;
-import java.security.AccessControlContext;
 import java.security.AccessController;
 import java.util.concurrent.atomic.AtomicInteger;
 import netscape.javascript.JSException;
@@ -93,7 +92,7 @@ class JSObject extends netscape.javascript.JSObject {
     }
     private static native void setMemberImpl(long peer, int peer_type,
                                              String name, Object value,
-                                             @SuppressWarnings("removal") AccessControlContext acc);
+                                             Object acc);
 
     @Override
     public void removeMember(String name) throws JSException {
@@ -120,7 +119,7 @@ class JSObject extends netscape.javascript.JSObject {
     }
     private static native void setSlotImpl(long peer, int peer_type,
                                            int index, Object value,
-                                           @SuppressWarnings("removal") AccessControlContext acc);
+                                           Object acc);
 
     @SuppressWarnings("removal")
     @Override
@@ -131,7 +130,7 @@ class JSObject extends netscape.javascript.JSObject {
     }
     private static native Object callImpl(long peer, int peer_type,
                                           String methodName, Object[] args,
-                                          @SuppressWarnings("removal") AccessControlContext acc);
+                                          Object acc);
 
     @Override
     public String toString() {

--- a/modules/javafx.web/src/main/native/Source/WebCore/bridge/jni/jsc/JNIUtilityPrivate.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bridge/jni/jsc/JNIUtilityPrivate.cpp
@@ -324,7 +324,7 @@ jthrowable dispatchJNICall(int count, RootObject*, jobject obj, bool isStatic, J
       env->SetObjectArrayElement(argsArray, i, args[i]);
     jmethodID invokeMethod =
         env->GetStaticMethodID(utilityCls, "fwkInvokeWithContext",
-                               "(Ljava/lang/reflect/Method;Ljava/lang/Object;[Ljava/lang/Object;Ljava/security/AccessControlContext;)Ljava/lang/Object;");
+                               "(Ljava/lang/reflect/Method;Ljava/lang/Object;[Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;");
     jobject r = env->CallStaticObjectMethod(utilityCls, invokeMethod,
                                             rmethod, obj, argsArray,
                                             accessControlContext);


### PR DESCRIPTION
This PR modifies the signature of four methods -- 3 `native` JNI methods and 1 Java method that is called from native code using JNI -- changing the type of one of the arguments from `AccessControlContext` to `Object`.

As a follow-on to removing security manager support, we are removing all references to the terminally deprecated AccessController and AccessControlConext classes, which is tracked by [JDK-8342993](https://bugs.openjdk.org/browse/JDK-8342993).

The Java code passes an `AccessControlContext` instance to the native `JSObject` code, which stores it in the object so that it can later pass it back to the `Utilities::fwkInvokeWithContext` Java method via a JNI upcall. The native WebKit otherwise does not use the `AccessControlConext` object. Since it is already treated as an opaque object by the native code, the easiest path to eliminating the references to `AccessControlConext` is to change the method signatures to pass an `Object` rather than `AccessControlConext`. This has two related advantages:

1. It will minimize the changes to native WebKit JNI code.
2. It will allow us to keep the native code identical between mainline jfx24 and earlier releases (e.g., jfx23u, jfx21u, etc), since earlier releases still need to be able to run with a security manager.

This bug fix needs to go in ahead of the fix for[JDK-8342993](https://bugs.openjdk.org/browse/JDK-8342993) and will be be backported to all earlier code lines (whereas none of the other SM follow-up fixes can be backported).

NOTE: Both this PR and PR #1620 touch the `Utilities::fwkInvokeWithContext` method. I did my fix in such a way that the two PRs can go in in either order with no conflicts. By doing it this way, it can be backported cleanly to earlier code lines. Consequently, after both PRs are integrated, there will be an unused local variable that can be removed. I will remove that as part of [JDK-8342993](https://bugs.openjdk.org/browse/JDK-8342993), along with the then-unneeded `SuppressWarnings` and unused `AccessController` import.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8343630](https://bugs.openjdk.org/browse/JDK-8343630): Pass AccessControlContext to/from WebKit as opaque object (**Bug** - P3)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Jay Bhaskar](https://openjdk.org/census#jbhaskar) (@jaybhaskar - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1626/head:pull/1626` \
`$ git checkout pull/1626`

Update a local copy of the PR: \
`$ git checkout pull/1626` \
`$ git pull https://git.openjdk.org/jfx.git pull/1626/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1626`

View PR using the GUI difftool: \
`$ git pr show -t 1626`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1626.diff">https://git.openjdk.org/jfx/pull/1626.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1626#issuecomment-2457838253)
</details>
