### PR TITLE
8347598: Change JavaFX release version to 25

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -24,7 +24,7 @@
 [general]
 project=openjfx
 jbs=jdk
-version=jfx24
+version=jfx25
 
 [repository]
 tags=(jdk-){0,1}([1-9]([0-9]*)(\.(0|[1-9][0-9]*)){0,3})(\+(([0-9]+))|(-ga))|[1-9]((\.\d{1,3}){0,2})-((b\d{2,3})|(ga))|[1-9]u(\d{1,3})-((b\d{2,3})|(ga))

--- a/build.properties
+++ b/build.properties
@@ -44,7 +44,7 @@ jfx.release.suffix=-ea
 jfx.experimental.feature.name=
 
 # UPDATE THE FOLLOWING VALUES FOR A NEW RELEASE
-jfx.release.major.version=24
+jfx.release.major.version=25
 jfx.release.minor.version=0
 jfx.release.security.version=0
 jfx.release.patch.version=0

--- a/modules/javafx.base/src/test/java/test/com/sun/javafx/runtime/VersionInfoTest.java
+++ b/modules/javafx.base/src/test/java/test/com/sun/javafx/runtime/VersionInfoTest.java
@@ -38,7 +38,7 @@ import static org.junit.jupiter.api.Assertions.*;
 public class VersionInfoTest {
 
     // Increment this feature-release counter for every major release.
-    private static final String FEATURE = "24";
+    private static final String FEATURE = "25";
 
     // The working directory at runtime is 'modules/javafx.base'.
     private static final String PROPERTIES_FILE = "build/module-lib/javafx.properties";


### PR DESCRIPTION
Bump the version number of JavaFX to 25. I will integrate this to master as part of forking the jfx24 stabilization branch, which is scheduled for Thursday, January 16, 2025 at 16:00 UTC.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347598](https://bugs.openjdk.org/browse/JDK-8347598): Change JavaFX release version to 25 (**Task** - P2)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Johan Vos](https://openjdk.org/census#jvos) (@johanvos - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1673/head:pull/1673` \
`$ git checkout pull/1673`

Update a local copy of the PR: \
`$ git checkout pull/1673` \
`$ git pull https://git.openjdk.org/jfx.git pull/1673/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1673`

View PR using the GUI difftool: \
`$ git pr show -t 1673`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1673.diff">https://git.openjdk.org/jfx/pull/1673.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1673#issuecomment-2587598797)
</details>
