### PR TITLE
8350917: Allow parent nodes to provide CSS styleable properties for child nodes

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/css/Styleable.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/Styleable.java
@@ -92,6 +92,20 @@ public interface Styleable {
     List<CssMetaData<? extends Styleable, ?>> getCssMetaData();
 
     /**
+     * Provides an immutable list of CSS meta data that a parent may contribute
+     * to any of its direct children.
+     * <p>
+     * Note: this method does not provide CSS meta data for <b>this</b> Styleable,
+     * only for its direct children!
+     *
+     * @return an immutable list of CSS meta data, never {@code null}
+     * @since 25
+     */
+    default List<CssMetaData<Styleable, ?>> getChildCssMetaData() {
+        return List.of();
+    }
+
+    /**
      * Return the parent of this Styleable, or null if there is no parent.
      * @return the parent of this Styleable, or null if there is no parent
      */

--- a/modules/javafx.graphics/src/main/java/javafx/css/StyleableProperty.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/StyleableProperty.java
@@ -64,16 +64,25 @@ import javafx.beans.value.WritableValue;
 public interface StyleableProperty<T> extends WritableValue<T> {
 
     /**
-     * This method is called from CSS code to set the value of the property.
-     * @param origin the origin
-     * @param value the value
+     * Applies a value to this property and track its origin. This allows for
+     * selectively overriding properties depending on origin priority.
+     * <p>
+     * Note: the provided origin can be {@code null}, indicating that the value is
+     * being reset to its default, and was not specifically set for any origin.
+     *
+     * @param origin the origin, can be {@code null}
+     * @param value the value, can be {@code null}
      */
     void applyStyle(StyleOrigin origin, T value);
 
     /**
-     * Tells the origin of the value of the property. This is needed to
-     * determine whether or not CSS can override the value.
-     * @return the style origin
+     * Returns the origin of the value of the property. This is used by the
+     * CSS engine to determine when values can be overridden.
+     * <p>
+     * Note: the returned origin can be {@code null}, indicating that this value
+     * was never set for any origin, or was reset to this state.
+     *
+     * @return the style origin, can be {@code null}
      */
     StyleOrigin getStyleOrigin();
 

--- a/modules/javafx.graphics/src/main/java/javafx/scene/CssStyleHelper.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/CssStyleHelper.java
@@ -832,8 +832,8 @@ final class CssStyleHelper {
         // transition to that value.
         transitionStateInProgress = true;
 
-        // The StyleCacheEntry (cache), when filled, holds previously calculated values 
-        // for each property. Missing values in this cache indicate no style affected 
+        // The StyleCacheEntry (cache), when filled, holds previously calculated values
+        // for each property. Missing values in this cache indicate no style affected
         // the value and should lead to a reset of the property to its previous value.
         //
         // If there was no cache present, then a new cache is created which will have

--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/HBox.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/HBox.java
@@ -32,6 +32,7 @@ import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.ObjectProperty;
 import javafx.css.CssMetaData;
+import javafx.css.StyleConverter;
 import javafx.css.StyleableBooleanProperty;
 import javafx.css.StyleableDoubleProperty;
 import javafx.css.StyleableObjectProperty;
@@ -161,8 +162,6 @@ public class HBox extends Pane {
     /* ******************************************************************
      *  BEGIN static methods
      ********************************************************************/
-    private static final String MARGIN_CONSTRAINT = "hbox-margin";
-    private static final String HGROW_CONSTRAINT = "hbox-hgrow";
 
     /**
      * Sets the horizontal grow priority for the child when contained by an hbox.
@@ -178,7 +177,7 @@ public class HBox extends Pane {
      * @param value the horizontal grow priority for the child
      */
     public static void setHgrow(Node child, Priority value) {
-        setConstraint(child, HGROW_CONSTRAINT, value);
+        setChildConstraint(child, StyleableProperties.CHILD_HGROW, value);
     }
 
     /**
@@ -187,7 +186,7 @@ public class HBox extends Pane {
      * @return the horizontal grow priority for the child or null if no priority was set
      */
     public static Priority getHgrow(Node child) {
-        return (Priority)getConstraint(child, HGROW_CONSTRAINT);
+        return getChildConstraint(child, StyleableProperties.CHILD_HGROW);
     }
 
     /**
@@ -198,7 +197,7 @@ public class HBox extends Pane {
      * @param value the margin of space around the child
      */
     public static void setMargin(Node child, Insets value) {
-        setConstraint(child, MARGIN_CONSTRAINT, value);
+        setChildConstraint(child, StyleableProperties.CHILD_MARGIN, value);
     }
 
     /**
@@ -207,7 +206,7 @@ public class HBox extends Pane {
      * @return the margin for the child or null if no margin was set
      */
     public static Insets getMargin(Node child) {
-        return (Insets)getConstraint(child, MARGIN_CONSTRAINT);
+        return getChildConstraint(child, StyleableProperties.CHILD_MARGIN);
     }
 
     private static final Callback<Node, Insets> marginAccessor = n -> getMargin(n);
@@ -740,6 +739,34 @@ public class HBox extends Pane {
             styleables.add(SPACING);
             STYLEABLES = Collections.unmodifiableList(styleables);
          }
+
+         private static final CssMetaData<Styleable, Priority> CHILD_HGROW = new CssMetaData<>("-fx-hbox-hgrow", StyleConverter.getEnumConverter(Priority.class)) {
+             @Override
+             public boolean isSettable(Styleable styleable) {
+                 return true;
+             }
+
+             @Override
+             public StyleableProperty<Priority> getStyleableProperty(Styleable styleable) {
+                 return childConstraintProperty((Node)styleable, this);
+             }
+         };
+
+         private static final CssMetaData<Styleable, Insets> CHILD_MARGIN = new CssMetaData<>("-fx-hbox-margin", StyleConverter.getInsetsConverter()) {
+             @Override
+             public boolean isSettable(Styleable styleable) {
+                 return true;
+             }
+
+             @Override
+             public StyleableProperty<Insets> getStyleableProperty(Styleable styleable) {
+                 return childConstraintProperty((Node)styleable, this);
+             }
+         };
+
+         private static final List<CssMetaData<Styleable, ?>> CHILD_STYLEABLES = List.of(
+             CHILD_HGROW, CHILD_MARGIN
+         );
     }
 
     /**
@@ -764,4 +791,8 @@ public class HBox extends Pane {
         return getClassCssMetaData();
     }
 
+    @Override
+    public List<CssMetaData<Styleable, ?>> getChildCssMetaData() {
+        return StyleableProperties.CHILD_STYLEABLES;
+    }
 }

--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/VBox.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/VBox.java
@@ -32,6 +32,7 @@ import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.ObjectProperty;
 import javafx.css.CssMetaData;
+import javafx.css.StyleConverter;
 import javafx.css.StyleableBooleanProperty;
 import javafx.css.StyleableDoubleProperty;
 import javafx.css.StyleableObjectProperty;
@@ -150,8 +151,6 @@ public class VBox extends Pane {
 /* ******************************************************************
      *  BEGIN static methods
      ********************************************************************/
-    private static final String MARGIN_CONSTRAINT = "vbox-margin";
-    private static final String VGROW_CONSTRAINT = "vbox-vgrow";
 
     /**
      * Sets the vertical grow priority for the child when contained by a vbox.
@@ -167,7 +166,7 @@ public class VBox extends Pane {
      * @param value the vertical grow priority for the child
      */
     public static void setVgrow(Node child, Priority value) {
-        setConstraint(child, VGROW_CONSTRAINT, value);
+        setChildConstraint(child, StyleableProperties.CHILD_VGROW, value);
     }
 
     /**
@@ -176,7 +175,7 @@ public class VBox extends Pane {
      * @return the vertical grow priority for the child or null if no priority was set
      */
     public static Priority getVgrow(Node child) {
-        return (Priority)getConstraint(child, VGROW_CONSTRAINT);
+        return getChildConstraint(child, StyleableProperties.CHILD_VGROW);
     }
 
     /**
@@ -187,7 +186,7 @@ public class VBox extends Pane {
      * @param value the margin of space around the child
      */
     public static void setMargin(Node child, Insets value) {
-        setConstraint(child, MARGIN_CONSTRAINT, value);
+        setChildConstraint(child, StyleableProperties.CHILD_MARGIN, value);
     }
 
     /**
@@ -196,7 +195,7 @@ public class VBox extends Pane {
      * @return the margin for the child or null if no margin was set
      */
     public static Insets getMargin(Node child) {
-        return (Insets)getConstraint(child, MARGIN_CONSTRAINT);
+        return getChildConstraint(child, StyleableProperties.CHILD_MARGIN);
     }
 
     private static final Callback<Node, Insets> marginAccessor = n -> getMargin(n);
@@ -660,6 +659,34 @@ public class VBox extends Pane {
             styleables.add(SPACING);
             STYLEABLES = Collections.unmodifiableList(styleables);
          }
+
+         private static final CssMetaData<Styleable, Priority> CHILD_VGROW = new CssMetaData<>("-fx-vbox-vgrow", StyleConverter.getEnumConverter(Priority.class)) {
+             @Override
+             public boolean isSettable(Styleable styleable) {
+                 return true;
+             }
+
+             @Override
+             public StyleableProperty<Priority> getStyleableProperty(Styleable styleable) {
+                 return childConstraintProperty((Node)styleable, this);
+             }
+         };
+
+         private static final CssMetaData<Styleable, Insets> CHILD_MARGIN = new CssMetaData<>("-fx-vbox-margin", StyleConverter.getInsetsConverter()) {
+             @Override
+             public boolean isSettable(Styleable styleable) {
+                 return true;
+             }
+
+             @Override
+             public StyleableProperty<Insets> getStyleableProperty(Styleable styleable) {
+                 return childConstraintProperty((Node)styleable, this);
+             }
+         };
+
+         private static final List<CssMetaData<Styleable, ?>> CHILD_STYLEABLES = List.of(
+             CHILD_VGROW, CHILD_MARGIN
+         );
     }
 
     /**
@@ -684,4 +711,8 @@ public class VBox extends Pane {
         return getClassCssMetaData();
     }
 
+    @Override
+    public List<CssMetaData<Styleable, ?>> getChildCssMetaData() {
+        return StyleableProperties.CHILD_STYLEABLES;
+    }
 }


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 2 [Reviewers](https://openjdk.org/bylaws#reviewer))
- [ ] Change requires a CSR request matching fixVersion jfx26 to be approved (needs to be created)

### Error
&nbsp;⚠️ The pull request body must not be empty.

### Issue
 * [JDK-8350917](https://bugs.openjdk.org/browse/JDK-8350917): Allow parent nodes to provide CSS styleable properties for child nodes (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1714/head:pull/1714` \
`$ git checkout pull/1714`

Update a local copy of the PR: \
`$ git checkout pull/1714` \
`$ git pull https://git.openjdk.org/jfx.git pull/1714/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1714`

View PR using the GUI difftool: \
`$ git pr show -t 1714`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1714.diff">https://git.openjdk.org/jfx/pull/1714.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1714#issuecomment-2692136812)
</details>
