### PR TITLE
8349098: TabPane: exception initializing in a background thread

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TabPaneSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TabPaneSkin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,16 +25,17 @@
 
 package javafx.scene.control.skin;
 
-import com.sun.javafx.scene.control.LambdaMultiplePropertyChangeListenerHandler;
-import com.sun.javafx.scene.control.Properties;
-import com.sun.javafx.scene.control.TabObservableList;
-import com.sun.javafx.util.Utils;
+import static com.sun.javafx.scene.control.skin.resources.ControlResources.getString;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import javafx.animation.Animation;
 import javafx.animation.Interpolator;
 import javafx.animation.KeyFrame;
 import javafx.animation.KeyValue;
 import javafx.animation.Timeline;
 import javafx.animation.Transition;
+import javafx.application.Platform;
 import javafx.beans.InvalidationListener;
 import javafx.beans.Observable;
 import javafx.beans.WeakInvalidationListener;
@@ -51,6 +52,7 @@ import javafx.css.PseudoClass;
 import javafx.css.Styleable;
 import javafx.css.StyleableObjectProperty;
 import javafx.css.StyleableProperty;
+import javafx.css.converter.EnumConverter;
 import javafx.event.ActionEvent;
 import javafx.event.EventHandler;
 import javafx.geometry.Bounds;
@@ -90,15 +92,11 @@ import javafx.scene.shape.Rectangle;
 import javafx.scene.transform.Rotate;
 import javafx.util.Duration;
 import javafx.util.Pair;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
-import javafx.css.converter.EnumConverter;
+import com.sun.javafx.scene.control.LambdaMultiplePropertyChangeListenerHandler;
+import com.sun.javafx.scene.control.Properties;
+import com.sun.javafx.scene.control.TabObservableList;
 import com.sun.javafx.scene.control.behavior.TabPaneBehavior;
-
-import static com.sun.javafx.scene.control.skin.resources.ControlResources.getString;
+import com.sun.javafx.util.Utils;
 
 /**
  * Default skin implementation for the {@link TabPane} control.
@@ -522,7 +520,7 @@ public class TabPaneSkin extends SkinBase<TabPane> {
                     }
                 };
 
-                if (closeTabAnimation.get() == TabAnimation.GROW) {
+                if (Platform.isFxApplicationThread() && (closeTabAnimation.get() == TabAnimation.GROW)) {
                     tabRegion.animationState = TabAnimationState.HIDING;
                     Timeline closedTabTimeline = tabRegion.currentAnimation =
                             createTimeline(tabRegion, Duration.millis(ANIMATION_SPEED), 0.0F, cleanup);
@@ -571,7 +569,7 @@ public class TabPaneSkin extends SkinBase<TabPane> {
             addTabContent(tab);
             final TabHeaderSkin tabRegion = tabHeaderArea.getTabHeaderSkin(tab);
             if (tabRegion != null) {
-                if (openTabAnimation.get() == TabAnimation.GROW) {
+                if (Platform.isFxApplicationThread() && (openTabAnimation.get() == TabAnimation.GROW)) {
                     tabRegion.animationState = TabAnimationState.SHOWING;
                     tabRegion.animationTransition.setValue(0.0);
                     tabRegion.setVisible(true);

--- a/tests/system/src/test/java/test/robot/javafx/scene/NodeInitializationStressTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/NodeInitializationStressTest.java
@@ -546,7 +546,6 @@ public class NodeInitializationStressTest extends RobotTestBase {
         });
     }
 
-    @Disabled("JDK-8349098") // FIX
     @Test
     public void tabPane() {
         assumeFalse(SKIP_TEST);


### PR DESCRIPTION
## Root Cause
Animation gets started in a background thread, which causes the animation handler to run in the FX application thread, thus creating simultaneous access to the control's fields (list of children in this case).

## Solution
Skip the animation.

The fix is similar to https://github.com/openjdk/jfx/pull/1698