### PR TITLE
8348744: Application window not always activated on macOS 15

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
@@ -283,11 +283,8 @@ jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved)
         // but it doesn't get activated, so this is needed:
         LOG("-> need to active application");
         dispatch_async(dispatch_get_main_queue(), ^{
-            [NSApp performSelector: @selector(activate)];
+            [NSApp activateIgnoringOtherApps:YES];
         });
-        // TODO: performSelector is used only to avoid a compiler
-        // warning with the 13.3 SDK. After updating to SDK 14
-        // this can be converted to a standard call.
     }
 }
 


### PR DESCRIPTION
Clean backport of macOS 15 activation fix to the `jfx24` stabilization branch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8348744](https://bugs.openjdk.org/browse/JDK-8348744): Application window not always activated on macOS 15 (**Bug** - P3)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1687/head:pull/1687` \
`$ git checkout pull/1687`

Update a local copy of the PR: \
`$ git checkout pull/1687` \
`$ git pull https://git.openjdk.org/jfx.git pull/1687/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1687`

View PR using the GUI difftool: \
`$ git pr show -t 1687`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1687.diff">https://git.openjdk.org/jfx/pull/1687.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1687#issuecomment-2621730639)
</details>
