### PR TITLE
8348736: RichTextArea clamp and getText

### DIFF
--- a/modules/jfx.incubator.richtext/src/main/java/jfx/incubator/scene/control/richtext/CodeArea.java
+++ b/modules/jfx.incubator.richtext/src/main/java/jfx/incubator/scene/control/richtext/CodeArea.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,8 @@
  */
 package jfx.incubator.scene.control.richtext;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.List;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.DoubleProperty;
@@ -45,6 +47,7 @@ import javafx.scene.Node;
 import javafx.scene.control.Labeled;
 import javafx.scene.text.Font;
 import com.sun.jfx.incubator.scene.control.richtext.Params;
+import com.sun.jfx.incubator.scene.control.richtext.StringBuilderStyledOutput;
 import com.sun.jfx.incubator.scene.control.richtext.util.RichUtils;
 import jfx.incubator.scene.control.richtext.model.CodeTextModel;
 import jfx.incubator.scene.control.richtext.model.StyledTextModel;
@@ -413,20 +416,23 @@ public class CodeArea extends RichTextArea {
     }
 
     /**
-     * Returns plain text.
+     * Returns plain text.  This method returns an empty string when the model is {@code null}.
      * @return plain text
      */
     public final String getText() {
-        // TODO or use save(DataFormat, Writer) ?
         StyledTextModel m = getModel();
-        StringBuilder sb = new StringBuilder(4096);
-        int sz = m.size();
-        for(int i=0; i<sz; i++) {
-            String s = m.getPlainText(i);
-            sb.append(s);
-            sb.append('\n');
+        if (m == null) {
+            return "";
         }
-        return sb.toString();
+        TextPos end = m.getDocumentEnd();
+        try (StringBuilderStyledOutput out = new StringBuilderStyledOutput()) {
+            out.setLineSeparator("\n");
+            m.export(TextPos.ZERO, end, out);
+            return out.toString();
+        } catch (IOException e) {
+            // should not happen
+            throw new UncheckedIOException(e);
+        }
     }
 
     /**

--- a/modules/jfx.incubator.richtext/src/main/java/jfx/incubator/scene/control/richtext/model/StyledTextModel.java
+++ b/modules/jfx.incubator.richtext/src/main/java/jfx/incubator/scene/control/richtext/model/StyledTextModel.java
@@ -550,24 +550,30 @@ public abstract class StyledTextModel {
      */
     public final TextPos clamp(TextPos p) {
         Objects.nonNull(p);
+        int len;
         int ct = size();
         int ix = p.index();
         if (ix < 0) {
             return TextPos.ZERO;
         } else if (ix < ct) {
-            int len = getParagraphLength(ix);
+            len = getParagraphLength(ix);
             if (p.offset() < len) {
                 return p;
             }
-            return TextPos.ofLeading(ix, len);
         } else {
             if (ct == 0) {
                 return TextPos.ZERO;
             } else {
                 ix = ct - 1;
-                int len = getParagraphLength(ix);
-                return TextPos.ofLeading(ix, len);
+                len = getParagraphLength(ix);
             }
+        }
+
+        int cix = len - 1;
+        if (cix < 0) {
+            return TextPos.ofLeading(ix, len);
+        } else {
+            return new TextPos(ix, len, cix, false);
         }
     }
 

--- a/modules/jfx.incubator.richtext/src/test/addExports
+++ b/modules/jfx.incubator.richtext/src/test/addExports
@@ -1,6 +1,7 @@
 --add-exports javafx.base/com.sun.javafx=ALL-UNNAMED
 #
 --add-exports javafx.graphics/com.sun.javafx.application=ALL-UNNAMED
+--add-exports javafx.graphics/com.sun.javafx.font=ALL-UNNAMED
 --add-exports javafx.graphics/com.sun.javafx.geom=ALL-UNNAMED
 --add-exports javafx.graphics/com.sun.javafx.perf=ALL-UNNAMED
 --add-exports javafx.graphics/com.sun.javafx.scene.text=ALL-UNNAMED

--- a/modules/jfx.incubator.richtext/src/test/java/test/jfx/incubator/scene/control/richtext/CodeAreaTest.java
+++ b/modules/jfx.incubator.richtext/src/test/java/test/jfx/incubator/scene/control/richtext/CodeAreaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package test.jfx.incubator.scene.control.richtext;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -32,18 +33,23 @@ import org.junit.jupiter.api.Test;
 import jfx.incubator.scene.control.richtext.CodeArea;
 import jfx.incubator.scene.control.richtext.model.CodeTextModel;
 import jfx.incubator.scene.control.richtext.model.RichTextModel;
+import jfx.incubator.scene.control.richtext.skin.CodeAreaSkin;
 
 /**
  * Tests CodeArea.
  */
 public class CodeAreaTest {
+    private CodeArea control;
+
     @BeforeEach
     public void beforeEach() {
         setUncaughtExceptionHandler();
+        control = new CodeArea();
+        control.setSkin(new CodeAreaSkin(control));
     }
 
     @AfterEach
-    public void cleanup() {
+    public void afterEach() {
         removeUncaughtExceptionHandler();
     }
 
@@ -59,6 +65,29 @@ public class CodeAreaTest {
 
     private void removeUncaughtExceptionHandler() {
         Thread.currentThread().setUncaughtExceptionHandler(null);
+    }
+
+    @Test
+    public void getText() {
+        control.setText("123");
+        String s = control.getText();
+        assertEquals("123", s);
+
+        control.setText(null);
+        s = control.getText();
+        assertEquals("", s);
+
+        control.setText("1\n2\n3\n4");
+        s = control.getText();
+        assertEquals("1\n2\n3\n4", s);
+
+        control.setText("1\r\n2\r\n3\r\n4");
+        s = control.getText();
+        assertEquals("1\n2\n3\n4", s);
+
+        control.setModel(null);
+        s = control.getText();
+        assertEquals("", s);
     }
 
     /** can set a null and non-null CodeTextModel */

--- a/modules/jfx.incubator.richtext/src/test/java/test/jfx/incubator/scene/control/richtext/RichTextAreaTest.java
+++ b/modules/jfx.incubator.richtext/src/test/java/test/jfx/incubator/scene/control/richtext/RichTextAreaTest.java
@@ -23,17 +23,61 @@
  * questions.
  */
 
-package test.com.sun.jfx.incubator.scene.control.richtext;
+package test.jfx.incubator.scene.control.richtext;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import com.sun.jfx.incubator.scene.control.richtext.VFlow;
 import jfx.incubator.scene.control.richtext.RichTextArea;
 import jfx.incubator.scene.control.richtext.RichTextAreaShim;
+import jfx.incubator.scene.control.richtext.SelectionSegment;
+import jfx.incubator.scene.control.richtext.TextPos;
+import jfx.incubator.scene.control.richtext.model.StyleAttributeMap;
+import jfx.incubator.scene.control.richtext.skin.RichTextAreaSkin;
 
 /**
  * Tests RichTextArea control.
  */
-public class TestRichTextArea {
+public class RichTextAreaTest {
+    private RichTextArea control;
+
+    @BeforeEach
+    public void beforeEach() {
+        control = new RichTextArea();
+        control.setSkin(new RichTextAreaSkin(control));
+    }
+
+    @AfterEach
+    public void afterEach() {
+    }
+
+    @Test
+    public void execute() {
+        control.appendText("a");
+        control.execute(RichTextArea.Tag.SELECT_ALL);
+
+        SelectionSegment sel = control.getSelection();
+        TextPos end = control.getDocumentEnd();
+        assertNotNull(end);
+        assertEquals(TextPos.ZERO, sel.getMin());
+        assertEquals(end, sel.getMax());
+    }
+
+    @Test
+    public void selectAll() {
+        control.appendText("a");
+        control.selectAll();
+
+        SelectionSegment sel = control.getSelection();
+        TextPos end = control.getDocumentEnd();
+        assertNotNull(end);
+        assertEquals(TextPos.ZERO, sel.getMin());
+        assertEquals(end, sel.getMax());
+    }
+
     /**
      * Tests the shim.
      */

--- a/modules/jfx.incubator.richtext/src/test/java/test/jfx/incubator/scene/control/richtext/model/TestRichTextModel.java
+++ b/modules/jfx.incubator.richtext/src/test/java/test/jfx/incubator/scene/control/richtext/model/TestRichTextModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package test.jfx.incubator.scene.control.richtext.model;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
@@ -35,7 +36,6 @@ import jfx.incubator.scene.control.richtext.TextPos;
 import jfx.incubator.scene.control.richtext.model.RichParagraph;
 import jfx.incubator.scene.control.richtext.model.RichTextModel;
 import jfx.incubator.scene.control.richtext.model.RichTextModelShim;
-import jfx.incubator.scene.control.richtext.model.StyleAttribute;
 import jfx.incubator.scene.control.richtext.model.StyleAttributeMap;
 import jfx.incubator.scene.control.richtext.model.StyledInput;
 import jfx.incubator.scene.control.richtext.model.StyledSegment;
@@ -252,5 +252,24 @@ public class TestRichTextModel {
         }
 
         return null;
+    }
+
+    private RichTextModel createModel(String text) {
+        RichTextModel m = new RichTextModel();
+        m.replace(null, TextPos.ZERO, TextPos.ZERO, text, false);
+        return m;
+    }
+
+    @Test
+    public void clamp() {
+        RichTextModel m = createModel("1\n2222\n");
+        assertEquals(TextPos.ofLeading(0, 0), m.clamp(TextPos.ofLeading(0, 0)));
+        assertEquals(new TextPos(0, 1, 0, false), m.clamp(TextPos.ofLeading(0, 100)));
+
+        assertEquals(TextPos.ofLeading(1, 0), m.clamp(TextPos.ofLeading(1, 0)));
+        assertEquals(TextPos.ofLeading(1, 1), m.clamp(TextPos.ofLeading(1, 1)));
+        assertEquals(new TextPos(1, 4, 3, false), m.clamp(TextPos.ofLeading(1, 100)));
+
+        assertEquals(TextPos.ofLeading(2, 0), m.clamp(TextPos.ofLeading(2, 100)));
     }
 }


### PR DESCRIPTION
Clean backport of RichTextArea clamp and getText fix to the jfx24 stabilization branch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8348736](https://bugs.openjdk.org/browse/JDK-8348736): RichTextArea clamp and getText (**Bug** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1688/head:pull/1688` \
`$ git checkout pull/1688`

Update a local copy of the PR: \
`$ git checkout pull/1688` \
`$ git pull https://git.openjdk.org/jfx.git pull/1688/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1688`

View PR using the GUI difftool: \
`$ git pr show -t 1688`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1688.diff">https://git.openjdk.org/jfx/pull/1688.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1688#issuecomment-2622398743)
</details>
