### PR TITLE
8349758: Memory leak in TreeTableView

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TreeTableViewSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TreeTableViewSkin.java
@@ -155,13 +155,15 @@ public class TreeTableViewSkin<T> extends TableViewSkinBase<T, TreeItem<T>, Tree
             control.edit(-1, null);
         };
 
-        lh.addChangeListener(control.rootProperty(), (src, prev, root) -> {
+        lh.addChangeListener(control.rootProperty(), true, (src, prev, root) -> {
             if (prev != null) {
                 prev.removeEventHandler(TreeItem.<T>treeNotificationEvent(), rootListener);
             }
             if (root != null) {
                 root.addEventHandler(TreeItem.<T>treeNotificationEvent(), rootListener);
             }
+            // fix for JDK-8094887
+            control.edit(-1, null);
             updateItemCount();
         });
 

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TreeTableViewSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TreeTableViewSkin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
 
 package javafx.scene.control.skin;
 
-import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.List;
 import javafx.beans.property.ObjectProperty;
@@ -47,7 +46,6 @@ import javafx.scene.control.TreeTableRow;
 import javafx.scene.control.TreeTableView;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.StackPane;
-import com.sun.javafx.scene.control.IDisconnectable;
 import com.sun.javafx.scene.control.ListenerHelper;
 import com.sun.javafx.scene.control.TreeTableViewBackingList;
 import com.sun.javafx.scene.control.behavior.TreeTableViewBehavior;
@@ -69,10 +67,8 @@ public class TreeTableViewSkin<T> extends TableViewSkinBase<T, TreeItem<T>, Tree
 
     TreeTableViewBackingList<T> tableBackingList;
     ObjectProperty<ObservableList<TreeItem<T>>> tableBackingListProperty;
-
-    private WeakReference<TreeItem<T>> weakRootRef;
     private final TreeTableViewBehavior<T>  behavior;
-    private IDisconnectable rootListener;
+    private final EventHandler<TreeItem.TreeModificationEvent<T>> rootListener;
 
 
 
@@ -97,8 +93,6 @@ public class TreeTableViewSkin<T> extends TableViewSkinBase<T, TreeItem<T>, Tree
 
         flow.setFixedCellSize(control.getFixedCellSize());
         flow.setCellFactory(flow -> createCell());
-
-        setRoot(getSkinnable().getRoot());
 
         ListenerHelper lh = ListenerHelper.get(this);
 
@@ -131,18 +125,55 @@ public class TreeTableViewSkin<T> extends TableViewSkinBase<T, TreeItem<T>, Tree
         behavior.setOnHorizontalUnitScroll(this::horizontalUnitScroll);
         behavior.setOnVerticalUnitScroll(this::verticalUnitScroll);
 
-        lh.addChangeListener(control.rootProperty(), (ev) -> {
+        rootListener = (ch) -> {
+            if (ch.wasAdded() && ch.wasRemoved() && ch.getAddedSize() == ch.getRemovedSize()) {
+                // Fix for JDK-8114432, where the children of a TreeItem were changing,
+                // but because the overall item count was staying the same, there was
+                // no event being fired to the skin to be informed that the items
+                // had changed. So, here we just watch for the case where the number
+                // of items being added is equal to the number of items being removed.
+                markItemCountDirty();
+                control.requestLayout();
+            } else if (ch.getEventType().equals(TreeItem.valueChangedEvent())) {
+                // Fix for JDK-8114657 and JDK-8114610.
+                requestRebuildCells();
+            } else {
+                // Fix for JDK-8115929. We are checking to see if the event coming
+                // from the TreeItem root is an event where the count has changed.
+                EventType<?> eventType = ch.getEventType();
+                while (eventType != null) {
+                    if (eventType.equals(TreeItem.<T>expandedItemCountChangeEvent())) {
+                        markItemCountDirty();
+                        control.requestLayout();
+                        break;
+                    }
+                    eventType = eventType.getSuperType();
+                }
+            }
+
             // fix for JDK-8094887
-            getSkinnable().edit(-1, null);
-            setRoot(getSkinnable().getRoot());
+            control.edit(-1, null);
+        };
+
+        lh.addChangeListener(control.rootProperty(), (src, prev, root) -> {
+            if (prev != null) {
+                prev.removeEventHandler(TreeItem.<T>treeNotificationEvent(), rootListener);
+            }
+            if (root != null) {
+                root.addEventHandler(TreeItem.<T>treeNotificationEvent(), rootListener);
+            }
+            updateItemCount();
         });
 
         lh.addChangeListener(control.showRootProperty(), (ev) -> {
             // if we turn off showing the root, then we must ensure the root
             // is expanded - otherwise we end up with no visible items in
             // the tree.
-            if (! getSkinnable().isShowRoot() && getRoot() != null) {
-                getRoot().setExpanded(true);
+            if (!control.isShowRoot()) {
+                TreeItem<T> root = control.getRoot();
+                if (root != null) {
+                    root.setExpanded(true);
+                }
             }
             // update the item count in the flow and behavior instances
             updateItemCount();
@@ -155,6 +186,8 @@ public class TreeTableViewSkin<T> extends TableViewSkinBase<T, TreeItem<T>, Tree
         lh.addChangeListener(control.fixedCellSizeProperty(), (ev) -> {
             flow.setFixedCellSize(getSkinnable().getFixedCellSize());
         });
+
+        updateItemCount();
     }
 
 
@@ -168,11 +201,6 @@ public class TreeTableViewSkin<T> extends TableViewSkinBase<T, TreeItem<T>, Tree
     @Override
     public void dispose() {
         flow.setCellFactory(null);
-
-        if (rootListener != null) {
-            rootListener.disconnect();
-            rootListener = null;
-        }
 
         if (behavior != null) {
             behavior.dispose();
@@ -277,52 +305,6 @@ public class TreeTableViewSkin<T> extends TableViewSkinBase<T, TreeItem<T>, Tree
 
         cell.updateTreeTableView(treeTableView);
         return cell;
-    }
-
-    private TreeItem<T> getRoot() {
-        return weakRootRef == null ? null : weakRootRef.get();
-    }
-    private void setRoot(TreeItem<T> newRoot) {
-        if (rootListener != null) {
-            rootListener.disconnect();
-            rootListener = null;
-        }
-        weakRootRef = new WeakReference<>(newRoot);
-        if (getRoot() != null) {
-            // TODO I wonder if it might be possible for the root ref to get collected between these two lines
-            // which would throw an NPE.  Perhaps we should simply use newRoot instance instead of getRoot().
-            rootListener = ListenerHelper.get(this).addEventHandler(getRoot(), TreeItem.<T>treeNotificationEvent(), e -> {
-                if (e.wasAdded() && e.wasRemoved() && e.getAddedSize() == e.getRemovedSize()) {
-                    // Fix for JDK-8114432, where the children of a TreeItem were changing,
-                    // but because the overall item count was staying the same, there was
-                    // no event being fired to the skin to be informed that the items
-                    // had changed. So, here we just watch for the case where the number
-                    // of items being added is equal to the number of items being removed.
-                    markItemCountDirty();
-                    getSkinnable().requestLayout();
-                } else if (e.getEventType().equals(TreeItem.valueChangedEvent())) {
-                    // Fix for JDK-8114657 and JDK-8114610.
-                    requestRebuildCells();
-                } else {
-                    // Fix for JDK-8115929. We are checking to see if the event coming
-                    // from the TreeItem root is an event where the count has changed.
-                    EventType<?> eventType = e.getEventType();
-                    while (eventType != null) {
-                        if (eventType.equals(TreeItem.<T>expandedItemCountChangeEvent())) {
-                            markItemCountDirty();
-                            getSkinnable().requestLayout();
-                            break;
-                        }
-                        eventType = eventType.getSuperType();
-                    }
-                }
-
-                // fix for JDK-8094887
-                getSkinnable().edit(-1, null);
-            });
-        }
-
-        updateItemCount();
     }
 
     /** {@inheritDoc} */


### PR DESCRIPTION
## Root Cause

An event handler was installed on the root property without removing it when the root changes.

## Solution

Replaced the weak parts with a change listener to the root property to ensure correct handling of the root value changes.

/reviewers 2

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8349758](https://bugs.openjdk.org/browse/JDK-8349758): Memory leak in TreeTableView (**Bug** - P3)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1706/head:pull/1706` \
`$ git checkout pull/1706`

Update a local copy of the PR: \
`$ git checkout pull/1706` \
`$ git pull https://git.openjdk.org/jfx.git pull/1706/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1706`

View PR using the GUI difftool: \
`$ git pr show -t 1706`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1706.diff">https://git.openjdk.org/jfx/pull/1706.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1706#issuecomment-2652286975)
</details>
