### PR TITLE
8349004: DatePicker: NPE in show() when initialized in a background thread

### DIFF
--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/DatePickerContent.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/DatePickerContent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,24 +25,26 @@
 
 package com.sun.javafx.scene.control;
 
+import static com.sun.javafx.PlatformUtil.isMac;
+import static java.time.temporal.ChronoField.DAY_OF_WEEK;
+import static java.time.temporal.ChronoField.MONTH_OF_YEAR;
+import static java.time.temporal.ChronoUnit.DAYS;
+import static java.time.temporal.ChronoUnit.MONTHS;
+import static java.time.temporal.ChronoUnit.WEEKS;
+import static java.time.temporal.ChronoUnit.YEARS;
 import java.time.DateTimeException;
 import java.time.LocalDate;
+import java.time.YearMonth;
+import java.time.chrono.ChronoLocalDate;
+import java.time.chrono.Chronology;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DecimalStyle;
-import java.time.chrono.Chronology;
-import java.time.chrono.ChronoLocalDate;
 import java.time.temporal.ChronoUnit;
 import java.time.temporal.ValueRange;
 import java.time.temporal.WeekFields;
-import java.time.YearMonth;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
-
-import static java.time.temporal.ChronoField.*;
-import static java.time.temporal.ChronoUnit.*;
-
-import com.sun.javafx.scene.control.skin.*;
 import javafx.application.Platform;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
@@ -51,8 +53,8 @@ import javafx.event.EventHandler;
 import javafx.scene.Node;
 import javafx.scene.Scene;
 import javafx.scene.control.Button;
-import javafx.scene.control.DatePicker;
 import javafx.scene.control.DateCell;
+import javafx.scene.control.DatePicker;
 import javafx.scene.control.Label;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.input.MouseButton;
@@ -61,15 +63,13 @@ import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.ColumnConstraints;
 import javafx.scene.layout.GridPane;
 import javafx.scene.layout.HBox;
-import javafx.scene.layout.VBox;
 import javafx.scene.layout.StackPane;
-
+import javafx.scene.layout.VBox;
+import com.sun.javafx.scene.NodeHelper;
+import com.sun.javafx.scene.control.skin.Utils;
 import com.sun.javafx.scene.control.skin.resources.ControlResources;
 import com.sun.javafx.scene.traversal.Direction;
 import com.sun.javafx.scene.traversal.TraversalMethod;
-
-import static com.sun.javafx.PlatformUtil.*;
-import com.sun.javafx.scene.NodeHelper;
 
 /**
  * The full content for the DatePicker popup. This class could
@@ -684,7 +684,7 @@ public class DatePickerContent extends VBox {
     public void goToDate(LocalDate date, boolean focusDayCell) {
         if (isValidDate(datePicker.getChronology(), date)) {
             displayedYearMonth.set(YearMonth.from(date));
-            if (focusDayCell) {
+            if (focusDayCell && Platform.isFxApplicationThread()) {
                 findDayCellForDate(date).requestFocus();
             }
         }

--- a/tests/system/src/test/java/test/robot/javafx/scene/NodeInitializationStressTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/NodeInitializationStressTest.java
@@ -314,7 +314,6 @@ public class NodeInitializationStressTest extends RobotTestBase {
         });
     }
 
-    @Disabled("JDK-8349004") // FIX
     @Test
     public void datePicker() {
         assumeFalse(SKIP_TEST);
@@ -323,12 +322,12 @@ public class NodeInitializationStressTest extends RobotTestBase {
             c.setSkin(new DatePickerSkin(c));
             return c;
         }, (c) -> {
-            c.show(); // fails here
+            accessControl(c);
             c.setValue(LocalDate.now());
             c.prefHeight(-1);
             c.setValue(LocalDate.EPOCH);
             c.prefWidth(-1);
-            accessControl(c);
+            c.show();
         });
     }
 


### PR DESCRIPTION
## Root Cause

Focus is being requested in show(), even a background thread.

## Solution

Do not request focus if in a background thread.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8349004](https://bugs.openjdk.org/browse/JDK-8349004): DatePicker: NPE in show() when initialized in a background thread (**Bug** - P4) ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1708/head:pull/1708` \
`$ git checkout pull/1708`

Update a local copy of the PR: \
`$ git checkout pull/1708` \
`$ git pull https://git.openjdk.org/jfx.git pull/1708/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1708`

View PR using the GUI difftool: \
`$ git pr show -t 1708`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1708.diff">https://git.openjdk.org/jfx/pull/1708.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1708#issuecomment-2654760142)
</details>
