### PR TITLE
8342461: Remove calls to doPrivileged in javafx.web/{android,ios}

### DIFF
--- a/modules/javafx.web/src/android/java/com/sun/webkit/Timer.java
+++ b/modules/javafx.web/src/android/java/com/sun/webkit/Timer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,9 +25,6 @@
 
 package com.sun.webkit;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-
 public class Timer {
     private static Timer instance;
     private static Mode mode;
@@ -44,14 +41,8 @@ public class Timer {
 
     public synchronized static Mode getMode() {
         if (mode == null) {
-            mode = Boolean.valueOf(AccessController.doPrivileged(
-                new PrivilegedAction<String>() {
-                    @Override
-                    public String run() {
-                        return System.getProperty(
-                                "com.sun.webkit.platformticks", "true");
-                    }
-                })) ? Mode.PLATFORM_TICKS : Mode.SEPARATE_THREAD;
+            mode = Boolean.valueOf(System.getProperty("com.sun.webkit.platformticks", "true"))
+                    ? Mode.PLATFORM_TICKS : Mode.SEPARATE_THREAD;
         }
         return mode;
     }

--- a/modules/javafx.web/src/android/java/com/sun/webkit/WebPage.java
+++ b/modules/javafx.web/src/android/java/com/sun/webkit/WebPage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,9 +26,6 @@
 package com.sun.webkit;
 
 import java.io.StringReader;
-import java.security.AccessControlContext;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.LinkedList;
 import java.util.List;
 import javax.xml.parsers.DocumentBuilder;
@@ -43,13 +40,8 @@ import org.xml.sax.InputSource;
 public final class WebPage {
 
     static {
-        AccessController.doPrivileged(new PrivilegedAction<Void>() {
-            public Void run() {
-System.out.println ("[JVDBG] I will load the webview system library");
-                System.loadLibrary("webview");
-                return null;
-            }
-        });
+        System.out.println ("[JVDBG] I will load the webview system library");
+        System.loadLibrary("webview");
     }
     public static int DND_DST_DROP;
     public static int DND_SRC_DROP;
@@ -184,10 +176,6 @@ System.out.println ("[JVDBG] I will load the webview system library");
     }
 
     public void dispatchInspectorMessageFromFrontend(String message) {
-        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
-    }
-
-    public AccessControlContext getAccessControlContext() {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 

--- a/modules/javafx.web/src/android/java/javafx/scene/web/WebEngine.java
+++ b/modules/javafx.web/src/android/java/javafx/scene/web/WebEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,8 +46,6 @@ import java.io.IOException;
 import java.lang.ref.WeakReference;
 import java.net.MalformedURLException;
 import java.net.URLConnection;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import javafx.animation.AnimationTimer;
 import javafx.beans.InvalidationListener;
 import javafx.beans.property.BooleanProperty;
@@ -1328,12 +1326,7 @@ final public class WebEngine {
                 final Callback<String,Void> messageCallback =
                         webEngine.debugger.messageCallback;
                 if (messageCallback != null) {
-                    AccessController.doPrivileged(new PrivilegedAction<Void>() {
-                        @Override public Void run() {
-                            messageCallback.call(message);
-                            return null;
-                        }
-                    }, webEngine.page.getAccessControlContext());
+                    messageCallback.call(message);
                     result = true;
                 }
             }

--- a/modules/javafx.web/src/ios/java/javafx/scene/web/ExportedJavaObject.java
+++ b/modules/javafx.web/src/ios/java/javafx/scene/web/ExportedJavaObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,10 +34,6 @@ import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-import java.security.PrivilegedExceptionAction;
 
 import com.sun.javafx.reflect.ReflectUtil;
 
@@ -172,14 +168,7 @@ class ExportedJavaObject {
     // returns JSON-encoded result
     public String call(final String methodName, final String args) throws CallException {
         try {
-            @SuppressWarnings("removal")
-            String result = AccessController.doPrivileged(new PrivilegedExceptionAction<String>() {
-                @Override
-                public String run() throws Exception {
-                    return callWorker(methodName, args);
-                }
-            }, getJSBridge().getAccessControlContext());
-            return result;
+            return callWorker(methodName, args);
         } catch (Exception e) {
             if (e instanceof CallException) {
                 throw (CallException) e;

--- a/modules/javafx.web/src/ios/java/javafx/scene/web/HTMLEditorSkin.java
+++ b/modules/javafx.web/src/ios/java/javafx/scene/web/HTMLEditorSkin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -77,9 +77,6 @@ import com.sun.javafx.scene.control.skin.FXVK;
 import com.sun.javafx.scene.web.behavior.HTMLEditorBehavior;
 import com.sun.javafx.scene.traversal.TraversalEngine;
 import com.sun.javafx.scene.traversal.TraverseListener;
-
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 
 import java.util.HashMap;
 import java.util.Locale;
@@ -762,11 +759,7 @@ public class HTMLEditorSkin extends SkinBase<HTMLEditor> implements TraverseList
 
         // fgColorButton.applyCss();
         // ColorPickerSkin fgColorPickerSkin = (ColorPickerSkin) fgColorButton.getSkin();
-        // String fgIcon = AccessController.doPrivileged(new PrivilegedAction<String>() {
-            // @Override public String run() {
-                // return HTMLEditorSkin.class.getResource(resources.getString("foregroundColorIcon")).toString();
-            // }
-        // });
+        // String fgIcon = HTMLEditorSkin.class.getResource(resources.getString("foregroundColorIcon")).toString();
         // ((StyleableProperty)fgColorPickerSkin.imageUrlProperty()).applyStyle(null,fgIcon);
 
         fgColorButton.setValue(DEFAULT_FG_COLOR);
@@ -788,11 +781,7 @@ public class HTMLEditorSkin extends SkinBase<HTMLEditor> implements TraverseList
 
         // bgColorButton.applyCss();
         // ColorPickerSkin  bgColorPickerSkin = (ColorPickerSkin) bgColorButton.getSkin();
-        // String bgIcon = AccessController.doPrivileged(new PrivilegedAction<String>() {
-            // @Override public String run() {
-                // return HTMLEditorSkin.class.getResource(resources.getString("backgroundColorIcon")).toString();
-            // }
-        // });
+        // String bgIcon = HTMLEditorSkin.class.getResource(resources.getString("backgroundColorIcon")).toString();
         // ((StyleableProperty)bgColorPickerSkin.imageUrlProperty()).applyStyle(null,bgIcon);
 
         bgColorButton.setValue(DEFAULT_BG_COLOR);
@@ -823,12 +812,7 @@ public class HTMLEditorSkin extends SkinBase<HTMLEditor> implements TraverseList
         button.getStyleClass().add(styleClass);
         toolbar.getItems().add(button);
 
-        @SuppressWarnings("removal")
-        Image icon = AccessController.doPrivileged(new PrivilegedAction<Image>() {
-            @Override public Image run() {
-                return new Image(HTMLEditorSkin.class.getResource(iconName).toString());
-            }
-        });
+        Image icon = new Image(HTMLEditorSkin.class.getResource(iconName).toString());
 //        button.setGraphic(new ImageView(icon));
         ((StyleableProperty)button.graphicProperty()).applyStyle(null,new ImageView(icon));
         button.setTooltip(new Tooltip(tooltipText));
@@ -855,12 +839,7 @@ public class HTMLEditorSkin extends SkinBase<HTMLEditor> implements TraverseList
             toggleButton.setToggleGroup(toggleGroup);
         }
 
-        @SuppressWarnings("removal")
-        Image icon = AccessController.doPrivileged(new PrivilegedAction<Image>() {
-            @Override public Image run() {
-                return new Image(HTMLEditorSkin.class.getResource(iconName).toString());
-            }
-        });
+        Image icon = new Image(HTMLEditorSkin.class.getResource(iconName).toString());
         ((StyleableProperty)toggleButton.graphicProperty()).applyStyle(null,new ImageView(icon));
 //        toggleButton.setGraphic(new ImageView(icon));
 
@@ -903,12 +882,7 @@ public class HTMLEditorSkin extends SkinBase<HTMLEditor> implements TraverseList
         if (orientation == RIGHT_TO_LEFT) {
             try {
                 final String iconName = resources.getString("numbersIcon-rtl");
-                @SuppressWarnings("removal")
-                Image icon = AccessController.doPrivileged(new PrivilegedAction<Image>() {
-                    @Override public Image run() {
-                        return new Image(HTMLEditorSkin.class.getResource(iconName).toString());
-                    }
-                });
+                Image icon = new Image(HTMLEditorSkin.class.getResource(iconName).toString());
                 numbersButton.setGraphic(new ImageView(icon));
             } catch (java.util.MissingResourceException ex) {
                 // ignore

--- a/modules/javafx.web/src/ios/java/javafx/scene/web/JS2JavaBridge.java
+++ b/modules/javafx.web/src/ios/java/javafx/scene/web/JS2JavaBridge.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,6 @@ package javafx.scene.web;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URLDecoder;
-import java.security.AccessControlContext;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -101,11 +100,6 @@ class JS2JavaBridge {
     }
     String getJavaBridge() {
         return javaBridge;
-    }
-
-    @SuppressWarnings("removal")
-    AccessControlContext getAccessControlContext() {
-        return webEngine.getAccessControlContext();
     }
 
     private void populateObject(String jsName, ExportedJavaObject jsObj) {

--- a/modules/javafx.web/src/ios/java/javafx/scene/web/WebEngine.java
+++ b/modules/javafx.web/src/ios/java/javafx/scene/web/WebEngine.java
@@ -49,9 +49,6 @@ import org.xml.sax.InputSource;
 import com.sun.javafx.tk.TKPulseListener;
 import com.sun.javafx.tk.Toolkit;
 import java.io.StringReader;
-import java.security.AccessControlContext;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import javafx.beans.property.*;
 import javafx.geometry.Rectangle2D;
 
@@ -517,9 +514,6 @@ final public class WebEngine {
      * Creates a new engine and loads a Web page into it.
      */
     public WebEngine(String url) {
-        @SuppressWarnings("removal")
-        AccessControlContext tmpAcc = AccessController.getContext();
-        accessControlContext = tmpAcc;
         js2javaBridge = new JS2JavaBridge(this);
         load(url);
     }
@@ -949,23 +943,8 @@ final public class WebEngine {
         }
     }
 
-    @SuppressWarnings("removal")
-    final private AccessControlContext accessControlContext;
-
-    @SuppressWarnings("removal")
-    AccessControlContext getAccessControlContext() {
-        return accessControlContext;
-    }
-
     private void dispatchWebEvent(final EventHandler handler, final WebEvent ev) {
-        @SuppressWarnings("removal")
-        Void result = AccessController.doPrivileged(new PrivilegedAction<Void>() {
-            @Override
-            public Void run() {
-                handler.handle(ev);
-                return null;
-            }
-        }, getAccessControlContext());
+        handler.handle(ev);
     }
 
     private class DebuggerImpl implements Debugger {


### PR DESCRIPTION
Removes `doPrivileged` remaining calls in the `javafx.web` module included in {android,ios} code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342461](https://bugs.openjdk.org/browse/JDK-8342461): Remove calls to doPrivileged in javafx.web/{android,ios} (**Bug** - P3)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Johan Vos](https://openjdk.org/census#jvos) (@johanvos - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1651/head:pull/1651` \
`$ git checkout pull/1651`

Update a local copy of the PR: \
`$ git checkout pull/1651` \
`$ git pull https://git.openjdk.org/jfx.git pull/1651/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1651`

View PR using the GUI difftool: \
`$ git pr show -t 1651`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1651.diff">https://git.openjdk.org/jfx/pull/1651.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1651#issuecomment-2504949796)
</details>
