### PR TITLE
AbstractPrimaryTimer should not print messages when javafx.verbose is false

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/scenario/animation/AbstractPrimaryTimer.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/scenario/animation/AbstractPrimaryTimer.java
@@ -102,8 +102,10 @@ public abstract class AbstractPrimaryTimer {
     static {
         Settings.addPropertyChangeListener(pcl);
         int pulse = Settings.getInt(PULSE_PROP, -1);
-        if (pulse != -1) {
-            System.err.println("Setting PULSE_DURATION to " + pulse + " hz");
+
+        boolean verbose = Boolean.getBoolean("javafx.verbose");
+        if (verbose && pulse != -1) {
+            System.out.println("Setting PULSE_DURATION to " + pulse + " hz");
         }
     }
 


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Error
&nbsp;⚠️ The pull request body must not be empty.

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1726/head:pull/1726` \
`$ git checkout pull/1726`

Update a local copy of the PR: \
`$ git checkout pull/1726` \
`$ git pull https://git.openjdk.org/jfx.git pull/1726/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1726`

View PR using the GUI difftool: \
`$ git pr show -t 1726`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1726.diff">https://git.openjdk.org/jfx/pull/1726.diff</a>

</details>
