### PR TITLE
8351067: Enforce Platform threading use

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/application/Platform.java
+++ b/modules/javafx.graphics/src/main/java/javafx/application/Platform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -421,8 +421,8 @@ public final class Platform {
      * This property is typically set to true the first time an
      * assistive technology, such as a screen reader, requests
      * information about any JavaFX window or its children.
-     *
-     * <p>This method may be called from any thread.</p>
+     * <p>
+     * This property can be accessed only from the FX application thread.
      *
      * @return the read-only boolean property indicating if accessibility is active
      *

--- a/modules/javafx.graphics/src/main/java/javafx/application/Platform.java
+++ b/modules/javafx.graphics/src/main/java/javafx/application/Platform.java
@@ -413,6 +413,7 @@ public final class Platform {
     private static ReadOnlyBooleanWrapper accessibilityActiveProperty;
 
     public static boolean isAccessibilityActive() {
+        Toolkit.getToolkit().checkFxUserThread();
         return accessibilityActiveProperty == null ? false : accessibilityActiveProperty.get();
     }
 
@@ -426,9 +427,12 @@ public final class Platform {
      *
      * @return the read-only boolean property indicating if accessibility is active
      *
+     * @throws IllegalStateException if this method is called on a thread
+     *     other than the JavaFX Application Thread.
      * @since JavaFX 8u40
      */
     public static ReadOnlyBooleanProperty accessibilityActiveProperty() {
+        Toolkit.getToolkit().checkFxUserThread();
         if (accessibilityActiveProperty == null) {
             accessibilityActiveProperty = new ReadOnlyBooleanWrapper(Platform.class, "accessibilityActive");
             accessibilityActiveProperty.bind(PlatformImpl.accessibilityActiveProperty());

--- a/modules/javafx.graphics/src/main/java/javafx/application/Platform.java
+++ b/modules/javafx.graphics/src/main/java/javafx/application/Platform.java
@@ -422,7 +422,7 @@ public final class Platform {
      * assistive technology, such as a screen reader, requests
      * information about any JavaFX window or its children.
      * <p>
-     * This property can be accessed only from the FX application thread.
+     * This property can be accessed only from the JavaFX Application Thread.
      *
      * @return the read-only boolean property indicating if accessibility is active
      *

--- a/modules/javafx.graphics/src/main/java/javafx/application/Platform.java
+++ b/modules/javafx.graphics/src/main/java/javafx/application/Platform.java
@@ -449,12 +449,15 @@ public final class Platform {
      * by JavaFX when the operating system reports that a platform preference has changed.
      *
      * @return the {@code Preferences} instance
+     * @throws IllegalStateException if this method is called on a thread
+     *     other than the JavaFX Application Thread.
      * @see <a href="Platform.Preferences.html#preferences-table-windows">Windows preferences</a>
      * @see <a href="Platform.Preferences.html#preferences-table-macos">macOS preferences</a>
      * @see <a href="Platform.Preferences.html#preferences-table-linux">Linux preferences</a>
      * @since 22
      */
     public static Preferences getPreferences() {
+        Toolkit.getToolkit().checkFxUserThread();
         PlatformImpl.checkPreferencesSupport();
         return PlatformImpl.getPlatformPreferences();
     }

--- a/tests/system/src/test/java/test/javafx/application/PlatformTest.java
+++ b/tests/system/src/test/java/test/javafx/application/PlatformTest.java
@@ -126,7 +126,7 @@ public class PlatformTest {
     }
 
     @Test
-    public void accessibilityActiveNotOnFxThread() {
+    public void testAccessorsNotOnFxThread() {
         assertThrows(IllegalStateException.class, Platform::accessibilityActiveProperty);
         assertThrows(IllegalStateException.class, Platform::getPreferences);
         assertThrows(IllegalStateException.class, Platform::isAccessibilityActive);

--- a/tests/system/src/test/java/test/javafx/application/PlatformTest.java
+++ b/tests/system/src/test/java/test/javafx/application/PlatformTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,24 +25,21 @@
 
 package test.javafx.application;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+import javafx.animation.KeyFrame;
+import javafx.animation.Timeline;
+import javafx.application.Platform;
+import javafx.util.Duration;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import test.util.Util;
-
-import javafx.animation.KeyFrame;
-import javafx.animation.Timeline;
-import javafx.util.Duration;
-import javafx.application.Platform;
-
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.atomic.AtomicReference;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class PlatformTest {
 
@@ -128,4 +125,9 @@ public class PlatformTest {
         assertNull(exceptionRef.get(), exceptionRef::toString);
     }
 
+    @Test
+    public void accessibilityActiveNotOnFxThread() {
+        assertThrows(IllegalStateException.class, Platform::isAccessibilityActive);
+        assertThrows(IllegalStateException.class, Platform::accessibilityActiveProperty);
+    }
 }

--- a/tests/system/src/test/java/test/javafx/application/PlatformTest.java
+++ b/tests/system/src/test/java/test/javafx/application/PlatformTest.java
@@ -127,7 +127,8 @@ public class PlatformTest {
 
     @Test
     public void accessibilityActiveNotOnFxThread() {
-        assertThrows(IllegalStateException.class, Platform::isAccessibilityActive);
         assertThrows(IllegalStateException.class, Platform::accessibilityActiveProperty);
+        assertThrows(IllegalStateException.class, Platform::getPreferences);
+        assertThrows(IllegalStateException.class, Platform::isAccessibilityActive);
     }
 }


### PR DESCRIPTION
Summary
-------

Adds a thread check to a number of `Platform` methods:
```
accessibilityActiveProperty()
getPreferences()
isAccessibilityActive()
```
These methods will throw an `IllegalStateException` if called on a thread other than the JavaFX Application Thread.

Problem
-------

JavaFX allows the Nodes and Scenes to be created and modified on any thread as long as they are not yet attached to a `Window` that is showing.

This is allowed in an implicit assumption that the construction code only modifies the properties of the said Nodes and Scenes, but not other static or global entities.  Concurrent multi-threaded access of such entities not only breaks the initialization of the properties, but also causes the failures down the road, if the change to the global properties happens while the Nodes and Scenes are still being constructed.

Even JavaFX platform developers did not avoid tripping over this issue, as can be illustrated by https://bugs.openjdk.org/browse/JDK-8348987 . 

Solution
--------

Fail each method fast with an  `IllegalStateException` if called from a background thread.

While this solution won't prevent other possible abuse, such as getting a reference to the property in the JavaFX Application Thread and later accessing it in a background thread, adding a check and allowing these methods to fail fast should prevent most likely scenarios.


/csr
/reviewers 2

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8351592](https://bugs.openjdk.org/browse/JDK-8351592) to be approved

### Issues
 * [JDK-8351067](https://bugs.openjdk.org/browse/JDK-8351067): Enforce Platform threading use (**Bug** - P4)
 * [JDK-8351592](https://bugs.openjdk.org/browse/JDK-8351592): Enforce Platform threading use (**CSR**)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Michael Strauß](https://openjdk.org/census#mstrauss) (@mstr2 - **Reviewer**) Review applies to [e9bb3403](https://git.openjdk.org/jfx/pull/1728/files/e9bb3403d3b8d0a2ff2e8711a667fee01e5bad09)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1728/head:pull/1728` \
`$ git checkout pull/1728`

Update a local copy of the PR: \
`$ git checkout pull/1728` \
`$ git pull https://git.openjdk.org/jfx.git pull/1728/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1728`

View PR using the GUI difftool: \
`$ git pr show -t 1728`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1728.diff">https://git.openjdk.org/jfx/pull/1728.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1728#issuecomment-2698660570)
</details>
