### PR TITLE
8348895: [testbug] Skip failing 3D lighting tests on macOS 14 or later on aarch64

### DIFF
--- a/tests/system/src/test/java/test/robot/test3d/PointLightIlluminationTest.java
+++ b/tests/system/src/test/java/test/robot/test3d/PointLightIlluminationTest.java
@@ -68,17 +68,37 @@ public class PointLightIlluminationTest extends VisualTestBase {
     private static final double COLOR_TOLERANCE    = 0.07;
     private static volatile Scene testScene = null;
 
-    // Used to skip failing tests until JDK-8318985 is fixed
+    // Used to skip failing tests on macOS 14 or later on aarch64 until JDK-8318985 is fixed
     private boolean isMacAarch64MacOS14;
+
+    private static int getFirstInt(String input) {
+        String str = input;
+        if (str == null) {
+            return -1;
+        }
+        str = str.trim();
+        if (str.isEmpty() || !Character.isDigit(str.charAt(0))) {
+            return -1;
+        }
+        str = str.split("\\D+")[0];
+        return Integer.parseInt(str);
+    }
 
     @BeforeEach
     public void setupEach() {
         assumeTrue(Platform.isSupported(ConditionalFeature.SCENE3D));
+
         // JDK-8318985
-        isMacAarch64MacOS14 = PlatformUtil.isMac() &&
-                "aarch64".equals(System.getProperty("os.arch")) &&
-                System.getProperty("os.version") != null &&
-                System.getProperty("os.version").startsWith("14");
+        isMacAarch64MacOS14 = false;
+        if (PlatformUtil.isMac() &&
+                "aarch64".equals(System.getProperty("os.arch"))) {
+
+            int majorVer = getFirstInt(System.getProperty("os.version"));
+            if (majorVer >= 14) {
+                isMacAarch64MacOS14 = true;
+            }
+        }
+
         // Use the same test scene for all tests
         if (testScene == null) {
             runAndWait(() -> {


### PR DESCRIPTION
Clean backport to the `jfx24` stabilization branch of test fix to exclude lighting tests on macOS 14+ (aarch64)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8348895](https://bugs.openjdk.org/browse/JDK-8348895): [testbug] Skip failing 3D lighting tests on macOS 14 or later on aarch64 (**Bug** - P3)


### Reviewers
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1689/head:pull/1689` \
`$ git checkout pull/1689`

Update a local copy of the PR: \
`$ git checkout pull/1689` \
`$ git pull https://git.openjdk.org/jfx.git pull/1689/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1689`

View PR using the GUI difftool: \
`$ git pr show -t 1689`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1689.diff">https://git.openjdk.org/jfx/pull/1689.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1689#issuecomment-2622457545)
</details>
