### PR TITLE
8349008: Remove temporary font file tracking code

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/FontFileWriter.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/FontFileWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,11 +29,6 @@ import java.io.File;
 import java.io.RandomAccessFile;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.Semaphore;
-import java.util.concurrent.TimeUnit;
-
 /*
  * Utility class to write sfnt-based font files.
  *
@@ -44,8 +39,6 @@ class FontFileWriter implements FontConstants {
     byte[] header;              // buffer for the header and directory
     int pos;                    // current position for the tables
     int headerPos;              // current buffer position in the header
-    int writtenBytes;
-    FontTracker tracker;
     File file;
     RandomAccessFile raFile;
 
@@ -56,7 +49,6 @@ class FontFileWriter implements FontConstants {
         if (raFile == null) {
             throw new IOException("File not open");
         }
-        checkTracker(size);
         raFile.setLength(size);
     }
 
@@ -76,20 +68,13 @@ class FontFileWriter implements FontConstants {
 
     public File openFile() throws IOException {
         pos = 0;
-        writtenBytes = 0;
         try {
             file = Files.createTempFile("+JXF", ".tmp").toFile();
         } catch (IOException e) {
             // don't reveal temporary directory location
             throw new IOException("Unable to create temporary file");
         }
-        if (tracker != null) {
-            tracker.add(file);
-        }
         raFile = new RandomAccessFile(file, "rw");
-        if (tracker != null) {
-            tracker.set(file, raFile);
-        }
         if (PrismFontFactory.debugFonts) {
             System.err.println("Temp file created: " + file.getPath());
         }
@@ -106,16 +91,10 @@ class FontFileWriter implements FontConstants {
             raFile.close();
             raFile = null;
         }
-        if (tracker != null) {
-            tracker.remove(file);
-        }
     }
 
     public void deleteFile() {
         if (file != null) {
-            if (tracker != null) {
-                tracker.subBytes(writtenBytes);
-            }
             try {
                 closeFile();
             } catch (Exception e) {
@@ -132,29 +111,6 @@ class FontFileWriter implements FontConstants {
         }
     }
 
-    public boolean isTracking() {
-        return tracker != null;
-    }
-
-    private void checkTracker(int size) throws IOException {
-        if (tracker != null) {
-            if (size < 0 || pos > FontTracker.MAX_FILE_SIZE - size) {
-                throw new IOException("File too big.");
-            }
-            if (tracker.getNumBytes() > FontTracker.MAX_TOTAL_BYTES - size) {
-                throw new IOException("Total files too big.");
-            }
-        }
-    }
-
-    private void checkSize(int size) throws IOException {
-        if (tracker != null) {
-            checkTracker(size);
-            tracker.addBytes(size);
-            writtenBytes += size;
-        }
-    }
-
     private void setHeaderPos(int pos) {
         headerPos = pos;
     }
@@ -164,7 +120,6 @@ class FontFileWriter implements FontConstants {
      */
     public void writeHeader(int format, short numTables) throws IOException {
         int size = TTCHEADERSIZE + (DIRECTORYENTRYSIZE * numTables);
-        checkSize(size);
         header = new byte[size];
 
         /* Spec:
@@ -223,124 +178,7 @@ class FontFileWriter implements FontConstants {
     public void writeBytes(byte[] buffer, int startPos, int length)
             throws IOException
     {
-        checkSize(length);
         raFile.write(buffer, startPos, length);
         pos += length;
-    }
-
-    /* Like JDK, FX allows untrusted code to create fonts which consume
-     * disk resource. We need to place some reasonable limit on the amount
-     * that can be consumed to prevent D.O.S type attacks.
-     */
-    static class FontTracker {
-        public static final int MAX_FILE_SIZE = 32 * 1024 * 1024;
-        public static final int MAX_TOTAL_BYTES = 10 * MAX_FILE_SIZE;
-
-        static int numBytes;
-        static FontTracker tracker;
-
-        public static synchronized FontTracker getTracker() {
-            if (tracker == null) {
-                tracker = new FontTracker();
-            }
-            return tracker;
-        }
-
-        public synchronized int getNumBytes() {
-            return numBytes;
-        }
-
-        public synchronized void addBytes(int sz) {
-            numBytes += sz;
-        }
-
-        public synchronized void subBytes(int sz) {
-            numBytes -= sz;
-        }
-
-        private static Semaphore cs = null;
-
-        /**
-         * Returns a counting semaphore.
-         */
-        private static synchronized Semaphore getCS() {
-            if (cs == null) {
-                // Make a semaphore with 5 permits that obeys the first-in first-out
-                // granting of permits.
-                cs = new Semaphore(5, true);
-            }
-            return cs;
-        }
-
-        public boolean acquirePermit() throws InterruptedException {
-            // This does a timed-out wait.
-            return getCS().tryAcquire(120, TimeUnit.SECONDS);
-        }
-
-        public void releasePermit() {
-            getCS().release();
-        }
-
-        public void add(File file) {
-            TempFileDeletionHook.add(file);
-        }
-
-        public void set(File file, RandomAccessFile raf) {
-            TempFileDeletionHook.set(file, raf);
-        }
-
-        public void remove(File file) {
-            TempFileDeletionHook.remove(file);
-        }
-
-        /**
-         * Helper class for cleanup of temp files created while processing fonts.
-         */
-        private static class TempFileDeletionHook {
-            private static HashMap<File, RandomAccessFile> files = new HashMap<>();
-
-            private static Thread t = null;
-            static void init() {
-                if (t == null) {
-                    // Add a shutdown hook to remove the temp file.
-                    t = new Thread(() -> {
-                        runHooks();
-                    });
-                    Runtime.getRuntime().addShutdownHook(t);
-                }
-            }
-
-            private TempFileDeletionHook() {}
-
-            static synchronized void add(File file) {
-                init();
-                files.put(file, null);
-            }
-
-            static synchronized void set(File file, RandomAccessFile raf) {
-                files.put(file, raf);
-            }
-
-            static synchronized void remove(File file) {
-                files.remove(file);
-            }
-
-            static synchronized void runHooks() {
-                if (files.isEmpty()) {
-                    return;
-                }
-
-                for (Map.Entry<File, RandomAccessFile> entry : files.entrySet())
-                {
-                    // Close the associated raf, and then delete the file.
-                    try {
-                        if (entry.getValue() != null) {
-                            entry.getValue().close();
-                        }
-                    } catch (Exception e) {}
-                    entry.getKey().delete();
-                }
-            }
-        }
     }
 }

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/PrismFontFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/PrismFontFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1405,8 +1405,7 @@ public abstract class PrismFontFactory implements FontFactory {
         } finally {
             /* If the data isn't a valid font, so that registering it
              * returns null, or we didn't get so far as copying the data,
-             * delete the tmp file and decrement the byte count
-             * in the tracker object before returning.
+             * delete the tmp file before returning.
              */
             if (fr == null) {
                 fontWriter.deleteFile();

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/PrismFontFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/PrismFontFactory.java
@@ -209,7 +209,7 @@ public abstract class PrismFontFactory implements FontFactory {
           createFontFile(String name, String filename,
                          int fIndex, boolean register,
                          boolean embedded,
-                         boolean copy, boolean tracked)
+                         boolean copy)
                          throws Exception;
 
     public abstract GlyphLayout createGlyphLayout();
@@ -219,13 +219,13 @@ public abstract class PrismFontFactory implements FontFactory {
     // contents of the TTC. Onus is on caller to enumerate all the fonts.
     private PrismFontFile createFontResource(String filename, int index) {
         return createFontResource(null, filename, index,
-                                  true, false, false, false);
+                                  true, false, false);
     }
 
     private PrismFontFile createFontResource(String name,
                                              String filename, int index,
                                              boolean register, boolean embedded,
-                                             boolean copy, boolean tracked) {
+                                             boolean copy) {
         String key = (filename+index).toLowerCase();
         /*
          * macOS: we need to load unique fonts for regular and bold.
@@ -241,7 +241,7 @@ public abstract class PrismFontFactory implements FontFactory {
 
         try {
             fr = createFontFile(name, filename, index, register,
-                                embedded, copy, tracked);
+                                embedded, copy);
             if (register) {
                 // Although it looks tempting here to store the lookup name
                 // as what we matched, it isn't safe to do so.
@@ -270,7 +270,7 @@ public abstract class PrismFontFactory implements FontFactory {
    public int findFontIndex(String targetName, String filename) {
 
          try {
-             PrismFontFile fr = createFontFile(null, filename, 0, false, false, false, false);
+             PrismFontFile fr = createFontFile(null, filename, 0, false, false, false);
 
              int cnt = fr.getFontCount();
              if (cnt == 1 || fr.getFullName().equalsIgnoreCase(targetName)) {
@@ -278,7 +278,7 @@ public abstract class PrismFontFactory implements FontFactory {
              }
              int index = 1;
              do {
-                 fr = createFontFile(null, filename, index, false, false, false, false);
+                 fr = createFontFile(null, filename, index, false, false, false);
                  String name = fr.getFullName();
                  if (name.equalsIgnoreCase(targetName)) {
                      return index;
@@ -295,7 +295,7 @@ public abstract class PrismFontFactory implements FontFactory {
     private PrismFontFile createFontResource(String name, String filename) {
         PrismFontFile[] pffArr =
             createFontResources(name, filename,
-                                true, false, false, false, true);
+                                true, false, false, true);
         if (pffArr == null || pffArr.length == 0) {
            return null;
         } else {
@@ -319,7 +319,6 @@ public abstract class PrismFontFactory implements FontFactory {
                                                 boolean register,
                                                 boolean embedded,
                                                 boolean copy,
-                                                boolean tracked,
                                                 boolean loadAll) {
 
         PrismFontFile[] fArr = null;
@@ -327,7 +326,7 @@ public abstract class PrismFontFactory implements FontFactory {
             return null;
         }
         PrismFontFile fr = createFontResource(name, filename, 0, register,
-                                              embedded, copy, tracked);
+                                              embedded, copy);
         if (fr == null) {
             return null;
         }
@@ -352,7 +351,7 @@ public abstract class PrismFontFactory implements FontFactory {
                 } else {
                     fr = createFontFile(null, filename, index,
                                         register, embedded,
-                                        copy, tracked);
+                                        copy);
                     if (fr == null) {
                         return null;
                     }
@@ -1384,7 +1383,7 @@ public abstract class PrismFontFactory implements FontFactory {
             fontWriter.closeFile();
 
             fr = loadEmbeddedFont1(name, tFile.getPath(), register, true,
-                                   fontWriter.isTracking(), loadAll);
+                                   loadAll);
 
             if (fr != null && fr.length > 0) {
                 /* Delete the file downloaded if it was decoded
@@ -1445,7 +1444,7 @@ public abstract class PrismFontFactory implements FontFactory {
                                      boolean loadAll) {
         addFileCloserHook();
         FontResource[] frArr =
-          loadEmbeddedFont1(name, path, register, false, false, loadAll);
+          loadEmbeddedFont1(name, path, register, false, loadAll);
         if (frArr != null && frArr.length > 0) {
             if (size <= 0) size = getSystemFontSize();
             int num = frArr.length;
@@ -1498,7 +1497,7 @@ public abstract class PrismFontFactory implements FontFactory {
     private synchronized
         PrismFontFile[] loadEmbeddedFont1(String name, String path,
                                           boolean register, boolean copy,
-                                          boolean tracked, boolean loadAll) {
+                                          boolean loadAll) {
 
         ++numEmbeddedFonts;
         /*
@@ -1512,8 +1511,7 @@ public abstract class PrismFontFactory implements FontFactory {
          * know to reference the file directly.
          */
         PrismFontFile[] frArr = createFontResources(name, path, register,
-                                                    true, copy, tracked,
-                                                    loadAll);
+                                                    true, copy, loadAll);
         if (frArr == null || frArr.length == 0) {
             return null; // yes, this means the caller needs to handle null.
         }

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/PrismFontFile.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/PrismFontFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -77,7 +77,6 @@ public abstract class PrismFontFile implements FontResource, FontConstants {
     boolean isCFF;
     boolean isEmbedded = false;
     boolean isCopy = false;
-    boolean isTracked = false;
     boolean isDecoded = false;
     boolean isRegistered = true;
 
@@ -89,18 +88,17 @@ public abstract class PrismFontFile implements FontResource, FontConstants {
 
     protected PrismFontFile(String name, String filename, int fIndex,
                           boolean register, boolean embedded,
-                          boolean copy, boolean tracked) throws Exception {
+                          boolean copy) throws Exception {
         this.filename = filename;
         this.isRegistered = register;
         this.isEmbedded = embedded;
         this.isCopy = copy;
-        this.isTracked = tracked;
         init(name, fIndex);
     }
 
     WeakReference<PrismFontFile> createFileDisposer(PrismFontFactory factory,
                                                     FileRefCounter rc) {
-        FileDisposer disposer = new FileDisposer(filename, isTracked, rc);
+        FileDisposer disposer = new FileDisposer(filename, rc);
         WeakReference<PrismFontFile> ref = Disposer.addRecord(this, disposer);
         disposer.setFactory(factory, ref);
         return ref;
@@ -196,15 +194,12 @@ public abstract class PrismFontFile implements FontResource, FontConstants {
 
     static class FileDisposer implements DisposerRecord {
         String fileName;
-        boolean isTracked;
         FileRefCounter refCounter;
         PrismFontFactory factory;
         WeakReference<PrismFontFile> refKey;
 
-        public FileDisposer(String fileName, boolean isTracked,
-                            FileRefCounter rc) {
+        public FileDisposer(String fileName, FileRefCounter rc) {
             this.fileName = fileName;
-            this.isTracked = isTracked;
             this.refCounter = rc;
         }
 
@@ -226,12 +221,6 @@ public abstract class PrismFontFile implements FontResource, FontConstants {
                     File file = new File(fileName);
                     int size = (int)file.length();
                     file.delete();
-                    // decrement tracker only after
-                    // successful deletion.
-                    if (isTracked) {
-                        FontFileWriter.FontTracker.
-                            getTracker().subBytes(size);
-                    }
                     if (factory != null && refKey != null) {
                         Object o = refKey.get();
                         if (o == null) {

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/coretext/CTFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/coretext/CTFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -65,10 +65,10 @@ public class CTFactory extends PrismFontFactory {
 
     @Override
     protected PrismFontFile createFontFile(String name, String filename,
-            int fIndex, boolean register, boolean embedded, boolean copy,
-            boolean tracked) throws Exception {
+            int fIndex, boolean register, boolean embedded, boolean copy)
+            throws Exception {
         return new CTFontFile(name, filename, fIndex, register,
-                              embedded, copy, tracked);
+                              embedded, copy);
     }
 
     @Override

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/coretext/CTFontFile.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/coretext/CTFontFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -66,7 +66,7 @@ class CTFontFile extends PrismFontFile {
 
     private long ctFontRef = 0;
     CTFontFile(String name, String filename, int fIndex, long fontRef) throws Exception {
-        super(name, filename, fIndex, false, false, false, false);
+        super(name, filename, fIndex, false, false, false);
 
         if (fontRef == 0) {
            throw new InternalError("Zero fontref");
@@ -76,8 +76,8 @@ class CTFontFile extends PrismFontFile {
     }
 
     CTFontFile(String name, String filename, int fIndex, boolean register,
-               boolean embedded, boolean copy, boolean tracked) throws Exception {
-        super(name, filename, fIndex, register, embedded, copy, tracked);
+               boolean embedded, boolean copy) throws Exception {
+        super(name, filename, fIndex, register, embedded, copy);
 
         // The super-class code that opens and reads the font can't handle font variations,
         // as used by the macOS "System Font"

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/directwrite/DWFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/directwrite/DWFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,10 +63,10 @@ public class DWFactory extends PrismFontFactory {
     @Override
     protected PrismFontFile createFontFile(String name, String filename,
                                            int fIndex, boolean register,
-                                           boolean embedded, boolean copy,
-                                           boolean tracked) throws Exception {
+                                           boolean embedded, boolean copy)
+                                           throws Exception {
         return new DWFontFile(name, filename, fIndex, register,
-                              embedded, copy, tracked);
+                              embedded, copy);
     }
 
     @Override public GlyphLayout createGlyphLayout() {

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/directwrite/DWFontFile.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/directwrite/DWFontFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,8 +39,8 @@ class DWFontFile extends PrismFontFile {
     private DWDisposer disposer;
 
     DWFontFile(String name, String filename, int fIndex, boolean register,
-               boolean embedded, boolean copy, boolean tracked) throws Exception {
-        super(name, filename, fIndex, register, embedded, copy, tracked);
+               boolean embedded, boolean copy) throws Exception {
+        super(name, filename, fIndex, register, embedded, copy);
         fontFace = createFontFace();
 
         if (PrismFontFactory.debugFonts) {

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/freetype/FTFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/freetype/FTFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -77,10 +77,10 @@ public class FTFactory extends PrismFontFactory {
     @Override
     protected PrismFontFile createFontFile(String name, String filename,
                                            int fIndex, boolean register,
-                                           boolean embedded, boolean copy,
-                                           boolean tracked) throws Exception {
+                                           boolean embedded, boolean copy)
+                                           throws Exception {
         return new FTFontFile(name, filename, fIndex, register,
-                              embedded, copy, tracked);
+                              embedded, copy);
     }
 
     @Override

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/freetype/FTFontFile.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/freetype/FTFontFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,8 +53,8 @@ class FTFontFile extends PrismFontFile {
     private FTDisposer disposer;
 
     FTFontFile(String name, String filename, int fIndex, boolean register,
-               boolean embedded, boolean copy, boolean tracked) throws Exception {
-        super(name, filename, fIndex, register, embedded, copy, tracked);
+               boolean embedded, boolean copy) throws Exception {
+        super(name, filename, fIndex, register, embedded, copy);
         init();
     }
 


### PR DESCRIPTION
This is a cleanup follow-up, removing `FontFileWriter.FontTracker` and all related uses. `FontTracker` was tracking font size use when SecurityManager was present, however since we removed SM, `FontTracker` was no longer activated and as such was dead code.

`FontFileWriter.FontTracker` and its use in `FontFileWriter` + related methods were removed. This in turn cleaned up `PrismFontFile` and made a couple of variables not longer used, including a `bool tracking` argument in constructor. These cleanups propagated to `PrismFontFactory`, `{CT,DW,FT}Factory` and `{CT,DW,FT}FontFile` classes.

Tests worked the same after this change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8349008](https://bugs.openjdk.org/browse/JDK-8349008): Remove temporary font file tracking code (**Bug** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1693/head:pull/1693` \
`$ git checkout pull/1693`

Update a local copy of the PR: \
`$ git checkout pull/1693` \
`$ git pull https://git.openjdk.org/jfx.git pull/1693/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1693`

View PR using the GUI difftool: \
`$ git pr show -t 1693`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1693.diff">https://git.openjdk.org/jfx/pull/1693.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1693#issuecomment-2627200686)
</details>
