### PR TITLE
8344114: Remove obsolete permission check methods from Font classes

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/FontFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/FontFactory.java
@@ -52,12 +52,6 @@ public interface FontFactory {
     public String[] getFontFullNames();
     public String[] getFontFullNames(String family);
 
-    // TODO: JDK-8344114: Consider removing this obsolete method
-    /*
-     * Indicates permission to load an embedded font
-     */
-    public boolean hasPermission();
-
     /**
      * Loads a font from the specified input stream.
      * If the load is successful such that the stream can be

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/FontFileWriter.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/FontFileWriter.java
@@ -50,9 +50,6 @@ class FontFileWriter implements FontConstants {
     RandomAccessFile raFile;
 
     public FontFileWriter() {
-        if (!hasTempPermission()) {
-            tracker = FontTracker.getTracker();
-        }
     }
 
     protected void setLength(int size) throws IOException {
@@ -229,16 +226,6 @@ class FontFileWriter implements FontConstants {
         checkSize(length);
         raFile.write(buffer, startPos, length);
         pos += length;
-    }
-
-    // TODO: JDK-8344114: Consider removing this obsolete method
-    /**
-     * Used with the byte count tracker for fonts created from streams.
-     * If a thread can create temp files anyway, there is no point in counting
-     * font bytes.
-     */
-    static boolean hasTempPermission() {
-        return true;
     }
 
     /* Like JDK, FX allows untrusted code to create fonts which consume

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/PrismFontFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/PrismFontFactory.java
@@ -1367,33 +1367,6 @@ public abstract class PrismFontFactory implements FontFactory {
                                      float size,
                                      boolean register,
                                      boolean loadAll) {
-
-        // Be extra conscious of pending temp file creation and resourcefully
-        // handle the temp file resources, among other things.
-        FontFileWriter.FontTracker tracker =
-            FontFileWriter.FontTracker.getTracker();
-        boolean acquired = false;
-        try {
-            acquired = tracker.acquirePermit();
-            if (!acquired) {
-                // Timed out waiting for resources.
-                return null;
-            }
-            return loadEmbeddedFont0(name, fontStream, size, register, loadAll);
-        } catch (InterruptedException e) {
-            // Interrupted while waiting to acquire a permit.
-            return null;
-        } finally {
-            if (acquired) {
-                tracker.releasePermit();
-            }
-        }
-    }
-
-    private PGFont[] loadEmbeddedFont0(String name, InputStream fontStream,
-                                       float size,
-                                       boolean register,
-                                       boolean loadAll) {
         PrismFontFile[] fr = null;
         FontFileWriter fontWriter = new FontFileWriter();
         try {

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/PrismFontFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/PrismFontFactory.java
@@ -1367,15 +1367,9 @@ public abstract class PrismFontFactory implements FontFactory {
                                      float size,
                                      boolean register,
                                      boolean loadAll) {
-        if (!hasPermission()) {
-            return new PGFont[] { createFont(DEFAULT_FULLNAME, size) } ;
-        }
-        if (FontFileWriter.hasTempPermission()) {
-            return loadEmbeddedFont0(name, fontStream, size, register, loadAll);
-        }
 
-        // Otherwise, be extra conscious of pending temp file creation and
-        // resourcefully handle the temp file resources, among other things.
+        // Be extra conscious of pending temp file creation and resourcefully
+        // handle the temp file resources, among other things.
         FontFileWriter.FontTracker tracker =
             FontFileWriter.FontTracker.getTracker();
         boolean acquired = false;
@@ -1476,9 +1470,6 @@ public abstract class PrismFontFactory implements FontFactory {
                                      float size,
                                      boolean register,
                                      boolean loadAll) {
-        if (!hasPermission()) {
-            return new PGFont[] { createFont(DEFAULT_FULLNAME, size) };
-        }
         addFileCloserHook();
         FontResource[] frArr =
           loadEmbeddedFont1(name, path, register, false, false, loadAll);
@@ -1747,11 +1738,6 @@ public abstract class PrismFontFactory implements FontFactory {
 //             }
         }
         return fontToFileMap;
-    }
-
-    @Override
-    public final boolean hasPermission() {
-        return true;
     }
 
     private static class TTFilter implements FilenameFilter {

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/PrismFontLoader.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/PrismFontLoader.java
@@ -67,10 +67,6 @@ public class PrismFontLoader extends FontLoader {
     private void loadEmbeddedFonts() {
         if (!embeddedFontsLoaded) {
             FontFactory fontFactory = getFontFactoryFromPipeline();
-            if (!fontFactory.hasPermission()) {
-                embeddedFontsLoaded = true;
-                return;
-            }
             Properties map = loadEmbeddedFontDefinitions();
             Enumeration<?> names = map.keys();
             ClassLoader loader = Thread.currentThread().getContextClassLoader();

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/j2d/J2DFontFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/j2d/J2DFontFactory.java
@@ -90,11 +90,6 @@ final class J2DFontFactory implements FontFactory {
         return prismFontFactory.isPlatformFont(name);
     }
 
-    @Override
-    public final boolean hasPermission() {
-        return prismFontFactory.hasPermission();
-    }
-
     /* This is an important but tricky one. We need to copy the
      * stream. I don't want to have to manage the temp file deletion here,
      * so although its non-optimal I will create a temp file, provide
@@ -106,12 +101,6 @@ final class J2DFontFactory implements FontFactory {
                                      float size,
                                      boolean register,
                                      boolean loadAll) {
-
-        if (!hasPermission()) {
-            PGFont[] fonts = new PGFont[1];
-            fonts[0] = createFont(DEFAULT_FULLNAME, size);
-            return fonts;
-        }
 
         PGFont[] fonts =
           prismFontFactory.loadEmbeddedFont(name, fontStream,
@@ -154,12 +143,6 @@ final class J2DFontFactory implements FontFactory {
                                      float size,
                                      boolean register,
                                      boolean loadAll) {
-
-        if (!hasPermission()) {
-            PGFont[] fonts = new PGFont[1];
-            fonts[0] = createFont(DEFAULT_FULLNAME, size);
-            return fonts;
-        }
 
         PGFont[] fonts =
             prismFontFactory.loadEmbeddedFont(name, path,


### PR DESCRIPTION
This PR removes obsolete permission check methods and fields from Font-related classes.

Verified the changes on Windows, did not see any regressions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344114](https://bugs.openjdk.org/browse/JDK-8344114): Remove obsolete permission check methods from Font classes (**Bug** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1659/head:pull/1659` \
`$ git checkout pull/1659`

Update a local copy of the PR: \
`$ git checkout pull/1659` \
`$ git pull https://git.openjdk.org/jfx.git pull/1659/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1659`

View PR using the GUI difftool: \
`$ git pr show -t 1659`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1659.diff">https://git.openjdk.org/jfx/pull/1659.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1659#issuecomment-2523719667)
</details>
