### PR TITLE
8349096: Split/MenuButton: exception initializing in a background thread

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ContextMenu.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ContextMenu.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,10 +25,7 @@
 
 package javafx.scene.control;
 
-import com.sun.javafx.beans.IDProperty;
-import com.sun.javafx.collections.TrackableObservableList;
-import com.sun.javafx.util.Utils;
-
+import javafx.application.Platform;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.ObjectPropertyBase;
 import javafx.collections.ListChangeListener.Change;
@@ -44,6 +41,9 @@ import javafx.scene.Node;
 import javafx.scene.Scene;
 import javafx.scene.control.skin.ContextMenuSkin;
 import javafx.stage.Window;
+import com.sun.javafx.beans.IDProperty;
+import com.sun.javafx.collections.TrackableObservableList;
+import com.sun.javafx.util.Utils;
 
 /**
  * <p>
@@ -242,8 +242,9 @@ public class ContextMenu extends PopupControl {
      * @param dy the dy value for the y-axis
      */
      public void show(Node anchor, Side side, double dx, double dy) {
-        if (anchor == null) return;
-        if (getItems().size() == 0) return;
+        if ((anchor == null) || (getItems().size() == 0) || !Platform.isFxApplicationThread()) {
+            return;
+        }
 
         getScene().setNodeOrientation(anchor.getEffectiveNodeOrientation());
         if (getScene().getStylesheets().isEmpty()) {

--- a/tests/system/src/test/java/test/robot/javafx/scene/NodeInitializationStressTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/NodeInitializationStressTest.java
@@ -386,7 +386,6 @@ public class NodeInitializationStressTest extends RobotTestBase {
         });
     }
 
-    @Disabled("JDK-8349096") // FIX
     @Test
     public void menuButton() {
         assumeFalse(SKIP_TEST);
@@ -502,7 +501,6 @@ public class NodeInitializationStressTest extends RobotTestBase {
         });
     }
 
-    @Disabled("JDK-8349096") // FIX
     @Test
     public void splitMenuButton() {
         assumeFalse(SKIP_TEST);


### PR DESCRIPTION
## Root Cause

The ContextMenu (PopupWindow) cannot be shown in a background thread.

## Solution

Bail out of `show()` if in a background thread.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8349096](https://bugs.openjdk.org/browse/JDK-8349096): Split/MenuButton: exception initializing in a background thread (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1709/head:pull/1709` \
`$ git checkout pull/1709`

Update a local copy of the PR: \
`$ git checkout pull/1709` \
`$ git pull https://git.openjdk.org/jfx.git pull/1709/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1709`

View PR using the GUI difftool: \
`$ git pr show -t 1709`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1709.diff">https://git.openjdk.org/jfx/pull/1709.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1709#issuecomment-2654779936)
</details>
