### PR TITLE
8346281: [Windows] RenderScale doesn't update to HiDPI changes

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/win/GlassWindow.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/win/GlassWindow.cpp
@@ -209,6 +209,10 @@ LRESULT CALLBACK GlassWindow::CBTFilter(int nCode, WPARAM wParam, LPARAM lParam)
     return ::CallNextHookEx(GlassWindow::sm_hCBTFilter, nCode, wParam, lParam);
 }
 
+#ifndef USER_DEFAULT_SCREEN_DPI
+#define USER_DEFAULT_SCREEN_DPI 96
+#endif
+
 #ifndef WM_DPICHANGED
 #define WM_DPICHANGED       0x02E0
 #endif
@@ -359,6 +363,10 @@ LRESULT GlassWindow::WindowProc(UINT msg, WPARAM wParam, LPARAM lParam)
                     break;
             }
             HandleViewSizeEvent(GetHWND(), msg, wParam, lParam);
+            break;
+        case WM_DPICHANGED:
+            HandleDPIEvent(wParam, lParam);
+            GlassScreen::HandleDisplayChange();
             break;
         case WM_MOVING:
             m_winChangingReason = WasMoved;
@@ -739,6 +747,15 @@ void GlassWindow::HandleSizeEvent(int type, RECT *pRect)
 
     env->CallVoidMethod(m_grefThis, midNotifyResize,
                         type, pRect->right-pRect->left, pRect->bottom-pRect->top);
+    CheckAndClearException(env);
+}
+
+void GlassWindow::HandleDPIEvent(WPARAM wParam, LPARAM lParam)
+{
+    JNIEnv* env = GetEnv();
+    float scale = (float) LOWORD(wParam) / (float) USER_DEFAULT_SCREEN_DPI;
+
+    env->CallVoidMethod(m_grefThis, midNotifyScaleChanged, scale, scale, scale, scale);
     CheckAndClearException(env);
 }
 


### PR DESCRIPTION
This PR adds the missing native implementation for Windows `GlassWindow::HandleDPIEvent`, to notify the (Java) window when there is a DPI change event, which can happen when the user changes the resolution of the screen (via Settings -> System -> Display -> scale), while the JavaFX application is running.

When such `WM_DPICHANGED` event happens, `GlassWindow::HandleDPIEvent` notifies the (Java) window, which changes its platform scale via `Window::notifyScaleChanged`, and `GlassScreen::HandleDisplayChange();` is needed too, to update the platform scale of the screen where the window is at as well.

There are no tests added to this PR, since these would require manual intervention to change the display. In any case, the test case added to the [issue](https://bugs.openjdk.org/browse/JDK-8346281) runs fine now when the app runs on a given screen and the user changes its resolution. 

There is a follow-up issue after this PR, that might require a more complex fix, for the case where the user changes the resolution of a different screen that is placed before the one that has the application (as location coordinates of the latter depend on the former), because there is no `WM_DPICHANGED` event in this case.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8346281](https://bugs.openjdk.org/browse/JDK-8346281): [Windows] RenderScale doesn't update to HiDPI changes (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1668/head:pull/1668` \
`$ git checkout pull/1668`

Update a local copy of the PR: \
`$ git checkout pull/1668` \
`$ git pull https://git.openjdk.org/jfx.git pull/1668/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1668`

View PR using the GUI difftool: \
`$ git pr show -t 1668`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1668.diff">https://git.openjdk.org/jfx/pull/1668.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1668#issuecomment-2559441958)
</details>
