### PR TITLE
8344111: Remove obsolete permission check methods from javafx.graphics

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/scene/input/DragboardHelper.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/scene/input/DragboardHelper.java
@@ -42,11 +42,6 @@ public class DragboardHelper {
     private DragboardHelper() {
     }
 
-    public static void setDataAccessRestriction(Dragboard dragboard,
-            boolean restricted) {
-        dragboardAccessor.setDataAccessRestriction(dragboard, restricted);
-    }
-
     public static TKClipboard getPeer(Dragboard dragboard) {
         return dragboardAccessor.getPeer(dragboard);
     }
@@ -64,7 +59,6 @@ public class DragboardHelper {
     }
 
     public interface DragboardAccessor {
-        void setDataAccessRestriction(Dragboard dragboard, boolean restricted);
         TKClipboard getPeer(Dragboard dragboard);
         Dragboard createDragboard(TKClipboard peer);
     }

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/stage/StageHelper.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/stage/StageHelper.java
@@ -63,11 +63,6 @@ public class StageHelper extends WindowHelper {
         stageAccessor.doVisibleChanged(window, visible);
     }
 
-    // TODO: JDK-8344111: Consider removing this obsolete method
-    public static void initSecurityDialog(Stage stage, boolean securityDialog) {
-        stageAccessor.initSecurityDialog(stage, securityDialog);
-    }
-
     public static void setPrimary(Stage stage, boolean primary) {
         stageAccessor.setPrimary(stage, primary);
     }
@@ -91,7 +86,6 @@ public class StageHelper extends WindowHelper {
     public static interface StageAccessor {
         void doVisibleChanging(Window window, boolean visible);
         void doVisibleChanged(Window window, boolean visible);
-        public void initSecurityDialog(Stage stage, boolean securityDialog);
         public void setPrimary(Stage stage,  boolean primary);
         public void setImportant(Stage stage,  boolean important);
     }

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/DummyToolkit.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/DummyToolkit.java
@@ -101,7 +101,7 @@ final public class DummyToolkit extends Toolkit {
     }
 
     @Override
-    public TKStage createTKStage(Window peerWindow, boolean securityDialog, StageStyle stageStyle, boolean primary, Modality modality, TKStage owner, boolean rtl) {
+    public TKStage createTKStage(Window peerWindow, StageStyle stageStyle, boolean primary, Modality modality, TKStage owner, boolean rtl) {
         throw new UnsupportedOperationException("Not supported yet.");
     }
 

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/Toolkit.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/Toolkit.java
@@ -360,7 +360,7 @@ public abstract class Toolkit {
 
     public abstract boolean isNestedLoopRunning();
 
-    public abstract TKStage createTKStage(Window peerWindow, boolean securityDialog, StageStyle stageStyle, boolean primary, Modality modality, TKStage owner, boolean rtl);
+    public abstract TKStage createTKStage(Window peerWindow, StageStyle stageStyle, boolean primary, Modality modality, TKStage owner, boolean rtl);
 
     public abstract TKStage createTKPopupStage(Window peerWindow, StageStyle popupStyle, TKStage owner);
     public abstract TKStage createTKEmbeddedStage(HostInterface host);

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassViewEventHandler.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassViewEventHandler.java
@@ -160,14 +160,6 @@ class GlassViewEventHandler extends View.EventHandler {
                         break;
                 }
 
-                if (stage != null) {
-                    if (keyCode == KeyCode.ESCAPE) {
-                        stage.setInAllowedEventHandler(false);
-                    } else {
-                        stage.setInAllowedEventHandler(true);
-                    }
-                }
-
                 switch (type) {
                     case com.sun.glass.events.KeyEvent.PRESS:
                         if (view.isInFullscreen() && stage != null) {
@@ -189,9 +181,6 @@ class GlassViewEventHandler extends View.EventHandler {
                         }
                 }
             } finally {
-                if (stage != null) {
-                    stage.setInAllowedEventHandler(false);
-                }
                 if (PULSE_LOGGING_ENABLED) {
                     PulseLogger.newInput(null);
                 }
@@ -331,18 +320,6 @@ class GlassViewEventHandler extends View.EventHandler {
 
             WindowStage stage = scene.getWindowStage();
             try {
-                if (stage != null) {
-                    switch (type) {
-                        case MouseEvent.UP:
-                        case MouseEvent.DOWN:
-                            stage.setInAllowedEventHandler(true);
-                            break;
-                        default:
-                            stage.setInAllowedEventHandler(false);
-                            break;
-                    }
-                }
-
                 if (scene.sceneListener != null) {
                     boolean shiftDown = (modifiers & KeyEvent.MODIFIER_SHIFT) != 0;
                     boolean controlDown = (modifiers & KeyEvent.MODIFIER_CONTROL) != 0;
@@ -381,9 +358,6 @@ class GlassViewEventHandler extends View.EventHandler {
                             backButtonDown, forwardButtonDown);
                 }
             } finally {
-                if (stage != null) {
-                    stage.setInAllowedEventHandler(false);
-                }
                 if (PULSE_LOGGING_ENABLED) {
                     PulseLogger.newInput(null);
                 }
@@ -421,9 +395,6 @@ class GlassViewEventHandler extends View.EventHandler {
         }
         WindowStage stage = scene.getWindowStage();
         try {
-            if (stage != null) {
-                stage.setInAllowedEventHandler(true);
-            }
             QuantumToolkit.runWithoutRenderLock(() -> {
                 if (scene.sceneListener != null) {
                     double pScaleX, pScaleY, spx, spy, sx, sy;
@@ -452,9 +423,6 @@ class GlassViewEventHandler extends View.EventHandler {
                 return null;
             });
         } finally {
-            if (stage != null) {
-                stage.setInAllowedEventHandler(false);
-            }
             if (PULSE_LOGGING_ENABLED) {
                 PulseLogger.newInput(null);
             }
@@ -473,9 +441,6 @@ class GlassViewEventHandler extends View.EventHandler {
         }
         WindowStage stage = scene.getWindowStage();
         try {
-            if (stage != null) {
-                stage.setInAllowedEventHandler(false);
-            }
             QuantumToolkit.runWithoutRenderLock(() -> {
                 if (scene.sceneListener != null) {
                     final Window w = view.getWindow();
@@ -514,9 +479,6 @@ class GlassViewEventHandler extends View.EventHandler {
                 return null;
             });
         } finally {
-            if (stage != null) {
-                stage.setInAllowedEventHandler(false);
-            }
             if (PULSE_LOGGING_ENABLED) {
                 PulseLogger.newInput(null);
             }
@@ -593,9 +555,6 @@ class GlassViewEventHandler extends View.EventHandler {
         }
         WindowStage stage = scene.getWindowStage();
         try {
-            if (stage != null) {
-                stage.setInAllowedEventHandler(true);
-            }
             QuantumToolkit.runWithoutRenderLock(() -> {
                 if (scene.sceneListener != null) {
                     String t = text != null ? text : "";
@@ -609,9 +568,6 @@ class GlassViewEventHandler extends View.EventHandler {
                 return null;
             });
         } finally {
-            if (stage != null) {
-                stage.setInAllowedEventHandler(false);
-            }
             if (PULSE_LOGGING_ENABLED) {
                 PulseLogger.newInput(null);
             }
@@ -911,9 +867,6 @@ class GlassViewEventHandler extends View.EventHandler {
         }
         WindowStage stage = scene.getWindowStage();
         try {
-            if (stage != null) {
-                stage.setInAllowedEventHandler(false);
-            }
             QuantumToolkit.runWithoutRenderLock(() -> {
                 if (scene.sceneListener != null) {
                     EventType<ScrollEvent> eventType;
@@ -966,9 +919,6 @@ class GlassViewEventHandler extends View.EventHandler {
                 return null;
             });
         } finally {
-            if (stage != null) {
-                stage.setInAllowedEventHandler(false);
-            }
             if (PULSE_LOGGING_ENABLED) {
                 PulseLogger.newInput(null);
             }
@@ -988,9 +938,6 @@ class GlassViewEventHandler extends View.EventHandler {
         }
         WindowStage stage = scene.getWindowStage();
         try {
-            if (stage != null) {
-                stage.setInAllowedEventHandler(false);
-            }
             QuantumToolkit.runWithoutRenderLock(() -> {
                 if (scene.sceneListener != null) {
                     EventType<ZoomEvent> eventType;
@@ -1040,9 +987,6 @@ class GlassViewEventHandler extends View.EventHandler {
                 return null;
             });
         } finally {
-            if (stage != null) {
-                stage.setInAllowedEventHandler(false);
-            }
             if (PULSE_LOGGING_ENABLED) {
                 PulseLogger.newInput(null);
             }
@@ -1061,9 +1005,6 @@ class GlassViewEventHandler extends View.EventHandler {
         }
         WindowStage stage = scene.getWindowStage();
         try {
-            if (stage != null) {
-                stage.setInAllowedEventHandler(false);
-            }
             QuantumToolkit.runWithoutRenderLock(() -> {
                 if (scene.sceneListener != null) {
                     EventType<RotateEvent> eventType;
@@ -1112,9 +1053,6 @@ class GlassViewEventHandler extends View.EventHandler {
                 return null;
             });
         } finally {
-            if (stage != null) {
-                stage.setInAllowedEventHandler(false);
-            }
             if (PULSE_LOGGING_ENABLED) {
                 PulseLogger.newInput(null);
             }
@@ -1132,9 +1070,6 @@ class GlassViewEventHandler extends View.EventHandler {
         }
         WindowStage stage = scene.getWindowStage();
         try {
-            if (stage != null) {
-                stage.setInAllowedEventHandler(false);
-            }
             QuantumToolkit.runWithoutRenderLock(() -> {
                 if (scene.sceneListener != null) {
                     EventType<SwipeEvent> eventType;
@@ -1186,9 +1121,6 @@ class GlassViewEventHandler extends View.EventHandler {
                 return null;
             });
         } finally {
-            if (stage != null) {
-                stage.setInAllowedEventHandler(false);
-            }
             if (PULSE_LOGGING_ENABLED) {
                 PulseLogger.newInput(null);
             }
@@ -1204,9 +1136,6 @@ class GlassViewEventHandler extends View.EventHandler {
         }
         WindowStage stage = scene.getWindowStage();
         try {
-            if (stage != null) {
-                stage.setInAllowedEventHandler(true);
-            }
             QuantumToolkit.runWithoutRenderLock(() -> {
                 if (scene.sceneListener != null) {
                     scene.sceneListener.touchEventBegin(time, touchEventCount,
@@ -1219,9 +1148,6 @@ class GlassViewEventHandler extends View.EventHandler {
                 return null;
             });
         } finally {
-            if (stage != null) {
-                stage.setInAllowedEventHandler(false);
-            }
             if (PULSE_LOGGING_ENABLED) {
                 PulseLogger.newInput(null);
             }
@@ -1239,9 +1165,6 @@ class GlassViewEventHandler extends View.EventHandler {
         }
         WindowStage stage = scene.getWindowStage();
         try {
-            if (stage != null) {
-                stage.setInAllowedEventHandler(true);
-            }
             QuantumToolkit.runWithoutRenderLock(() -> {
                 if (scene.sceneListener != null) {
                     TouchPoint.State state;
@@ -1287,9 +1210,6 @@ class GlassViewEventHandler extends View.EventHandler {
                 return null;
             });
         } finally {
-            if (stage != null) {
-                stage.setInAllowedEventHandler(false);
-            }
             if (PULSE_LOGGING_ENABLED) {
                 PulseLogger.newInput(null);
             }
@@ -1304,9 +1224,6 @@ class GlassViewEventHandler extends View.EventHandler {
         }
         WindowStage stage = scene.getWindowStage();
         try {
-            if (stage != null) {
-                stage.setInAllowedEventHandler(true);
-            }
             QuantumToolkit.runWithoutRenderLock(() -> {
                 if (scene.sceneListener != null) {
                     scene.sceneListener.touchEventEnd();
@@ -1314,9 +1231,6 @@ class GlassViewEventHandler extends View.EventHandler {
                 return null;
             });
         } finally {
-            if (stage != null) {
-                stage.setInAllowedEventHandler(false);
-            }
             if (PULSE_LOGGING_ENABLED) {
                 PulseLogger.newInput(null);
             }

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassViewEventHandler.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassViewEventHandler.java
@@ -97,34 +97,6 @@ class GlassViewEventHandler extends View.EventHandler {
         }
     }
 
-    // TODO: JDK-8344111: Consider removing this obsolete method
-    // Default fullscreen allows limited keyboard input.
-    // It will only receive events from the following keys:
-    // DOWN, UP, LEFT, RIGHT, SPACE, TAB, PAGE_UP, PAGE_DOWN,
-    // HOME, END, ENTER.
-    private static boolean allowableFullScreenKeys(int key) {
-        switch (key) {
-            case KeyEvent.VK_DOWN:
-            case KeyEvent.VK_UP:
-            case KeyEvent.VK_LEFT:
-            case KeyEvent.VK_RIGHT:
-            case KeyEvent.VK_SPACE:
-            case KeyEvent.VK_TAB:
-            case KeyEvent.VK_PAGE_DOWN:
-            case KeyEvent.VK_PAGE_UP:
-            case KeyEvent.VK_HOME:
-            case KeyEvent.VK_END:
-            case KeyEvent.VK_ENTER:
-                return true;
-        }
-        return false;
-    }
-
-    // TODO: JDK-8344111: Consider removing this obsolete method
-    private boolean checkFullScreenKeyEvent(int type, int key, char chars[], int modifiers) {
-        return scene.getWindowStage().isTrustedFullScreen() || allowableFullScreenKeys(key);
-    }
-
     private final PaintCollector collector = PaintCollector.getInstance();
 
     private static EventType<javafx.scene.input.KeyEvent> keyEventType(int glassType) {
@@ -207,11 +179,6 @@ class GlassViewEventHandler extends View.EventHandler {
                         /* NOBREAK */
                     case com.sun.glass.events.KeyEvent.RELEASE:
                     case com.sun.glass.events.KeyEvent.TYPED:
-                        if (view.isInFullscreen()) {
-                            if (!checkFullScreenKeyEvent(type, key, chars, modifiers)) {
-                                break;
-                            }
-                        }
                         if (scene.sceneListener != null) {
                             consumed = scene.sceneListener.keyEvent(keyEvent);
                         }

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/QuantumToolkit.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/QuantumToolkit.java
@@ -608,9 +608,9 @@ public final class QuantumToolkit extends Toolkit {
         }
     }
 
-    @Override public TKStage createTKStage(Window peerWindow, boolean securityDialog, StageStyle stageStyle, boolean primary, Modality modality, TKStage owner, boolean rtl) {
+    @Override public TKStage createTKStage(Window peerWindow, StageStyle stageStyle, boolean primary, Modality modality, TKStage owner, boolean rtl) {
         assertToolkitRunning();
-        WindowStage stage = new WindowStage(peerWindow, securityDialog, stageStyle, modality, owner);
+        WindowStage stage = new WindowStage(peerWindow, stageStyle, modality, owner);
         if (primary) {
             stage.setIsPrimary();
         }
@@ -681,9 +681,7 @@ public final class QuantumToolkit extends Toolkit {
 
     @Override public TKStage createTKPopupStage(Window peerWindow, StageStyle popupStyle, TKStage owner) {
         assertToolkitRunning();
-        boolean securityDialog = owner instanceof WindowStage ?
-                ((WindowStage)owner).isSecurityDialog() : false;
-        WindowStage stage = new WindowStage(peerWindow, securityDialog, popupStyle, null, owner);
+        WindowStage stage = new WindowStage(peerWindow, popupStyle, null, owner);
         stage.setIsPopup();
         stage.init(systemMenu);
         return stage;

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/WindowStage.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/WindowStage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,7 +59,6 @@ public class WindowStage extends GlassStage {
     private StageStyle style;
     private GlassStage owner = null;
     private Modality modality = Modality.NONE;
-    private final boolean securityDialog;
 
     private OverlayWarning warning = null;
     private boolean rtl = false;
@@ -88,11 +87,10 @@ public class WindowStage extends GlassStage {
                                  ".QuantumMessagesBundle", LOCALE);
 
 
-    public WindowStage(javafx.stage.Window peerWindow, boolean securityDialog, final StageStyle stageStyle, Modality modality, TKStage owner) {
+    public WindowStage(javafx.stage.Window peerWindow, final StageStyle stageStyle, Modality modality, TKStage owner) {
         this.style = stageStyle;
         this.owner = (GlassStage)owner;
         this.modality = modality;
-        this.securityDialog = securityDialog;
 
         if (peerWindow instanceof javafx.stage.Stage) {
             fxStage = (Stage)peerWindow;
@@ -114,10 +112,6 @@ public class WindowStage extends GlassStage {
 
     final void setIsPopup() {
         isPopupStage = true;
-    }
-
-    final boolean isSecurityDialog() {
-        return securityDialog;
     }
 
     // Called by QuantumToolkit, so we can override initPlatformWindow in subclasses
@@ -181,9 +175,6 @@ public class WindowStage extends GlassStage {
                     app.createWindow(ownerWindow, Screen.getMainScreen(), windowMask);
             platformWindow.setResizable(resizable);
             platformWindow.setFocusable(focusable);
-            if (securityDialog) {
-                platformWindow.setLevel(Window.Level.FLOATING);
-            }
             if (fxStage != null && fxStage.getScene() != null) {
                 javafx.scene.paint.Paint paint = fxStage.getScene().getFill();
                 if (paint instanceof javafx.scene.paint.Color) {
@@ -560,9 +551,6 @@ public class WindowStage extends GlassStage {
 
     @Override
     public void setAlwaysOnTop(boolean alwaysOnTop) {
-        // The securityDialog flag takes precedence over alwaysOnTop
-        if (securityDialog) return;
-
         if (isAlwaysOnTop == alwaysOnTop) {
             return;
         }
@@ -580,18 +568,11 @@ public class WindowStage extends GlassStage {
         // note: for child windows this is ignored and we fail silently
     }
 
-    // TODO: JDK-8344111: Consider removing this obsolete method
-    // Return true if this stage is trusted for full screen (it always is)
-    boolean isTrustedFullScreen() {
-        return true;
-    }
-
     // Safely exit full screen
     void exitFullScreen() {
         setFullScreen(false);
     }
 
-    // TODO: JDK-8344111: Consider removing this obsolete field
     private boolean fullScreenFromUserEvent = false;
 
     private KeyCombination savedFullScreenExitKey = null;
@@ -613,8 +594,7 @@ public class WindowStage extends GlassStage {
                 // indicating that the fullscreen request came from an input
                 // event handler.
                 // If not notify the stageListener to reset fullscreen to false.
-                final boolean isTrusted = isTrustedFullScreen();
-                if (!isTrusted && !fullScreenFromUserEvent) {
+                if (!fullScreenFromUserEvent) {
                     exitFullScreen();
                     fullscreenChanged(false);
                 } else {
@@ -627,7 +607,7 @@ public class WindowStage extends GlassStage {
                         KeyCombination key = null;
                         String exitMessage = null;
 
-                        if (isTrusted && (fxStage != null)) {
+                        if (fxStage != null) {
                             // copy the user set definitions for later use.
                             key = fxStage.getFullScreenExitKeyCombination();
 

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/WindowStage.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/WindowStage.java
@@ -68,10 +68,6 @@ public class WindowStage extends GlassStage {
     private boolean isInFullScreen = false;
     private boolean isAlwaysOnTop = false;
 
-    // A flag to indicate whether a call was generated from
-    // an allowed input event handler.
-    private boolean inAllowedEventHandler = false;
-
     // An active window is visible && enabled && focusable.
     // The list is maintained in the z-order, so that the last element
     // represents the topmost window (or more accurately, the last
@@ -573,8 +569,6 @@ public class WindowStage extends GlassStage {
         setFullScreen(false);
     }
 
-    private boolean fullScreenFromUserEvent = false;
-
     private KeyCombination savedFullScreenExitKey = null;
 
     public final KeyCombination getSavedFullScreenExitKey() {
@@ -590,61 +584,52 @@ public class WindowStage extends GlassStage {
         View v = platformWindow.getView();
         if (isVisible() && v != null && v.isInFullscreen() != isInFullScreen) {
             if (isInFullScreen) {
-                // Check whether app is full screen trusted or flag is set
-                // indicating that the fullscreen request came from an input
-                // event handler.
-                // If not notify the stageListener to reset fullscreen to false.
-                if (!fullScreenFromUserEvent) {
-                    exitFullScreen();
-                    fullscreenChanged(false);
+                v.enterFullscreen(false, false, false);
+                if (warning != null && warning.inWarningTransition()) {
+                    warning.setView(getViewScene());
                 } else {
-                    v.enterFullscreen(false, false, false);
-                    if (warning != null && warning.inWarningTransition()) {
-                        warning.setView(getViewScene());
-                    } else {
-                        boolean showWarning = true;
+                    boolean showWarning = true;
 
-                        KeyCombination key = null;
-                        String exitMessage = null;
+                    KeyCombination key = null;
+                    String exitMessage = null;
 
-                        if (fxStage != null) {
-                            // copy the user set definitions for later use.
-                            key = fxStage.getFullScreenExitKeyCombination();
+                    if (fxStage != null) {
+                        // copy the user set definitions for later use.
+                        key = fxStage.getFullScreenExitKeyCombination();
 
-                            exitMessage = fxStage.getFullScreenExitHint();
+                        exitMessage = fxStage.getFullScreenExitHint();
+                    }
+
+                    savedFullScreenExitKey =
+                            key == null
+                            ? defaultFullScreenExitKeycombo
+                            : key;
+
+                    if (
+                        // the hint is ""
+                        "".equals(exitMessage) ||
+                        // if the key is NO_MATCH
+                        (savedFullScreenExitKey.equals(KeyCombination.NO_MATCH))
+                            ) {
+                        showWarning = false;
+                    }
+
+                    // the hint is not set, use the key for the message
+                    if (showWarning && exitMessage == null) {
+                        if (key == null) {
+                            exitMessage = RESOURCES.getString("OverlayWarningESC");
+                        } else {
+                            String f = RESOURCES.getString("OverlayWarningKey");
+                            exitMessage = f.format(f, savedFullScreenExitKey.toString());
                         }
+                    }
 
-                        savedFullScreenExitKey =
-                                key == null
-                                ? defaultFullScreenExitKeycombo
-                                : key;
+                    if (showWarning && warning == null) {
+                        setWarning(new OverlayWarning(getViewScene()));
+                    }
 
-                        if (
-                            // the hint is ""
-                            "".equals(exitMessage) ||
-                            // if the key is NO_MATCH
-                            (savedFullScreenExitKey.equals(KeyCombination.NO_MATCH))
-                                ) {
-                            showWarning = false;
-                        }
-
-                        // the hint is not set, use the key for the message
-                        if (showWarning && exitMessage == null) {
-                            if (key == null) {
-                                exitMessage = RESOURCES.getString("OverlayWarningESC");
-                            } else {
-                                String f = RESOURCES.getString("OverlayWarningKey");
-                                exitMessage = f.format(f, savedFullScreenExitKey.toString());
-                            }
-                        }
-
-                        if (showWarning && warning == null) {
-                            setWarning(new OverlayWarning(getViewScene()));
-                        }
-
-                        if (showWarning && warning != null) {
-                            warning.warn(exitMessage);
-                        }
+                    if (showWarning && warning != null) {
+                        warning.warn(exitMessage);
                     }
                 }
             } else {
@@ -654,8 +639,6 @@ public class WindowStage extends GlassStage {
                 }
                 v.exitFullscreen(false);
             }
-            // Reset flag once we are done process fullscreen
-            fullScreenFromUserEvent = false;
         } else if (!isVisible() && warning != null) {
             // if the window is closed - re-open with fresh warning
             warning.cancel();
@@ -675,12 +658,6 @@ public class WindowStage extends GlassStage {
     @Override public void setFullScreen(boolean fullScreen) {
         if (isInFullScreen == fullScreen) {
             return;
-        }
-
-       // Set a flag indicating whether this method was called from
-        // an allowed input event handler.
-        if (isInAllowedEventHandler()) {
-            fullScreenFromUserEvent = true;
         }
 
         GlassStage fsWindow = activeFSWindow.get();
@@ -857,14 +834,6 @@ public class WindowStage extends GlassStage {
             platformWindow.toFront();
             platformWindow.requestFocus();
         }
-    }
-
-    public void setInAllowedEventHandler(boolean inAllowedEventHandler) {
-        this.inAllowedEventHandler = inAllowedEventHandler;
-    }
-
-    private boolean isInAllowedEventHandler() {
-        return inAllowedEventHandler;
     }
 
     @Override

--- a/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
@@ -3073,15 +3073,11 @@ public class Scene implements EventTarget {
                 DragEvent dragEvent =
                         new DragEvent(DragEvent.ANY, dndGesture.dragboard, x, y, screenX, screenY,
                                 transferMode, null, null, pick(x, y));
-                // Data dropped to the app can be accessed without restriction
-                DragboardHelper.setDataAccessRestriction(dndGesture.dragboard, false);
 
                 TransferMode tm;
                 try {
                     tm = dndGesture.processTargetDrop(dragEvent);
                 } finally {
-                    DragboardHelper.setDataAccessRestriction(
-                            dndGesture.dragboard, true);
                 }
 
                 if (dndGesture.source == null) {
@@ -3219,11 +3215,6 @@ public class Scene implements EventTarget {
                         try {
                             fireEvent(target, detectedEvent);
                         } finally {
-                            // Putting data to dragboard finished, restrict access to them
-                            if (dragboard != null) {
-                                DragboardHelper.setDataAccessRestriction(
-                                        dragboard, true);
-                            }
                         }
                     }
 
@@ -3255,11 +3246,6 @@ public class Scene implements EventTarget {
             try {
                 fireEvent(target != null ? target : Scene.this, me);
             } finally {
-                // Putting data to dragboard finished, restrict access to them
-                if (dragboard != null) {
-                    DragboardHelper.setDataAccessRestriction(
-                            dragboard, true);
-                }
             }
 
             dragDetectedProcessed();
@@ -3469,9 +3455,6 @@ public class Scene implements EventTarget {
                 dragboard = createDragboard(null, true);
             }
 
-            // The app can see what it puts to dragboard without restriction
-            DragboardHelper.setDataAccessRestriction(dragboard, false);
-
             this.source = source;
             potentialTarget = source;
             sourceTransferModes = t;
@@ -3521,13 +3504,9 @@ public class Scene implements EventTarget {
                         new DragEvent(DragEvent.ANY, dndGesture.dragboard, x, y, screenX, screenY,
                         transferMode, null, null, null);
 
-                // DRAG_DONE event is delivered to gesture source, it can access
-                // its own data without restriction
-                DragboardHelper.setDataAccessRestriction(dndGesture.dragboard, false);
                 try {
                     dndGesture.processDropEnd(dragEvent);
                 } finally {
-                    DragboardHelper.setDataAccessRestriction(dndGesture.dragboard, true);
                 }
                 dndGesture = null;
             }

--- a/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
@@ -3074,11 +3074,7 @@ public class Scene implements EventTarget {
                         new DragEvent(DragEvent.ANY, dndGesture.dragboard, x, y, screenX, screenY,
                                 transferMode, null, null, pick(x, y));
 
-                TransferMode tm;
-                try {
-                    tm = dndGesture.processTargetDrop(dragEvent);
-                } finally {
-                }
+                TransferMode tm = dndGesture.processTargetDrop(dragEvent);
 
                 if (dndGesture.source == null) {
                     dndGesture.dragboard = null;
@@ -3212,10 +3208,7 @@ public class Scene implements EventTarget {
                                 mouseEvent.getSource(), target,
                                 MouseEvent.DRAG_DETECTED);
 
-                        try {
-                            fireEvent(target, detectedEvent);
-                        } finally {
-                        }
+                        fireEvent(target, detectedEvent);
                     }
 
                     dragDetectedProcessed();
@@ -3243,10 +3236,7 @@ public class Scene implements EventTarget {
             processingDragDetected();
 
             final EventTarget target = de.getPickResult().getIntersectedNode();
-            try {
-                fireEvent(target != null ? target : Scene.this, me);
-            } finally {
-            }
+            fireEvent(target != null ? target : Scene.this, me);
 
             dragDetectedProcessed();
 
@@ -3504,10 +3494,7 @@ public class Scene implements EventTarget {
                         new DragEvent(DragEvent.ANY, dndGesture.dragboard, x, y, screenX, screenY,
                         transferMode, null, null, null);
 
-                try {
-                    dndGesture.processDropEnd(dragEvent);
-                } finally {
-                }
+                dndGesture.processDropEnd(dragEvent);
                 dndGesture = null;
             }
         }

--- a/modules/javafx.graphics/src/main/java/javafx/scene/input/Dragboard.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/input/Dragboard.java
@@ -152,11 +152,6 @@ public final class Dragboard extends Clipboard {
         // private and package private methods.
         DragboardHelper.setDragboardAccessor(new DragboardHelper.DragboardAccessor() {
 
-            // TODO: JDK-8344111: Consider removing this obsolete method
-            @Override
-            public void setDataAccessRestriction(Dragboard dragboard, boolean restricted) {
-            }
-
             @Override
             public TKClipboard getPeer(Dragboard dragboard) {
                 return dragboard.getPeer();

--- a/modules/javafx.graphics/src/main/java/javafx/stage/Stage.java
+++ b/modules/javafx.graphics/src/main/java/javafx/stage/Stage.java
@@ -189,10 +189,6 @@ public class Stage extends Window {
                 ((Stage) window).doVisibleChanged(visible);
             }
 
-            @Override public void initSecurityDialog(Stage stage, boolean securityDialog) {
-                stage.initSecurityDialog(securityDialog);
-            }
-
             @Override
             public void setPrimary(Stage stage, boolean primary) {
                 stage.setPrimary(primary);
@@ -279,41 +275,6 @@ public class Stage extends Window {
     private boolean primary = false;
 
     //------------------------------------------------------------------
-
-    // Flag indicating that this stage is being used to show a security dialog
-    private boolean securityDialog = false;
-
-    // TODO: JDK-8344111: Consider removing this obsolete method
-    /**
-     * Sets a flag indicating that this stage is used for a security dialog and
-     * must always be on top. If set, this will cause the window to be always
-     * on top, regardless of the setting of the alwaysOnTop property.
-     * NOTE: this flag must be set prior to showing the stage the first time.
-     *
-     * @param securityDialog flag indicating that this Stage is being used to
-     * show a security dialog that should be always-on-top
-     *
-     * @throws IllegalStateException if this property is set after the stage
-     * has ever been made visible.
-     *
-     * @defaultValue false
-     */
-    final void initSecurityDialog(boolean securityDialog) {
-        if (hasBeenVisible) {
-            throw new IllegalStateException("Cannot set securityDialog once stage has been set visible");
-        }
-
-        this.securityDialog = securityDialog;
-    }
-
-    /**
-     * Returns the state of the securityDialog flag.
-     *
-     * @return a flag indicating whether or not this is a security dialog
-     */
-    final boolean isSecurityDialog() {
-        return securityDialog;
-    }
 
     /*
      * Sets this stage to be the primary stage.
@@ -1125,8 +1086,8 @@ public class Stage extends Window {
             boolean rtl = scene != null && scene.getEffectiveNodeOrientation() == NodeOrientation.RIGHT_TO_LEFT;
 
             StageStyle stageStyle = getStyle();
-            setPeer(toolkit.createTKStage(this, isSecurityDialog(),
-                    stageStyle, isPrimary(), getModality(), tkStage, rtl));
+            setPeer(toolkit.createTKStage(this, stageStyle, isPrimary(),
+                    getModality(), tkStage, rtl));
             getPeer().setMinimumSize((int) Math.ceil(getMinWidth()),
                     (int) Math.ceil(getMinHeight()));
             getPeer().setMaximumSize((int) Math.floor(getMaxWidth()),

--- a/modules/javafx.graphics/src/shims/java/javafx/stage/StageShim.java
+++ b/modules/javafx.graphics/src/shims/java/javafx/stage/StageShim.java
@@ -31,8 +31,4 @@ public class StageShim {
         return stage.isPrimary();
     }
 
-    public static boolean isSecurityDialog(Stage stage) {
-        return stage.isSecurityDialog();
-    }
-
 }

--- a/modules/javafx.graphics/src/test/java/test/com/sun/javafx/pgstub/StubToolkit.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/javafx/pgstub/StubToolkit.java
@@ -119,7 +119,7 @@ public class StubToolkit extends Toolkit {
     }
 
     @Override
-    public TKStage createTKStage(Window peerWindow, boolean securityDialog, StageStyle stageStyle, boolean primary, Modality modality, TKStage owner, boolean rtl) {
+    public TKStage createTKStage(Window peerWindow, StageStyle stageStyle, boolean primary, Modality modality, TKStage owner, boolean rtl) {
 
         return new StubStage();
     }


### PR DESCRIPTION
This PR removes obsolete permission checks from javafx.graphics _minus_ Font classes (handled by a separate PR).

The only part I did not remove from methods/fields listed in the issue is `WindowStage.fullScreenFromUserEvent`. This flag seems quite extensively used and did not seem to have anything to do with permission checks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344111](https://bugs.openjdk.org/browse/JDK-8344111): Remove obsolete permission check methods from javafx.graphics (**Bug** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1658/head:pull/1658` \
`$ git checkout pull/1658`

Update a local copy of the PR: \
`$ git checkout pull/1658` \
`$ git pull https://git.openjdk.org/jfx.git pull/1658/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1658`

View PR using the GUI difftool: \
`$ git pr show -t 1658`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1658.diff">https://git.openjdk.org/jfx/pull/1658.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1658#issuecomment-2523715965)
</details>
