### PR TITLE
8351276: Prevent redundant computeValue calls when a chain of mappings becomes observed

### DIFF
--- a/modules/javafx.base/src/main/java/com/sun/javafx/binding/LazyObjectBinding.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/binding/LazyObjectBinding.java
@@ -43,9 +43,9 @@ abstract class LazyObjectBinding<T> extends ObjectBinding<T> {
 
     @Override
     public void addListener(ChangeListener<? super T> listener) {
-        super.addListener(listener);
+        updateSubscriptionBeforeAdd();
 
-        updateSubscriptionAfterAdd();
+        super.addListener(listener);
     }
 
     @Override
@@ -57,9 +57,9 @@ abstract class LazyObjectBinding<T> extends ObjectBinding<T> {
 
     @Override
     public void addListener(InvalidationListener listener) {
-        super.addListener(listener);
+        updateSubscriptionBeforeAdd();
 
-        updateSubscriptionAfterAdd();
+        super.addListener(listener);
     }
 
     @Override
@@ -75,9 +75,14 @@ abstract class LazyObjectBinding<T> extends ObjectBinding<T> {
     }
 
     /**
-     * Called after a listener was added to start observing inputs if they're not observed already.
+     * Called before a listener was added to start observing inputs if they're not observed already.
+     * This is done before the addition of a listener to be able to start observing its source
+     * before the first listener queries the current value. By doing this, this first query will
+     * also be immediately cached, as observed bindings are allowed to do so. This potentially avoids
+     * many redundant compute value calls, especially if the source was also not yet observed (and
+     * its source, and so on).
      */
-    private void updateSubscriptionAfterAdd() {
+    private void updateSubscriptionBeforeAdd() {
         if (!wasObserved) { // was first observer registered?
             subscription = observeSources(); // start observing source
             wasObserved = true;

--- a/modules/javafx.base/src/main/java/javafx/beans/value/ObservableValue.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/value/ObservableValue.java
@@ -368,8 +368,17 @@ public interface ObservableValue<T> extends Observable {
         Objects.requireNonNull(valueSubscriber, "valueSubscriber cannot be null");
         ChangeListener<T> listener = (obs, old, current) -> valueSubscriber.accept(current);
 
-        valueSubscriber.accept(getValue());  // eagerly send current value
         addListener(listener);
+
+        /*
+         * Below we eagerly send the current value. This is done after the listener
+         * was added so that observables that may only cache values when observed
+         * can first become observed (allowing caching) and are then queried (likely
+         * getting the value from the cache). Doing this the other way around would
+         * result in the value (or chain of values) being computed twice.
+         */
+
+        valueSubscriber.accept(getValue());
 
         return () -> removeListener(listener);
     }

--- a/modules/javafx.base/src/test/java/test/javafx/beans/value/ObservableValueFluentBindingsTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/beans/value/ObservableValueFluentBindingsTest.java
@@ -58,10 +58,11 @@ public class ObservableValueFluentBindingsTest {
     private final ChangeListener<String> changeListener = (obs, old, current) -> values.add(current);
     private final InvalidationListener invalidationListener = obs -> invalidations++;
 
-    private StringProperty property = new SimpleStringProperty("Initial");
+    private final StringProperty property = new SimpleStringProperty("Initial");
 
     @Nested
     class GivenAQuadMappedObservable {
+
         AtomicInteger calls1 = new AtomicInteger(0);
         AtomicInteger calls2 = new AtomicInteger(0);
         AtomicInteger calls3 = new AtomicInteger(0);

--- a/modules/javafx.base/src/test/java/test/javafx/beans/value/ObservableValueFluentBindingsTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/beans/value/ObservableValueFluentBindingsTest.java
@@ -35,6 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -58,6 +59,128 @@ public class ObservableValueFluentBindingsTest {
     private final InvalidationListener invalidationListener = obs -> invalidations++;
 
     private StringProperty property = new SimpleStringProperty("Initial");
+
+    @Nested
+    class GivenAQuadMappedObservable {
+        AtomicInteger calls1 = new AtomicInteger(0);
+        AtomicInteger calls2 = new AtomicInteger(0);
+        AtomicInteger calls3 = new AtomicInteger(0);
+        AtomicInteger calls4 = new AtomicInteger(0);
+
+        ObservableValue<String> observableValue = property
+            .map(x -> x + calls1.incrementAndGet())
+            .map(x -> x + calls2.incrementAndGet())
+            .map(x -> x + calls3.incrementAndGet())
+            .map(x -> x + calls4.incrementAndGet());
+
+        {
+            assertEquals(0, calls1.get());
+            assertEquals(0, calls2.get());
+            assertEquals(0, calls3.get());
+            assertEquals(0, calls4.get());
+        }
+
+        @Nested
+        class WhenObservedByInvalidationListener {
+            {
+                observableValue.addListener(obs -> {});
+            }
+
+            @Test
+            void computeValueShouldBeCalledOnlyOnce() {
+                assertEquals(1, calls1.get());
+                assertEquals(1, calls2.get());
+                assertEquals(1, calls3.get());
+                assertEquals(1, calls4.get());
+            }
+        }
+
+        @Nested
+        class WhenObservedByChangeListener {
+            {
+                observableValue.addListener((obs, o, n) -> {});
+            }
+
+            @Test
+            void computeValueShouldBeCalledOnlyOnce() {
+                assertEquals(1, calls1.get());
+                assertEquals(1, calls2.get());
+                assertEquals(1, calls3.get());
+                assertEquals(1, calls4.get());
+            }
+        }
+
+        @Nested
+        class WhenObservedByInvalidationSubscriber {
+            {
+                observableValue.subscribe(() -> {});
+            }
+
+            @Test
+            void computeValueShouldBeCalledOnlyOnce() {
+                assertEquals(1, calls1.get());
+                assertEquals(1, calls2.get());
+                assertEquals(1, calls3.get());
+                assertEquals(1, calls4.get());
+            }
+        }
+
+        @Nested
+        class WhenObservedByValueSubscriber {
+            {
+                observableValue.subscribe(v -> {});
+            }
+
+            @Test
+            void computeValueShouldBeCalledOnlyOnce() {
+                assertEquals(1, calls1.get());
+                assertEquals(1, calls2.get());
+                assertEquals(1, calls3.get());
+                assertEquals(1, calls4.get());
+            }
+        }
+
+        @Nested
+        class WhenObservedByChangeSubscriber {
+            {
+                observableValue.subscribe((o, n) -> {});
+            }
+
+            @Test
+            void computeValueShouldBeCalledOnlyOnce() {
+                assertEquals(1, calls1.get());
+                assertEquals(1, calls2.get());
+                assertEquals(1, calls3.get());
+                assertEquals(1, calls4.get());
+            }
+        }
+    }
+
+    @Test
+    void computeValueShouldBeCalledOnlyOnceWhenNewlyObserved() {
+        AtomicInteger calls1 = new AtomicInteger(0);
+        AtomicInteger calls2 = new AtomicInteger(0);
+        AtomicInteger calls3 = new AtomicInteger(0);
+        AtomicInteger calls4 = new AtomicInteger(0);
+
+        ObservableValue<String> observableValue = property
+            .map(x -> x + calls1.incrementAndGet())
+            .map(x -> x + calls2.incrementAndGet())
+            .map(x -> x + calls3.incrementAndGet())
+            .map(x -> x + calls4.incrementAndGet());
+
+        assertEquals(0, calls1.get());
+        assertEquals(0, calls2.get());
+        assertEquals(0, calls3.get());
+        assertEquals(0, calls4.get());
+
+        observableValue.addListener((obs, o, n) -> {});
+
+        assertEquals(1, calls1.get());
+        assertEquals(1, calls2.get());
+        assertEquals(1, calls3.get());
+        assertEquals(1, calls4.get());
+    }
 
     @Nested
     class When_map_Called {


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8351276](https://bugs.openjdk.org/browse/JDK-8351276): Prevent redundant computeValue calls when a chain of mappings becomes observed (**Bug** - P4)


### Reviewers
 * [Michael Strauß](https://openjdk.org/census#mstrauss) (@mstr2 - **Reviewer**)
 * [Nir Lisker](https://openjdk.org/census#nlisker) (@nlisker - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1730/head:pull/1730` \
`$ git checkout pull/1730`

Update a local copy of the PR: \
`$ git checkout pull/1730` \
`$ git pull https://git.openjdk.org/jfx.git pull/1730/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1730`

View PR using the GUI difftool: \
`$ git pr show -t 1730`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1730.diff">https://git.openjdk.org/jfx/pull/1730.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1730#issuecomment-2705638504)
</details>
