### PR TITLE
8332947: [macos] java.awt.desktop.OpenURIHandler is not receiving events

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassAccessible.h
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassAccessible.h
@@ -44,6 +44,7 @@ jMapper jVariantToID;
 
 id variantToID(JNIEnv *env, jobject variant);
 NSString* jStringToNSString(JNIEnv *env, jstring string);
+jstring NSStringToJavaString(JNIEnv *env, NSString* string);
 NSArray* jArrayToNSArray(JNIEnv *env, jarray srcArray, jMapper);
 
 /* Accessible class IDs for classes, methods, and fields (this could be in GlassStatics.h) */

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassAccessible.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassAccessible.m
@@ -275,6 +275,22 @@ NSString* jStringToNSString(JNIEnv *env, jstring string) {
     return result;
 }
 
+jstring NSStringToJavaString(JNIEnv *env, NSString* string) {
+    if (string == NULL) {
+       return NULL;
+    }
+    jsize len = [string length];
+    unichar *buffer = (unichar*)calloc(len, sizeof(unichar));
+    if (buffer == NULL) {
+       return NULL;
+    }
+    NSRange crange = NSMakeRange(0, len);
+    [string getCharacters:buffer range:crange];
+    jstring jStr = (*env)->NewString(env, buffer, len);
+    free(buffer);
+    return jStr;
+}
+
 id variantToID(JNIEnv *env, jobject variant) {
     if (variant == NULL) return NULL;
     jint type = (*env)->GetIntField(env, variant, jVariantType);

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
@@ -405,6 +405,22 @@ jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved)
     GLASS_CHECK_EXCEPTION(env);
 }
 
+- (void)application:(NSApplication *)application openURLs:(NSArray<NSURL *> *)urls
+{
+    LOG("GlassApplication:application:openURLs");
+
+    GET_MAIN_JENV;
+    jclass appEventHandlerClass = [GlassHelper ClassForName:"com.apple.eawt._AppEventHandler" withEnv:env];
+    jmethodID handleOpenURIMethod = (*env)->GetStaticMethodID(env, appEventHandlerClass, "handleOpenURI", "(Ljava/lang/String;)V");
+
+    for (NSURL *url in urls) {
+        jstring jURL = NSStringToJavaString(jEnv, url.absoluteString);
+
+        (*env)->CallStaticVoidMethod(env, appEventHandlerClass, handleOpenURIMethod, jURL);
+        (*env)->DeleteLocalRef(env, jURL);
+    }
+}
+
 - (void)application:(NSApplication *)theApplication openFiles:(NSArray *)filenames
 {
     LOG("GlassApplication:application:openFiles");


### PR DESCRIPTION
When trying to register an open URI handler when using JavaFX with a native menu, this task fails on Mac.
Either the native menu is not shown or the URIs are not received.

This pull request fixes this issue if the registration takes place inside the start method of an application before calling the show method.

The test for this pull request is non trivial, as the application needs to be installed on the Mac before it can be tested. Therefore the test is provided in a separate repository and it needs to be discussed if the test is necessary to have inside the JFX repo and if so, how it should be integrated.

Co-Author: @floriankirmaier

Link to the test repo: https://github.com/pabulaner/openurifx

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 2 [Reviewers](https://openjdk.org/bylaws#reviewer))

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Issue
 * [JDK-8332947](https://bugs.openjdk.org/browse/JDK-8332947): [macos] java.awt.desktop.OpenURIHandler is not receiving events (**Bug** - P4)(⚠️ The fixVersion in this issue is [25] but the fixVersion in .jcheck/conf is jfx25, a new backport will be created when this pr is integrated.)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1720/head:pull/1720` \
`$ git checkout pull/1720`

Update a local copy of the PR: \
`$ git checkout pull/1720` \
`$ git pull https://git.openjdk.org/jfx.git pull/1720/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1720`

View PR using the GUI difftool: \
`$ git pr show -t 1720`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1720.diff">https://git.openjdk.org/jfx/pull/1720.diff</a>

</details>
