### PR TITLE
8342992: Security manager check should not use deprecated methods

### DIFF
--- a/modules/javafx.base/src/main/java/com/sun/javafx/SecurityUtil.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/SecurityUtil.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.sun.javafx;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+/**
+ * Utility class to check for the presence of a security manager.
+ */
+public class SecurityUtil {
+
+    // Prevent class from being instantiated.
+    private SecurityUtil() {}
+
+    /**
+     * Check for the presence of a security manager (from an older JDK) and
+     * throw UnsupportedOperationException if enabled. Use reflection to avoid
+     * a dependency on an API that is deprecated for removal. This method does
+     * nothing if the security manager is not enabled or if
+     * System::getSecurityManager cannot be invoked.
+     *
+     * @throws UnsupportedOperationException if the security manager is enabled
+     */
+    public static void checkSecurityManager() {
+        try {
+            // Call System.getSecurityManager() using reflection. Throw an
+            // UnsupportedOperationException if it returns a non-null object.
+            // If we cannot find or invoke getSecurityManager, ignore the error.
+            Method meth = System.class.getMethod("getSecurityManager");
+            Object sm = meth.invoke(null);
+            if (sm != null) {
+                throw new UnsupportedOperationException("JavaFX does not support running with the Security Manager");
+            }
+        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException ex) {
+            // Ignore the error
+        }
+    }
+}

--- a/modules/javafx.base/src/main/java/com/sun/javafx/reflect/MethodUtil.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/reflect/MethodUtil.java
@@ -25,6 +25,7 @@
 
 package com.sun.javafx.reflect;
 
+import com.sun.javafx.SecurityUtil;
 import java.security.AllPermission;
 import java.security.AccessController;
 import java.security.PermissionCollection;
@@ -77,6 +78,12 @@ class Trampoline {
  * Create a trampoline class.
  */
 public final class MethodUtil extends SecureClassLoader {
+
+    static {
+        // Check for security manager (throws exception if enabled)
+        SecurityUtil.checkSecurityManager();
+    }
+
     private static final String MISC_PKG = "com.sun.javafx.reflect.";
     private static final String TRAMPOLINE = MISC_PKG + "Trampoline";
     private static final Method bounce = getTrampoline();

--- a/modules/javafx.base/src/main/java/com/sun/javafx/reflect/ReflectUtil.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/reflect/ReflectUtil.java
@@ -26,9 +26,15 @@
 
 package com.sun.javafx.reflect;
 
+import com.sun.javafx.SecurityUtil;
 import java.lang.reflect.Proxy;
 
 public final class ReflectUtil {
+
+    static {
+        // Check for security manager (throws exception if enabled)
+        SecurityUtil.checkSecurityManager();
+    }
 
     private ReflectUtil() {
     }

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/application/LauncherImpl.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/application/LauncherImpl.java
@@ -26,6 +26,7 @@
 package com.sun.javafx.application;
 
 import com.sun.javafx.PlatformUtil;
+import com.sun.javafx.SecurityUtil;
 import javafx.application.Application;
 import javafx.application.Preloader;
 import javafx.application.Preloader.ErrorNotification;
@@ -57,12 +58,8 @@ import com.sun.javafx.stage.StageHelper;
 public class LauncherImpl {
 
     static {
-        @SuppressWarnings("removal")
-        var sm = System.getSecurityManager();
-        if (sm != null) {
-            throw new UnsupportedOperationException("JavaFX does not support running with the Security Manager");
-        }
-
+        // Check for security manager (throws exception if enabled)
+        SecurityUtil.checkSecurityManager();
     }
 
     /**

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/application/PlatformImpl.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/application/PlatformImpl.java
@@ -27,6 +27,7 @@ package com.sun.javafx.application;
 
 import static com.sun.javafx.FXPermissions.CREATE_TRANSPARENT_WINDOW_PERMISSION;
 import com.sun.javafx.PlatformUtil;
+import com.sun.javafx.SecurityUtil;
 import com.sun.javafx.application.preferences.PlatformPreferences;
 import com.sun.javafx.application.preferences.PreferenceMapping;
 import com.sun.javafx.css.StyleManager;
@@ -61,12 +62,8 @@ import javafx.util.FXPermission;
 public class PlatformImpl {
 
     static {
-        @SuppressWarnings("removal")
-        var sm = System.getSecurityManager();
-        if (sm != null) {
-            throw new UnsupportedOperationException("JavaFX does not support running with the Security Manager");
-        }
-
+        // Check for security manager (throws exception if enabled)
+        SecurityUtil.checkSecurityManager();
     }
 
     private static AtomicBoolean initialized = new AtomicBoolean(false);


### PR DESCRIPTION
As specified in the security manager removal CSR, [JDK-8341858](https://bugs.openjdk.org/browse/JDK-8341858), JavaFX now checks at startup whether the security manager is enabled and fails fast with an `UnsupportedOperationException` if it is. The check is currently done in the `<clinit>` methods of `PlatformImpl` and `LauncherImpl` by calling the deprecated `System::getSecurityManager` method.

This PR creates a new `SecurityUtility::checkSecurityManager` utility method in `javafx.base` that uses reflection to avoid calling API that is deprecated for removal. I also added a call to `checkSecurityManager` in `ReflectUtil` and `MethodUtil` in `javafx.base` for non-graphical applications that only use `javafx.base`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342992](https://bugs.openjdk.org/browse/JDK-8342992): Security manager check should not use deprecated methods (**Bug** - P3)


### Reviewers
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1627/head:pull/1627` \
`$ git checkout pull/1627`

Update a local copy of the PR: \
`$ git checkout pull/1627` \
`$ git pull https://git.openjdk.org/jfx.git pull/1627/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1627`

View PR using the GUI difftool: \
`$ git pr show -t 1627`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1627.diff">https://git.openjdk.org/jfx/pull/1627.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1627#issuecomment-2458028151)
</details>
