### PR TITLE
8315873: [GHA] Update checkout and cache action to use v4

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -99,7 +99,7 @@ jobs:
 # FIXME: enable cache for boot JDK
 #      - name: Restore boot JDK from cache
 #        id: bootjdk
-#        uses: actions/cache@v2
+#        uses: actions/cache@v4
 #        with:
 #          path: ~/bootjdk/${{ env.BOOT_JDK_VERSION }}
 #          key: bootjdk-${{ runner.os }}-${{ env.BOOT_JDK_VERSION }}-${{ env.BOOT_JDK_SHA256 }}-v1
@@ -184,7 +184,7 @@ jobs:
 # FIXME: enable cache for boot JDK
 #      - name: Restore boot JDK from cache
 #        id: bootjdk
-#        uses: actions/cache@v2
+#        uses: actions/cache@v4
 #        with:
 #          path: ~/bootjdk/${{ env.BOOT_JDK_VERSION }}
 #          key: bootjdk-${{ runner.os }}-${{ env.BOOT_JDK_VERSION }}-${{ env.BOOT_JDK_SHA256 }}-v1
@@ -270,7 +270,7 @@ jobs:
 # FIXME: enable cache for boot JDK
 #      - name: Restore boot JDK from cache
 #        id: bootjdk
-#        uses: actions/cache@v2
+#        uses: actions/cache@v4
 #        with:
 #          path: ~/bootjdk/${{ env.BOOT_JDK_VERSION }}
 #          key: bootjdk-${{ runner.os }}-${{ env.BOOT_JDK_VERSION }}-${{ env.BOOT_JDK_SHA256 }}-v1
@@ -347,7 +347,7 @@ jobs:
 # FIXME: enable cache for boot JDK
 #      - name: Restore boot JDK from cache
 #        id: bootjdk
-#        uses: actions/cache@v2
+#        uses: actions/cache@v4
 #        with:
 #          path: ~/bootjdk/${{ env.BOOT_JDK_VERSION }}
 #          key: bootjdk-${{ runner.os }}-${{ env.BOOT_JDK_VERSION }}-${{ env.BOOT_JDK_SHA256 }}-v1

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -362,7 +362,7 @@ jobs:
 
       - name: Restore cygwin packages from cache
         id: cygwin
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/cygwin/packages
           key: cygwin-packages-${{ runner.os }}-v1

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -58,7 +58,7 @@ jobs:
     name: "Gradle Wrapper Validation"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: gradle/wrapper-validation-action@v1
 
 
@@ -82,7 +82,7 @@ jobs:
 
     steps:
       - name: Checkout the source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: jfx
 
@@ -168,7 +168,7 @@ jobs:
 
     steps:
       - name: Checkout the source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: jfx
 
@@ -254,7 +254,7 @@ jobs:
 
     steps:
       - name: Checkout the source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: jfx
 
@@ -340,7 +340,7 @@ jobs:
 
     steps:
       - name: Checkout the source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: jfx
 


### PR DESCRIPTION
In GHA, the two actions `checkout` and `cache` need to be updated to version 4.

**Checkout action**

- The Node is updated to version 20.
- We do not explicitly specify node version
- But we use the action checkout, which should be updated to latest version as advised.
- With checkout@v4, GHA would use node 20.
- Although, apart from warning we may not see any real issue, as we don’t use node and don’t specify any version.
- End of life for Actions Node16 :  https://github.blog/changelog/2024-09-25-end-of-life-for-actions-node16/
- GitHub Actions: Transitioning from Node 16 to Node 20: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/
- Updated dates for Actions runner using Node20 instead of Node16 by default: https://github.blog/changelog/2024-05-17-updated-dates-for-actions-runner-using-node20-instead-of-node16-by-default/ 
- Action checkout version 4.00 Release note: https://github.com/actions/checkout/releases/tag/v4.0.0 

**Cache action**
- Currently we use action cache version 2, for Windows build
- Cache v1-v2 will be deprecated starting February 1st, 2025
- **Our workflow could start to FAIL on Windows, starting Feb 1st, 2025**
- Refer: Notice of upcoming deprecations and changes in GitHub Actions services: https://github.blog/changelog/2024-09-16-notice-of-upcoming-deprecations-and-changes-in-github-actions-services/
- Refer: Important changes under What’s new : https://github.com/actions/cache 


Verification:
1. The build should complete successfully on all platforms.
2. **cache action**: In GitHub actions, it showed a warning related to `cache` action: See the Windows x64 related warning on any recent build under actions tab : https://github.com/arapte/jfx/actions/runs/12428608806
**Warning message:**
`Your workflow is using a version of actions/cache that is scheduled for deprecation, actions/cache@v2. Please update your workflow to use the latest version of actions/cache to avoid interruptions. Learn more: https://github.blog/changelog/2024-09-16-notice-of-upcoming-deprecations-and-changes-in-github-actions-services/`
This warning disappears with this change: https://github.com/arapte/jfx/actions/runs/12581903371
3. **checkout action**: no specific check point.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315873](https://bugs.openjdk.org/browse/JDK-8315873): [GHA] Update checkout and cache action to use v4 (**Bug** - P3)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1669/head:pull/1669` \
`$ git checkout pull/1669`

Update a local copy of the PR: \
`$ git checkout pull/1669` \
`$ git pull https://git.openjdk.org/jfx.git pull/1669/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1669`

View PR using the GUI difftool: \
`$ git pr show -t 1669`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1669.diff">https://git.openjdk.org/jfx/pull/1669.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1669#issuecomment-2567765084)
</details>
