### PR TITLE
8348423: [TestBug] stress test Nodes initialization from a background thread

### DIFF
--- a/tests/system/src/test/java/test/robot/javafx/scene/NodeInitializationBackgroundThreadTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/NodeInitializationBackgroundThreadTest.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package test.robot.javafx.scene;
+
+import static org.junit.jupiter.api.Assertions.fail;
+import java.time.LocalDate;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import javafx.application.Platform;
+import javafx.geometry.Point2D;
+import javafx.geometry.Pos;
+import javafx.scene.Node;
+import javafx.scene.control.Accordion;
+import javafx.scene.control.DatePicker;
+import javafx.scene.control.Label;
+import javafx.scene.control.PasswordField;
+import javafx.scene.control.TextArea;
+import javafx.scene.control.TextField;
+import javafx.scene.control.TextInputControl;
+import javafx.scene.control.TitledPane;
+import javafx.scene.control.Tooltip;
+import javafx.scene.control.skin.AccordionSkin;
+import javafx.scene.control.skin.DatePickerSkin;
+import javafx.scene.control.skin.LabelSkin;
+import javafx.scene.control.skin.TextAreaSkin;
+import javafx.scene.control.skin.TextFieldSkin;
+import javafx.scene.layout.BorderPane;
+import javafx.util.Duration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import test.robot.testharness.RobotTestBase;
+
+/**
+ * Tests Node initialization from a background thread, per
+ *
+ * https://openjfx.io/javadoc/23/javafx.graphics/javafx/scene/Node.html
+ *
+ * "Node objects may be constructed and modified on any thread as long they are not yet attached to a Scene in a Window
+ * that is showing. An application must attach nodes to such a Scene or modify them on the JavaFX Application Thread."
+ */
+public class NodeInitializationBackgroundThreadTest extends RobotTestBase {
+    private static final int THREAD_COUNT = 100;
+    private static final int DURATION = 2000;
+    private static final AtomicLong seq = new AtomicLong();
+    private static final AtomicBoolean failed = new AtomicBoolean();
+
+    @Test
+    public void accordion() {
+        test(() -> {
+            Accordion c = new Accordion();
+            c.setSkin(new AccordionSkin(c));
+            c.getPanes().add(new TitledPane("Accordion", new BorderPane()));
+            return c;
+        }, (c) -> {
+            c.prefHeight(-1);
+            c.prefWidth(-1);
+        });
+    }
+
+    @Disabled("JDK-8349004") // FIX
+    @Test
+    public void datePicker() {
+        test(() -> {
+            DatePicker c = new DatePicker();
+            c.setSkin(new DatePickerSkin(c));
+            return c;
+        }, (c) -> {
+            c.show(); // fails here
+            c.setValue(LocalDate.now());
+            c.prefHeight(-1);
+            c.setValue(LocalDate.EPOCH);
+            c.prefWidth(-1);
+        });
+    }
+
+    @Test
+    public void passwordField() {
+        test(() -> {
+            PasswordField c = new PasswordField();
+            c.setSkin(new TextFieldSkin(c));
+            return c;
+        }, (c) -> {
+            // could not get it to fail
+            access(c);
+            c.setAlignment(Pos.CENTER);
+            c.getCharacters();
+        });
+    }
+
+    @Disabled("JDK-8347392") // FIX
+    @Test
+    public void textArea() {
+        test(() -> {
+            TextArea c = new TextArea();
+            c.setSkin(new TextAreaSkin(c));
+            return c;
+        }, (c) -> {
+            access(c);
+        });
+    }
+
+    @Test
+    public void textField() {
+        test(() -> {
+            TextField c = new TextField();
+            c.setSkin(new TextFieldSkin(c));
+            return c;
+        }, (c) -> {
+            // could not get it to fail
+            access(c);
+            c.setAlignment(Pos.CENTER);
+            c.getCharacters();
+        });
+    }
+
+    @Disabled("JDK-8348100") // FIX
+    @Test
+    public void tooltip() {
+        test(() -> {
+            Tooltip t = new Tooltip("this is a tooltip");
+            t.setShowDelay(Duration.ZERO);
+            t.setHideDelay(Duration.ZERO);
+            Label c = new Label("testing tooltip");
+            c.setSkin(new LabelSkin(c));
+            c.setTooltip(t);
+            return c;
+        }, (c) -> {
+            Tooltip t = c.getTooltip();
+            t.isShowing();
+            t.setGraphic(new Label("yo!"));
+            if (Platform.isFxApplicationThread()) {
+                Point2D p = c.localToScreen(c.getWidth() / 2.0, c.getHeight() / 2.0);
+                robot.mouseMove(p);
+            }
+        });
+    }
+
+    private void access(TextInputControl c) {
+        c.setPrefWidth(20);
+        c.setPromptText("yo");
+        c.setText(nextString());
+        c.prefHeight(-1);
+        c.getControlCssMetaData();
+    }
+
+    private <T extends Node> void test(Supplier<T> generator, Consumer<T> operation) {
+        T visibleNode = generator.get();
+        String title = visibleNode.getClass().getSimpleName();
+        
+        setContent(visibleNode);
+        setTitle(title);
+
+        AtomicBoolean running = new AtomicBoolean(true);
+        CountDownLatch counter = new CountDownLatch(THREAD_COUNT);
+
+        try {
+            for (int i = 0; i < THREAD_COUNT; i++) {
+                new Thread(title) {
+                    @Override
+                    public void run() {
+                        try {
+                            T n = generator.get();
+                            int count = 0;
+                            while (running.get()) {
+                                operation.accept(n);
+    
+                                count++;
+                                if ((count % 100) == 0) {
+                                    inFx(() -> {
+                                        operation.accept(visibleNode);
+                                    });
+                                }
+                            }
+                        } finally {
+                            counter.countDown();
+                        }
+                    }
+                }.start();
+            }
+
+            sleep(DURATION);
+        } finally {
+            running.set(false);
+        }
+
+        // let them finish
+        try {
+            counter.await(500, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            fail(e);
+        }
+    }
+
+    private static String nextString() {
+        long ix = seq.incrementAndGet();
+        if ((ix % 10) == 0) {
+            return null;
+        }
+        return "_a" + ix + "\nyo!";
+    }
+
+    @BeforeAll
+    public static void beforeAll() {
+        // this might be made a part of the base class (RobotTestBase)
+        Thread.setDefaultUncaughtExceptionHandler((t, e) -> {
+            e.printStackTrace();
+            failed.set(true);
+            // we could also accumulate stack trace(s) and send them to fail() in afterEach()
+        });
+    }
+
+    @BeforeEach
+    public void beforeEach() {
+        failed.set(false);
+    }
+
+    @AfterEach
+    public void afterEach() {
+        if (failed.get()) {
+            fail();
+        }
+    }
+}

--- a/tests/system/src/test/java/test/robot/javafx/scene/NodeInitializationBackgroundThreadTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/NodeInitializationBackgroundThreadTest.java
@@ -144,10 +144,11 @@ import test.robot.testharness.RobotTestBase;
  * - WebView
  *
  * NOTE: I suspect this test might be a bit unstable and/or platform-dependent, due to its multi-threaded nature.
+ *
+ * TODO add remaining Nodes to the test.
  */
 public class NodeInitializationBackgroundThreadTest extends RobotTestBase {
-    private static final int THREAD_COUNT = 100;
-    private static final int DURATION = 2000;
+    private static final int DURATION = 5000;
     private static final AtomicLong seq = new AtomicLong();
     private static final AtomicBoolean failed = new AtomicBoolean();
 
@@ -161,7 +162,7 @@ public class NodeInitializationBackgroundThreadTest extends RobotTestBase {
         }, this::accessControl);
     }
 
-    @Disabled("JDK-8349091")
+    @Disabled("JDK-8349091") // FIX
     @Test
     public void areaChart() {
         test(() -> {
@@ -174,7 +175,7 @@ public class NodeInitializationBackgroundThreadTest extends RobotTestBase {
         });
     }
 
-    @Disabled("JDK-8349091")
+    @Disabled("JDK-8349091") // FIX
     @Test
     public void barChart() {
         test(() -> {
@@ -187,7 +188,7 @@ public class NodeInitializationBackgroundThreadTest extends RobotTestBase {
         });
     }
 
-    @Disabled("JDK-8349091")
+    @Disabled("JDK-8349091") // FIX
     @Test
     public void bubbleChart() {
         test(() -> {
@@ -333,7 +334,7 @@ public class NodeInitializationBackgroundThreadTest extends RobotTestBase {
         });
     }
 
-    @Disabled("JDK-8349091")
+    @Disabled("JDK-8349091") // FIX
     @Test
     public void lineChart() {
         test(() -> {
@@ -430,6 +431,7 @@ public class NodeInitializationBackgroundThreadTest extends RobotTestBase {
         });
     }
 
+    @Disabled("JDK-8349091") // FIX
     @Test
     public void scatterChart() {
         test(() -> {
@@ -482,7 +484,7 @@ public class NodeInitializationBackgroundThreadTest extends RobotTestBase {
         });
     }
 
-    @Disabled("JDK-8349091")
+    @Disabled("JDK-8349091") // FIX
     @Test
     public void stackedAreaChart() {
         test(() -> {
@@ -495,7 +497,7 @@ public class NodeInitializationBackgroundThreadTest extends RobotTestBase {
         });
     }
 
-    @Disabled("JDK-8349091")
+    @Disabled("JDK-8349091") // FIX
     @Test
     public void stackedBarChart() {
         test(() -> {
@@ -508,7 +510,7 @@ public class NodeInitializationBackgroundThreadTest extends RobotTestBase {
         });
     }
 
-    @Disabled("JDK-8349098")
+    @Disabled("JDK-8349098") // FIX
     @Test
     public void tabPane() {
         test(() -> {
@@ -729,11 +731,12 @@ public class NodeInitializationBackgroundThreadTest extends RobotTestBase {
         setTitle(title);
         setContent(visibleNode);
 
+        int threadCount = 1 + Runtime.getRuntime().availableProcessors() * 2;
         AtomicBoolean running = new AtomicBoolean(true);
-        CountDownLatch counter = new CountDownLatch(THREAD_COUNT);
+        CountDownLatch counter = new CountDownLatch(threadCount);
 
         try {
-            for (int i = 0; i < THREAD_COUNT; i++) {
+            for (int i = 0; i < threadCount; i++) {
                 new Thread(title) {
                     @Override
                     public void run() {
@@ -762,7 +765,7 @@ public class NodeInitializationBackgroundThreadTest extends RobotTestBase {
             running.set(false);
         }
 
-        // let them finish
+        // let all threads finish
         try {
             counter.await(500, TimeUnit.SECONDS);
         } catch (InterruptedException e) {

--- a/tests/system/src/test/java/test/robot/javafx/scene/NodeInitializationBackgroundThreadTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/NodeInitializationBackgroundThreadTest.java
@@ -375,6 +375,7 @@ public class NodeInitializationBackgroundThreadTest extends RobotTestBase {
         });
     }
 
+    @Disabled("JDK-8349105") // FIX
     @Test
     public void pagination() {
         test(() -> {

--- a/tests/system/src/test/java/test/robot/javafx/scene/NodeInitializationBackgroundThreadTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/NodeInitializationBackgroundThreadTest.java
@@ -143,6 +143,10 @@ import test.robot.testharness.RobotTestBase;
  * - MenuBar
  * - WebView
  *
+ * The test creates a visible node of a given type, and at the same time, starts a number of background threads
+ * which also create nodes of the same type.  Each such thread makes repeated accesses of its own node for the duration
+ * of test.  Also, the visible node gets accessed periodically just to shake things up.
+ *
  * NOTE: I suspect this test might be a bit unstable and/or platform-dependent, due to its multi-threaded nature.
  *
  * TODO add remaining Nodes to the test.
@@ -221,7 +225,6 @@ public class NodeInitializationBackgroundThreadTest extends RobotTestBase {
         test(() -> {
             return new Canvas(30, 30);
         }, (c) -> {
-            // could not get it to fail
             accessNode(c);
             GraphicsContext g = c.getGraphicsContext2D();
             g.setFill(Color.RED);
@@ -399,7 +402,6 @@ public class NodeInitializationBackgroundThreadTest extends RobotTestBase {
             c.setSkin(new TextFieldSkin(c));
             return c;
         }, (c) -> {
-            // could not get it to fail
             accessTextInputControl(c);
             c.setAlignment(Pos.CENTER);
             c.getCharacters();
@@ -573,7 +575,6 @@ public class NodeInitializationBackgroundThreadTest extends RobotTestBase {
             c.setSkin(new TextFieldSkin(c));
             return c;
         }, (c) -> {
-            // could not get it to fail
             accessTextInputControl(c);
             c.setAlignment(Pos.CENTER);
             c.getCharacters();

--- a/tests/system/src/test/java/test/robot/javafx/scene/NodeInitializationBackgroundThreadTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/NodeInitializationBackgroundThreadTest.java
@@ -36,6 +36,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import javafx.application.Platform;
+import javafx.beans.property.SimpleObjectProperty;
 import javafx.geometry.Point2D;
 import javafx.geometry.Pos;
 import javafx.geometry.Side;
@@ -78,11 +79,19 @@ import javafx.scene.control.SpinnerValueFactory;
 import javafx.scene.control.SplitMenuButton;
 import javafx.scene.control.Tab;
 import javafx.scene.control.TabPane;
+import javafx.scene.control.TableColumn;
+import javafx.scene.control.TableView;
 import javafx.scene.control.TextArea;
 import javafx.scene.control.TextField;
 import javafx.scene.control.TextInputControl;
 import javafx.scene.control.TitledPane;
+import javafx.scene.control.ToggleButton;
+import javafx.scene.control.ToolBar;
 import javafx.scene.control.Tooltip;
+import javafx.scene.control.TreeItem;
+import javafx.scene.control.TreeTableColumn;
+import javafx.scene.control.TreeTableView;
+import javafx.scene.control.TreeView;
 import javafx.scene.control.skin.AccordionSkin;
 import javafx.scene.control.skin.ButtonSkin;
 import javafx.scene.control.skin.CheckBoxSkin;
@@ -100,11 +109,19 @@ import javafx.scene.control.skin.ScrollPaneSkin;
 import javafx.scene.control.skin.SpinnerSkin;
 import javafx.scene.control.skin.SplitMenuButtonSkin;
 import javafx.scene.control.skin.TabPaneSkin;
+import javafx.scene.control.skin.TableViewSkin;
 import javafx.scene.control.skin.TextAreaSkin;
 import javafx.scene.control.skin.TextFieldSkin;
+import javafx.scene.control.skin.TitledPaneSkin;
+import javafx.scene.control.skin.ToggleButtonSkin;
+import javafx.scene.control.skin.ToolBarSkin;
+import javafx.scene.control.skin.TreeTableViewSkin;
+import javafx.scene.control.skin.TreeViewSkin;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.Region;
 import javafx.scene.paint.Color;
+import javafx.scene.text.Text;
+import javafx.scene.text.TextFlow;
 import javafx.util.Duration;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -125,6 +142,8 @@ import test.robot.testharness.RobotTestBase;
  * - HTMLEditor
  * - MenuBar
  * - WebView
+ *
+ * NOTE: I suspect this test might be a bit unstable and/or platform-dependent, due to its multi-threaded nature.
  */
 public class NodeInitializationBackgroundThreadTest extends RobotTestBase {
     private static final int THREAD_COUNT = 100;
@@ -132,7 +151,7 @@ public class NodeInitializationBackgroundThreadTest extends RobotTestBase {
     private static final AtomicLong seq = new AtomicLong();
     private static final AtomicBoolean failed = new AtomicBoolean();
 
-//    @Test
+    @Test
     public void accordion() {
         test(() -> {
             Accordion c = new Accordion();
@@ -196,7 +215,7 @@ public class NodeInitializationBackgroundThreadTest extends RobotTestBase {
         });
     }
 
-//    @Test
+    @Test
     public void canvas() {
         test(() -> {
             return new Canvas(30, 30);
@@ -238,7 +257,7 @@ public class NodeInitializationBackgroundThreadTest extends RobotTestBase {
         });
     }
 
-//    @Test
+    @Test
     public void colorPicker() {
         test(() -> {
             ColorPicker c = new ColorPicker();
@@ -255,7 +274,7 @@ public class NodeInitializationBackgroundThreadTest extends RobotTestBase {
         });
     }
 
-//    @Test
+    @Test
     public void comboBox() {
         test(() -> {
             ComboBox c = new ComboBox();
@@ -327,7 +346,7 @@ public class NodeInitializationBackgroundThreadTest extends RobotTestBase {
         });
     }
 
-//    @Test
+    @Test
     public void listView() {
         test(() -> {
             ListView c = new ListView();
@@ -355,7 +374,7 @@ public class NodeInitializationBackgroundThreadTest extends RobotTestBase {
         });
     }
 
-//    @Test
+    @Test
     public void pagination() {
         test(() -> {
             Pagination c = new Pagination();
@@ -371,7 +390,7 @@ public class NodeInitializationBackgroundThreadTest extends RobotTestBase {
         });
     }
 
-//    @Test
+    @Test
     public void passwordField() {
         test(() -> {
             PasswordField c = new PasswordField();
@@ -411,7 +430,7 @@ public class NodeInitializationBackgroundThreadTest extends RobotTestBase {
         });
     }
 
-//    @Test
+    @Test
     public void scatterChart() {
         test(() -> {
             ScatterChart c = new ScatterChart(createNumberAxis("x"), createNumberAxis("y"));
@@ -423,7 +442,7 @@ public class NodeInitializationBackgroundThreadTest extends RobotTestBase {
         });
     }
 
-//    @Test
+    @Test
     public void scrollPane() {
         test(() -> {
             ScrollPane c = new ScrollPane(new Label("ScrollPane"));
@@ -435,7 +454,7 @@ public class NodeInitializationBackgroundThreadTest extends RobotTestBase {
         });
     }
 
-//    @Test
+    @Test
     public void spinner() {
         test(() -> {
             Spinner c = new Spinner();
@@ -463,7 +482,7 @@ public class NodeInitializationBackgroundThreadTest extends RobotTestBase {
         });
     }
 
-//    @Disabled("JDK-8349091")
+    @Disabled("JDK-8349091")
     @Test
     public void stackedAreaChart() {
         test(() -> {
@@ -489,6 +508,7 @@ public class NodeInitializationBackgroundThreadTest extends RobotTestBase {
         });
     }
 
+    @Disabled("JDK-8349098")
     @Test
     public void tabPane() {
         test(() -> {
@@ -499,6 +519,35 @@ public class NodeInitializationBackgroundThreadTest extends RobotTestBase {
         }, (c) -> {
             c.getTabs().setAll(createTabs());
             accessControl(c);
+        });
+    }
+
+    @Test
+    public void tableView() {
+        test(() -> {
+            TableView<String> c = new TableView<>();
+            c.setSkin(new TableViewSkin(c));
+            c.getItems().setAll(createTableItems());
+            TableColumn<String,String> col = new TableColumn<>("Table");
+            col.setCellValueFactory((cdf) -> {
+                Object v = cdf.getValue();
+                return new SimpleObjectProperty(v.toString());
+            });
+            c.getColumns().add(col);
+            return c;
+        }, (c) -> {
+            c.getItems().setAll(createTableItems());
+            accessControl(c);
+        });
+    }
+
+    @Test
+    public void text() {
+        test(() -> {
+            return new Text(nextString());
+        }, (c) -> {
+            c.setText(nextString());
+            accessNode(c);
         });
     }
 
@@ -514,7 +563,7 @@ public class NodeInitializationBackgroundThreadTest extends RobotTestBase {
         });
     }
 
-//    @Test
+    @Test
     public void textField() {
         test(() -> {
             TextField c = new TextField();
@@ -525,6 +574,59 @@ public class NodeInitializationBackgroundThreadTest extends RobotTestBase {
             accessTextInputControl(c);
             c.setAlignment(Pos.CENTER);
             c.getCharacters();
+        });
+    }
+
+    @Test
+    public void textFlow() {
+        test(() -> {
+            TextFlow c = new TextFlow();
+            c.getChildren().setAll(createTextItems());
+            return c;
+        }, (c) -> {
+            c.getChildren().setAll(createTextItems());
+            accessRegion(c);
+        });
+    }
+
+    @Disabled("JDK-8347392") // FIX
+    @Test
+    public void titledPane() {
+        test(() -> {
+            TitledPane c = new TitledPane("TitledPane", null);
+            c.setSkin(new TitledPaneSkin(c));
+            return c;
+        }, (c) -> {
+            c.setAnimated(nextBoolean());
+            c.setExpanded(nextBoolean());
+            c.setContent(new Label(nextString()));
+            accessControl(c);
+        });
+    }
+
+    @Disabled("JDK-8347392") // FIX
+    @Test
+    public void toggleButton() {
+        test(() -> {
+            ToggleButton c = new ToggleButton("ToggleButton");
+            c.setSkin(new ToggleButtonSkin(c));
+            return c;
+        }, (c) -> {
+            accessControl(c);
+            c.setSelected(nextBoolean());
+        });
+    }
+
+    @Test
+    public void toolBar() {
+        test(() -> {
+            ToolBar c = new ToolBar();
+            c.setSkin(new ToolBarSkin(c));
+            c.getItems().setAll(createButtons());
+            return c;
+        }, (c) -> {
+            c.getItems().setAll(createButtons());
+            accessControl(c);
         });
     }
 
@@ -547,6 +649,43 @@ public class NodeInitializationBackgroundThreadTest extends RobotTestBase {
                 Point2D p = c.localToScreen(c.getWidth() / 2.0, c.getHeight() / 2.0);
                 robot.mouseMove(p);
             }
+        });
+    }
+
+    @Test
+    public void treeTableView() {
+        test(() -> {
+            TreeTableView<String> c = new TreeTableView<>();
+            c.setSkin(new TreeTableViewSkin(c));
+            c.setRoot(createRoot());
+            TreeTableColumn<String,String> col = new TreeTableColumn<>("TreeTable");
+            col.setCellValueFactory((cdf) -> {
+                Object v = cdf.getValue();
+                return new SimpleObjectProperty(v.toString());
+            });
+            c.getColumns().add(col);
+            return c;
+        }, (c) -> {
+            c.setRoot(createRoot());
+            accessControl(c);
+        });
+    }
+
+    @Test
+    public void treeView() {
+        Supplier<TreeItem<String>> gen = () -> {
+            TreeItem<String> root = new TreeItem<>(null);
+            return root;
+        };
+
+        test(() -> {
+            TreeView<String> c = new TreeView<>();
+            c.setSkin(new TreeViewSkin(c));
+            c.setRoot(createRoot());
+            return c;
+        }, (c) -> {
+            c.setRoot(createRoot());
+            accessControl(c);
         });
     }
 
@@ -648,6 +787,15 @@ public class NodeInitializationBackgroundThreadTest extends RobotTestBase {
         return "_a" + ix + "\nyo!";
     }
 
+    private static List<Node> createButtons() {
+        int sz = new Random().nextInt(5);
+        ArrayList<Node> a = new ArrayList<>(sz);
+        for (int i = 0; i < sz; i++) {
+            a.add(new Button(nextString()));
+        }
+        return a;
+    }
+
     private static CategoryAxis createCategoryAxis(String text) {
         CategoryAxis a = new CategoryAxis();
         a.setLabel(text);
@@ -693,10 +841,38 @@ public class NodeInitializationBackgroundThreadTest extends RobotTestBase {
         return a;
     }
 
+    private static TreeItem<String> createRoot() {
+        TreeItem<String> root = new TreeItem<>(null);
+        int sz = new Random().nextInt(20);
+        for (int i = 0; i < sz; i++) {
+            root.getChildren().add(new TreeItem<>(nextString()));
+        }
+        root.setExpanded(nextBoolean());
+        return root;
+    }
+
     private static List<Tab> createTabs() {
         ArrayList<Tab> a = new ArrayList<>();
         for (int i = 0; i < 3; i++) {
             a.add(new Tab(nextString()));
+        }
+        return a;
+    }
+
+    private static List<String> createTableItems() {
+        int sz = new Random().nextInt(20);
+        ArrayList<String> a = new ArrayList<>(sz);
+        for (int i = 0; i < sz; i++) {
+            a.add(nextString());
+        }
+        return a;
+    }
+
+    private static List<Text> createTextItems() {
+        int sz = new Random().nextInt(20);
+        ArrayList<Text> a = new ArrayList<>(sz);
+        for (int i = 0; i < sz; i++) {
+            a.add(new Text(nextString()));
         }
         return a;
     }

--- a/tests/system/src/test/java/test/robot/javafx/scene/NodeInitializationStressTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/NodeInitializationStressTest.java
@@ -706,11 +706,6 @@ public class NodeInitializationStressTest extends RobotTestBase {
     @Test
     public void treeView() {
         assumeFalse(SKIP_TEST);
-        Supplier<TreeItem<String>> gen = () -> {
-            TreeItem<String> root = new TreeItem<>(null);
-            return root;
-        };
-
         test(() -> {
             TreeView<String> c = new TreeView<>();
             c.setSkin(new TreeViewSkin(c));

--- a/tests/system/src/test/java/test/robot/javafx/scene/NodeInitializationStressTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/NodeInitializationStressTest.java
@@ -176,6 +176,7 @@ public class NodeInitializationStressTest extends RobotTestBase {
     @Disabled("JDK-8349091") // FIX
     @Test
     public void areaChart() {
+        assumeFalse(SKIP_TEST);
         test(() -> {
             AreaChart c = new AreaChart(createNumberAxis("x"), createNumberAxis("y"));
             c.getData().setAll(createNumberSeries());
@@ -189,6 +190,7 @@ public class NodeInitializationStressTest extends RobotTestBase {
     @Disabled("JDK-8349091") // FIX
     @Test
     public void barChart() {
+        assumeFalse(SKIP_TEST);
         test(() -> {
             BarChart c = new BarChart(createCategoryAxis("x"), createNumberAxis("y"));
             c.getData().setAll(createCategorySeries());
@@ -202,6 +204,7 @@ public class NodeInitializationStressTest extends RobotTestBase {
     @Disabled("JDK-8349091") // FIX
     @Test
     public void bubbleChart() {
+        assumeFalse(SKIP_TEST);
         test(() -> {
             BubbleChart c = new BubbleChart(createNumberAxis("x"), createNumberAxis("y"));
             c.getData().setAll(createNumberSeries());
@@ -215,6 +218,7 @@ public class NodeInitializationStressTest extends RobotTestBase {
     @Disabled("JDK-8347392") // FIX
     @Test
     public void button() {
+        assumeFalse(SKIP_TEST);
         test(() -> {
             Button c = new Button();
             c.setSkin(new ButtonSkin(c));
@@ -245,6 +249,7 @@ public class NodeInitializationStressTest extends RobotTestBase {
     @Disabled("JDK-8347392") // FIX
     @Test
     public void checkBox() {
+        assumeFalse(SKIP_TEST);
         test(() -> {
             CheckBox c = new CheckBox("checkbox");
             c.setSkin(new CheckBoxSkin(c));
@@ -259,6 +264,7 @@ public class NodeInitializationStressTest extends RobotTestBase {
     @Disabled("JDK-8347392") // FIX
     @Test
     public void choiceBox() {
+        assumeFalse(SKIP_TEST);
         test(() -> {
             ChoiceBox c = new ChoiceBox();
             c.setSkin(new ChoiceBoxSkin(c));
@@ -308,6 +314,7 @@ public class NodeInitializationStressTest extends RobotTestBase {
     @Disabled("JDK-8349004") // FIX
     @Test
     public void datePicker() {
+        assumeFalse(SKIP_TEST);
         test(() -> {
             DatePicker c = new DatePicker();
             c.setSkin(new DatePickerSkin(c));
@@ -325,6 +332,7 @@ public class NodeInitializationStressTest extends RobotTestBase {
     @Disabled("JDK-8347392") // FIX
     @Test
     public void hyperlink() {
+        assumeFalse(SKIP_TEST);
         test(() -> {
             Hyperlink c = new Hyperlink("Hyperlink");
             c.setSkin(new HyperlinkSkin(c));
@@ -338,6 +346,7 @@ public class NodeInitializationStressTest extends RobotTestBase {
     @Disabled("JDK-8347392") // FIX
     @Test
     public void label() {
+        assumeFalse(SKIP_TEST);
         test(() -> {
             Label c = new Label("Label");
             c.setSkin(new LabelSkin(c));
@@ -351,6 +360,7 @@ public class NodeInitializationStressTest extends RobotTestBase {
     @Disabled("JDK-8349091") // FIX
     @Test
     public void lineChart() {
+        assumeFalse(SKIP_TEST);
         test(() -> {
             LineChart c = new LineChart(createNumberAxis("x"), createNumberAxis("y"));
             c.getData().setAll(createNumberSeries());
@@ -378,6 +388,7 @@ public class NodeInitializationStressTest extends RobotTestBase {
     @Disabled("JDK-8349096") // FIX
     @Test
     public void menuButton() {
+        assumeFalse(SKIP_TEST);
         test(() -> {
             MenuButton c = new MenuButton();
             c.setSkin(new MenuButtonSkin(c));
@@ -393,6 +404,7 @@ public class NodeInitializationStressTest extends RobotTestBase {
     @Disabled("JDK-8349105") // FIX
     @Test
     public void pagination() {
+        assumeFalse(SKIP_TEST);
         test(() -> {
             Pagination c = new Pagination();
             c.setSkin(new PaginationSkin(c));
@@ -424,6 +436,7 @@ public class NodeInitializationStressTest extends RobotTestBase {
     @Disabled("JDK-8349090") // FIX
     @Test
     public void pieChart() {
+        assumeFalse(SKIP_TEST);
         test(() -> {
             PieChart c = new PieChart();
             c.getData().setAll(createPieSeries());
@@ -437,6 +450,7 @@ public class NodeInitializationStressTest extends RobotTestBase {
     @Disabled("JDK-8347392") // FIX
     @Test
     public void radioButton() {
+        assumeFalse(SKIP_TEST);
         test(() -> {
             RadioButton c = new RadioButton("RadioButton");
             c.setSkin(new RadioButtonSkin(c));
@@ -450,6 +464,7 @@ public class NodeInitializationStressTest extends RobotTestBase {
     @Disabled("JDK-8349091") // FIX
     @Test
     public void scatterChart() {
+        assumeFalse(SKIP_TEST);
         test(() -> {
             ScatterChart c = new ScatterChart(createNumberAxis("x"), createNumberAxis("y"));
             c.getData().setAll(createNumberSeries());
@@ -490,6 +505,7 @@ public class NodeInitializationStressTest extends RobotTestBase {
     @Disabled("JDK-8349096") // FIX
     @Test
     public void splitMenuButton() {
+        assumeFalse(SKIP_TEST);
         test(() -> {
             SplitMenuButton c = new SplitMenuButton();
             c.setSkin(new SplitMenuButtonSkin(c));
@@ -505,6 +521,7 @@ public class NodeInitializationStressTest extends RobotTestBase {
     @Disabled("JDK-8349091") // FIX
     @Test
     public void stackedAreaChart() {
+        assumeFalse(SKIP_TEST);
         test(() -> {
             StackedAreaChart c = new StackedAreaChart(createNumberAxis("x"), createNumberAxis("y"));
             c.getData().setAll(createNumberSeries());
@@ -518,6 +535,7 @@ public class NodeInitializationStressTest extends RobotTestBase {
     @Disabled("JDK-8349091") // FIX
     @Test
     public void stackedBarChart() {
+        assumeFalse(SKIP_TEST);
         test(() -> {
             StackedBarChart c = new StackedBarChart(createCategoryAxis("x"), createNumberAxis("y"));
             c.getData().setAll(createCategorySeries());
@@ -531,6 +549,7 @@ public class NodeInitializationStressTest extends RobotTestBase {
     @Disabled("JDK-8349098") // FIX
     @Test
     public void tabPane() {
+        assumeFalse(SKIP_TEST);
         test(() -> {
             TabPane c = new TabPane();
             c.setSkin(new TabPaneSkin(c));
@@ -576,6 +595,7 @@ public class NodeInitializationStressTest extends RobotTestBase {
     @Disabled("JDK-8347392") // FIX
     @Test
     public void textArea() {
+        assumeFalse(SKIP_TEST);
         test(() -> {
             TextArea c = new TextArea();
             c.setSkin(new TextAreaSkin(c));
@@ -615,6 +635,7 @@ public class NodeInitializationStressTest extends RobotTestBase {
     @Disabled("JDK-8347392") // FIX
     @Test
     public void titledPane() {
+        assumeFalse(SKIP_TEST);
         test(() -> {
             TitledPane c = new TitledPane("TitledPane", null);
             c.setSkin(new TitledPaneSkin(c));
@@ -630,6 +651,7 @@ public class NodeInitializationStressTest extends RobotTestBase {
     @Disabled("JDK-8347392") // FIX
     @Test
     public void toggleButton() {
+        assumeFalse(SKIP_TEST);
         test(() -> {
             ToggleButton c = new ToggleButton("ToggleButton");
             c.setSkin(new ToggleButtonSkin(c));
@@ -657,6 +679,7 @@ public class NodeInitializationStressTest extends RobotTestBase {
     @Disabled("JDK-8348100") // FIX
     @Test
     public void tooltip() {
+        assumeFalse(SKIP_TEST);
         // TODO will have a better test in JDK-8348100
     }
 

--- a/tests/system/src/test/java/test/robot/javafx/scene/NodeInitializationStressTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/NodeInitializationStressTest.java
@@ -133,8 +133,7 @@ import org.junit.jupiter.api.Test;
 import test.robot.testharness.RobotTestBase;
 
 /**
- * Tests Node initialization from a background thread, per the {@link Node} specification.
- *
+ * Stress tests the Node initialization from a background thread, per the {@link Node} specification:
  * "Node objects may be constructed and modified on any thread as long they are not yet attached to a Scene in a Window
  * that is showing. An application must attach nodes to such a Scene or modify them on the JavaFX Application Thread."
  *
@@ -152,7 +151,7 @@ import test.robot.testharness.RobotTestBase;
  *
  * TODO add remaining Nodes to the test.
  */
-public class NodeInitializationBackgroundThreadTest extends RobotTestBase {
+public class NodeInitializationStressTest extends RobotTestBase {
     private static final int DURATION = 5000;
     private static final AtomicLong seq = new AtomicLong();
     private static final AtomicBoolean failed = new AtomicBoolean();

--- a/tests/system/src/test/java/test/robot/javafx/scene/NodeInitializationStressTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/NodeInitializationStressTest.java
@@ -751,8 +751,8 @@ public class NodeInitializationStressTest extends RobotTestBase {
         accessNode(c);
         c.prefHeight(-1);
         c.prefWidth(-1);
-        c.setPrefWidth(20);
-        c.setPrefHeight(20);
+        c.setPrefWidth(nextBoolean(0.1) ? 20 : 100);
+        c.setPrefHeight(nextBoolean(0.1) ? 20 : 100);
     }
 
     private <T extends Node> void test(Supplier<T> generator, Consumer<T> operation) {
@@ -792,7 +792,7 @@ public class NodeInitializationStressTest extends RobotTestBase {
                 try {
                     Random r = new Random();
                     while (running.get()) {
-                        sleep(1 + r.nextInt(50));
+                        sleep(1 + r.nextInt(20));
                         runAndWait(() -> {
                             operation.accept(visibleNode);
                         });
@@ -832,6 +832,15 @@ public class NodeInitializationStressTest extends RobotTestBase {
     private static boolean nextBoolean() {
         // creating new Random instances each time to avoid additional synchronization
         return new Random().nextBoolean();
+    }
+
+    /**
+     * Randomly returns true with the specified probability.
+     * @param probability the probability value in the range (0.0 ... 1.0)
+     * @return the boolean value
+     */
+    private static boolean nextBoolean(double probability) {
+        return new Random().nextDouble() < probability;
     }
 
     private static Color nextColor() {

--- a/tests/system/src/test/java/test/robot/javafx/scene/control/behavior/BehaviorRobotTestBase.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/control/behavior/BehaviorRobotTestBase.java
@@ -60,16 +60,16 @@ public abstract class BehaviorRobotTestBase<C extends Control> extends RobotTest
     public void beforeEach() {
         Platform.runLater(() -> {
             step = 0;
-            content.setCenter(control);
+            contentPane.setCenter(control);
         });
     }
 
     @AfterEach
     public void afterEach() {
         Platform.runLater(() -> {
-            content.setCenter(null);
+            contentPane.setCenter(null);
         });
-        content.removeEventFilter(KeyEvent.ANY, keyListener);
+        contentPane.removeEventFilter(KeyEvent.ANY, keyListener);
     }
 
     /**

--- a/tests/system/src/test/java/test/robot/javafx/scene/control/behavior/BehaviorRobotTestBase.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/control/behavior/BehaviorRobotTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,45 +26,27 @@
 package test.robot.javafx.scene.control.behavior;
 
 import java.util.HashMap;
-import java.util.concurrent.CountDownLatch;
 import java.util.function.BooleanSupplier;
-import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.event.EventHandler;
 import javafx.geometry.Point2D;
-import javafx.scene.Scene;
 import javafx.scene.control.Control;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
-import javafx.scene.input.MouseButton;
-import javafx.scene.layout.BorderPane;
-import javafx.scene.robot.Robot;
-import javafx.stage.Stage;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import com.sun.javafx.PlatformUtil;
+import test.robot.testharness.RobotTestBase;
 import test.util.Util;
 
 /**
  * Base class for testing behaviors with Robot.
  */
-public abstract class BehaviorRobotTestBase<C extends Control> {
+public abstract class BehaviorRobotTestBase<C extends Control> extends RobotTestBase {
 
-    protected static final int STAGE_WIDTH = 400;
-    protected static final int STAGE_HEIGHT = 300;
     /** causes the execute() function to wait for idle */
     protected static final Object PULSE = new Object();
-    private static CountDownLatch startupLatch;
-    /** Scene valid only during test */
-    protected static Scene scene;
-    /** Stage valid only during test */
-    protected static Stage stage;
-    protected static BorderPane content;
-    /** The Robot instance */
-    protected static Robot robot;
     private int step;
     private static HashMap<Character,KeyCode> keyCodes;
     protected final C control;
@@ -72,23 +54,6 @@ public abstract class BehaviorRobotTestBase<C extends Control> {
 
     protected BehaviorRobotTestBase(C c) {
         this.control = c;
-    }
-
-    public static class App extends Application {
-        @Override
-        public void start(Stage primaryStage) throws Exception {
-            stage = primaryStage;
-            robot = new Robot();
-            content = new BorderPane();
-            scene = new Scene(content);
-            stage.setScene(scene);
-            stage.setWidth(STAGE_WIDTH);
-            stage.setHeight(STAGE_HEIGHT);
-            stage.setOnShown(l -> {
-                Platform.runLater(() -> startupLatch.countDown());
-            });
-            stage.show();
-        }
     }
 
     @BeforeEach
@@ -105,17 +70,6 @@ public abstract class BehaviorRobotTestBase<C extends Control> {
             content.setCenter(null);
         });
         content.removeEventFilter(KeyEvent.ANY, keyListener);
-    }
-
-    @BeforeAll
-    public static void initFX() throws Exception {
-        startupLatch = new CountDownLatch(1);
-        Util.launch(startupLatch, App.class);
-    }
-
-    @AfterAll
-    public static void teardownOnce() {
-        Util.shutdown();
     }
 
     /**
@@ -343,86 +297,8 @@ public abstract class BehaviorRobotTestBase<C extends Control> {
         };
     }
 
-    /**
-     * Triggers and waits for 10 pulses to complete in this test's scene.
-     */
-    protected void waitForIdle() {
-        Util.waitForIdle(scene);
-    }
-
-    /**
-     * Performs the mouse click with the {@code MouseButton.PRIMARY} via Robot.
-     * Must be called from the FX Application thread.
-     */
-    protected void mouseClick() {
-        mouseClick(MouseButton.PRIMARY);
-    }
-
-    /**
-     * Performs the mouse click with the specified button via Robot.
-     * Must be called from the FX Application thread.
-     * @param b the button
-     */
-    protected void mouseClick(MouseButton b) {
-        robot.mouseClick(b);
-    }
-
-    /**
-     * Performs the mouse press with the {@code MouseButton.PRIMARY} via Robot.
-     * Must be called from the FX Application thread.
-     */
-    protected void mousePress() {
-        mousePress(MouseButton.PRIMARY);
-    }
-
-    /**
-     * Performs the mouse press with the specified button via Robot.
-     * Must be called from the FX Application thread.
-     * @param b the button
-     */
-    protected void mousePress(MouseButton b) {
-        robot.mousePress(b);
-    }
-
-    /**
-     * Performs the mouse release with the {@code MouseButton.PRIMARY} via Robot.
-     * Must be called from the FX Application thread.
-     */
-    protected void mouseRelease() {
-        mouseRelease(MouseButton.PRIMARY);
-    }
-
-    /**
-     * Performs the mouse release with the specified button via Robot.
-     * Must be called from the FX Application thread.
-     * @param b the button
-     */
-    protected void mouseRelease(MouseButton b) {
-        robot.mouseRelease(b);
-    }
-
     protected void mouseMove(double x, double y) {
         Point2D p = control.localToScreen(x, y);
         robot.mouseMove(p.getX(), p.getY());
-    }
-
-    /**
-     * To be used only for debugging, to be able to observe the intermediate state of the UI.
-     * Please do not use this method in the actual tests.
-     * @param seconds the number of seconds to sleep
-     * @return the Runnable
-     */
-    protected Runnable sleep(int seconds) {
-        return exe(() -> {
-            try {
-                Thread.sleep(seconds * 1000L);
-            } catch (Exception e) {
-            }
-        });
-    }
-
-    // debugging aid
-    protected void p(Object v) {
-        System.out.println(v);
     }
 }

--- a/tests/system/src/test/java/test/robot/javafx/scene/control/behavior/TextAreaRTLTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/control/behavior/TextAreaRTLTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -191,7 +191,7 @@ public class TextAreaRTLTest extends TextInputBehaviorRobotTest<TextArea> {
             BorderPane pp = new BorderPane(t);
             pp.setManaged(false);
 
-            content.getChildren().add(pp);
+            contentPane.getChildren().add(pp);
 
             pp.layout();
             t.applyCss();
@@ -201,9 +201,9 @@ public class TextAreaRTLTest extends TextInputBehaviorRobotTest<TextArea> {
             try {
                 WritableImage im = pp.snapshot(null, null);
                 selectionColor = im.getPixelReader().getColor(30, 8);
-                content.layout();
+                contentPane.layout();
             } finally {
-                content.getChildren().remove(pp);
+                contentPane.getChildren().remove(pp);
             }
         }
 

--- a/tests/system/src/test/java/test/robot/testharness/RobotTestBase.java
+++ b/tests/system/src/test/java/test/robot/testharness/RobotTestBase.java
@@ -39,7 +39,8 @@ import org.junit.jupiter.api.BeforeAll;
 import test.util.Util;
 
 /**
- * Similar to VisualTestBase, but more convenient.
+ * Base class for robot-based tests which creates a stage with the the BorderPane content
+ * to be used by individual tests.
  */
 public class RobotTestBase {
     protected static final int STAGE_WIDTH = 400;
@@ -59,10 +60,10 @@ public class RobotTestBase {
             stage = primaryStage;
             robot = new Robot();
             content = new BorderPane();
+            content.setPrefWidth(STAGE_WIDTH);
+            content.setPrefHeight(STAGE_HEIGHT);
             scene = new Scene(content);
             stage.setScene(scene);
-            stage.setWidth(STAGE_WIDTH);
-            stage.setHeight(STAGE_HEIGHT);
             stage.setOnShown(l -> {
                 Platform.runLater(() -> startupLatch.countDown());
             });
@@ -150,7 +151,7 @@ public class RobotTestBase {
      * @param n the node
      */
     public void setContent(Node n) {
-        inFx(() -> {
+        runAndWait(() -> {
             content.setCenter(n);
         });
         waitForIdle();
@@ -161,7 +162,7 @@ public class RobotTestBase {
      * @param title the title
      */
     public void setTitle(String title) {
-        inFx(() -> {
+        runAndWait(() -> {
             stage.setTitle(title);
         });
     }
@@ -170,10 +171,8 @@ public class RobotTestBase {
      * Executes code in the FX Application thread.
      * @param r the code to execute
      */
-    public void inFx(Runnable r) {
-        Util.runAndWait(() -> {
-            r.run();
-        });
+    public void runAndWait(Runnable r) {
+        Util.runAndWait(r);
     }
 
     /**

--- a/tests/system/src/test/java/test/robot/testharness/RobotTestBase.java
+++ b/tests/system/src/test/java/test/robot/testharness/RobotTestBase.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package test.robot.testharness;
+
+import static org.junit.jupiter.api.Assertions.fail;
+import java.util.concurrent.CountDownLatch;
+import javafx.application.Application;
+import javafx.application.Platform;
+import javafx.scene.Node;
+import javafx.scene.Scene;
+import javafx.scene.input.MouseButton;
+import javafx.scene.layout.BorderPane;
+import javafx.scene.robot.Robot;
+import javafx.stage.Stage;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import test.util.Util;
+
+/**
+ * Similar to VisualTestBase, but more convenient.
+ */
+public class RobotTestBase {
+    protected static final int STAGE_WIDTH = 400;
+    protected static final int STAGE_HEIGHT = 300;
+    private static CountDownLatch startupLatch;
+    /** Scene valid only during test */
+    protected static Scene scene;
+    /** Stage valid only during test */
+    protected static Stage stage;
+    protected static BorderPane content;
+    /** The Robot instance */
+    protected static Robot robot;
+
+    public static class App extends Application {
+        @Override
+        public void start(Stage primaryStage) throws Exception {
+            stage = primaryStage;
+            robot = new Robot();
+            content = new BorderPane();
+            scene = new Scene(content);
+            stage.setScene(scene);
+            stage.setWidth(STAGE_WIDTH);
+            stage.setHeight(STAGE_HEIGHT);
+            stage.setOnShown(l -> {
+                Platform.runLater(() -> startupLatch.countDown());
+            });
+            stage.show();
+        }
+    }
+
+    @BeforeAll
+    public static void initFX() throws Exception {
+        startupLatch = new CountDownLatch(1);
+        Util.launch(startupLatch, App.class);
+    }
+
+    @AfterAll
+    public static void teardownOnce() {
+        Util.shutdown();
+    }
+
+    /**
+     * Triggers and waits for 10 pulses to complete in this test's scene.
+     */
+    protected void waitForIdle() {
+        Util.waitForIdle(scene);
+    }
+
+    /**
+     * Performs the mouse click with the {@code MouseButton.PRIMARY} via Robot.
+     * Must be called from the FX Application thread.
+     */
+    protected void mouseClick() {
+        mouseClick(MouseButton.PRIMARY);
+    }
+
+    /**
+     * Performs the mouse click with the specified button via Robot.
+     * Must be called from the FX Application thread.
+     * @param b the button
+     */
+    protected void mouseClick(MouseButton b) {
+        robot.mouseClick(b);
+    }
+
+    /**
+     * Performs the mouse press with the {@code MouseButton.PRIMARY} via Robot.
+     * Must be called from the FX Application thread.
+     */
+    protected void mousePress() {
+        mousePress(MouseButton.PRIMARY);
+    }
+
+    /**
+     * Performs the mouse press with the specified button via Robot.
+     * Must be called from the FX Application thread.
+     * @param b the button
+     */
+    protected void mousePress(MouseButton b) {
+        robot.mousePress(b);
+    }
+
+    /**
+     * Performs the mouse release with the {@code MouseButton.PRIMARY} via Robot.
+     * Must be called from the FX Application thread.
+     */
+    protected void mouseRelease() {
+        mouseRelease(MouseButton.PRIMARY);
+    }
+
+    /**
+     * Performs the mouse release with the specified button via Robot.
+     * Must be called from the FX Application thread.
+     * @param b the button
+     */
+    protected void mouseRelease(MouseButton b) {
+        robot.mouseRelease(b);
+    }
+
+    // debugging aid
+    protected void p(Object v) {
+        System.out.println(v);
+    }
+
+    /**
+     * Sets the center Node inside the main Scene's BorderPane,
+     * waits for idle.
+     * @param n the node
+     */
+    public void setContent(Node n) {
+        inFx(() -> {
+            content.setCenter(n);
+        });
+        waitForIdle();
+    }
+
+    /**
+     * Sets the main window title.
+     * @param title the title
+     */
+    public void setTitle(String title) {
+        inFx(() -> {
+            stage.setTitle(title);
+        });
+    }
+
+    /**
+     * Executes code in the FX Application thread.
+     * @param r the code to execute
+     */
+    public void inFx(Runnable r) {
+        Util.runAndWait(() -> {
+            r.run();
+        });
+    }
+
+    /**
+     * Thread.sleep() alias that fails the test if an {@code InterruptedException} gets thrown.
+     * @param milliseconds the number of milliseconds to sleep
+     */
+    protected void sleep(int milliseconds) {
+        try {
+            Thread.sleep(milliseconds);
+        } catch (InterruptedException e) {
+            fail(e);
+        }
+    }
+}

--- a/tests/system/src/test/java/test/robot/testharness/RobotTestBase.java
+++ b/tests/system/src/test/java/test/robot/testharness/RobotTestBase.java
@@ -50,23 +50,25 @@ public class RobotTestBase {
     protected static Scene scene;
     /** Stage valid only during test */
     protected static Stage stage;
-    protected static BorderPane content;
+    protected static BorderPane contentPane;
     /** The Robot instance */
     protected static Robot robot;
 
     public static class App extends Application {
         @Override
         public void start(Stage primaryStage) throws Exception {
-            stage = primaryStage;
             robot = new Robot();
-            content = new BorderPane();
-            content.setPrefWidth(STAGE_WIDTH);
-            content.setPrefHeight(STAGE_HEIGHT);
-            scene = new Scene(content);
+            contentPane = new BorderPane();
+            contentPane.setPrefWidth(STAGE_WIDTH);
+            contentPane.setPrefHeight(STAGE_HEIGHT);
+            scene = new Scene(contentPane);
+
+            stage = primaryStage;
             stage.setScene(scene);
             stage.setOnShown(l -> {
                 Platform.runLater(() -> startupLatch.countDown());
             });
+            stage.setAlwaysOnTop(true);
             stage.show();
         }
     }
@@ -152,7 +154,7 @@ public class RobotTestBase {
      */
     public void setContent(Node n) {
         runAndWait(() -> {
-            content.setCenter(n);
+            contentPane.setCenter(n);
         });
         waitForIdle();
     }


### PR DESCRIPTION
Created a test that validates various Nodes can be initialized in a background thread.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8348423](https://bugs.openjdk.org/browse/JDK-8348423): [TestBug] stress test Nodes initialization from a background thread (**Bug** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1690/head:pull/1690` \
`$ git checkout pull/1690`

Update a local copy of the PR: \
`$ git checkout pull/1690` \
`$ git pull https://git.openjdk.org/jfx.git pull/1690/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1690`

View PR using the GUI difftool: \
`$ git pr show -t 1690`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1690.diff">https://git.openjdk.org/jfx/pull/1690.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1690#issuecomment-2625950431)
</details>
