### PR TITLE
8342993: Remove uses of AccessController and AccessControlContext from JavaFX

### DIFF
--- a/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanIntegerProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanIntegerProperty.java
@@ -106,7 +106,6 @@ public final class JavaBeanIntegerProperty extends IntegerProperty implements Ja
      * property throws an {@code IllegalAccessException} or an
      * {@code InvocationTargetException}.
      */
-    @SuppressWarnings("removal")
     @Override
     public int get() {
         try {

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Accessible.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Accessible.java
@@ -27,7 +27,6 @@ package com.sun.glass.ui;
 
 import static javafx.scene.AccessibleAttribute.PARENT;
 import static javafx.scene.AccessibleAttribute.ROLE;
-import java.security.AccessControlContext;
 import com.sun.javafx.scene.NodeHelper;
 import com.sun.javafx.scene.SceneHelper;
 import com.sun.javafx.tk.quantum.QuantumToolkit;
@@ -51,9 +50,6 @@ public abstract class Accessible {
 
         public void executeAction(AccessibleAction action, Object... parameters) {
         }
-
-        @SuppressWarnings("removal")
-        public abstract AccessControlContext getAccessControlContext();
     }
 
     public EventHandler getEventHandler() {
@@ -120,21 +116,6 @@ public abstract class Accessible {
             node = (Node)acc.getAttribute(PARENT);
         }
         return null;
-    }
-
-    /*
-     * IMPORTANT: Calling to the user code should not proceed if
-     * this method returns NULL.
-     */
-    @SuppressWarnings("removal")
-    private final AccessControlContext getAccessControlContext() {
-        AccessControlContext acc = null;
-        try {
-            acc = eventHandler.getAccessControlContext();
-        } catch (Exception e) {
-            /* The node was already removed from the scene */
-        }
-        return acc;
     }
 
     private class GetAttribute implements Supplier<Object> {

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/stage/EmbeddedWindow.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/stage/EmbeddedWindow.java
@@ -82,8 +82,7 @@ public class EmbeddedWindow extends Window {
         Toolkit toolkit = Toolkit.getToolkit();
         if (visible && (WindowHelper.getPeer(this) == null)) {
             // Setup the peer
-            WindowHelper.setPeer(this, toolkit.createTKEmbeddedStage(host,
-                    WindowHelper.getAccessControlContext(this)));
+            WindowHelper.setPeer(this, toolkit.createTKEmbeddedStage(host));
             WindowHelper.setPeerListener(this, new WindowPeerListener(this));
         }
     }

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/stage/WindowHelper.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/stage/WindowHelper.java
@@ -31,8 +31,6 @@ import javafx.beans.property.ReadOnlyObjectProperty;
 import javafx.stage.Screen;
 import javafx.stage.Window;
 
-import java.security.AccessControlContext;
-
 /**
  * Used to access internal window methods.
  */
@@ -130,11 +128,6 @@ public class WindowHelper {
         windowAccessor.notifyScaleChanged(window, newOutputScaleX, newOutputScaleY);
     }
 
-    @SuppressWarnings("removal")
-    static AccessControlContext getAccessControlContext(Window window) {
-        return windowAccessor.getAccessControlContext(window);
-    }
-
     public static void setWindowAccessor(final WindowAccessor newAccessor) {
         if (windowAccessor != null) {
             throw new IllegalStateException();
@@ -169,8 +162,5 @@ public class WindowHelper {
         void notifyScaleChanged(Window window, double newOutputScaleX, double newOutputScaleY);
 
         ReadOnlyObjectProperty<Screen> screenProperty(Window window);
-
-        @SuppressWarnings("removal")
-        AccessControlContext getAccessControlContext(Window window);
     }
 }

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/DummyToolkit.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/DummyToolkit.java
@@ -47,7 +47,6 @@ import javafx.stage.StageStyle;
 import javafx.stage.Window;
 import java.io.File;
 import java.io.InputStream;
-import java.security.AccessControlContext;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -102,17 +101,17 @@ final public class DummyToolkit extends Toolkit {
     }
 
     @Override
-    public TKStage createTKStage(Window peerWindow, boolean securityDialog, StageStyle stageStyle, boolean primary, Modality modality, TKStage owner, boolean rtl, @SuppressWarnings("removal") AccessControlContext acc) {
+    public TKStage createTKStage(Window peerWindow, boolean securityDialog, StageStyle stageStyle, boolean primary, Modality modality, TKStage owner, boolean rtl) {
         throw new UnsupportedOperationException("Not supported yet.");
     }
 
     @Override
-    public TKStage createTKPopupStage(Window peerWindow, StageStyle popupStyle, TKStage owner, @SuppressWarnings("removal") AccessControlContext acc) {
+    public TKStage createTKPopupStage(Window peerWindow, StageStyle popupStyle, TKStage owner) {
         throw new UnsupportedOperationException("Not supported yet.");
     }
 
     @Override
-    public TKStage createTKEmbeddedStage(HostInterface host, @SuppressWarnings("removal") AccessControlContext acc) {
+    public TKStage createTKEmbeddedStage(HostInterface host) {
         throw new UnsupportedOperationException("Not supported yet.");
     }
 

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/LocalClipboard.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/LocalClipboard.java
@@ -25,7 +25,6 @@
 
 package com.sun.javafx.tk;
 
-import java.security.AccessControlContext;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -41,11 +40,6 @@ final class LocalClipboard implements TKClipboard {
 
     public LocalClipboard() {
         values = new HashMap<>();
-    }
-
-    @Override
-    public void setSecurityContext(@SuppressWarnings("removal") final AccessControlContext ctx) {
-        // ctx not needed
     }
 
     @Override

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/TKClipboard.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/TKClipboard.java
@@ -25,7 +25,6 @@
 
 package com.sun.javafx.tk;
 
-import java.security.AccessControlContext;
 import java.util.Set;
 import javafx.scene.image.Image;
 
@@ -39,11 +38,6 @@ import javafx.util.Pair;
  * callers (and so forth).
  */
 public interface TKClipboard {
-
-    /**
-     * This method is used to set security context of the Stage.
-     */
-    public void setSecurityContext(@SuppressWarnings("removal") AccessControlContext ctx);
 
     /**
      * Gets the set of DataFormat types on this Clipboard instance which have

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/TKScene.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/TKScene.java
@@ -25,7 +25,6 @@
 
 package com.sun.javafx.tk;
 
-import java.security.AccessControlContext;
 import com.sun.javafx.sg.prism.NGCamera;
 import com.sun.javafx.sg.prism.NGLightBase;
 import com.sun.javafx.sg.prism.NGNode;
@@ -86,7 +85,4 @@ public interface TKScene {
     public void entireSceneNeedsRepaint();
 
     public TKClipboard createDragboard(boolean isDragSource);
-
-    @SuppressWarnings("removal")
-    public AccessControlContext getAccessControlContext();
 }

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/TKStage.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/TKStage.java
@@ -25,7 +25,6 @@
 
 package com.sun.javafx.tk;
 
-import java.security.AccessControlContext;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyCodeCombination;
 import javafx.scene.input.KeyCombination.ModifierValue;
@@ -47,7 +46,7 @@ public interface TKStage {
      *
      * @return scenePeer The peer of the scene to be displayed
      */
-    public TKScene createTKScene(boolean depthBuffer, boolean msaa, @SuppressWarnings("removal") AccessControlContext acc);
+    public TKScene createTKScene(boolean depthBuffer, boolean msaa);
 
     /**
      * Set the scene to be displayed in this stage

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/Toolkit.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/Toolkit.java
@@ -55,8 +55,6 @@ import javafx.stage.Window;
 import java.io.File;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
-import java.security.AccessControlContext;
-import java.security.AccessController;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -95,6 +93,9 @@ public abstract class Toolkit {
     private static String tk;
     private static Toolkit TOOLKIT;
     private static Thread fxUserThread = null;
+
+    // Used as the (dummy) value for the various listener maps
+    private static final Object dummyObj = new Object();
 
     private static final String QUANTUM_TOOLKIT     = "com.sun.javafx.tk.quantum.QuantumToolkit";
     private static final String DEFAULT_TOOLKIT     = QUANTUM_TOOLKIT;
@@ -211,9 +212,7 @@ public abstract class Toolkit {
 
         // Check a system property to see if there is a specific toolkit to use.
         String forcedToolkit = null;
-        try {
-            forcedToolkit = System.getProperty("javafx.toolkit");
-        } catch (SecurityException ex) {}
+        forcedToolkit = System.getProperty("javafx.toolkit");
 
         if (forcedToolkit == null) {
             forcedToolkit = tk;
@@ -363,31 +362,25 @@ public abstract class Toolkit {
 
     public abstract boolean isNestedLoopRunning();
 
-    public abstract TKStage createTKStage(Window peerWindow, boolean securityDialog, StageStyle stageStyle, boolean primary, Modality modality, TKStage owner, boolean rtl, @SuppressWarnings("removal") AccessControlContext acc);
+    public abstract TKStage createTKStage(Window peerWindow, boolean securityDialog, StageStyle stageStyle, boolean primary, Modality modality, TKStage owner, boolean rtl);
 
-    public abstract TKStage createTKPopupStage(Window peerWindow, StageStyle popupStyle, TKStage owner, @SuppressWarnings("removal") AccessControlContext acc);
-    public abstract TKStage createTKEmbeddedStage(HostInterface host, @SuppressWarnings("removal") AccessControlContext acc);
+    public abstract TKStage createTKPopupStage(Window peerWindow, StageStyle popupStyle, TKStage owner);
+    public abstract TKStage createTKEmbeddedStage(HostInterface host);
 
-    @SuppressWarnings("removal")
-    private final Map<TKPulseListener,AccessControlContext> stagePulseListeners = new WeakHashMap<>();
-    @SuppressWarnings("removal")
-    private final Map<TKPulseListener,AccessControlContext> scenePulseListeners = new WeakHashMap<>();
-    @SuppressWarnings("removal")
-    private final Map<TKPulseListener,AccessControlContext> postScenePulseListeners = new WeakHashMap<>();
-    @SuppressWarnings("removal")
-    private final Map<TKListener,AccessControlContext> toolkitListeners = new WeakHashMap<>();
+    // The following collections of listeners is weakly referenced here in order
+    // to allow garbage collection when the listeners are otherwise no longer
+    // referenced. We use a WeakHashMap with a dummy object as a value, rather
+    // than a HashSet of WeakReferences so that the entries are automatically
+    // removed when the listener goes out of reference.
+    private final Map<TKPulseListener,Object> stagePulseListeners = new WeakHashMap<>();
+    private final Map<TKPulseListener,Object> scenePulseListeners = new WeakHashMap<>();
+    private final Map<TKPulseListener,Object> postScenePulseListeners = new WeakHashMap<>();
+    private final Map<TKListener,Object> toolkitListeners = new WeakHashMap<>();
 
     // The set of shutdown hooks is strongly held to avoid premature GC.
     private final Set<Runnable> shutdownHooks = new HashSet<>();
 
-    @SuppressWarnings("removal")
-    private void runPulse(final TKPulseListener listener,
-            final AccessControlContext acc) {
-
-        if (acc == null) {
-            throw new IllegalStateException("Invalid AccessControlContext");
-        }
-
+    private void runPulse(final TKPulseListener listener) {
         listener.pulse();
     }
 
@@ -395,34 +388,28 @@ public abstract class Toolkit {
         // Stages need to be notified of pulses before scenes so the Stage can resized
         // and those changes propogated to scene before it gets its pulse to update
 
-        // Copy of listener map
-        @SuppressWarnings("removal")
-        final Map<TKPulseListener,AccessControlContext> stagePulseList =
-                new WeakHashMap<>();
-        @SuppressWarnings("removal")
-        final Map<TKPulseListener,AccessControlContext> scenePulseList =
-                new WeakHashMap<>();
-        @SuppressWarnings("removal")
-        final Map<TKPulseListener,AccessControlContext> postScenePulseList =
-                new WeakHashMap<>();
+        // Copy of listener keySet
+        final Set<TKPulseListener> stagePulseList = new HashSet<>();
+        final Set<TKPulseListener> scenePulseList = new HashSet<>();
+        final Set<TKPulseListener> postScenePulseList = new HashSet<>();
 
         synchronized (this) {
-            stagePulseList.putAll(stagePulseListeners);
-            scenePulseList.putAll(scenePulseListeners);
-            postScenePulseList.putAll(postScenePulseListeners);
+            stagePulseList.addAll(stagePulseListeners.keySet());
+            scenePulseList.addAll(scenePulseListeners.keySet());
+            postScenePulseList.addAll(postScenePulseListeners.keySet());
         }
-        for (@SuppressWarnings("removal") Map.Entry<TKPulseListener,AccessControlContext> entry : stagePulseList.entrySet()) {
-            runPulse(entry.getKey(), entry.getValue());
+        for (TKPulseListener listener : stagePulseList) {
+            runPulse(listener);
         }
-        for (@SuppressWarnings("removal") Map.Entry<TKPulseListener,AccessControlContext> entry : scenePulseList.entrySet()) {
-            runPulse(entry.getKey(), entry.getValue());
+        for (TKPulseListener listener : scenePulseList) {
+            runPulse(listener);
         }
-        for (@SuppressWarnings("removal") Map.Entry<TKPulseListener,AccessControlContext> entry : postScenePulseList.entrySet()) {
-            runPulse(entry.getKey(), entry.getValue());
+        for (TKPulseListener listener : postScenePulseList) {
+            runPulse(listener);
         }
 
         if (lastTkPulseListener != null) {
-            runPulse(lastTkPulseListener, lastTkPulseAcc);
+            runPulse(lastTkPulseListener);
         }
     }
     public void addStageTkPulseListener(TKPulseListener listener) {
@@ -430,9 +417,7 @@ public abstract class Toolkit {
             return;
         }
         synchronized (this) {
-            @SuppressWarnings("removal")
-            AccessControlContext acc = AccessController.getContext();
-            stagePulseListeners.put(listener, acc);
+            stagePulseListeners.put(listener, dummyObj);
         }
     }
     public void removeStageTkPulseListener(TKPulseListener listener) {
@@ -445,9 +430,7 @@ public abstract class Toolkit {
             return;
         }
         synchronized (this) {
-            @SuppressWarnings("removal")
-            AccessControlContext acc = AccessController.getContext();
-            scenePulseListeners.put(listener, acc);
+            scenePulseListeners.put(listener, dummyObj);
         }
     }
     public void removeSceneTkPulseListener(TKPulseListener listener) {
@@ -460,9 +443,7 @@ public abstract class Toolkit {
             return;
         }
         synchronized (this) {
-            @SuppressWarnings("removal")
-            AccessControlContext acc = AccessController.getContext();
-            postScenePulseListeners.put(listener, acc);
+            postScenePulseListeners.put(listener, dummyObj);
         }
     }
     public void removePostSceneTkPulseListener(TKPulseListener listener) {
@@ -475,9 +456,7 @@ public abstract class Toolkit {
         if (listener == null) {
             return;
         }
-        @SuppressWarnings("removal")
-        AccessControlContext acc = AccessController.getContext();
-        toolkitListeners.put(listener, acc);
+        toolkitListeners.put(listener, dummyObj);
     }
 
     public void removeTkListener(TKListener listener) {
@@ -485,11 +464,8 @@ public abstract class Toolkit {
     }
 
     private TKPulseListener lastTkPulseListener = null;
-    @SuppressWarnings("removal")
-    private AccessControlContext lastTkPulseAcc = null;
-    @SuppressWarnings("removal")
+
     public void setLastTkPulseListener(TKPulseListener listener) {
-        lastTkPulseAcc = AccessController.getContext();
         lastTkPulseListener = listener;
     }
 

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/Toolkit.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/Toolkit.java
@@ -371,7 +371,7 @@ public abstract class Toolkit {
     // to allow garbage collection when the listeners are otherwise no longer
     // referenced. We use a WeakHashMap with a dummy object as a value, rather
     // than a HashSet of WeakReferences so that the entries are automatically
-    // removed when the listener goes out of reference.
+    // removed after the listener is garbage collected.
     private final Map<TKPulseListener,Object> stagePulseListeners = new WeakHashMap<>();
     private final Map<TKPulseListener,Object> scenePulseListeners = new WeakHashMap<>();
     private final Map<TKPulseListener,Object> postScenePulseListeners = new WeakHashMap<>();

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/EmbeddedStage.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/EmbeddedStage.java
@@ -25,7 +25,6 @@
 
 package com.sun.javafx.tk.quantum;
 
-import java.security.AccessControlContext;
 import java.util.List;
 
 import com.sun.javafx.embed.AbstractEvents;
@@ -46,10 +45,8 @@ final class EmbeddedStage extends GlassStage implements EmbeddedStageInterface {
     // TKStage methods
 
     @Override
-    public TKScene createTKScene(boolean depthBuffer, boolean msaa, @SuppressWarnings("removal") AccessControlContext acc) {
-        EmbeddedScene scene = new EmbeddedScene(host, depthBuffer, msaa);
-        scene.setSecurityContext(acc);
-        return scene;
+    public TKScene createTKScene(boolean depthBuffer, boolean msaa) {
+        return new EmbeddedScene(host, depthBuffer, msaa);
     }
 
     @Override

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassScene.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassScene.java
@@ -28,8 +28,6 @@ package com.sun.javafx.tk.quantum;
 import javafx.application.Platform;
 import javafx.scene.input.InputMethodRequests;
 import javafx.stage.StageStyle;
-import java.security.AccessControlContext;
-import java.security.AccessController;
 import java.util.concurrent.atomic.AtomicBoolean;
 import com.sun.glass.ui.Clipboard;
 import com.sun.glass.ui.ClipboardAssistance;
@@ -74,9 +72,6 @@ abstract class GlassScene implements TKScene {
 
     SceneState sceneState;
 
-    @SuppressWarnings("removal")
-    private AccessControlContext accessCtrlCtx = null;
-
     protected GlassScene(boolean depthBuffer, boolean msaa) {
         this.msaa = msaa;
         this.depthBuffer = depthBuffer;
@@ -96,28 +91,6 @@ abstract class GlassScene implements TKScene {
         dropTargetListener = null;
         inputMethodRequests = null;
         sceneState = null;
-    }
-
-    // To be used by subclasses to enforce context check
-    @SuppressWarnings("removal")
-    @Override
-    public final AccessControlContext getAccessControlContext() {
-        if (accessCtrlCtx == null) {
-            throw new RuntimeException("Scene security context has not been set!");
-        }
-        return accessCtrlCtx;
-    }
-
-    @SuppressWarnings("removal")
-    public final void setSecurityContext(AccessControlContext ctx) {
-        if (accessCtrlCtx != null) {
-            throw new RuntimeException("Scene security context has been already set!");
-        }
-        AccessControlContext acc = AccessController.getContext();
-        // JDK doesn't provide public APIs to get ACC intersection,
-        // so using this ugly workaround
-        accessCtrlCtx = GlassStage.doIntersectionPrivilege(
-                () -> AccessController.getContext(), acc, ctx);
     }
 
     @Override

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassStage.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassStage.java
@@ -25,9 +25,6 @@
 
 package com.sun.javafx.tk.quantum;
 
-import java.security.AccessControlContext;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
@@ -54,9 +51,6 @@ abstract class GlassStage implements TKStage {
     private boolean visible;
 
     private boolean important = true;
-
-    @SuppressWarnings("removal")
-    private AccessControlContext accessCtrlCtx = null;
 
     protected static final AtomicReference<GlassStage> activeFSWindow = new AtomicReference<>();
 
@@ -92,39 +86,6 @@ abstract class GlassStage implements TKStage {
         if (this.scene != null) {
             this.scene.setStage(this);
         }
-    }
-
-    // To be used by subclasses to enforce context check
-    @SuppressWarnings("removal")
-    final AccessControlContext getAccessControlContext() {
-        if (accessCtrlCtx == null) {
-            throw new RuntimeException("Stage security context has not been set!");
-        }
-        return accessCtrlCtx;
-    }
-
-    @SuppressWarnings("removal")
-    static AccessControlContext doIntersectionPrivilege(PrivilegedAction<AccessControlContext> action,
-                                                       AccessControlContext stack,
-                                                       AccessControlContext context) {
-        // As part of the security manager removal, this entire method will be eliminated.
-        // This method used to compute the intersection of two access control contexts using
-        // a custom doPrivilegedWithCombiner method. This was only used in other calls to
-        // doPrivilieged, so there is no harm in skipping the intersection and just
-        // returning the context.
-        return context;
-    }
-
-    @SuppressWarnings("removal")
-    public final void setSecurityContext(AccessControlContext ctx) {
-        if (accessCtrlCtx != null) {
-            throw new RuntimeException("Stage security context has been already set!");
-        }
-        AccessControlContext acc = AccessController.getContext();
-        // JDK doesn't provide public APIs to get ACC intersection,
-        // so using this ugly workaround
-        accessCtrlCtx = doIntersectionPrivilege(
-                () -> AccessController.getContext(), acc, ctx);
     }
 
     @Override public void requestFocus() {

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/QuantumClipboard.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/QuantumClipboard.java
@@ -36,7 +36,6 @@ import java.io.ObjectOutput;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.nio.ByteBuffer;
-import java.security.AccessControlContext;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -72,15 +71,6 @@ final class QuantumClipboard implements TKClipboard {
      * Handle to the Glass peer.
      */
     private ClipboardAssistance systemAssistant;
-
-    /**
-     * Security access context for image loading
-     *      com.sun.javafx.tk.quantum.QuantumClipboard
-     *      javafx.scene.input.Clipboard
-     *          ... user code ...
-     */
-    @SuppressWarnings("removal")
-    private AccessControlContext accessContext = null;
 
     /**
      * Distinguishes between clipboard and dragboard. This is needed
@@ -119,21 +109,6 @@ final class QuantumClipboard implements TKClipboard {
      * Disallow direct creation of QuantumClipboard
      */
     private QuantumClipboard() {
-    }
-
-    @Override public void setSecurityContext(@SuppressWarnings("removal") AccessControlContext acc) {
-        if (accessContext != null) {
-            throw new RuntimeException("Clipboard security context has been already set!");
-        }
-        accessContext = acc;
-    }
-
-    @SuppressWarnings("removal")
-    private AccessControlContext getAccessControlContext() {
-        if (accessContext == null) {
-            throw new RuntimeException("Clipboard security context has not been set!");
-        }
-        return accessContext;
     }
 
     /**

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/QuantumToolkit.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/QuantumToolkit.java
@@ -60,7 +60,6 @@ import java.io.InputStream;
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.IntBuffer;
-import java.security.AccessControlContext;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -609,10 +608,9 @@ public final class QuantumToolkit extends Toolkit {
         }
     }
 
-    @Override public TKStage createTKStage(Window peerWindow, boolean securityDialog, StageStyle stageStyle, boolean primary, Modality modality, TKStage owner, boolean rtl, @SuppressWarnings("removal") AccessControlContext acc) {
+    @Override public TKStage createTKStage(Window peerWindow, boolean securityDialog, StageStyle stageStyle, boolean primary, Modality modality, TKStage owner, boolean rtl) {
         assertToolkitRunning();
         WindowStage stage = new WindowStage(peerWindow, securityDialog, stageStyle, modality, owner);
-        stage.setSecurityContext(acc);
         if (primary) {
             stage.setIsPrimary();
         }
@@ -681,24 +679,19 @@ public final class QuantumToolkit extends Toolkit {
         eventLoopMap = null;
     }
 
-    @Override public TKStage createTKPopupStage(Window peerWindow,
-                                                StageStyle popupStyle,
-                                                TKStage owner,
-                                                @SuppressWarnings("removal") AccessControlContext acc) {
+    @Override public TKStage createTKPopupStage(Window peerWindow, StageStyle popupStyle, TKStage owner) {
         assertToolkitRunning();
         boolean securityDialog = owner instanceof WindowStage ?
                 ((WindowStage)owner).isSecurityDialog() : false;
         WindowStage stage = new WindowStage(peerWindow, securityDialog, popupStyle, null, owner);
-        stage.setSecurityContext(acc);
         stage.setIsPopup();
         stage.init(systemMenu);
         return stage;
     }
 
-    @Override public TKStage createTKEmbeddedStage(HostInterface host, @SuppressWarnings("removal") AccessControlContext acc) {
+    @Override public TKStage createTKEmbeddedStage(HostInterface host) {
         assertToolkitRunning();
         EmbeddedStage stage = new EmbeddedStage(host);
-        stage.setSecurityContext(acc);
         return stage;
     }
 

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/WindowStage.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/WindowStage.java
@@ -26,7 +26,6 @@
 package com.sun.javafx.tk.quantum;
 
 import java.nio.ByteBuffer;
-import java.security.AccessControlContext;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -239,9 +238,8 @@ public class WindowStage extends GlassStage {
         return style;
     }
 
-    @Override public TKScene createTKScene(boolean depthBuffer, boolean msaa, @SuppressWarnings("removal") AccessControlContext acc) {
+    @Override public TKScene createTKScene(boolean depthBuffer, boolean msaa) {
         ViewScene scene = new ViewScene(depthBuffer, msaa);
-        scene.setSecurityContext(acc);
         return scene;
     }
 

--- a/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
@@ -103,7 +103,6 @@ import javafx.scene.transform.Rotate;
 import javafx.scene.transform.Transform;
 import javafx.stage.Window;
 import javafx.util.Callback;
-import java.security.AccessControlContext;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -10433,26 +10432,6 @@ public abstract class Node implements EventTarget, Styleable {
         if (accessible == null) {
             accessible = Application.GetApplication().createAccessible();
             accessible.setEventHandler(new Accessible.EventHandler() {
-                @SuppressWarnings("removal")
-                @Override public AccessControlContext getAccessControlContext() {
-                    Scene scene = getScene();
-                    if (scene == null) {
-                        /* This can happen during the release process of an accessible object. */
-                        throw new RuntimeException("Accessbility requested for node not on a scene");
-                    }
-                    if (scene.getPeer() != null) {
-                        return scene.getPeer().getAccessControlContext();
-                    } else {
-                        /* In some rare cases the accessible for a Node is needed
-                         * before its scene is made visible. For example, the screen reader
-                         * might ask a Menu for its ContextMenu before the ContextMenu
-                         * is made visible. That is a problem because the Window for the
-                         * ContextMenu is only created immediately before the first time
-                         * it is shown.
-                         */
-                        return scene.acc;
-                    }
-                }
                 @Override public Object getAttribute(AccessibleAttribute attribute, Object... parameters) {
                     return queryAccessibleAttribute(attribute, parameters);
                 }

--- a/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
@@ -88,8 +88,6 @@ import com.sun.javafx.logging.PlatformLogger;
 import com.sun.javafx.logging.PlatformLogger.Level;
 
 import java.io.File;
-import java.security.AccessControlContext;
-import java.security.AccessController;
 import java.util.*;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Stream;
@@ -183,9 +181,6 @@ public class Scene implements EventTarget {
     private final SceneAntialiasing antiAliasing;
 
     private EnumSet<DirtyBits> dirtyBits = EnumSet.noneOf(DirtyBits.class);
-
-    @SuppressWarnings("removal")
-    final AccessControlContext acc = AccessController.getContext();
 
     private Camera defaultCamera;
 
@@ -831,7 +826,7 @@ public class Scene implements EventTarget {
         setAllowPGAccess(true);
 
         Toolkit tk = Toolkit.getToolkit();
-        peer = windowPeer.createTKScene(isDepthBufferInternal(), getAntiAliasingInternal(), acc);
+        peer = windowPeer.createTKScene(isDepthBufferInternal(), getAntiAliasingInternal());
         PerformanceTracker.logEvent("Scene.initPeer TKScene created");
         peer.setTKSceneListener(new ScenePeerListener());
         peer.setTKScenePaintListener(new ScenePeerPaintListener());
@@ -6436,11 +6431,6 @@ public class Scene implements EventTarget {
         if (accessible == null) {
             accessible = Application.GetApplication().createAccessible();
             accessible.setEventHandler(new Accessible.EventHandler() {
-                @SuppressWarnings("removal")
-                @Override public AccessControlContext getAccessControlContext() {
-                    return getPeer().getAccessControlContext();
-                }
-
                 @Override public Object getAttribute(AccessibleAttribute attribute,
                                                      Object... parameters) {
                     switch (attribute) {

--- a/modules/javafx.graphics/src/main/java/javafx/scene/input/Clipboard.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/input/Clipboard.java
@@ -27,8 +27,6 @@ package javafx.scene.input;
 
 import com.sun.javafx.scene.input.ClipboardHelper;
 import java.io.File;
-import java.security.AccessControlContext;
-import java.security.AccessController;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -177,9 +175,6 @@ public class Clipboard {
      * the system will invoke the provided callback to stream the image data over to the client.
      */
 
-    @SuppressWarnings("removal")
-    private final AccessControlContext acc = AccessController.getContext();
-
     /**
      * Gets the current system clipboard, through which data can be stored and
      * retrieved. There is ever only one system clipboard for a JavaFX application.
@@ -197,7 +192,6 @@ public class Clipboard {
         if (peer == null) {
             throw new NullPointerException();
         }
-        peer.setSecurityContext(acc);
         this.peer = peer;
     }
 

--- a/modules/javafx.graphics/src/main/java/javafx/stage/PopupWindow.java
+++ b/modules/javafx.graphics/src/main/java/javafx/stage/PopupWindow.java
@@ -531,7 +531,7 @@ public abstract class PopupWindow extends Window {
             // Setup the peer
             StageStyle popupStyle;
             popupStyle = StageStyle.TRANSPARENT;
-            setPeer(toolkit.createTKPopupStage(this, popupStyle, getOwnerWindow().getPeer(), acc));
+            setPeer(toolkit.createTKPopupStage(this, popupStyle, getOwnerWindow().getPeer()));
             setPeerListener(new PopupWindowPeerListener(PopupWindow.this));
         }
     }

--- a/modules/javafx.graphics/src/main/java/javafx/stage/Stage.java
+++ b/modules/javafx.graphics/src/main/java/javafx/stage/Stage.java
@@ -1126,7 +1126,7 @@ public class Stage extends Window {
 
             StageStyle stageStyle = getStyle();
             setPeer(toolkit.createTKStage(this, isSecurityDialog(),
-                    stageStyle, isPrimary(), getModality(), tkStage, rtl, acc));
+                    stageStyle, isPrimary(), getModality(), tkStage, rtl));
             getPeer().setMinimumSize((int) Math.ceil(getMinWidth()),
                     (int) Math.ceil(getMinHeight()));
             getPeer().setMaximumSize((int) Math.floor(getMaxWidth()),

--- a/modules/javafx.graphics/src/main/java/javafx/stage/Window.java
+++ b/modules/javafx.graphics/src/main/java/javafx/stage/Window.java
@@ -25,8 +25,6 @@
 
 package javafx.stage;
 
-import java.security.AccessControlContext;
-import java.security.AccessController;
 import java.util.HashMap;
 
 import javafx.application.Platform;
@@ -207,12 +205,6 @@ public class Window implements EventTarget {
                     public ReadOnlyObjectProperty<Screen> screenProperty(Window window) {
                         return window.screenProperty();
                     }
-
-                    @SuppressWarnings("removal")
-                    @Override
-                    public AccessControlContext getAccessControlContext(Window window) {
-                        return window.acc;
-                    }
                 });
     }
 
@@ -226,9 +218,6 @@ public class Window implements EventTarget {
     public static ObservableList<Window> getWindows() {
         return unmodifiableWindows;
     }
-
-    @SuppressWarnings("removal")
-    final AccessControlContext acc = AccessController.getContext();
 
     /**
      * Constructor for subclasses to call.

--- a/modules/javafx.graphics/src/test/java/test/com/sun/javafx/pgstub/StubScene.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/javafx/pgstub/StubScene.java
@@ -25,7 +25,6 @@
 
 package test.com.sun.javafx.pgstub;
 
-import java.security.AccessControlContext;
 import com.sun.javafx.sg.prism.NGCamera;
 import com.sun.javafx.sg.prism.NGLightBase;
 import com.sun.javafx.sg.prism.NGNode;
@@ -143,11 +142,5 @@ public class StubScene implements TKScene {
 
     public NGCamera getCamera() {
         return camera;
-    }
-
-    @SuppressWarnings("removal")
-    @Override
-    public AccessControlContext getAccessControlContext() {
-        return null;
     }
 }

--- a/modules/javafx.graphics/src/test/java/test/com/sun/javafx/pgstub/StubStage.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/javafx/pgstub/StubStage.java
@@ -25,7 +25,6 @@
 
 package test.com.sun.javafx.pgstub;
 
-import java.security.AccessControlContext;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Queue;
@@ -48,7 +47,7 @@ public class StubStage implements TKStage {
     }
 
     @Override
-    public TKScene createTKScene(boolean depthBuffer, boolean msaa, @SuppressWarnings("removal") AccessControlContext acc) {
+    public TKScene createTKScene(boolean depthBuffer, boolean msaa) {
         return new StubScene();
     }
 

--- a/modules/javafx.graphics/src/test/java/test/com/sun/javafx/pgstub/StubToolkit.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/javafx/pgstub/StubToolkit.java
@@ -65,7 +65,6 @@ import javafx.util.Pair;
 
 import java.io.File;
 import java.io.InputStream;
-import java.security.AccessControlContext;
 import java.util.*;
 import java.util.concurrent.Future;
 
@@ -120,18 +119,18 @@ public class StubToolkit extends Toolkit {
     }
 
     @Override
-    public TKStage createTKStage(Window peerWindow, boolean securityDialog, StageStyle stageStyle, boolean primary, Modality modality, TKStage owner, boolean rtl, @SuppressWarnings("removal") AccessControlContext acc) {
+    public TKStage createTKStage(Window peerWindow, boolean securityDialog, StageStyle stageStyle, boolean primary, Modality modality, TKStage owner, boolean rtl) {
 
         return new StubStage();
     }
 
     @Override
-    public TKStage createTKPopupStage(Window peerWindow, StageStyle popupStyle, TKStage owner, @SuppressWarnings("removal") AccessControlContext acc) {
+    public TKStage createTKPopupStage(Window peerWindow, StageStyle popupStyle, TKStage owner) {
         return new StubPopupStage();
     }
 
     @Override
-    public TKStage createTKEmbeddedStage(HostInterface host, @SuppressWarnings("removal") AccessControlContext acc) {
+    public TKStage createTKEmbeddedStage(HostInterface host) {
         return new StubStage();
     }
 
@@ -375,10 +374,6 @@ public class StubToolkit extends Toolkit {
         private Image image;
         private double offsetX;
         private double offsetY;
-
-        @Override
-        public void setSecurityContext(@SuppressWarnings("removal") AccessControlContext ctx) {
-        }
 
         @Override public Set<DataFormat> getContentTypes() {
             return map.keySet();

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/input/DragAndDropTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/input/DragAndDropTest.java
@@ -27,7 +27,6 @@ package test.javafx.scene.input;
 
 import com.sun.javafx.scene.SceneHelper;
 
-import java.security.AccessControlContext;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -1614,10 +1613,6 @@ public class DragAndDropTest {
         private Image image;
         private double offsetX;
         private double offsetY;
-
-        @Override
-        public void setSecurityContext(@SuppressWarnings("removal") AccessControlContext ctx) {
-        }
 
         @Override
         public Object getContent(DataFormat df) {

--- a/modules/javafx.web/src/main/java/com/sun/webkit/Utilities.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/Utilities.java
@@ -27,7 +27,6 @@ package com.sun.webkit;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.security.AccessControlContext;
 import java.util.List;
 import java.util.Set;
 
@@ -89,14 +88,11 @@ public abstract class Utilities {
         "sun.misc"
     );
 
-    @SuppressWarnings("removal")
     private static Object fwkInvokeWithContext(final Method method,
                                                final Object instance,
                                                final Object[] args,
-                                               Object accObj)
+                                               Object dummyAcc) // UNUSED
             throws Throwable {
-
-        AccessControlContext acc = (AccessControlContext) accObj;
 
         final Class<?> clazz = method.getDeclaringClass();
         if (clazz.equals(java.lang.Class.class)) {

--- a/modules/javafx.web/src/main/java/com/sun/webkit/dom/JSObject.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/dom/JSObject.java
@@ -37,7 +37,11 @@ class JSObject extends netscape.javascript.JSObject {
     static final int JS_DOM_NODE_OBJECT  = 1;
     static final int JS_DOM_WINDOW_OBJECT  = 2;
 
-    // Dummy object used as a placeholder for the former access control comnect
+    // Dummy object used as a placeholder for the former access control context.
+    // This is passed to the native WebKit code where it is stored (as an opaque
+    // object) and later passed back to Java code.
+    // We do this, rather than removing the parameter, in order to keep the
+    // native WebKit code the same across different release families.
     private static final Object dummyAcc = new Object();
 
     private final long peer;     // C++ peer - now it is the DOMObject instance

--- a/modules/javafx.web/src/main/java/com/sun/webkit/dom/JSObject.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/dom/JSObject.java
@@ -42,7 +42,7 @@ class JSObject extends netscape.javascript.JSObject {
     // object) and later passed back to Java code.
     // We do this, rather than removing the parameter, in order to keep the
     // native WebKit code the same across different release families.
-    private static final Object dummyAcc = new Object();
+    private static final Object DUMMY_ACC = new Object();
 
     private final long peer;     // C++ peer - now it is the DOMObject instance
     private final int peer_type; // JS_XXXX const
@@ -92,7 +92,7 @@ class JSObject extends netscape.javascript.JSObject {
     @Override
     public void setMember(String name, Object value) throws JSException {
         Invoker.getInvoker().checkEventThread();
-        setMemberImpl(peer, peer_type, name, value, dummyAcc);
+        setMemberImpl(peer, peer_type, name, value, DUMMY_ACC);
     }
     private static native void setMemberImpl(long peer, int peer_type,
                                              String name, Object value,
@@ -117,7 +117,7 @@ class JSObject extends netscape.javascript.JSObject {
     @Override
     public void setSlot(int index, Object value) throws JSException {
         Invoker.getInvoker().checkEventThread();
-        setSlotImpl(peer, peer_type, index, value,dummyAcc);
+        setSlotImpl(peer, peer_type, index, value, DUMMY_ACC);
     }
     private static native void setSlotImpl(long peer, int peer_type,
                                            int index, Object value,
@@ -126,7 +126,7 @@ class JSObject extends netscape.javascript.JSObject {
     @Override
     public Object call(String methodName, Object... args) throws JSException {
         Invoker.getInvoker().checkEventThread();
-        return callImpl(peer, peer_type, methodName, args,dummyAcc);
+        return callImpl(peer, peer_type, methodName, args, DUMMY_ACC);
     }
     private static native Object callImpl(long peer, int peer_type,
                                           String methodName, Object[] args,

--- a/modules/javafx.web/src/main/java/com/sun/webkit/dom/JSObject.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/dom/JSObject.java
@@ -28,7 +28,6 @@ package com.sun.webkit.dom;
 import com.sun.webkit.Disposer;
 import com.sun.webkit.DisposerRecord;
 import com.sun.webkit.Invoker;
-import java.security.AccessController;
 import java.util.concurrent.atomic.AtomicInteger;
 import netscape.javascript.JSException;
 
@@ -37,6 +36,9 @@ class JSObject extends netscape.javascript.JSObject {
     static final int JS_CONTEXT_OBJECT  = 0;
     static final int JS_DOM_NODE_OBJECT  = 1;
     static final int JS_DOM_WINDOW_OBJECT  = 2;
+
+    // Dummy object used as a placeholder for the former access control comnect
+    private static final Object dummyAcc = new Object();
 
     private final long peer;     // C++ peer - now it is the DOMObject instance
     private final int peer_type; // JS_XXXX const
@@ -83,12 +85,10 @@ class JSObject extends netscape.javascript.JSObject {
     private static native Object getMemberImpl(long peer, int peer_type,
                                                String name);
 
-    @SuppressWarnings("removal")
     @Override
     public void setMember(String name, Object value) throws JSException {
         Invoker.getInvoker().checkEventThread();
-        setMemberImpl(peer, peer_type, name, value,
-                      AccessController.getContext());
+        setMemberImpl(peer, peer_type, name, value, dummyAcc);
     }
     private static native void setMemberImpl(long peer, int peer_type,
                                              String name, Object value,
@@ -110,23 +110,19 @@ class JSObject extends netscape.javascript.JSObject {
     private static native Object getSlotImpl(long peer, int peer_type,
                                              int index);
 
-    @SuppressWarnings("removal")
     @Override
     public void setSlot(int index, Object value) throws JSException {
         Invoker.getInvoker().checkEventThread();
-        setSlotImpl(peer, peer_type, index, value,
-                    AccessController.getContext());
+        setSlotImpl(peer, peer_type, index, value,dummyAcc);
     }
     private static native void setSlotImpl(long peer, int peer_type,
                                            int index, Object value,
                                            Object acc);
 
-    @SuppressWarnings("removal")
     @Override
     public Object call(String methodName, Object... args) throws JSException {
         Invoker.getInvoker().checkEventThread();
-        return callImpl(peer, peer_type, methodName, args,
-                        AccessController.getContext());
+        return callImpl(peer, peer_type, methodName, args,dummyAcc);
     }
     private static native Object callImpl(long peer, int peer_type,
                                           String methodName, Object[] args,

--- a/modules/javafx.web/src/main/java/com/sun/webkit/network/SocketStreamHandle.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/network/SocketStreamHandle.java
@@ -103,10 +103,7 @@ final class SocketStreamHandle {
         if (webPage == null) {
             logger.finest("{0} is not associated with any web "
                     + "page, aborted", this);
-            // In theory we could pump this error through the doRun()'s
-            // error handling code but in that case that error handling
-            // code would have to run outside the doPrivileged block,
-            // which is something we want to avoid.
+
             didFail(0, "Web socket is not associated with any web page");
             didClose();
             return;

--- a/modules/javafx.web/src/main/java/javafx/scene/web/HTMLEditorSkin.java
+++ b/modules/javafx.web/src/main/java/javafx/scene/web/HTMLEditorSkin.java
@@ -775,7 +775,7 @@ public class HTMLEditorSkin extends SkinBase<HTMLEditor> {
         // JDK-8115747: Icon URLs are now specified in CSS.
         // fgColorButton.applyCss();
         // ColorPickerSkin fgColorPickerSkin = (ColorPickerSkin) fgColorButton.getSkin();
-        // String fgIcon = AccessController.doPrivileged((PrivilegedAction<String>) () -> HTMLEditorSkin.class.getResource(resources.getString("foregroundColorIcon")).toString());
+        // String fgIcon = HTMLEditorSkin.class.getResource(resources.getString("foregroundColorIcon")).toString();
         // ((StyleableProperty)fgColorPickerSkin.imageUrlProperty()).applyStyle(null,fgIcon);
 
         fgColorButton.setValue(DEFAULT_FG_COLOR);
@@ -796,7 +796,7 @@ public class HTMLEditorSkin extends SkinBase<HTMLEditor> {
         // JDK-8115747: Icon URLs are now specified in CSS.
         // bgColorButton.applyCss();
         // ColorPickerSkin  bgColorPickerSkin = (ColorPickerSkin) bgColorButton.getSkin();
-        // String bgIcon = AccessController.doPrivileged((PrivilegedAction<String>) () -> HTMLEditorSkin.class.getResource(resources.getString("backgroundColorIcon")).toString());
+        // String bgIcon = HTMLEditorSkin.class.getResource(resources.getString("backgroundColorIcon")).toString();
         // ((StyleableProperty)bgColorPickerSkin.imageUrlProperty()).applyStyle(null,bgIcon);
 
         bgColorButton.setValue(DEFAULT_BG_COLOR);


### PR DESCRIPTION
This PR removes all remaining uses of `AccessController` and `AccessControlContext`, which represent the last remaining uses of the terminally deprecated security APIs except for those in the `/ios/` or `/android/` directories.

With the removal of doPrivileged and the `if (System.getSecurityManager() != null)` code paths, the ACC is no longer used, so can be completely eliminated. Along with this, I removed all unused imports of security-related APIs and all related `@SuppressWarnings("removal") annotations.

### Notes to reviewers

* Most of the changes were straight-forward removals of methods and fields to save, retrieve and pass around the `AccessControlContext`.
* The Toolkit class stores a collection of listeners in a `WeakHashMap` with the listener as the key (thus weakly held) and the ACC as the value. We no longer need or want the ACC, but I kept the use of `WeakHashMap` and changed the value type to `Object`, storing a singleton dummy object as the value for each entry. This minimizes the changes, while preserving the behavior of reclaiming the entries when they are garbage collected.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8342993](https://bugs.openjdk.org/browse/JDK-8342993): Remove uses of AccessController and AccessControlContext from JavaFX (**Bug** - P3)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Michael Strauß](https://openjdk.org/census#mstrauss) (@mstr2 - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1638/head:pull/1638` \
`$ git checkout pull/1638`

Update a local copy of the PR: \
`$ git checkout pull/1638` \
`$ git pull https://git.openjdk.org/jfx.git pull/1638/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1638`

View PR using the GUI difftool: \
`$ git pr show -t 1638`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1638.diff">https://git.openjdk.org/jfx/pull/1638.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1638#issuecomment-2477550328)
</details>
