### PR TITLE
8347715: RichTextArea Follow-up: Minor Bugs

### DIFF
--- a/modules/jfx.incubator.richtext/src/main/java/com/sun/jfx/incubator/scene/control/richtext/VFlow.java
+++ b/modules/jfx.incubator.richtext/src/main/java/com/sun/jfx/incubator/scene/control/richtext/VFlow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -603,9 +603,6 @@ public class VFlow extends Pane implements StyleResolver, StyledTextModel.Listen
 
     public final void updateRateRestartBlink() {
         Duration t2 = control.getCaretBlinkPeriod();
-        if (t2 == null) {
-            t2 = Params.DEFAULT_CARET_BLINK_PERIOD;
-        }
         Duration t1 = t2.divide(2.0);
 
         caretAnimation.stop();

--- a/modules/jfx.incubator.richtext/src/main/java/com/sun/jfx/incubator/scene/control/richtext/VFlow.java
+++ b/modules/jfx.incubator.richtext/src/main/java/com/sun/jfx/incubator/scene/control/richtext/VFlow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -603,6 +603,9 @@ public class VFlow extends Pane implements StyleResolver, StyledTextModel.Listen
 
     public final void updateRateRestartBlink() {
         Duration t2 = control.getCaretBlinkPeriod();
+        if (t2 == null) {
+            t2 = Params.DEFAULT_CARET_BLINK_PERIOD;
+        }
         Duration t1 = t2.divide(2.0);
 
         caretAnimation.stop();

--- a/modules/jfx.incubator.richtext/src/main/java/jfx/incubator/scene/control/richtext/RichTextArea.java
+++ b/modules/jfx.incubator.richtext/src/main/java/jfx/incubator/scene/control/richtext/RichTextArea.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -385,13 +385,13 @@ public class RichTextArea extends Control {
     }
 
     /**
-     * Determines the caret blink period.  This property cannot be set to {@code null}.
+     * Determines the caret blink period.  A {@code null} value will be interpreted as 1000 ms.
      * <p>
      * This property can be styled with CSS using {@code -fx-caret-blink-period} name.
      * @implNote The property object implements {@link StyleableProperty} interface.
      *
      * @return the caret blink period property
-     * @defaultValue 1000 ms
+     * @defaultValue null
      */
     public final ObjectProperty<Duration> caretBlinkPeriodProperty() {
         if (caretBlinkPeriod == null) {
@@ -399,20 +399,8 @@ public class RichTextArea extends Control {
                 StyleableProperties.CARET_BLINK_PERIOD,
                 this,
                 "caretBlinkPeriod",
-                Params.DEFAULT_CARET_BLINK_PERIOD
-            ) {
-                private Duration old;
-
-                @Override
-                public void invalidated() {
-                    final Duration v = get();
-                    if (v == null) {
-                        set(old);
-                        throw new NullPointerException("cannot set caretBlinkPeriodProperty to null");
-                    }
-                    old = v;
-                }
-            };
+                null
+            );
         }
         return caretBlinkPeriod;
     }
@@ -422,7 +410,7 @@ public class RichTextArea extends Control {
     }
 
     public final Duration getCaretBlinkPeriod() {
-        return caretBlinkPeriod == null ? Params.DEFAULT_CARET_BLINK_PERIOD : caretBlinkPeriod.get();
+        return caretBlinkPeriod == null ? null : caretBlinkPeriod.get();
     }
 
     /**
@@ -826,7 +814,7 @@ public class RichTextArea extends Control {
     }
 
     public final void setUseContentHeight(boolean on) {
-        useContentHeightProperty().set(true);
+        useContentHeightProperty().set(on);
     }
 
     /**
@@ -866,7 +854,7 @@ public class RichTextArea extends Control {
     }
 
     public final void setUseContentWidth(boolean on) {
-        useContentWidthProperty().set(true);
+        useContentWidthProperty().set(on);
     }
 
     /**

--- a/modules/jfx.incubator.richtext/src/main/java/jfx/incubator/scene/control/richtext/RichTextArea.java
+++ b/modules/jfx.incubator.richtext/src/main/java/jfx/incubator/scene/control/richtext/RichTextArea.java
@@ -385,13 +385,13 @@ public class RichTextArea extends Control {
     }
 
     /**
-     * Determines the caret blink period.  A {@code null} value will be interpreted as 1000 ms.
+     * Determines the caret blink period.  This property cannot be set to {@code null}.
      * <p>
      * This property can be styled with CSS using {@code -fx-caret-blink-period} name.
      * @implNote The property object implements {@link StyleableProperty} interface.
      *
      * @return the caret blink period property
-     * @defaultValue null
+     * @defaultValue 1000 ms
      */
     public final ObjectProperty<Duration> caretBlinkPeriodProperty() {
         if (caretBlinkPeriod == null) {
@@ -399,8 +399,20 @@ public class RichTextArea extends Control {
                 StyleableProperties.CARET_BLINK_PERIOD,
                 this,
                 "caretBlinkPeriod",
-                null
-            );
+                Params.DEFAULT_CARET_BLINK_PERIOD
+            ) {
+                private Duration old;
+
+                @Override
+                public void invalidated() {
+                    final Duration v = get();
+                    if (v == null) {
+                        set(old);
+                        throw new NullPointerException("cannot set caretBlinkPeriodProperty to null");
+                    }
+                    old = v;
+                }
+            };
         }
         return caretBlinkPeriod;
     }
@@ -410,7 +422,7 @@ public class RichTextArea extends Control {
     }
 
     public final Duration getCaretBlinkPeriod() {
-        return caretBlinkPeriod == null ? null : caretBlinkPeriod.get();
+        return caretBlinkPeriod == null ? Params.DEFAULT_CARET_BLINK_PERIOD : caretBlinkPeriod.get();
     }
 
     /**


### PR DESCRIPTION
Found during writing the API tests:

- setUseContentHeight/Width (true -> on)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347715](https://bugs.openjdk.org/browse/JDK-8347715): RichTextArea Follow-up: Minor Bugs (**Bug** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1676/head:pull/1676` \
`$ git checkout pull/1676`

Update a local copy of the PR: \
`$ git checkout pull/1676` \
`$ git pull https://git.openjdk.org/jfx.git pull/1676/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1676`

View PR using the GUI difftool: \
`$ git pr show -t 1676`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1676.diff">https://git.openjdk.org/jfx/pull/1676.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1676#issuecomment-2590333334)
</details>
