### PR TITLE
8346227: Seal Paint and Material

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/Toolkit.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/Toolkit.java
@@ -594,23 +594,12 @@ public abstract class Toolkit {
     }
 
     public Object getPaint(Paint paint) {
-        if (paint instanceof Color) {
-            return createColorPaint((Color) paint);
-        }
-
-        if (paint instanceof LinearGradient) {
-            return getPaint((LinearGradient) paint);
-        }
-
-        if (paint instanceof RadialGradient) {
-            return getPaint((RadialGradient) paint);
-        }
-
-        if (paint instanceof ImagePattern) {
-            return createImagePatternPaint((ImagePattern) paint);
-        }
-
-        return null;
+        return switch (paint) {
+            case Color color -> createColorPaint(color);
+            case LinearGradient gradient -> getPaint(gradient);
+            case RadialGradient gradient -> getPaint(gradient);
+            case ImagePattern pattern -> createImagePatternPaint(pattern);
+        };
     }
 
     protected static final double clampStopOffset(double offset) {

--- a/modules/javafx.graphics/src/main/java/javafx/scene/paint/ImagePattern.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/paint/ImagePattern.java
@@ -383,7 +383,6 @@ public final class ImagePattern extends Paint {
     @Override Object acc_getPlatformPaint() {
         if (acc_isMutable() || platformPaint == null) {
             platformPaint = Toolkit.getToolkit().getPaint(this);
-            assert platformPaint != null;
         }
         return platformPaint;
     }

--- a/modules/javafx.graphics/src/main/java/javafx/scene/paint/Material.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/paint/Material.java
@@ -45,7 +45,7 @@ import javafx.scene.shape.Shape3D;
  *
  * @since JavaFX 8.0
  */
-public abstract class Material {
+public abstract sealed class Material permits PhongMaterial {
 
     static {
         // This is used by classes in different packages to get access to

--- a/modules/javafx.graphics/src/main/java/javafx/scene/paint/Paint.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/paint/Paint.java
@@ -45,7 +45,8 @@ import javafx.animation.Interpolatable;
  *
  * @since JavaFX 2.0
  */
-public abstract class Paint implements Interpolatable<Paint> {
+public abstract sealed class Paint implements Interpolatable<Paint>
+                                   permits Color, LinearGradient, RadialGradient, ImagePattern {
 
     static {
         Toolkit.setPaintAccessor(new Toolkit.PaintAccessor() {

--- a/modules/javafx.graphics/src/main/java/javafx/scene/paint/PhongMaterial.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/paint/PhongMaterial.java
@@ -431,7 +431,7 @@ import javafx.scene.shape.TriangleMesh;
  * @see Shape3D
  * @since JavaFX 8.0
  */
-public class PhongMaterial extends Material {
+public non-sealed class PhongMaterial extends Material {
 
     private boolean diffuseColorDirty = true;
     private boolean specularColorDirty = true;


### PR DESCRIPTION
The `Paint` and `Material` classes can't be extended by user code, because their implementations require special support in internal JavaFX code. The classes should be sealed.

/csr
/reviewers 2

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8346461](https://bugs.openjdk.org/browse/JDK-8346461) to be approved
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issues
 * [JDK-8346227](https://bugs.openjdk.org/browse/JDK-8346227): Seal Paint and Material (**Enhancement** - P4)
 * [JDK-8346461](https://bugs.openjdk.org/browse/JDK-8346461): Seal Paint and Material (**CSR**)


### Reviewers
 * [Nir Lisker](https://openjdk.org/census#nlisker) (@nlisker - **Reviewer**)
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1665/head:pull/1665` \
`$ git checkout pull/1665`

Update a local copy of the PR: \
`$ git checkout pull/1665` \
`$ git pull https://git.openjdk.org/jfx.git pull/1665/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1665`

View PR using the GUI difftool: \
`$ git pr show -t 1665`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1665.diff">https://git.openjdk.org/jfx/pull/1665.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1665#issuecomment-2542551066)
</details>
