### PR TITLE
8337246: SpinnerSkin does not consume ENTER KeyEvent when editor ActionEvent is consumed

### DIFF
--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/SpinnerBehavior.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/SpinnerBehavior.java
@@ -31,13 +31,11 @@ import javafx.event.EventHandler;
 import javafx.scene.control.Spinner;
 import javafx.scene.control.SpinnerValueFactory;
 import com.sun.javafx.scene.control.inputmap.InputMap;
+import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
 import javafx.util.Duration;
 
 import java.util.List;
-
-import static javafx.scene.input.KeyCode.*;
-import static com.sun.javafx.scene.control.inputmap.InputMap.KeyMapping;
 
 public class SpinnerBehavior<T> extends BehaviorBase<Spinner<T>> {
 
@@ -69,7 +67,20 @@ public class SpinnerBehavior<T> extends BehaviorBase<Spinner<T>> {
         }
     };
 
+    private final EventHandler<KeyEvent> spinnerKeyHandler = e -> {
+        boolean arrowsAreVertical = arrowsAreVertical();
+        KeyCode increment = arrowsAreVertical ? KeyCode.UP : KeyCode.RIGHT;
+        KeyCode decrement = arrowsAreVertical ? KeyCode.DOWN : KeyCode.LEFT;
 
+        if (e.getCode() == increment) {
+            increment(1);
+            e.consume();
+        }
+        else if (e.getCode() == decrement) {
+            decrement(1);
+            e.consume();
+        }
+    };
 
     /***************************************************************************
      *                                                                         *
@@ -84,24 +95,16 @@ public class SpinnerBehavior<T> extends BehaviorBase<Spinner<T>> {
         // InputMap installed on the control, if it is non-null, allowing us to pick up any user-specified mappings)
         spinnerInputMap = createInputMap();
 
-        // then spinner-specific mappings for key and mouse input
-        addDefaultMapping(spinnerInputMap,
-            new KeyMapping(UP, KeyEvent.KEY_PRESSED, e -> {
-                if (arrowsAreVertical()) increment(1); else FocusTraversalInputMap.traverseUp(e);
-            }),
-            new KeyMapping(RIGHT, KeyEvent.KEY_PRESSED, e -> {
-                if (! arrowsAreVertical()) increment(1); else FocusTraversalInputMap.traverseRight(e);
-            }),
-            new KeyMapping(LEFT, KeyEvent.KEY_PRESSED, e -> {
-                if (! arrowsAreVertical()) decrement(1); else FocusTraversalInputMap.traverseLeft(e);
-            }),
-            new KeyMapping(DOWN, KeyEvent.KEY_PRESSED, e -> {
-                if (arrowsAreVertical()) decrement(1); else FocusTraversalInputMap.traverseDown(e);
-            })
-        );
+        spinner.addEventFilter(KeyEvent.KEY_PRESSED, spinnerKeyHandler);
     }
 
 
+    @Override
+    public void dispose() {
+        getNode().removeEventFilter(KeyEvent.KEY_PRESSED, spinnerKeyHandler);
+
+        super.dispose();
+    }
 
     /***************************************************************************
      *                                                                         *

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/SpinnerTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/SpinnerTest.java
@@ -1603,8 +1603,6 @@ public class SpinnerTest {
         stage.setWidth(200);
         stage.setHeight(200);
 
-        intSpinner.setEditable(true);
-
         Button defaultButton = new Button("OK");
         defaultButton.setOnAction(arg0 -> { enterDefaultPass = true; });
         defaultButton.setDefaultButton(true);


### PR DESCRIPTION
This is a proof of concept fix for the linked issue.

We'll need to discuss if using an event filter in the Behavior is the appropriate fix and how much impact this may have on current applications.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337246](https://bugs.openjdk.org/browse/JDK-8337246): SpinnerSkin does not consume ENTER KeyEvent when editor ActionEvent is consumed (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1629/head:pull/1629` \
`$ git checkout pull/1629`

Update a local copy of the PR: \
`$ git checkout pull/1629` \
`$ git pull https://git.openjdk.org/jfx.git pull/1629/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1629`

View PR using the GUI difftool: \
`$ git pr show -t 1629`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1629.diff">https://git.openjdk.org/jfx/pull/1629.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1629#issuecomment-2462342303)
</details>
