### PR TITLE
8343760: GHA: macOS / aarch64 builds depend on Xcode 14 which will be removed

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -298,6 +298,8 @@ jobs:
           java -version
           which ant
           ant -version
+          # We want to use Xcode 14, but GHA as removed it from the macOS 14 runners
+          # sudo xcode-select --switch /Applications/Xcode_14.3.1.app/Contents/Developer
           xcodebuild -version
 
       - name: Build JavaFX artifacts

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -298,7 +298,7 @@ jobs:
           java -version
           which ant
           ant -version
-          # We want to use Xcode 14, but GHA as removed it from the macOS 14 runners
+          # We want to use Xcode 14, but GHA removed it from the macOS 14 runners
           # sudo xcode-select --switch /Applications/Xcode_14.3.1.app/Contents/Developer
           xcodebuild -version
 

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -298,7 +298,6 @@ jobs:
           java -version
           which ant
           ant -version
-          sudo xcode-select --switch /Applications/Xcode_14.3.1.app/Contents/Developer
           xcodebuild -version
 
       - name: Build JavaFX artifacts


### PR DESCRIPTION
Fix the GHA build on macOS / aarch64, which uses a macOS 14 GitHub Actions runner, by using the default Xcode 15 rather than explicitly selecting Xcode 14.

GitHub has announced the removal of Xcode 14 from their macOS 14 images. See the following pages:

https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md
https://github.com/actions/runner-images/issues/10703

The following build failed, suggesting that they may have done this already:

https://github.com/jayathirthrao/jfx/actions/runs/11718276557/job/32639337526

At least one other build has failed as well. Subsequent builds passed, so they might be rolling it out incrementally, but in any case, we need to stop relying on using Xcode 14 on macOS 14.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343760](https://bugs.openjdk.org/browse/JDK-8343760): GHA: macOS / aarch64 builds depend on Xcode 14 which will be removed (**Bug** - P3)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1630/head:pull/1630` \
`$ git checkout pull/1630`

Update a local copy of the PR: \
`$ git checkout pull/1630` \
`$ git pull https://git.openjdk.org/jfx.git pull/1630/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1630`

View PR using the GUI difftool: \
`$ git pr show -t 1630`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1630.diff">https://git.openjdk.org/jfx/pull/1630.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1630#issuecomment-2463061192)
</details>
