### PR TITLE
8348744: Application window not always activated on macOS 15

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
@@ -283,11 +283,8 @@ jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved)
         // but it doesn't get activated, so this is needed:
         LOG("-> need to active application");
         dispatch_async(dispatch_get_main_queue(), ^{
-            [NSApp performSelector: @selector(activate)];
+            [NSApp activateIgnoringOtherApps:YES];
         });
-        // TODO: performSelector is used only to avoid a compiler
-        // warning with the 13.3 SDK. After updating to SDK 14
-        // this can be converted to a standard call.
     }
 }
 


### PR DESCRIPTION
The fix for [JDK-8319066](https://bugs.openjdk.org/browse/JDK-8319066) added a needed call to activate a JavaFX window on macOS 14 or later via `[NSApp activate]`. In macOS 15, this doesn't always activate the window; even on macOS 14 there are certain cases where it might not. In all other places where we need to activate a window we call `[NSApp activateIgnoringOtherApps:YES]`. This is also what AWT uses in all places.

The fix is to replace the call to `activate` with a call to `activateIgnoringOtherApps`. I ran a full set of headful tests on macOS 15, 14, and 13 (although the code is not executed on  macOS 13), and everything looks good on my end.

Worth noting is that `NSApp::activateIgnoringOtherApps` is deprecated as of MacOS SDK 14, which means that we might have problems in the future when we update the Xcode toolchain (or if they eventually degrade it so that the `ignoringOtherApps` part of this call stops doing anything), but that will be a problem we need to address anyway, affecting other places in  JavaFX and AWT.

I intend to backported this fix to `jfx24` after it is integrated into mainline (for 25).

/reviewers 2

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8348744](https://bugs.openjdk.org/browse/JDK-8348744): Application window not always activated on macOS 15 (**Bug** - P3)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Jose Pereda](https://openjdk.org/census#jpereda) (@jperedadnr - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1685/head:pull/1685` \
`$ git checkout pull/1685`

Update a local copy of the PR: \
`$ git checkout pull/1685` \
`$ git pull https://git.openjdk.org/jfx.git pull/1685/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1685`

View PR using the GUI difftool: \
`$ git pr show -t 1685`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1685.diff">https://git.openjdk.org/jfx/pull/1685.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1685#issuecomment-2618893565)
</details>
