### PR TITLE
8347752: Running RichTextArea demos via ant on JDK 24 prints warnings

### DIFF
--- a/apps/samples/RichTextAreaDemo/build.xml
+++ b/apps/samples/RichTextAreaDemo/build.xml
@@ -77,28 +77,28 @@ unless built as a part of openjfx repository where the default value is sufficie
 
 	<target name="run-codearea-demo">
 		<exec executable="java">
-			<arg line="--module-path '${javafx.home}/lib' --add-modules 'javafx.base,javafx.graphics,javafx.controls,jfx.incubator.input,jfx.incubator.richtext' -classpath 'dist/${TARGET}.jar' com.oracle.demo.richtext.codearea.CodeAreaDemoApp" />
+			<arg line="--module-path '${javafx.home}/lib' --add-modules 'javafx.base,javafx.graphics,javafx.controls,jfx.incubator.input,jfx.incubator.richtext' -classpath 'dist/${TARGET}.jar' --enable-native-access=javafx.graphics --sun-misc-unsafe-memory-access=allow com.oracle.demo.richtext.codearea.CodeAreaDemoApp" />
 		</exec>
 	</target>
 
 
 	<target name="run-notebook-demo">
 		<exec executable="java">
-			<arg line="--module-path '${javafx.home}/lib' --add-modules 'javafx.base,javafx.graphics,javafx.controls,jfx.incubator.input,jfx.incubator.richtext' -classpath 'dist/${TARGET}.jar' com.oracle.demo.richtext.notebook.NotebookMockupApp" />
+			<arg line="--module-path '${javafx.home}/lib' --add-modules 'javafx.base,javafx.graphics,javafx.controls,jfx.incubator.input,jfx.incubator.richtext' -classpath 'dist/${TARGET}.jar' --enable-native-access=javafx.graphics --sun-misc-unsafe-memory-access=allow com.oracle.demo.richtext.notebook.NotebookMockupApp" />
 		</exec>
 	</target>
 
 
 	<target name="run-richeditor-demo">
 		<exec executable="java">
-			<arg line="--module-path ${javafx.home}/lib --add-modules javafx.base,javafx.graphics,javafx.controls,jfx.incubator.input,jfx.incubator.richtext -classpath dist/${TARGET}.jar com.oracle.demo.richtext.editor.RichEditorDemoApp" />
+			<arg line="--module-path ${javafx.home}/lib --add-modules javafx.base,javafx.graphics,javafx.controls,jfx.incubator.input,jfx.incubator.richtext -classpath dist/${TARGET}.jar --enable-native-access=javafx.graphics --sun-misc-unsafe-memory-access=allow com.oracle.demo.richtext.editor.RichEditorDemoApp" />
 		</exec>
 	</target>
 
 
 	<target name="run-richtextarea-demo">
 		<exec executable="java">
-			<arg line="--module-path ${javafx.home}/lib --add-modules javafx.base,javafx.graphics,javafx.controls,jfx.incubator.input,jfx.incubator.richtext -classpath dist/${TARGET}.jar com.oracle.demo.richtext.rta.RichTextAreaDemoApp" />
+			<arg line="--module-path ${javafx.home}/lib --add-modules javafx.base,javafx.graphics,javafx.controls,jfx.incubator.input,jfx.incubator.richtext -classpath dist/${TARGET}.jar --enable-native-access=javafx.graphics --sun-misc-unsafe-memory-access=allow com.oracle.demo.richtext.rta.RichTextAreaDemoApp" />
 		</exec>
 	</target>
 


### PR DESCRIPTION
added
```
--enable-native-access=javafx.graphics --sun-misc-unsafe-memory-access=allow
```
flags to the command line which starts the demos.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347752](https://bugs.openjdk.org/browse/JDK-8347752): Running RichTextArea demos via ant on JDK 24 prints warnings (**Bug** - P4)


### Reviewers
 * [Lukasz Kostyra](https://openjdk.org/census#lkostyra) (@lukostyra - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1678/head:pull/1678` \
`$ git checkout pull/1678`

Update a local copy of the PR: \
`$ git checkout pull/1678` \
`$ git pull https://git.openjdk.org/jfx.git pull/1678/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1678`

View PR using the GUI difftool: \
`$ git pr show -t 1678`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1678.diff">https://git.openjdk.org/jfx/pull/1678.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1678#issuecomment-2591342463)
</details>
