### PR TITLE
8346222: SwingNodePlatformExitCrashTest fails with JUnit 5.11.3

### DIFF
--- a/tests/system/src/test/java/test/robot/javafx/embed/swing/SwingNodeBase.java
+++ b/tests/system/src/test/java/test/robot/javafx/embed/swing/SwingNodeBase.java
@@ -53,6 +53,7 @@ public class SwingNodeBase {
     public static final int LONG_WAIT_TIME = 2500;
 
     protected static Robot robot;
+    protected static boolean doShutdown = true;
 
     // Used to launch the application before running any test
     private static final CountDownLatch launchLatch = new CountDownLatch(1);
@@ -78,7 +79,9 @@ public class SwingNodeBase {
 
     @AfterAll
     public static void teardownOnce() {
-        Util.shutdown();
+        if (doShutdown) {
+            Util.shutdown();
+        }
     }
 
     public static void runWaitSleep(Runnable run) {

--- a/tests/system/src/test/java/test/robot/javafx/embed/swing/SwingNodePlatformExitCrashTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/embed/swing/SwingNodePlatformExitCrashTest.java
@@ -29,8 +29,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.concurrent.CountDownLatch;
 import javax.swing.SwingUtilities;
 import javafx.application.Platform;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import test.util.Util;
 
@@ -52,9 +51,10 @@ public class SwingNodePlatformExitCrashTest extends SwingNodeBase {
         myApp.disposeDialog();
     }
 
-    @AfterAll
-    public static void teardownOnce() {
-        // No-op as Toolkit shutdown is already done in Platform.exit
-        // and calling superclass teardownOnce will cause hang
+    @BeforeAll
+    public static void skipShutDown() {
+        // Skip shutdown as Toolkit shutdown is already done in Platform.exit
+        // and will cause hang if called
+        doShutdown = false;
     }
 }


### PR DESCRIPTION
This PR fixes a latent test bug in test bug in `SwingNodePlatformExitCrashTest` by setting a flag to skip shutdown rather than relying on a quirk of JUnit 5.8.1.

I discovered this while testing PR #1662 which updates JUnit to 5.11.3.

```
$ gradle sdk shims
$ gradle -PTEST_ONLY=true -PFULL_TEST=true -PUSE_ROBOT=true :systemTests:test --tests SwingNodePlatformExitCrashTest
...
SwingNodePlatformExitCrashTest > executionError FAILED
    org.opentest4j.AssertionFailedError: Exceeded timeout limit of 10000 msec
        at app//test.util.Util.runAndWait(Util.java:168)
        at app//test.util.Util.runAndWait(Util.java:139)
        at app//test.util.Util.shutdown(Util.java:316)
        at app//test.robot.javafx.embed.swing.SwingNodeBase.teardownOnce(SwingNodeBase.java:81)
        ...
```

The abstract `SwingNodeBase` base class calls `Util::shutdown` from its static `tearDownOnce` method, annotated with `@AfterAll`. The `SwingNodePlatformExitCrashTest` shuts down the FX toolkit as part of the test so must not call shutdown a second time. The current test logic attempts to "override" the static method in the base class with an @AfterAll annotation on a static method of the same name in the subclass. This accidentally works in JUnit 5.8 by hiding the method in the parent class, but no longer does in JUnit 5.11.

The right fix is for the subclass to set a flag such that the superclass will skip the call to `Util::shutdown`.