### PR TITLE
8344443: Deprecate FXPermission for removal

### DIFF
--- a/modules/javafx.base/src/main/java/javafx/util/FXPermission.java
+++ b/modules/javafx.base/src/main/java/javafx/util/FXPermission.java
@@ -43,7 +43,12 @@ import java.security.BasicPermission;
  * @see java.security.PermissionCollection
  *
  * @since 9
+ *
+ * @deprecated This class was only useful in connection with the
+ *       Security Manager, which is no longer supported.
+ *       There is no replacement for this class.
  */
+@Deprecated(since = "24", forRemoval = true)
 public final class FXPermission extends BasicPermission {
 
     private static final long serialVersionUID = 2890556410764946054L;


### PR DESCRIPTION
This PR deprecates the FXPermission class for removal. The intent is to deprecate it in 24 and remove it in 26.

This class no longer does anything. Now that we have finished the post-SM removal cleanup, there are no remaining references FXPermission in JavaFX.

/csr
/reviewers 2

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8344456](https://bugs.openjdk.org/browse/JDK-8344456) to be approved
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issues
 * [JDK-8344443](https://bugs.openjdk.org/browse/JDK-8344443): Deprecate FXPermission for removal (**Enhancement** - P4)
 * [JDK-8344456](https://bugs.openjdk.org/browse/JDK-8344456): Deprecate FXPermission for removal (**CSR**)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1643/head:pull/1643` \
`$ git checkout pull/1643`

Update a local copy of the PR: \
`$ git checkout pull/1643` \
`$ git pull https://git.openjdk.org/jfx.git pull/1643/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1643`

View PR using the GUI difftool: \
`$ git pr show -t 1643`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1643.diff">https://git.openjdk.org/jfx/pull/1643.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1643#issuecomment-2483880447)
</details>
