### PR TITLE
Fix null handling in updateUndoRedoState method

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TextInputControl.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TextInputControl.java
@@ -1244,7 +1244,10 @@ public abstract class TextInputControl extends Control {
         updateUndoRedoState();
     }
 
-    private void updateUndoRedoState() {
+    private void updateUndoRedoState() {        
+        if (undoChange == null) {
+            return;
+        }
         undoable.set(undoChange != undoChangeHead);
         redoable.set(undoChange.next != null);
     }


### PR DESCRIPTION
The updateUndoRedoState method now properly handles cases where undoChange is null, preventing null pointer exceptions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1657/head:pull/1657` \
`$ git checkout pull/1657`

Update a local copy of the PR: \
`$ git checkout pull/1657` \
`$ git pull https://git.openjdk.org/jfx.git pull/1657/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1657`

View PR using the GUI difftool: \
`$ git pr show -t 1657`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1657.diff">https://git.openjdk.org/jfx/pull/1657.diff</a>

</details>
