### PR TITLE
8335587: TextInputControl: Binding prompt text that contains linebreak causes exception

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TextInputControl.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TextInputControl.java
@@ -320,6 +320,9 @@ public abstract class TextInputControl extends Control {
             String txt = get();
             if (txt != null && txt.contains("\n")) {
                 txt = txt.replace("\n", "");
+                if(isBound()){
+                    unbind();
+                }
                 set(txt);
             }
         }

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TextInputControl.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TextInputControl.java
@@ -320,7 +320,7 @@ public abstract class TextInputControl extends Control {
             String txt = get();
             if (txt != null && txt.contains("\n")) {
                 txt = txt.replace("\n", "");
-                if(isBound()){
+                if (isBound()) {
                     unbind();
                 }
                 set(txt);

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TextInputControlTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TextInputControlTest.java
@@ -25,11 +25,6 @@
 
 package test.javafx.scene.control;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 import java.util.Collection;
 import java.util.List;
 import javafx.beans.property.BooleanProperty;
@@ -56,6 +51,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import com.sun.javafx.tk.Toolkit;
 import test.com.sun.javafx.pgstub.StubToolkit;
 import test.com.sun.javafx.scene.control.infrastructure.KeyEventFirer;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  */
@@ -109,6 +105,39 @@ public class TextInputControlTest {
     public void textDefaultsToEmptyString(Class<?> type) {
         setup(type);
         assertEquals("", textInput.getText());
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void bindPromptTextWithoutLineBreaks(Class<?> type) {
+        setup(type);
+        String promptWithoutLinebreaks = "Prompt without\tlinebreaks";
+        StringProperty promptProperty = new SimpleStringProperty(promptWithoutLinebreaks);
+        textInput.promptTextProperty().bind(promptProperty);
+        assertEquals(promptWithoutLinebreaks, textInput.getPromptText());
+        textInput.promptTextProperty().unbind();
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void bindPromptTextWithLineBreaks(Class<?> type) {
+        setup(type);
+        String promptWithLinebreaks = "Prompt\nwith\nLineBreaks\nand\nmixed\tcharacters \uD83C\uDF0D";
+        StringProperty promptProperty = new SimpleStringProperty(promptWithLinebreaks);
+        textInput.promptTextProperty().bind(promptProperty);
+        String expectedPromptWithoutLineBreaks = promptWithLinebreaks.replace("\n", "");
+        assertEquals(expectedPromptWithoutLineBreaks, textInput.getPromptText());
+        textInput.promptTextProperty().unbind();
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void bindPromptTextWithNull(Class<?> type) {
+        setup(type);
+        StringProperty promptPropertyNull = new SimpleStringProperty(null);
+        textInput.promptTextProperty().bind(promptPropertyNull);
+        assertNull(textInput.getPromptText());
+        textInput.promptTextProperty().unbind();
     }
 
     @ParameterizedTest


### PR DESCRIPTION
When binding the promptTextProperty of a TextInputControl (TextField or TextArea) to a text that contains linebreaks/newlines ("\n") the "bind" call causes a RuntimeException to be thrown, the solution to it is to unbind before calling the set(txt) method to set the new value for the property.
Also added tests to test this new fix

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335587](https://bugs.openjdk.org/browse/JDK-8335587): TextInputControl: Binding prompt text that contains linebreak causes exception (**Bug** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Marius Hanl](https://openjdk.org/census#mhanl) (@Maran23 - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1694/head:pull/1694` \
`$ git checkout pull/1694`

Update a local copy of the PR: \
`$ git checkout pull/1694` \
`$ git pull https://git.openjdk.org/jfx.git pull/1694/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1694`

View PR using the GUI difftool: \
`$ git pr show -t 1694`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1694.diff">https://git.openjdk.org/jfx/pull/1694.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1694#issuecomment-2634183503)
</details>
