### PR TITLE
8333275: ComboBox: adding an item from editor changes editor text

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ComboBox.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ComboBox.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ComboBox.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ComboBox.java
@@ -598,20 +598,35 @@ public class ComboBox<T> extends ComboBoxBase<T> {
                     }
                 }
 
+                int index = -1;
                 int shift = 0;
+                T editorValue;
+
+                try {
+                    editorValue = comboBox.getConverter().fromString(comboBox.getEditor().getText());
+                } catch (RuntimeException ex) {
+                    editorValue = null;
+                }
+
                 while (c.next()) {
                     comboBox.wasSetAllCalled = comboBox.previousItemCount == c.getRemovedSize();
 
                     if (c.wasReplaced()) {
-                        // no-op
+                        index = -1;
+                    } else if (c.wasAdded() && editorValue != null && c.getAddedSubList().contains(editorValue)) {
+                        index = c.getFrom() + c.getAddedSubList().indexOf(editorValue);
                     } else if (c.wasAdded() || c.wasRemoved()) {
+                        index = -1;
+
                         if (c.getFrom() <= getSelectedIndex() && getSelectedIndex()!= -1) {
                             shift += c.wasAdded() ? c.getAddedSize() : -c.getRemovedSize();
                         }
                     }
                 }
 
-                if (shift != 0) {
+                if (index >= 0) {
+                    clearAndSelect(index);
+                } else if (shift != 0) {
                     clearAndSelect(getSelectedIndex() + shift);
                 } else if (comboBox.wasSetAllCalled && getSelectedIndex() >= 0 && getSelectedItem() != null) {
                     // try to find the previously selected item

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ListView.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ListView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ListView.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ListView.java
@@ -1306,6 +1306,14 @@ public class ListView<T> extends Control {
                 while (c.next()) {
                     final T selectedItem = getSelectedItem();
                     final int selectedIndex = getSelectedIndex();
+                    int addedItemOffset = -1;
+
+                    if (c.wasAdded()
+                            && selectedItem != null
+                            && (addedItemOffset = c.getAddedSubList().indexOf(selectedItem)) >= 0
+                            && selectedIndex == c.getFrom() + addedItemOffset) {
+                        doSelectionUpdate = false;
+                    }
 
                     if (listView.getItems() == null || listView.getItems().isEmpty()) {
                         selectedItemChange = c;

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
@@ -659,6 +659,48 @@ public class ComboBoxTest {
         assertEquals("pineapple", comboBox.getValue());
     }
 
+    @Test public void ensureEditorValueDoesNotChangeWhenCurrentEditorValueIsAddedToItemsList() {
+        @SuppressWarnings("unchecked")
+        var listView = (ListView<String>)((ComboBoxListViewSkin<String>)comboBox.getSkin()).getPopupContent();
+        comboBox.setEditable(true);
+        comboBox.getItems().setAll("a", "b", "c");
+        comboBox.getSelectionModel().select(1);
+        assertEquals("b", comboBox.getEditor().getText());
+        assertEquals("b", comboBox.getValue());
+        assertEquals("b", listView.getSelectionModel().getSelectedItem());
+        assertEquals(1, listView.getSelectionModel().getSelectedIndex());
+
+        comboBox.getEditor().setText("d");
+        comboBox.getItems().add(0, comboBox.getEditor().getText());
+        assertEquals(List.of("d", "a", "b", "c"), comboBox.getItems());
+        assertEquals(0, comboBox.getSelectionModel().getSelectedIndex());
+        assertEquals(0, listView.getSelectionModel().getSelectedIndex());
+        assertEquals("d", comboBox.getSelectionModel().getSelectedItem());
+        assertEquals("d", listView.getSelectionModel().getSelectedItem());
+        assertEquals("d", comboBox.getEditor().getText());
+        assertEquals("d", comboBox.getValue());
+
+        comboBox.getEditor().setText("e");
+        comboBox.getItems().addAll(0, List.of(comboBox.getEditor().getText(), "f"));
+        assertEquals(List.of("e", "f", "d", "a", "b", "c"), comboBox.getItems());
+        assertEquals(0, comboBox.getSelectionModel().getSelectedIndex());
+        assertEquals(0, listView.getSelectionModel().getSelectedIndex());
+        assertEquals("e", comboBox.getSelectionModel().getSelectedItem());
+        assertEquals("e", listView.getSelectionModel().getSelectedItem());
+        assertEquals("e", comboBox.getEditor().getText());
+        assertEquals("e", comboBox.getValue());
+
+        comboBox.getEditor().setText("h");
+        comboBox.getItems().addAll(0, List.of("g", comboBox.getEditor().getText(), "i"));
+        assertEquals(List.of("g", "h", "i", "e", "f", "d", "a", "b", "c"), comboBox.getItems());
+        assertEquals(1, comboBox.getSelectionModel().getSelectedIndex());
+        assertEquals(1, listView.getSelectionModel().getSelectedIndex());
+        assertEquals("h", comboBox.getSelectionModel().getSelectedItem());
+        assertEquals("h", listView.getSelectionModel().getSelectedItem());
+        assertEquals("h", comboBox.getEditor().getText());
+        assertEquals("h", comboBox.getValue());
+    }
+
     /*********************************************************************
      * Tests for default values                                         *
      ********************************************************************/


### PR DESCRIPTION
When the current editor value of a `ComboBox` is added to its items list, the editor value may be changed to an entirely unrelated item in the list. However, our expectation would be that the editor reflects the newly added item instead.

Under normal circumstances, adding items to the list in front of the current item causes `selectedIndex` to be shifted by the number of items added, keeping the editor value in sync with the currently selected item.

Let's illustrate this with an example:
`items = [foo, bar, baz]`, `selectedIndex = 0`, `selectedItem = foo`

The user changes the editor value to `qux` and inserts the value at list position 0, causing the current index to be shifted to the right (in `ComboBoxSelectionModel::itemsContentObserver`):
`items = [qux, foo, bar, baz]`, `selectedIndex = 1`, `selectedItem = foo`

The index is shifted a second time in `ListViewBitSetSelectionModel::updateSelection`:
`items = [qux, foo, bar, baz]`, `selectedIndex = 2`, `selectedItem = bar`

Now `bar` is selected and shown in the editor, but we would expect `qux` instead. The fix is to detect that we're inserting the current editor value in `ComboBoxSelectionModel::itemsContentObserver`, and select the correct item directly. We also need to account for this situation in `ListViewBitSetSelectionModel`, where we check whether the current value is already contained in the added values.

/reviewers 2

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8333275](https://bugs.openjdk.org/browse/JDK-8333275): ComboBox: adding an item from editor changes editor text (**Bug** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1692/head:pull/1692` \
`$ git checkout pull/1692`

Update a local copy of the PR: \
`$ git checkout pull/1692` \
`$ git pull https://git.openjdk.org/jfx.git pull/1692/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1692`

View PR using the GUI difftool: \
`$ git pr show -t 1692`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1692.diff">https://git.openjdk.org/jfx/pull/1692.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1692#issuecomment-2626180203)
</details>
