### PR TITLE
8347937: Canvas pattern test fails on WebKit 620.1

### DIFF
--- a/modules/javafx.web/src/main/java/com/sun/webkit/graphics/WCImageFrame.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/graphics/WCImageFrame.java
@@ -35,6 +35,15 @@ public abstract class WCImageFrame extends Ref {
      */
     public abstract int[] getSize();
 
+    public static int[] getSize(Object image) {
+        // JDK-8347937 workaround
+        if (image instanceof WCImageFrame) {
+            return ((WCImageFrame)image).getSize();
+        }
+
+        return null;
+    }
+
     protected void destroyDecodedData() {
     }
 }

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/java/NativeImageJava.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/java/NativeImageJava.cpp
@@ -47,14 +47,17 @@ IntSize PlatformImageNativeImageBackend::size() const
     }
 
     JNIEnv* env = WTF::GetJavaEnv();
-    static jmethodID midGetSize = env->GetMethodID(
-        PG_GetImageFrameClass(env),
+    jclass wcImageFrameClz = PG_GetImageFrameClass(env);
+    static jmethodID midGetSize = env->GetStaticMethodID(
+        wcImageFrameClz,
         "getSize",
-        "()[I");
+        "(Ljava/lang/Object;)[I");
     ASSERT(midGetSize);
-    JLocalRef<jintArray> jsize((jintArray)env->CallObjectMethod(
-                        jobject(*m_platformImage->getImage().get()),
-                        midGetSize));
+    JLocalRef<jintArray> jsize((jintArray)env->CallStaticObjectMethod(
+                        wcImageFrameClz,
+                        midGetSize,
+                        jobject(*m_platformImage->getImage().get())
+                        ));
     if (!jsize) {
         return {};
     }

--- a/modules/javafx.web/src/test/java/test/javafx/scene/web/CanvasTest.java
+++ b/modules/javafx.web/src/test/java/test/javafx/scene/web/CanvasTest.java
@@ -121,7 +121,6 @@ public class CanvasTest extends TestBase {
     }
 
     // JDK-8234471
-    @Disabled("JDK-8347937")
     @Test public void testCanvasPattern() throws Exception {
         final String htmlCanvasContent = "\n"
             + "<canvas id='canvaspattern' width='100' height='100'></canvas>\n"


### PR DESCRIPTION
Hi!

This is my desperate fix for what I believe to be a critical bug. Since my knowledge of the codebase is minimal, and the class structure is a bit controversial, my fix is mostly based on historical excavation.

#  What is the problem?
VM started to crash after webkit 620.1 update when running simple [CanvasTest](https://github.com/openjdk/jfx/blob/1c3cfcb8bb4e8874406d3a5b507f38859f4c1d9b/modules/javafx.web/src/test/java/test/javafx/scene/web/CanvasTest.java#L125).  Running with `-Xcheck:jni ` reveals invalid object is passed to JNI [call](https://github.com/openjdk/jfx/blob/0555fb25a16b6b6705a42c6d8592cf1c6ddccc67/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/java/NativeImageJava.cpp#L56): expected is`WCImageFrame` but provided is `RTImage` (an descendant of `WCImage`). The latter has no `getSize` method.
Stack trace
```
    frame #4: 0x0000000101a36094 libjvm.dylib`checked_jni_CallObjectMethodV(env=0x0000000124a89cb0, obj=0x000000012310f9e8, methodID=0x00006000019abde8, args="\xa0\U00000012\U0000001ev\U00000001") at jniCheck.cpp:1012:1 [opt]
    frame #5: 0x000000033e88ea60 libjfxwebkit.dylib`JNIEnv_::CallObjectMethod(this=0x0000000124a89cb0, obj=0x000000012310f9e8, methodID=0x00006000019abde8) at jni.h:906:18
    frame #6: 0x00000003426fcda0 libjfxwebkit.dylib`WebCore::PlatformImageNativeImageBackend::size(this=0x0000600000e12790) const at NativeImageJava.cpp:55:48
    frame #7: 0x000000034258d76c libjfxwebkit.dylib`WebCore::NativeImage::size(this=0x00000001761c2c00) const at NativeImage.cpp:89:23
    frame #8: 0x00000003425723c0 libjfxwebkit.dylib`WebCore::ImageFrame::ImageFrame(this=0x00000001761e1270, nativeImage=0x000000016fdf7090) at ImageFrame.cpp:40:29
    frame #9: 0x0000000342572420 libjfxwebkit.dylib`WebCore::ImageFrame::ImageFrame(this=0x00000001761e1270, nativeImage=0x000000016fdf7090) at ImageFrame.cpp:39:1
    frame #10: 0x00000003425a4d7c libjfxwebkit.dylib`WebCore::NativeImageSource::NativeImageSource(this=0x00000001761e1260, nativeImage=0x000000016fdf7090) at NativeImageSource.cpp:37:7
    frame #11: 0x00000003425a4d24 libjfxwebkit.dylib`WebCore::NativeImageSource::NativeImageSource(this=0x00000001761e1260, nativeImage=0x000000016fdf7090) at NativeImageSource.cpp:38:1
    frame #12: 0x00000003425a4cac libjfxwebkit.dylib`WebCore::NativeImageSource::create(nativeImage=0x000000016fdf7090) at NativeImageSource.cpp:33:26
    frame #13: 0x00000003423a6f18 libjfxwebkit.dylib`WebCore::BitmapImage::BitmapImage(this=0x00000001761e1200, image=0x000000016fdf7090) at BitmapImage.cpp:67:16
    frame #14: 0x00000003423a6b60 libjfxwebkit.dylib`WebCore::BitmapImage::BitmapImage(this=0x00000001761e1200, image=0x000000016fdf7090) at BitmapImage.cpp:68:1
    frame #15: 0x00000003423a6bd0 libjfxwebkit.dylib`WebCore::BitmapImage::create(nativeImage=0x000000016fdf70e0) at BitmapImage.cpp:52:26
    frame #16: 0x00000003416abcf0 libjfxwebkit.dylib`WebCore::HTMLCanvasElement::copiedImage(this=0x0000000321008640) const at HTMLCanvasElement.cpp:903:29
    frame #17: 0x0000000341899e70 libjfxwebkit.dylib`WebCore::CanvasRenderingContext2DBase::createPattern(this=0x0000000321008b00, canvas=0x0000000321008640, repeatX=true, repeatY=true) at CanvasRenderingContext2DBase.cpp:2232:32 
```

# Historical excavation
There was a similar problem in the [past](https://hg.openjdk.org/openjfx/10-dev/rt/rev/542116615e59).  The predecessor of `PlatformImageNativeImageBackend::size` knew that there is an `Image` (like gif with multiple frames, or still image) and ImageFrame.  But then it assumes "NativeImage" is always backed by `WCImageFrame`

# The fix
The fix restores original idea and checks the backend class.  The method returns zero size if the `m_platformImage` is not `WCImageFrame`


# The alternative
I believe there is a more straightforward and correct way to fix this. Don't hesitate to reject the PR if you know a better solution.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8347937](https://bugs.openjdk.org/browse/JDK-8347937)

### Issue
 * [JDK-8347937](https://bugs.openjdk.org/browse/JDK-8347937): Canvas pattern test fails and crashes on WebKit 620.1 (**Bug** - P2) ⚠️ Title mismatch between PR and JBS.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1734/head:pull/1734` \
`$ git checkout pull/1734`

Update a local copy of the PR: \
`$ git checkout pull/1734` \
`$ git pull https://git.openjdk.org/jfx.git pull/1734/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1734`

View PR using the GUI difftool: \
`$ git pr show -t 1734`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1734.diff">https://git.openjdk.org/jfx/pull/1734.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1734#issuecomment-2722328423)
</details>
