### PR TITLE
8344155: Add missing @Override annotation to GIFImageLoader2

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/iio/gif/GIFImageLoader2.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/iio/gif/GIFImageLoader2.java
@@ -198,6 +198,7 @@ public class GIFImageLoader2 extends ImageLoaderImpl {
     }
 
     // loads next image frame or null if no more
+    @Override
     public ImageFrame load(int imageIndex, double imgw, double imgh, boolean preserveAspectRatio, boolean smooth,
                            float screenPixelScale, float imagePixelScale) throws IOException {
         ImageTools.validateMaxDimensions(imgw, imgh, imagePixelScale);


### PR DESCRIPTION
The method `load(...)` is missing an `@Override` annotation.

A single reviewer is sufficient.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344155](https://bugs.openjdk.org/browse/JDK-8344155): Add missing @<!---->Override annotation to GIFImageLoader2 (**Bug** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1636/head:pull/1636` \
`$ git checkout pull/1636`

Update a local copy of the PR: \
`$ git checkout pull/1636` \
`$ git pull https://git.openjdk.org/jfx.git pull/1636/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1636`

View PR using the GUI difftool: \
`$ git pr show -t 1636`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1636.diff">https://git.openjdk.org/jfx/pull/1636.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1636#issuecomment-2475068196)
</details>
