### PR TITLE
8340693: [TestBug] Format Error in USKeyboardTest

### DIFF
--- a/tests/system/src/test/java/test/robot/com/sun/glass/ui/monocle/USKeyboardTest.java
+++ b/tests/system/src/test/java/test/robot/com/sun/glass/ui/monocle/USKeyboardTest.java
@@ -114,7 +114,7 @@ public class USKeyboardTest {
             ui.processLine("EV_SYN");
             TestLogShim.waitForLog("Key released: SHIFT");
         }
-        TestLogShim.waitForLog("Key typed: %0$c", new Object[] { c });
+        TestLogShim.waitForLog("Key typed: %1$c", new Object[] { c });
     }
 
     /**


### PR DESCRIPTION
The USKeyboardTest tests were failing with IllegalFormatArgumentIndexException at index 0, in java.util.Formatter the first argument is referred to as 1$ not 0$ .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340693](https://bugs.openjdk.org/browse/JDK-8340693): [TestBug] Format Error in USKeyboardTest (**Bug** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1683/head:pull/1683` \
`$ git checkout pull/1683`

Update a local copy of the PR: \
`$ git checkout pull/1683` \
`$ git pull https://git.openjdk.org/jfx.git pull/1683/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1683`

View PR using the GUI difftool: \
`$ git pr show -t 1683`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1683.diff">https://git.openjdk.org/jfx/pull/1683.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1683#issuecomment-2622476772)
</details>
