### PR TITLE
8335470: [XWayland] JavaFX tests that use AWT Robot fail on Wayland

### DIFF
--- a/tests/system/src/test/java/test/robot/javafx/embed/swing/LinuxScreencastHangCrashTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/embed/swing/LinuxScreencastHangCrashTest.java
@@ -56,7 +56,6 @@ public class LinuxScreencastHangCrashTest {
 
     @BeforeAll
     public static void init() throws Exception {
-        Assumptions.assumeTrue(!Util.isOnWayland()); // JDK-8335470
         Assumptions.assumeTrue(Util.isOnWayland());
         robot = new Robot();
     }

--- a/tests/system/src/test/java/test/robot/javafx/embed/swing/SwingNodeJDialogTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/embed/swing/SwingNodeJDialogTest.java
@@ -39,7 +39,6 @@ public class SwingNodeJDialogTest extends SwingNodeBase {
 
     @Test
     public void testJDialogAbove() throws InterruptedException, InvocationTargetException {
-        assumeTrue(!Util.isOnWayland()); // JDK-8335470
         myApp.createStageAndDialog();
         myApp.showDialog();
 
@@ -50,7 +49,6 @@ public class SwingNodeJDialogTest extends SwingNodeBase {
 
     @Test
     public void testNodeRemovalAfterShow() throws InterruptedException, InvocationTargetException {
-        assumeTrue(!Util.isOnWayland()); // JDK-8335470
         myApp.createStageAndDialog();
         myApp.showDialog();
 
@@ -65,7 +63,6 @@ public class SwingNodeJDialogTest extends SwingNodeBase {
 
     @Test
     public void testNodeRemovalBeforeShow() throws InterruptedException, InvocationTargetException {
-        assumeTrue(!Util.isOnWayland()); // JDK-8335470
         myApp.createStageAndDialog();
         myApp.detachSwingNode();
         myApp.showDialog();
@@ -78,7 +75,6 @@ public class SwingNodeJDialogTest extends SwingNodeBase {
 
     @Test
     public void testStageCloseAfterShow() throws InvocationTargetException, InterruptedException {
-        assumeTrue(!Util.isOnWayland()); // JDK-8335470
         myApp.createStageAndDialog();
         myApp.showDialog();
         testAbove(true);
@@ -88,7 +84,6 @@ public class SwingNodeJDialogTest extends SwingNodeBase {
 
     @Test
     public void testStageCloseBeforeShow() throws InvocationTargetException, InterruptedException {
-        assumeTrue(!Util.isOnWayland()); // JDK-8335470
         myApp.createStageAndDialog();
         myApp.closeStage();
         myApp.showDialog();
@@ -99,7 +94,6 @@ public class SwingNodeJDialogTest extends SwingNodeBase {
 
     @Test
     public void testNodeRemovalBeforeShowHoldEDT() throws InterruptedException, InvocationTargetException {
-        assumeTrue(!Util.isOnWayland()); // JDK-8335470
         myApp.createAndShowStage();
         CountDownLatch latch = new CountDownLatch(1);
         SwingUtilities.invokeLater(()-> {
@@ -117,7 +111,6 @@ public class SwingNodeJDialogTest extends SwingNodeBase {
 
     @Test
     public void testStageCloseBeforeShowHoldEDT() throws InvocationTargetException, InterruptedException {
-        assumeTrue(!Util.isOnWayland()); // JDK-8335470
         myApp.createAndShowStage();
         CountDownLatch latch = new CountDownLatch(1);
         SwingUtilities.invokeLater(()-> {

--- a/tests/system/src/test/java/test/robot/javafx/scene/SRGBTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/SRGBTest.java
@@ -216,7 +216,6 @@ public class SRGBTest extends VisualTestBase {
     @Test
     @Timeout(value=15)
     public void sRGBPixelTest() throws Exception {
-        assumeTrue(!Util.isOnWayland()); // JDK-8335470
         Rectangle swatch = prepareStage();
 
         for (TestColor testColor : TestColor.values()) {


### PR DESCRIPTION
This PR enables several previously disabled test cases for Wayland, as the required fixes are already in the promoted build. ([JDK-8335469](https://bugs.openjdk.org/browse/JDK-8335469), [JDK-8335468](https://bugs.openjdk.org/browse/JDK-8335468))