### PR TITLE
8344067: TableCell indices may not match the TableRow index

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableRowSkinBase.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableRowSkinBase.java
@@ -165,15 +165,7 @@ public abstract class TableRowSkinBase<T,
         // use invalidation listener here to update even when item equality is true
         // (e.g. see RT-22463)
         registerInvalidationListener(control.itemProperty(), o -> requestCellUpdate());
-        registerChangeListener(control.indexProperty(), e -> {
-            // Fix for RT-36661, where empty table cells were showing content, as they
-            // had incorrect table cell indices (but the table row index was correct).
-            // Note that we only do the update on empty cells to avoid the issue
-            // noted below in requestCellUpdate().
-            if (getSkinnable().isEmpty()) {
-                requestCellUpdate();
-            }
-        });
+        registerChangeListener(control.indexProperty(), e -> requestCellUpdate());
     }
 
 

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewRowTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewRowTest.java
@@ -219,16 +219,16 @@ public class TableViewRowTest {
 
         row.updateIndex(0);
 
-        List<TableCell<String, String>> cells = row.getChildrenUnmodifiable().stream().
-                filter(TableCell.class::isInstance).map(e -> (TableCell<String, String>) e).toList();
+        List<TableCell<String, String>> cells = row.getChildrenUnmodifiable().stream()
+                .filter(TableCell.class::isInstance).map(e -> (TableCell<String, String>) e).toList();
         for (TableCell<String, String> cell : cells) {
             assertEquals(0, cell.getIndex());
         }
 
         row.updateIndex(1);
 
-        cells = row.getChildrenUnmodifiable().stream().
-                filter(TableCell.class::isInstance).map(e -> (TableCell<String, String>) e).toList();
+        cells = row.getChildrenUnmodifiable().stream()
+                .filter(TableCell.class::isInstance).map(e -> (TableCell<String, String>) e).toList();
         for (TableCell<String, String> cell : cells) {
             assertEquals(1, cell.getIndex());
         }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewRowTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewRowTest.java
@@ -27,6 +27,8 @@ package test.javafx.scene.control;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import javafx.scene.control.SelectionMode;
@@ -204,5 +206,31 @@ public class TableViewRowTest {
         row.updateIndex(0);
 
         assertTrue(isItemChangedCalled.get());
+    }
+
+    @Test
+    void testUpdateRowIndexManually() {
+        TableView<String> table = ControlUtils.createTableView();
+
+        TableRow<String> row = new TableRow<>();
+        row.updateTableView(table);
+
+        stageLoader = new StageLoader(row);
+
+        row.updateIndex(0);
+
+        List<TableCell<String, String>> cells = row.getChildrenUnmodifiable().stream().
+                filter(TableCell.class::isInstance).map(e -> (TableCell<String, String>) e).toList();
+        for (TableCell<String, String> cell : cells) {
+            assertEquals(0, cell.getIndex());
+        }
+
+        row.updateIndex(1);
+
+        cells = row.getChildrenUnmodifiable().stream().
+                filter(TableCell.class::isInstance).map(e -> (TableCell<String, String>) e).toList();
+        for (TableCell<String, String> cell : cells) {
+            assertEquals(1, cell.getIndex());
+        }
     }
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
@@ -6329,4 +6329,54 @@ public class TableViewTest {
 
         assertEquals(1, startEditCounter.get());
     }
+
+    @Test
+    void testReSetItemsWithSameItemShouldUpdateCellIndices() {
+        table.setFixedCellSize(24);
+
+        final TableColumn<String, String> c = new TableColumn<>("C");
+        c.setCellValueFactory(value -> new SimpleStringProperty(value.getValue()));
+        table.getColumns().add(c);
+
+        for (int i = 0; i < 60; i++) {
+            table.getItems().add(String.valueOf(i));
+        }
+        String lastItem = "UniqueLastItem";
+        table.getItems().add(lastItem);
+
+        stageLoader = new StageLoader(table);
+        stageLoader.getStage().setWidth(300);
+        stageLoader.getStage().setHeight(300);
+
+        // Scroll to the bottom.
+        VirtualScrollBar scrollBar = VirtualFlowTestUtils.getVirtualFlowVerticalScrollbar(table);
+        scrollBar.setValue(1);
+
+        Toolkit.getToolkit().firePulse();
+
+        IndexedCell<String> row = VirtualFlowTestUtils.getCell(table, 60);
+        assertEquals(lastItem, row.getItem());
+
+        List<TableCell<String, String>> cells = row.getChildrenUnmodifiable().stream().
+                filter(TableCell.class::isInstance).map(e -> (TableCell<String, String>) e).toList();
+
+        for (TableCell<String, String> cell : cells) {
+            assertEquals(60, cell.getIndex());
+        }
+
+        // Re-set the items, but reuse one item from the previous items list.
+        table.setItems(FXCollections.observableArrayList(lastItem));
+
+        Toolkit.getToolkit().firePulse();
+
+        row = VirtualFlowTestUtils.getCell(table, 0);
+        assertEquals(lastItem, row.getItem());
+
+        cells = row.getChildrenUnmodifiable().stream().
+                filter(TableCell.class::isInstance).map(e -> (TableCell<String, String>) e).toList();
+
+        for (TableCell<String, String> cell : cells) {
+            assertEquals(0, cell.getIndex());
+        }
+    }
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
@@ -6357,8 +6357,8 @@ public class TableViewTest {
         IndexedCell<String> row = VirtualFlowTestUtils.getCell(table, 60);
         assertEquals(lastItem, row.getItem());
 
-        List<TableCell<String, String>> cells = row.getChildrenUnmodifiable().stream().
-                filter(TableCell.class::isInstance).map(e -> (TableCell<String, String>) e).toList();
+        List<TableCell<String, String>> cells = row.getChildrenUnmodifiable().stream()
+                .filter(TableCell.class::isInstance).map(e -> (TableCell<String, String>) e).toList();
 
         for (TableCell<String, String> cell : cells) {
             assertEquals(60, cell.getIndex());
@@ -6372,8 +6372,8 @@ public class TableViewTest {
         row = VirtualFlowTestUtils.getCell(table, 0);
         assertEquals(lastItem, row.getItem());
 
-        cells = row.getChildrenUnmodifiable().stream().
-                filter(TableCell.class::isInstance).map(e -> (TableCell<String, String>) e).toList();
+        cells = row.getChildrenUnmodifiable().stream()
+                .filter(TableCell.class::isInstance).map(e -> (TableCell<String, String>) e).toList();
 
         for (TableCell<String, String> cell : cells) {
             assertEquals(0, cell.getIndex());

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableRowTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableRowTest.java
@@ -1004,16 +1004,16 @@ public class TreeTableRowTest {
 
         row.updateIndex(0);
 
-        List<TreeTableCell<String, String>> cells = row.getChildrenUnmodifiable().stream().
-                filter(TreeTableCell.class::isInstance).map(e -> (TreeTableCell<String, String>) e).toList();
+        List<TreeTableCell<String, String>> cells = row.getChildrenUnmodifiable().stream()
+                .filter(TreeTableCell.class::isInstance).map(e -> (TreeTableCell<String, String>) e).toList();
         for (TreeTableCell<String, String> cell : cells) {
             assertEquals(0, cell.getIndex());
         }
 
         row.updateIndex(1);
 
-        cells = row.getChildrenUnmodifiable().stream().
-                filter(TreeTableCell.class::isInstance).map(e -> (TreeTableCell<String, String>) e).toList();
+        cells = row.getChildrenUnmodifiable().stream()
+                .filter(TreeTableCell.class::isInstance).map(e -> (TreeTableCell<String, String>) e).toList();
         for (TreeTableCell<String, String> cell : cells) {
             assertEquals(1, cell.getIndex());
         }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableRowTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableRowTest.java
@@ -31,6 +31,8 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static test.com.sun.javafx.scene.control.infrastructure.ControlTestUtils.assertStyleClassContains;
+
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import javafx.scene.control.SelectionMode;
@@ -989,5 +991,31 @@ public class TreeTableRowTest {
         row.updateIndex(0);
 
         assertTrue(isItemChangedCalled.get());
+    }
+
+    @Test
+    void testUpdateRowIndexManually() {
+        TreeTableView<String> table = ControlUtils.createTreeTableView();
+
+        TreeTableRow<String> row = new TreeTableRow<>();
+        row.updateTreeTableView(table);
+
+        stageLoader = new StageLoader(row);
+
+        row.updateIndex(0);
+
+        List<TreeTableCell<String, String>> cells = row.getChildrenUnmodifiable().stream().
+                filter(TreeTableCell.class::isInstance).map(e -> (TreeTableCell<String, String>) e).toList();
+        for (TreeTableCell<String, String> cell : cells) {
+            assertEquals(0, cell.getIndex());
+        }
+
+        row.updateIndex(1);
+
+        cells = row.getChildrenUnmodifiable().stream().
+                filter(TreeTableCell.class::isInstance).map(e -> (TreeTableCell<String, String>) e).toList();
+        for (TreeTableCell<String, String> cell : cells) {
+            assertEquals(1, cell.getIndex());
+        }
     }
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
@@ -7536,4 +7536,58 @@ public class TreeTableViewTest {
 
         assertEquals(1, startEditCounter.get());
     }
+
+    @Test
+    void testReSetItemsWithSameItemShouldUpdateCellIndices() {
+        treeTableView.setRoot(new TreeItem<>());
+        treeTableView.getRoot().setExpanded(true);
+        treeTableView.setShowRoot(false);
+        treeTableView.setFixedCellSize(24);
+
+        final TreeTableColumn<String, String> c = new TreeTableColumn<>("C");
+        c.setCellValueFactory(value -> new SimpleStringProperty(value.getValue().getValue()));
+        treeTableView.getColumns().add(c);
+
+        for (int i = 0; i < 60; i++) {
+            treeTableView.getRoot().getChildren().add(new TreeItem<>(String.valueOf(i)));
+        }
+        String lastItem = "UniqueLastItem";
+        TreeItem<String> lastTreeItem = new TreeItem<>(lastItem);
+        treeTableView.getRoot().getChildren().add(lastTreeItem);
+
+        stageLoader = new StageLoader(treeTableView);
+        stageLoader.getStage().setWidth(300);
+        stageLoader.getStage().setHeight(300);
+
+        // Scroll to the bottom.
+        VirtualScrollBar scrollBar = VirtualFlowTestUtils.getVirtualFlowVerticalScrollbar(treeTableView);
+        scrollBar.setValue(1);
+
+        Toolkit.getToolkit().firePulse();
+
+        IndexedCell<String> row = VirtualFlowTestUtils.getCell(treeTableView, 60);
+        assertEquals(lastItem, row.getItem());
+
+        List<TreeTableCell<String, String>> cells = row.getChildrenUnmodifiable().stream().
+                filter(TreeTableCell.class::isInstance).map(e -> (TreeTableCell<String, String>) e).toList();
+
+        for (TreeTableCell<String, String> cell : cells) {
+            assertEquals(60, cell.getIndex());
+        }
+
+        // Re-set the items, but reuse one item from the previous items list.
+        treeTableView.getRoot().getChildren().setAll(lastTreeItem);
+
+        Toolkit.getToolkit().firePulse();
+
+        row = VirtualFlowTestUtils.getCell(treeTableView, 0);
+        assertEquals(lastItem, row.getItem());
+
+        cells = row.getChildrenUnmodifiable().stream().
+                filter(TreeTableCell.class::isInstance).map(e -> (TreeTableCell<String, String>) e).toList();
+
+        for (TreeTableCell<String, String> cell : cells) {
+            assertEquals(0, cell.getIndex());
+        }
+    }
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
@@ -7568,8 +7568,8 @@ public class TreeTableViewTest {
         IndexedCell<String> row = VirtualFlowTestUtils.getCell(treeTableView, 60);
         assertEquals(lastItem, row.getItem());
 
-        List<TreeTableCell<String, String>> cells = row.getChildrenUnmodifiable().stream().
-                filter(TreeTableCell.class::isInstance).map(e -> (TreeTableCell<String, String>) e).toList();
+        List<TreeTableCell<String, String>> cells = row.getChildrenUnmodifiable().stream()
+                .filter(TreeTableCell.class::isInstance).map(e -> (TreeTableCell<String, String>) e).toList();
 
         for (TreeTableCell<String, String> cell : cells) {
             assertEquals(60, cell.getIndex());
@@ -7583,8 +7583,8 @@ public class TreeTableViewTest {
         row = VirtualFlowTestUtils.getCell(treeTableView, 0);
         assertEquals(lastItem, row.getItem());
 
-        cells = row.getChildrenUnmodifiable().stream().
-                filter(TreeTableCell.class::isInstance).map(e -> (TreeTableCell<String, String>) e).toList();
+        cells = row.getChildrenUnmodifiable().stream()
+                .filter(TreeTableCell.class::isInstance).map(e -> (TreeTableCell<String, String>) e).toList();
 
         for (TreeTableCell<String, String> cell : cells) {
             assertEquals(0, cell.getIndex());


### PR DESCRIPTION
This PR fixes a bug where the `TableCell` indices can be outdated (not synchronized) with the `TableRow` index.

What normally happens is:
- Index is changed: Cell update is requested when the row is empty (otherwise noop)
- Item is changed: Cell update is requested, which will now update the indices of the underlying `TableCells`

Under some circumstances, when a `TableRow` is reused (e.g. index 60 -> 1) the item can be the same 
-> `oldIndex != newIndex && oldItem == newItem`
This can happen when the items of a `TableView` are changed, but some items are the same in both item lists (Think about a filter, where we filter down 60 to 2 items).

-> In this scenario, the cell update is not triggered, so the underlying `TableCell` indices will not be updated ever (e.g. they still have index 60 set, but the row has 1 now). 

The fix is to always update the underlying `TableCell` indices when the `TableRow` index changed. 
While usually the item is different when the index changed, this is not always the case (there is no guarantee that the item changed, as we can see in the example, where the cell is reused).

---

Also made sure that the issues linked in the code and ticket do not regress:
- https://bugs.openjdk.org/browse/JDK-8095357
- https://bugs.openjdk.org/browse/JDK-8115269

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344067](https://bugs.openjdk.org/browse/JDK-8344067): TableCell indices may not match the TableRow index (**Bug** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1635/head:pull/1635` \
`$ git checkout pull/1635`

Update a local copy of the PR: \
`$ git checkout pull/1635` \
`$ git pull https://git.openjdk.org/jfx.git pull/1635/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1635`

View PR using the GUI difftool: \
`$ git pr show -t 1635`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1635.diff">https://git.openjdk.org/jfx/pull/1635.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1635#issuecomment-2471600990)
</details>
