### PR TITLE
8344906: Simplify Java version parsing in the build file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1932,7 +1932,7 @@ task verifyJava() {
     doLast {
         Version minVersionInfo = Version.parse("${jfxBuildJdkVersionMin}+${jfxBuildJdkBuildnumMin}") // from build.properties
         if (jdkVersionInfo.compareTo(minVersionInfo) < 0) {
-            fail("java version mismatch: JDK version (${jdkVersionInfo}) < minimum version (${minVersionInfo})")                             
+            fail("java version mismatch: JDK version (${jdkVersionInfo}) < minimum version (${minVersionInfo})")
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -235,29 +235,6 @@ void setupTools(String name, Closure loader, Closure processor) {
     }
 }
 
-//String[] parseJavaVersion(String jRuntimeVersion) {
-//    def jVersion = jRuntimeVersion.split("[-\\+]")[0]
-//    def tmpBuildNumber = "0"
-//    if (jVersion.startsWith("1.")) {
-//        // This is a pre-JEP-223 version string
-//        def dashbIdx = jRuntimeVersion.lastIndexOf("-b")
-//        if (dashbIdx != -1) {
-//            tmpBuildNumber = jRuntimeVersion.substring(dashbIdx + 2)
-//        }
-//    } else {
-//        // This is a post-JEP-223 version string
-//        def plusIdx = jRuntimeVersion.indexOf("+")
-//        if (plusIdx != -1) {
-//            tmpBuildNumber = jRuntimeVersion.substring(plusIdx + 1)
-//        }
-//    }
-//    def jBuildNumber = tmpBuildNumber.split("[-\\+]")[0]
-//    def versionInfo = new String[2];
-//    versionInfo[0] = jVersion
-//    versionInfo[1] = jBuildNumber
-//    return versionInfo
-//}
-
 /**
  * Fails the build with the specified error message
  *
@@ -760,7 +737,7 @@ if (!file(JAVADOC).exists()) throw new Exception("Missing or incorrect path to '
 //
 // We need to parse the second line
 Version jdkVersionInfo;
-try(BufferedReader inStream = new java.io.BufferedReader(new java.io.InputStreamReader(
+try (BufferedReader inStream = new java.io.BufferedReader(new java.io.InputStreamReader(
         new java.lang.ProcessBuilder(JAVA, "-fullversion").start().getErrorStream()))) {
     String v = inStream.readLine().trim();
     if (v != null) {

--- a/build.gradle
+++ b/build.gradle
@@ -1485,7 +1485,7 @@ logger.quiet("java build number: " + javaVersionInfo.build().orElse(0))
 
 logger.quiet("jdk.runtime.version: " + jdkVersionInfo)
 logger.quiet("jdk version: " + jdkVersionInfo.feature())
-logger.quiet("jdk build " + javaVersionInfo.build().orElse(0))
+logger.quiet("jdk build: " + javaVersionInfo.build().orElse(0))
 logger.quiet("minimum jdk version: ${jfxBuildJdkVersionMin}")
 logger.quiet("minimum jdk build number: ${jfxBuildJdkBuildnumMin}")
 logger.quiet("Java target version: ${JAVA_TARGET_VERSION}")

--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,7 @@ import java.util.concurrent.Future
 import java.util.zip.ZipEntry
 import java.util.zip.ZipFile
 import java.util.zip.ZipOutputStream
+import java.lang.Runtime.Version
 
 /******************************************************************************
  *                              Utility methods                               *
@@ -234,28 +235,28 @@ void setupTools(String name, Closure loader, Closure processor) {
     }
 }
 
-String[] parseJavaVersion(String jRuntimeVersion) {
-    def jVersion = jRuntimeVersion.split("[-\\+]")[0]
-    def tmpBuildNumber = "0"
-    if (jVersion.startsWith("1.")) {
-        // This is a pre-JEP-223 version string
-        def dashbIdx = jRuntimeVersion.lastIndexOf("-b")
-        if (dashbIdx != -1) {
-            tmpBuildNumber = jRuntimeVersion.substring(dashbIdx + 2)
-        }
-    } else {
-        // This is a post-JEP-223 version string
-        def plusIdx = jRuntimeVersion.indexOf("+")
-        if (plusIdx != -1) {
-            tmpBuildNumber = jRuntimeVersion.substring(plusIdx + 1)
-        }
-    }
-    def jBuildNumber = tmpBuildNumber.split("[-\\+]")[0]
-    def versionInfo = new String[2];
-    versionInfo[0] = jVersion
-    versionInfo[1] = jBuildNumber
-    return versionInfo
-}
+//String[] parseJavaVersion(String jRuntimeVersion) {
+//    def jVersion = jRuntimeVersion.split("[-\\+]")[0]
+//    def tmpBuildNumber = "0"
+//    if (jVersion.startsWith("1.")) {
+//        // This is a pre-JEP-223 version string
+//        def dashbIdx = jRuntimeVersion.lastIndexOf("-b")
+//        if (dashbIdx != -1) {
+//            tmpBuildNumber = jRuntimeVersion.substring(dashbIdx + 2)
+//        }
+//    } else {
+//        // This is a post-JEP-223 version string
+//        def plusIdx = jRuntimeVersion.indexOf("+")
+//        if (plusIdx != -1) {
+//            tmpBuildNumber = jRuntimeVersion.substring(plusIdx + 1)
+//        }
+//    }
+//    def jBuildNumber = tmpBuildNumber.split("[-\\+]")[0]
+//    def versionInfo = new String[2];
+//    versionInfo[0] = jVersion
+//    versionInfo[1] = jBuildNumber
+//    return versionInfo
+//}
 
 /**
  * Fails the build with the specified error message
@@ -417,11 +418,6 @@ defineProperty("JAVADOC", cygpathExe("$JDK_HOME/bin/javadoc"))
 defineProperty("JMOD", cygpathExe("$JDK_HOME/bin/jmod"))
 defineProperty("JDK_DOCS", "https://docs.oracle.com/en/java/javase/21/docs/api/")
 defineProperty("JDK_JMODS", cygpath(System.getenv("JDK_JMODS")) ?: cygpath(System.getenv("JDK_HOME") + "/jmods"))
-
-defineProperty("javaRuntimeVersion", System.getProperty("java.runtime.version"))
-def javaVersionInfo = parseJavaVersion(javaRuntimeVersion)
-defineProperty("javaVersion", javaVersionInfo[0])
-defineProperty("javaBuildNumber", javaVersionInfo[1])
 
 defineProperty("libAVRepositoryURL", "https://github.com/libav/libav/archive")
 defineProperty("FFmpegRepositoryURL", "https://www.ffmpeg.org/releases/")
@@ -763,36 +759,29 @@ if (!file(JAVADOC).exists()) throw new Exception("Missing or incorrect path to '
 // Java HotSpot(TM) 64-Bit Server VM (build 24.45-b08, mixed mode)
 //
 // We need to parse the second line
-def inStream = new java.io.BufferedReader(new java.io.InputStreamReader(new java.lang.ProcessBuilder(JAVA, "-fullversion").start().getErrorStream()));
-try {
+Version jdkVersionInfo;
+try(BufferedReader inStream = new java.io.BufferedReader(new java.io.InputStreamReader(
+        new java.lang.ProcessBuilder(JAVA, "-fullversion").start().getErrorStream()))) {
     String v = inStream.readLine().trim();
     if (v != null) {
         int ib = v.indexOf("full version \"");
         if (ib != -1) {
             String str = v.substring(ib);
             String ver = str.substring(str.indexOf("\"") + 1, str.size() - 1);
-
-            defineProperty("jdkRuntimeVersion", ver)
-            def jdkVersionInfo = parseJavaVersion(ver)
-            defineProperty("jdkVersion", jdkVersionInfo[0])
-            defineProperty("jdkBuildNumber", jdkVersionInfo[1])
+            jdkVersionInfo = Version.parse(ver);
 
             // Define global properties based on the version of Java
             // For example, we could define a "jdk18OrLater" property as
             // follows that could then be used to implement conditional build
             // logic based on whether we were running on JDK 18 or later,
             // should the need arise.
-//            def status = compareJdkVersion(jdkVersion, "18")
-//            ext.jdk18OrLater = (status >= 0)
+//            ext.jdk18OrLater = jdkVersionInfo.feature() >= 18
 
-            def status = compareJdkVersion(jdkVersion, "24")
-            ext.jdk24OrLater = (status >= 0)
+            ext.jdk24OrLater = jdkVersionInfo.feature() >= 24
         }
     }
-} finally {
-    inStream.close();
 }
-if (!project.hasProperty("jdkRuntimeVersion")) throw new Exception("Unable to determine the version of Java in JDK_HOME at $JDK_HOME");
+if (jdkVersionInfo == null) throw new Exception("Unable to determine the version of Java in JDK_HOME at $JDK_HOME");
 
 // Use --upgrade-module-path instead of --module-path when compiling and
 // running tests if we are using a JDK that includes an upgradable
@@ -1511,12 +1500,15 @@ logger.quiet("OS_NAME: $OS_NAME")
 logger.quiet("OS_ARCH: $OS_ARCH")
 logger.quiet("JAVA_HOME: $JAVA_HOME")
 logger.quiet("JDK_HOME: $JDK_HOME")
-logger.quiet("java.runtime.version: ${javaRuntimeVersion}")
-logger.quiet("java version: ${javaVersion}")
-logger.quiet("java build number: ${javaBuildNumber}")
-logger.quiet("jdk.runtime.version: ${jdkRuntimeVersion}")
-logger.quiet("jdk version: ${jdkVersion}")
-logger.quiet("jdk build number: ${jdkBuildNumber}")
+
+Version javaVersionInfo = Runtime.version()
+logger.quiet("java.runtime.version: " + javaVersionInfo)
+logger.quiet("java version: " + javaVersionInfo.feature())
+logger.quiet("java build number: " + javaVersionInfo.build().orElse(0))
+
+logger.quiet("jdk.runtime.version: " + jdkVersionInfo)
+logger.quiet("jdk version: " + jdkVersionInfo.feature())
+logger.quiet("jdk build " + javaVersionInfo.build().orElse(0))
 logger.quiet("minimum jdk version: ${jfxBuildJdkVersionMin}")
 logger.quiet("minimum jdk build number: ${jfxBuildJdkBuildnumMin}")
 logger.quiet("Java target version: ${JAVA_TARGET_VERSION}")
@@ -1950,41 +1942,6 @@ void addValidateSourceSets(Project project, Collection<SourceSet> sourceSets) {
     addValidateSourceSets(project, sourceSets, []);
 }
 
-
-/**
- * Parses a JDK version string. The string must be in one of the following
- * two formats:
- *
- *     major.minor.subminor
- * or
- *     major.minor.subminor_update
- *
- * In both cases a list of 4 integers is returned, with element 3 set to
- * 0 in the former case.
- */
-List parseJdkVersion(String version) {
-    def arr = version.split("[_\\.]");
-    def intArr = [];
-    arr.each { s -> intArr += Integer.parseInt(s); }
-    while (intArr.size() < 4) intArr += 0;
-    return intArr;
-}
-
-/**
- * Returns -1, 0, or 1 depending on whether JDK version "a" is less than,
- * equal to, or grater than version "b".
- */
-int compareJdkVersion(String a, String b) {
-    def aIntArr = parseJdkVersion(a);
-    def bIntArr = parseJdkVersion(b);
-
-    for (int i = 0; i < 4; i++) {
-        if (aIntArr[i] < bIntArr[i]) return -1;
-        if (aIntArr[i] > bIntArr[i]) return  1;
-    }
-    return 0;
-}
-
 /**
  * Returns true if the name of task or name of task's project contains word test/Test.
  */
@@ -1996,15 +1953,9 @@ boolean isTestTask(Task task) {
 // Task to verify the minimum level of Java needed to build JavaFX
 task verifyJava() {
     doLast {
-        def status = compareJdkVersion(jdkVersion, jfxBuildJdkVersionMin);
-        if (status < 0) {
-            fail("java version mismatch: JDK version (${jdkVersion}) < minimum version (${jfxBuildJdkVersionMin})")
-        } else if (status == 0) {
-            def buildNum = Integer.parseInt(jdkBuildNumber)
-            def minBuildNum = Integer.parseInt(jfxBuildJdkBuildnumMin)
-            if (buildNum != 0 && buildNum < minBuildNum) {
-                fail("JDK build number ($buildNum) < minimum build number ($minBuildNum)")
-            }
+        Version minVersionInfo = Version.parse("${jfxBuildJdkVersionMin}+${jfxBuildJdkBuildnumMin}") // from build.properties
+        if (jdkVersionInfo.compareTo(minVersionInfo) < 0) {
+            fail("java version mismatch: JDK version (${jdkVersionInfo}) < minimum version (${minVersionInfo})")                             
         }
     }
 }


### PR DESCRIPTION
Replaces the manual versions handling with [Version](https://docs.oracle.com/en/java/javase/23/docs/api/java.base/java/lang/Runtime.Version.html).

Changes:
* Removed the methods `parseJavaVersion(String)`, `parseJdkVersion(String)` and `compareJdkVersion(String, String)`, and replaced them with `Version.parse` and `Version.compareTo` methods.
* Removed the build properties of the Java version on which the Gradle build runs because they are only used for logging. Replaced with logging them directly. Note that Gradle logs by itself the info of the runtime it uses, so there's no need to logs these manually.
* Simplified the build JDK version by working directly with `Version` instead of a `String`. This allows to store less build properties. Also used try-with-resources to close the stream. Note that the whole build JDK manual invocation hack should be replaced with the Java Toolchain.
* Simplified the `verifyJava` task, which could also be replaced with built-in Gradle tools.

/reviewers 2

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8344906](https://bugs.openjdk.org/browse/JDK-8344906): Simplify Java version parsing in the build file (**Enhancement** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1647/head:pull/1647` \
`$ git checkout pull/1647`

Update a local copy of the PR: \
`$ git checkout pull/1647` \
`$ git pull https://git.openjdk.org/jfx.git pull/1647/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1647`

View PR using the GUI difftool: \
`$ git pr show -t 1647`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1647.diff">https://git.openjdk.org/jfx/pull/1647.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1647#issuecomment-2495426974)
</details>
