### PR TITLE
8349679: build.gradle: increase system test memory limit to 1GB

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -4272,6 +4272,8 @@ project(":systemTests") {
 
         // enable native access for all modules with native code
         jvmArgs enableNativeAll
+
+        maxHeapSize = "1000m"
 
         // FIXME: Remove this when JDK-8334137 is fixed
         if (jdk24OrLater) {


### PR DESCRIPTION
Increased max heap size for system tests from 521Mb to 1000Mb.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349679](https://bugs.openjdk.org/browse/JDK-8349679): build.gradle: increase system test memory limit to 1GB (**Enhancement** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Johan Vos](https://openjdk.org/census#jvos) (@johanvos - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1701/head:pull/1701` \
`$ git checkout pull/1701`

Update a local copy of the PR: \
`$ git checkout pull/1701` \
`$ git pull https://git.openjdk.org/jfx.git pull/1701/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1701`

View PR using the GUI difftool: \
`$ git pr show -t 1701`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1701.diff">https://git.openjdk.org/jfx/pull/1701.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1701#issuecomment-2644311604)
</details>
