### PR TITLE
8349756: Memory leak in PaginationSkin when setting page count / index

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/PaginationSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/PaginationSkin.java
@@ -198,7 +198,6 @@ public class PaginationSkin extends SkinBase<Pagination> {
         resetIndexes(true);
 
         navigation = new NavigationControl();
-        navigation.initializePageIndicators();
 
         getChildren().addAll(currentStackPane, nextStackPane, navigation);
 
@@ -909,6 +908,7 @@ public class PaginationSkin extends SkinBase<Pagination> {
                     HBox.setMargin(rightArrowButton, new Insets(0, 0, 0, snapSizeX(newValue.doubleValue())));
                 }
             });
+            initializePageIndicators();
         }
 
         private void initializeNavigationHandlers() {
@@ -950,8 +950,8 @@ public class PaginationSkin extends SkinBase<Pagination> {
                 ib.setToggleGroup(indicatorButtons);
                 controlBox.getChildren().add(ib);
             }
-            navigation.updateTooltipVisible();
-            navigation.updateBulletIndicatorType();
+            updateTooltipVisible();
+            updateBulletIndicatorType();
             controlBox.getChildren().add(rightArrowButton);
         }
 

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/PaginationSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/PaginationSkin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,6 +63,7 @@ import javafx.scene.control.Control;
 import javafx.scene.control.Label;
 import javafx.scene.control.Pagination;
 import javafx.scene.control.SkinBase;
+import javafx.scene.control.Toggle;
 import javafx.scene.control.ToggleButton;
 import javafx.scene.control.ToggleGroup;
 import javafx.scene.control.Tooltip;
@@ -108,7 +109,7 @@ public class PaginationSkin extends SkinBase<Pagination> {
     private Timeline timeline;
     private Rectangle clipRect;
 
-    private NavigationControl navigation;
+    private final NavigationControl navigation;
     private int fromIndex;
     private int previousIndex;
     private int currentIndex;
@@ -196,7 +197,8 @@ public class PaginationSkin extends SkinBase<Pagination> {
         // sets the current page index property in control to the same value (no-op)
         resetIndexes(true);
 
-        this.navigation = new NavigationControl();
+        navigation = new NavigationControl();
+        navigation.initializePageIndicators();
 
         getChildren().addAll(currentStackPane, nextStackPane, navigation);
 
@@ -229,6 +231,10 @@ public class PaginationSkin extends SkinBase<Pagination> {
                 return;
             }
             resetIndiciesAndNav();
+        });
+
+        lh.addListChangeListener(control.getStyleClass(), (ch) -> {
+            navigation.updateBulletIndicatorType();
         });
 
         initializeSwipeAndTouchHandlers();
@@ -367,6 +373,7 @@ public class PaginationSkin extends SkinBase<Pagination> {
             tooltipVisible = new StyleableBooleanProperty(DEFAULT_TOOLTIP_VISIBLE) {
                 @Override
                 protected void invalidated() {
+                    navigation.updateTooltipVisible();
                     getSkinnable().requestLayout();
                 }
 
@@ -889,7 +896,6 @@ public class PaginationSkin extends SkinBase<Pagination> {
 
             getChildren().addAll(controlBox, pageInformation);
             initializeNavigationHandlers();
-            initializePageIndicators();
             updatePageIndex();
 
             // listen to changes to arrowButtonGap and update margins
@@ -944,6 +950,8 @@ public class PaginationSkin extends SkinBase<Pagination> {
                 ib.setToggleGroup(indicatorButtons);
                 controlBox.getChildren().add(ib);
             }
+            navigation.updateTooltipVisible();
+            navigation.updateBulletIndicatorType();
             controlBox.getChildren().add(rightArrowButton);
         }
 
@@ -1284,6 +1292,24 @@ public class PaginationSkin extends SkinBase<Pagination> {
 
             layoutInArea(controlBox, controlBoxX, controlBoxY, controlBoxWidth, controlBoxHeight, 0, controlBoxHPos, controlBoxVPos);
         }
+
+        private void updateTooltipVisible() {
+            boolean on = tooltipVisibleProperty().get();
+            for (Toggle t : indicatorButtons.getToggles()) {
+                if (t instanceof IndicatorButton b) {
+                    b.setTooltipVisible(on);
+                }
+            }
+        }
+
+        private void updateBulletIndicatorType() {
+            boolean on = getSkinnable().getStyleClass().contains(Pagination.STYLE_CLASS_BULLET);
+            for (Toggle t : indicatorButtons.getToggles()) {
+                if (t instanceof IndicatorButton b) {
+                    b.setBulletIndicatorType(on);
+                }
+            }
+        }
     }
 
     class IndicatorButton extends ToggleButton {
@@ -1292,13 +1318,6 @@ public class PaginationSkin extends SkinBase<Pagination> {
         public IndicatorButton(int pageNumber) {
             this.pageNumber = pageNumber;
             setFocusTraversable(false);
-
-            ListenerHelper lh = ListenerHelper.get(PaginationSkin.this);
-
-            lh.addListChangeListener(getSkinnable().getStyleClass(), (ch) -> {
-                setIndicatorType();
-            });
-            setIndicatorType();
 
             setOnAction(arg0 -> {
                     getNode().requestFocus();
@@ -1310,16 +1329,12 @@ public class PaginationSkin extends SkinBase<Pagination> {
                     }
             });
 
-            lh.addChangeListener(tooltipVisibleProperty(), true, (visible) -> {
-                setTooltipVisible(visible);
-            });
-
             prefHeightProperty().bind(minHeightProperty());
             setAccessibleRole(AccessibleRole.PAGE_ITEM);
         }
 
-        private void setIndicatorType() {
-            if (getSkinnable().getStyleClass().contains(Pagination.STYLE_CLASS_BULLET)) {
+        private void setBulletIndicatorType(boolean on) {
+            if (on) {
                 getStyleClass().remove("number-button");
                 getStyleClass().add("bullet-button");
                 setText(null);
@@ -1499,5 +1514,4 @@ public class PaginationSkin extends SkinBase<Pagination> {
     public List<CssMetaData<? extends Styleable, ?>> getCssMetaData() {
         return getClassCssMetaData();
     }
-
 }


### PR DESCRIPTION
## Root Cause

Each time a `PaginationSkin.IndicatorButton` gets created it adds two listeners (to the control's `styleClass` property and to the skin's tooltipVisible property) via `ListenerHelper`.  This was not detected by the `SkinMemoryLeakTest` because all listeners got removed correctly upon skin change.

## Solution

Add a single listener to the control's `styleClass` property at the skin level, and insert the call to the skin's `tooltipVisible` property both of which iterate over indicator button to do their thing.


<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8349756](https://bugs.openjdk.org/browse/JDK-8349756): Memory leak in PaginationSkin when setting page count / index (**Bug** - P3)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1705/head:pull/1705` \
`$ git checkout pull/1705`

Update a local copy of the PR: \
`$ git checkout pull/1705` \
`$ git pull https://git.openjdk.org/jfx.git pull/1705/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1705`

View PR using the GUI difftool: \
`$ git pr show -t 1705`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1705.diff">https://git.openjdk.org/jfx/pull/1705.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1705#issuecomment-2651457966)
</details>
