### PR TITLE
8350437: [GHA] Update gradle wrapper-validation action to v3

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: gradle/wrapper-validation-action@v1
+      - uses: gradle/actions/wrapper-validation@v3
 
 
   linux_x64_build:


### PR DESCRIPTION
Update the GitHub gradle wrapper-validation action to v3. In addition to being a good practice in general, we've had a few intermittent failures in the existing validation task, and updating to the latest might help with this.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350437](https://bugs.openjdk.org/browse/JDK-8350437): [GHA] Update gradle wrapper-validation action to v3 (**Bug** - P3)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1718/head:pull/1718` \
`$ git checkout pull/1718`

Update a local copy of the PR: \
`$ git checkout pull/1718` \
`$ git pull https://git.openjdk.org/jfx.git pull/1718/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1718`

View PR using the GUI difftool: \
`$ git pr show -t 1718`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1718.diff">https://git.openjdk.org/jfx/pull/1718.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1718#issuecomment-2671549327)
</details>
