### PR TITLE
8170720: VetoableListDecorator: Indexes to remove are not aggregated

### DIFF
--- a/modules/javafx.base/src/main/java/com/sun/javafx/collections/VetoableListDecorator.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/collections/VetoableListDecorator.java
@@ -134,8 +134,8 @@ public abstract class VetoableListDecorator<E> implements ObservableList<E> {
                     toBeRemoved[pointer + 2] = offset + i + 1;
                     pointer += 2;
                 } else {
-                    if (toBeRemoved[pointer - 1] == offset + i) {
-                        toBeRemoved[pointer - 1] = offset + i + 1;
+                    if (toBeRemoved[pointer] == offset + i) {
+                        toBeRemoved[pointer] = offset + i + 1;
                     } else {
                         int[] tmp = new int[toBeRemoved.length + 2];
                         System.arraycopy(toBeRemoved, 0, tmp, 0, toBeRemoved.length);

--- a/modules/javafx.base/src/test/java/test/javafx/collections/VetoableObservableListTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/collections/VetoableObservableListTest.java
@@ -233,12 +233,36 @@ public class VetoableObservableListTest {
     public void testRemoveAll() {
         list.removeAll(Arrays.asList("bar", "eggs", "foobar"));
         assertSingleCall(new String[0], new int[] {1,2,3,4});
+
+        list.setAll("a", "b", "c", "d", "e", "f");
+        calls.clear();
+        list.removeAll(List.of("b", "c", "d"));
+        assertEquals(List.of("a", "e", "f"), list);
+        assertSingleCall(new String[0], new int[] {1, 4});
+
+        list.setAll("a", "b", "c", "d", "e", "f");
+        calls.clear();
+        list.removeAll(List.of("a", "b", "d", "e", "f"));
+        assertEquals(List.of("c"), list);
+        assertSingleCall(new String[0], new int[] {0, 2, 3, 6});
     }
 
     @Test
     public void testRetainAll() {
         list.retainAll(Arrays.asList("foo", "barfoo", "ham"));
         assertSingleCall(new String[0], new int[] {1,2,3,4});
+
+        list.setAll("a", "b", "c", "d", "e", "f");
+        calls.clear();
+        list.retainAll(List.of("a", "f"));
+        assertEquals(List.of("a", "f"), list);
+        assertSingleCall(new String[0], new int[] {1, 5});
+
+        list.setAll("a", "b", "c", "d", "e", "f");
+        calls.clear();
+        list.retainAll(List.of("c"));
+        assertEquals(List.of("c"), list);
+        assertSingleCall(new String[0], new int[] {0, 2, 3, 6});
     }
 
     @Test


### PR DESCRIPTION
`VetoableListDecorator` does not correctly report removed indices. Instead of reporting ranges like `[0, 3)`, it always reports a pairwise list of single removals like `[0, 1, 1, 2, 2, 3)`.

The reason is a off-by-one error, and the fix is simple.

/reviewers 2

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8170720](https://bugs.openjdk.org/browse/JDK-8170720): VetoableListDecorator: Indexes to remove are not aggregated (**Bug** - P3)


### Reviewers
 * [Lukasz Kostyra](https://openjdk.org/census#lkostyra) (@lukostyra - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1675/head:pull/1675` \
`$ git checkout pull/1675`

Update a local copy of the PR: \
`$ git checkout pull/1675` \
`$ git pull https://git.openjdk.org/jfx.git pull/1675/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1675`

View PR using the GUI difftool: \
`$ git pr show -t 1675`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1675.diff">https://git.openjdk.org/jfx/pull/1675.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1675#issuecomment-2588617589)
</details>
