### PR TITLE
Merge ecec2645a99a9c1343ddf08c4009df578d5b2165

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -24,7 +24,7 @@
 [general]
 project=openjfx
 jbs=jdk
-version=jfx24
+version=jfx25
 
 [repository]
 tags=(jdk-){0,1}([1-9]([0-9]*)(\.(0|[1-9][0-9]*)){0,3})(\+(([0-9]+))|(-ga))|[1-9]((\.\d{1,3}){0,2})-((b\d{2,3})|(ga))|[1-9]u(\d{1,3})-((b\d{2,3})|(ga))

--- a/build.properties
+++ b/build.properties
@@ -44,7 +44,7 @@ jfx.release.suffix=-ea
 jfx.experimental.feature.name=
 
 # UPDATE THE FOLLOWING VALUES FOR A NEW RELEASE
-jfx.release.major.version=24
+jfx.release.major.version=25
 jfx.release.minor.version=0
 jfx.release.security.version=0
 jfx.release.patch.version=0

--- a/modules/javafx.base/src/test/java/test/com/sun/javafx/runtime/VersionInfoTest.java
+++ b/modules/javafx.base/src/test/java/test/com/sun/javafx/runtime/VersionInfoTest.java
@@ -38,7 +38,7 @@ import static org.junit.jupiter.api.Assertions.*;
 public class VersionInfoTest {
 
     // Increment this feature-release counter for every major release.
-    private static final String FEATURE = "24";
+    private static final String FEATURE = "25";
 
     // The working directory at runtime is 'modules/javafx.base'.
     private static final String PROPERTIES_FILE = "build/module-lib/javafx.properties";

--- a/modules/javafx.media/src/main/java/com/sun/media/jfxmediaimpl/MetadataParserImpl.java
+++ b/modules/javafx.media/src/main/java/com/sun/media/jfxmediaimpl/MetadataParserImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -108,6 +108,10 @@ public abstract class MetadataParserImpl extends Thread implements com.sun.media
         metadata.put(tag, value);
     }
 
+    protected void disposeMetadata() {
+        metadata.clear();
+    }
+
     protected void done() {
         synchronized (listeners) {
             if (!metadata.isEmpty()) {
@@ -128,6 +132,10 @@ public abstract class MetadataParserImpl extends Thread implements com.sun.media
             return rawMetaBlob.position();
         }
         return streamPosition;
+    }
+
+    protected long getStreamLength() {
+        return locator.getContentLength();
     }
 
     protected void startRawMetadata(int sizeHint) {


### PR DESCRIPTION
Clean merge of January CPU content into ~~jfx:master~~ `jfx:jfx24`.

Reviewer: @johanvos

/reviewers 1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Reviewers
 * [Johan Vos](https://openjdk.org/census#jvos) (@johanvos - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1680/head:pull/1680` \
`$ git checkout pull/1680`

Update a local copy of the PR: \
`$ git checkout pull/1680` \
`$ git pull https://git.openjdk.org/jfx.git pull/1680/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1680`

View PR using the GUI difftool: \
`$ git pr show -t 1680`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1680.diff">https://git.openjdk.org/jfx/pull/1680.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1680#issuecomment-2605109973)
</details>
