### PR TITLE
8335469: [XWayland] crash when an AWT ScreenCast session overlaps with an FX ScreenCast session

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/gtk/fp_pipewire.h
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/fp_pipewire.h
@@ -58,7 +58,6 @@ void (*fp_pw_stream_destroy)(struct pw_stream *stream);
 
 
 void (*fp_pw_init)(int *argc, char **argv[]);
-void (*fp_pw_deinit)(void);
 
 struct pw_core *
 (*fp_pw_context_connect_fd)(struct pw_context *context,

--- a/modules/javafx.graphics/src/main/native-glass/gtk/screencast_pipewire.c
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/screencast_pipewire.c
@@ -129,10 +129,6 @@ static void doCleanup() {
         screenSpace.screenCount = 0;
     }
 
-    if (!sessionClosed) {
-        fp_pw_deinit();
-    }
-
     g_string_set_size(activeSessionToken, 0);
     sessionClosed = TRUE;
 }
@@ -579,6 +575,13 @@ static gboolean doLoop(GdkRectangle requestedArea) {
         pw.loop = fp_pw_thread_loop_new("JFX Pipewire Thread", NULL);
 
         if (!pw.loop) {
+            // in case someone called the pw_deinit before
+            DEBUG_SCREENCAST("pw_init\n", NULL);
+            fp_pw_init(NULL, NULL);
+            pw.loop = fp_pw_thread_loop_new("JFX Pipewire Thread", NULL);
+        }
+
+        if (!pw.loop) {
             DEBUG_SCREENCAST("!!! Could not create a loop\n", NULL);
             doCleanup();
             return FALSE;
@@ -702,7 +705,6 @@ static gboolean loadSymbols() {
     LOAD_SYMBOL(fp_pw_stream_disconnect, "pw_stream_disconnect");
     LOAD_SYMBOL(fp_pw_stream_destroy, "pw_stream_destroy");
     LOAD_SYMBOL(fp_pw_init, "pw_init");
-    LOAD_SYMBOL(fp_pw_deinit, "pw_deinit");
     LOAD_SYMBOL(fp_pw_context_connect_fd, "pw_context_connect_fd");
     LOAD_SYMBOL(fp_pw_core_disconnect, "pw_core_disconnect");
     LOAD_SYMBOL(fp_pw_context_new, "pw_context_new");

--- a/tests/system/src/test/java/test/robot/javafx/embed/swing/LinuxScreencastHangCrashTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/embed/swing/LinuxScreencastHangCrashTest.java
@@ -133,10 +133,10 @@ public class LinuxScreencastHangCrashTest {
     @Order(2)
     @Timeout(value=60)
     @ValueSource(ints = {
-            DELAY_KEEP_SESSION,
-            DELAY_BEFORE_SESSION_CLOSE, // 3 following are just in case
-            DELAY_BEFORE_SESSION_CLOSE - 25,
-            DELAY_BEFORE_SESSION_CLOSE + 25
+        DELAY_KEEP_SESSION,
+        DELAY_BEFORE_SESSION_CLOSE, // 3 following are just in case
+        DELAY_BEFORE_SESSION_CLOSE - 25,
+        DELAY_BEFORE_SESSION_CLOSE + 25
     })
     public void testCrash(int delay) throws Exception {
         System.out.println("Testing with delay: " + delay);

--- a/tests/system/src/test/java/test/robot/javafx/embed/swing/LinuxScreencastHangCrashTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/embed/swing/LinuxScreencastHangCrashTest.java
@@ -1,3 +1,28 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
 package test.robot.javafx.embed.swing;
 
 import java.awt.Robot;

--- a/tests/system/src/test/java/test/robot/javafx/embed/swing/LinuxScreencastHangCrashTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/embed/swing/LinuxScreencastHangCrashTest.java
@@ -26,7 +26,6 @@
 package test.robot.javafx.embed.swing;
 
 import java.awt.Robot;
-import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -39,6 +38,8 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import test.util.Util;
 
 @TestMethodOrder(OrderAnnotation.class)
@@ -98,9 +99,7 @@ public class LinuxScreencastHangCrashTest {
     private static void initFX() {
         if (!isFxStarted) {
             System.out.println("Platform.startup");
-            Platform.startup(() -> {
-                jfxRobot = new javafx.scene.robot.Robot();
-            });
+            Platform.startup(() -> jfxRobot = new javafx.scene.robot.Robot());
             isFxStarted = true;
         }
     }
@@ -130,27 +129,22 @@ public class LinuxScreencastHangCrashTest {
         robot.delay(DELAY_WAIT_FOR_SESSION_TO_CLOSE);
     }
 
-    @Test
+    @ParameterizedTest
     @Order(2)
     @Timeout(value=60)
-    public void testCrash() {
-        List.of(
-                DELAY_KEEP_SESSION,
-                DELAY_BEFORE_SESSION_CLOSE, // 3 following are just in case
-                DELAY_BEFORE_SESSION_CLOSE - 25,
-                DELAY_BEFORE_SESSION_CLOSE + 25
-        ).forEach(delay -> {
-            System.out.println("Testing with delay: " + delay);
-            try {
-                awtPixel();
-                robot.delay(delay);
-                fxPixel();
-                robot.delay(delay);
-                awtPixelOnFxThread();
-                robot.delay(delay);
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-        });
+    @ValueSource(ints = {
+            DELAY_KEEP_SESSION,
+            DELAY_BEFORE_SESSION_CLOSE, // 3 following are just in case
+            DELAY_BEFORE_SESSION_CLOSE - 25,
+            DELAY_BEFORE_SESSION_CLOSE + 25
+    })
+    public void testCrash(int delay) throws Exception {
+        System.out.println("Testing with delay: " + delay);
+        awtPixel();
+        robot.delay(delay);
+        fxPixel();
+        robot.delay(delay);
+        awtPixelOnFxThread();
+        robot.delay(delay);
     }
 }

--- a/tests/system/src/test/java/test/robot/javafx/embed/swing/LinuxScreencastHangCrashTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/embed/swing/LinuxScreencastHangCrashTest.java
@@ -26,15 +26,12 @@
 package test.robot.javafx.embed.swing;
 
 import java.awt.Robot;
-import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import javax.swing.SwingUtilities;
 
 import javafx.application.Platform;
 import javafx.scene.paint.Color;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
@@ -55,7 +52,6 @@ public class LinuxScreencastHangCrashTest {
     private static final int DELAY_KEEP_SESSION = DELAY_BEFORE_SESSION_CLOSE - 1000;
 
     private static volatile boolean isFxStarted = false;
-    private static volatile boolean isFirstRun = true;
 
     @BeforeAll
     public static void init() throws Exception {
@@ -106,14 +102,6 @@ public class LinuxScreencastHangCrashTest {
                 jfxRobot = new javafx.scene.robot.Robot();
             });
             isFxStarted = true;
-        }
-    }
-
-    private static void checkFirstRun() {
-        if (isFirstRun) {
-            isFirstRun = false;
-        } else {
-            robot.delay(DELAY_WAIT_FOR_SESSION_TO_CLOSE);
         }
     }
 

--- a/tests/system/src/test/java/test/robot/javafx/embed/swing/LinuxScreencastHangCrashTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/embed/swing/LinuxScreencastHangCrashTest.java
@@ -126,7 +126,6 @@ public class LinuxScreencastHangCrashTest {
         robot.delay(DELAY_WAIT_FOR_SESSION_TO_CLOSE);
 
         awtPixel();
-        robot.delay(DELAY_WAIT_FOR_SESSION_TO_CLOSE);
     }
 
     @ParameterizedTest
@@ -140,11 +139,15 @@ public class LinuxScreencastHangCrashTest {
     })
     public void testCrash(int delay) throws Exception {
         System.out.println("Testing with delay: " + delay);
+
+        robot.delay(DELAY_WAIT_FOR_SESSION_TO_CLOSE);
         awtPixel();
         robot.delay(delay);
         fxPixel();
+
+        robot.delay(DELAY_WAIT_FOR_SESSION_TO_CLOSE);
+        fxPixel();
         robot.delay(delay);
         awtPixelOnFxThread();
-        robot.delay(delay);
     }
 }

--- a/tests/system/src/test/java/test/robot/javafx/embed/swing/LinuxScreencastHangCrashTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/embed/swing/LinuxScreencastHangCrashTest.java
@@ -1,0 +1,143 @@
+package test.robot.javafx.embed.swing;
+
+import java.awt.Robot;
+import java.lang.reflect.InvocationTargetException;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import javax.swing.SwingUtilities;
+
+import javafx.application.Platform;
+import javafx.scene.paint.Color;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.Timeout;
+import test.util.Util;
+
+@TestMethodOrder(OrderAnnotation.class)
+public class LinuxScreencastHangCrashTest {
+
+    private static Robot robot;
+    private static javafx.scene.robot.Robot jfxRobot;
+
+    private static final int DELAY_BEFORE_SESSION_CLOSE = 2000;
+    private static final int DELAY_WAIT_FOR_SESSION_TO_CLOSE = DELAY_BEFORE_SESSION_CLOSE + 250;
+    private static final int DELAY_KEEP_SESSION = DELAY_BEFORE_SESSION_CLOSE - 1000;
+
+    private static volatile boolean isFxStarted = false;
+    private static volatile boolean isFirstRun = true;
+
+    @BeforeAll
+    public static void init() throws Exception {
+        Assumptions.assumeTrue(!Util.isOnWayland()); // JDK-8335470
+        Assumptions.assumeTrue(Util.isOnWayland());
+        robot = new Robot();
+    }
+
+
+    static void awtPixel() {
+        System.out.println("awtPixel on " + Thread.currentThread().getName());
+        java.awt.Color pixelColor = robot.getPixelColor(100, 100);
+        System.out.println("\tAWT pixelColor: " + pixelColor);
+    }
+
+    private static void awtPixelOnFxThread() throws InterruptedException {
+        System.out.println("awtPixelOnFxThread");
+        initFX();
+        CountDownLatch latch = new CountDownLatch(1);
+        Platform.runLater(() -> {
+            awtPixel();
+            latch.countDown();
+        });
+        if (!latch.await(5, TimeUnit.SECONDS)) {
+            throw new RuntimeException("Timed out waiting for awt pixel on FX thread");
+        }
+    }
+
+    private static void fxPixel() throws InterruptedException {
+        System.out.println("fxPixel");
+        initFX();
+
+        CountDownLatch latch = new CountDownLatch(1);
+        Platform.runLater(() -> {
+            Color pixelColor = jfxRobot.getPixelColor(100, 100);
+            System.out.println("\tFX pixelColor: " + pixelColor);
+            latch.countDown();
+        });
+        if (!latch.await(5, TimeUnit.SECONDS)) {
+            throw new RuntimeException("Timed out waiting for FX pixelColor");
+        }
+    }
+
+    private static void initFX() {
+        if (!isFxStarted) {
+            System.out.println("Platform.startup");
+            Platform.startup(() -> {
+                jfxRobot = new javafx.scene.robot.Robot();
+            });
+            isFxStarted = true;
+        }
+    }
+
+    private static void checkFirstRun() {
+        if (isFirstRun) {
+            isFirstRun = false;
+        } else {
+            robot.delay(DELAY_WAIT_FOR_SESSION_TO_CLOSE);
+        }
+    }
+
+    @Test
+    @Order(1)
+    @Timeout(value=30)
+    public void testHang() throws Exception {
+        awtPixel();
+        robot.delay(DELAY_WAIT_FOR_SESSION_TO_CLOSE);
+
+        initFX();
+        robot.delay(500);
+        awtPixel();
+        robot.delay(DELAY_WAIT_FOR_SESSION_TO_CLOSE);
+
+        awtPixelOnFxThread();
+        robot.delay(DELAY_WAIT_FOR_SESSION_TO_CLOSE);
+
+        fxPixel();
+        robot.delay(DELAY_WAIT_FOR_SESSION_TO_CLOSE);
+
+        awtPixelOnFxThread();
+        robot.delay(DELAY_WAIT_FOR_SESSION_TO_CLOSE);
+
+        awtPixel();
+        robot.delay(DELAY_WAIT_FOR_SESSION_TO_CLOSE);
+    }
+
+    @Test
+    @Order(2)
+    @Timeout(value=60)
+    public void testCrash() {
+        List.of(
+                DELAY_KEEP_SESSION,
+                DELAY_BEFORE_SESSION_CLOSE, // 3 following are just in case
+                DELAY_BEFORE_SESSION_CLOSE - 25,
+                DELAY_BEFORE_SESSION_CLOSE + 25
+        ).forEach(delay -> {
+            System.out.println("Testing with delay: " + delay);
+            try {
+                awtPixel();
+                robot.delay(delay);
+                fxPixel();
+                robot.delay(delay);
+                awtPixelOnFxThread();
+                robot.delay(delay);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+}


### PR DESCRIPTION
This is the FX counterpart of the [openjdk/jdk/pull/22131](https://github.com/openjdk/jdk/pull/22131) / `b.`(aka crash prevention part)

It does not crash without the [openjdk/jdk/pull/22131](https://github.com/openjdk/jdk/pull/22131) / `a.` part.

The crash prevention part  is the same for the JDK and JavaFX, except that this PR includes a test.

---- 

Internally the ScreenCast session keeps open for 2s (both JDK and JFX, and their implementations are almost identical).
This is to reduce overhead in case of frequent consecutive screen captures.

When we perform a [cleanup](https://github.com/openjdk/jdk/blob/db56266ad164b4ecae59451dc0a832097dbfbd8e/src/java.desktop/unix/native/libawt_xawt/awt/screencast_pipewire.c#L91) to close the session, we internally call [`pw_deinit`](https://docs.pipewire.org/group__pw__pipewire.html#gafa6045cd7391b467af4575c6752d6c4e).

It becomes a problem if these sessions overlap in time, so that the second session cleanup crashes when it tries to call pipewire functions without initializing the pipewire system by  [`pw_init`](https://docs.pipewire.org/group__pw__pipewire.html#ga06c879b2d800579f4724109054368d99) (please note that `This function can be called multiple times.`).

So the solution is not to call `pw_deinit` because we don't really need it, and it needs to be applied to both the JDK and JavaFX.

[jdk commit](https://github.com/openjdk/jdk/pull/22131/commits/19956fda202269e92ec70670bc88c8d3c7accf73) / [jfx commit](https://github.com/openjdk/jfx/pull/1639/commits/dba8a8871a38831d0a0da697a2be41f0c240c8f0)

----

The newly introduced test is disabled for now(as part  of [JDK-8335470](https://bugs.openjdk.org/browse/JDK-8335470)), because it requires the fix on both the JavaFX and JDK sides.
For the same reason `tests/system/src/test/java/test/robot/javafx/embed/swing/SwingNodeJDialogTest.java` and `tests/system/src/test/java/test/robot/javafx/scene/SRGBTest.java` are not enabled back.
But if the JDK and JavaFX have the fixes, everything works fine.
Testing in other different scenarios also looks good.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8335469](https://bugs.openjdk.org/browse/JDK-8335469): [XWayland] crash when an AWT ScreenCast session overlaps with an FX ScreenCast session (**Bug** - P3)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Lukasz Kostyra](https://openjdk.org/census#lkostyra) (@lukostyra - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1639/head:pull/1639` \
`$ git checkout pull/1639`

Update a local copy of the PR: \
`$ git checkout pull/1639` \
`$ git pull https://git.openjdk.org/jfx.git pull/1639/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1639`

View PR using the GUI difftool: \
`$ git pr show -t 1639`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1639.diff">https://git.openjdk.org/jfx/pull/1639.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1639#issuecomment-2477811868)
</details>
