### PR TITLE
8286831: WebView can't switch to Chinese input method in GTK3

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/gtk/GlassApplication.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/GlassApplication.cpp
@@ -182,6 +182,7 @@ JNIEXPORT void JNICALL Java_com_sun_glass_ui_gtk_GtkApplication__1init
     process_events_prev = (GdkEventFunc) handler;
     disableGrab = (gboolean) _disableGrab;
 
+    XSetLocaleModifiers("");
     glass_gdk_x11_display_set_window_scale(gdk_display_get_default(), 1);
     gdk_event_handler_set(process_events, NULL, NULL);
 


### PR DESCRIPTION
This PR fixes a bug where the can't switch input method in GTK3.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8286831](https://bugs.openjdk.org/browse/JDK-8286831): WebView can't switch to Chinese input method in GTK3 (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1660/head:pull/1660` \
`$ git checkout pull/1660`

Update a local copy of the PR: \
`$ git checkout pull/1660` \
`$ git pull https://git.openjdk.org/jfx.git pull/1660/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1660`

View PR using the GUI difftool: \
`$ git pr show -t 1660`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1660.diff">https://git.openjdk.org/jfx/pull/1660.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1660#issuecomment-2524834593)
</details>
