### PR TITLE
8351878: RichTextArea: Pasting from RTF doesn't apply formatting

### DIFF
--- a/modules/jfx.incubator.richtext/src/main/java/com/sun/jfx/incubator/scene/control/richtext/rtf/AttrSet.java
+++ b/modules/jfx.incubator.richtext/src/main/java/com/sun/jfx/incubator/scene/control/richtext/rtf/AttrSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -87,6 +87,7 @@ public class AttrSet {
         return StyleAttributeMap.builder().
             setBold(getBoolean(StyleAttributeMap.BOLD)).
             setFontFamily(getString(StyleAttributeMap.FONT_FAMILY)).
+            setFontSize(getDouble(StyleAttributeMap.FONT_SIZE)).
             setItalic(getBoolean(StyleAttributeMap.ITALIC)).
             setTextColor(getColor(StyleAttributeMap.TEXT_COLOR)).
             setUnderline(getBoolean(StyleAttributeMap.UNDERLINE)).
@@ -109,6 +110,14 @@ public class AttrSet {
         Object v = attrs.get(attr);
         if (v instanceof Color c) {
             return c;
+        }
+        return null;
+    }
+
+    private Double getDouble(Object attr) {
+        Object v = attrs.get(attr);
+        if (v instanceof Number n) {
+            return n.doubleValue();
         }
         return null;
     }

--- a/modules/jfx.incubator.richtext/src/main/java/com/sun/jfx/incubator/scene/control/richtext/rtf/RTFParser.java
+++ b/modules/jfx.incubator.richtext/src/main/java/com/sun/jfx/incubator/scene/control/richtext/rtf/RTFParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,10 @@ package com.sun.jfx.incubator.scene.control.richtext.rtf;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.CharsetDecoder;
+import java.nio.charset.CoderResult;
 
 /**
  * <b>RTFParser</b> is a subclass of <b>AbstractFilter</b> which understands basic RTF syntax
@@ -59,6 +63,13 @@ abstract class RTFParser extends AbstractFilter {
     private final int S_aftertick = 4; // after reading \'
     private final int S_aftertickc = 5; // after reading \'x
     private final int S_inblob = 6; // in a \bin blob
+
+    // For fcharset control word
+    protected CharsetDecoder decoder;
+    private final byte[] ba = new byte[2];
+    protected final ByteBuffer decoderBB = ByteBuffer.wrap(ba);
+    private final char[] ca = new char[1];
+    private final CharBuffer decoderCB = CharBuffer.wrap(ca);
 
     /** Implemented by subclasses to interpret a parameter-less RTF keyword.
      *  The keyword is passed without the leading '/' or any delimiting
@@ -98,6 +109,9 @@ abstract class RTFParser extends AbstractFilter {
         rtfSpecialsTable['\\'] = true;
     }
 
+    // Defined for replacement character
+    private static final char REPLACEMENT_CHAR = '\uFFFD';
+
     public RTFParser() {
         currentCharacters = new StringBuffer();
         state = S_text;
@@ -105,6 +119,9 @@ abstract class RTFParser extends AbstractFilter {
         level = 0;
 
         specialsTable = rtfSpecialsTable;
+        // Initialize byte buffer for CharsetDecoder
+        decoderBB.clear();
+        decoderBB.limit(1);
     }
 
     @Override
@@ -169,6 +186,9 @@ abstract class RTFParser extends AbstractFilter {
                 }
                 state = S_backslashed;
             } else {
+                // SBCS: ASCII character
+                // DBCS: Non lead byte
+                ch = decode(ch);
                 currentCharacters.append(ch);
             }
             break;
@@ -286,7 +306,8 @@ abstract class RTFParser extends AbstractFilter {
             state = S_text;
             if (Character.digit(ch, 16) != -1) {
                 pendingCharacter = pendingCharacter * 16 + Character.digit(ch, 16);
-                ch = translationTable[pendingCharacter];
+                // Use translationTable if decoder is not defined
+                ch = decoder == null ? translationTable[pendingCharacter] : decode((char)pendingCharacter);
                 if (ch != 0) {
                     handleText(ch);
                 }
@@ -342,5 +363,34 @@ abstract class RTFParser extends AbstractFilter {
         }
 
         super.close();
+    }
+
+    private char decode(char ch) {
+        if (decoder == null) return ch;
+        decoderBB.put((byte) ch);
+        decoderBB.rewind();
+        decoderCB.clear();
+        CoderResult cr = decoder.decode(decoderBB, decoderCB, false);
+        if (cr.isUnderflow()) {
+            if (decoderCB.position() == 1) {
+                // Converted to Unicode (including replacement character)
+                decoder.reset();
+                decoderBB.clear();
+                decoderBB.limit(1);
+                return ca[0];
+            } else {
+                // Detected lead byte
+                decoder.reset();
+                decoderBB.limit(2);
+                decoderBB.position(1);
+                return 0; // Skip write operation if return value is 0
+            }
+        } else {
+            // Fallback, should not be called
+            decoder.reset();
+            decoderBB.clear();
+            decoderBB.limit(1);
+            return REPLACEMENT_CHAR;
+        }
     }
 }

--- a/modules/jfx.incubator.richtext/src/main/java/com/sun/jfx/incubator/scene/control/richtext/rtf/RTFParser.java
+++ b/modules/jfx.incubator.richtext/src/main/java/com/sun/jfx/incubator/scene/control/richtext/rtf/RTFParser.java
@@ -66,10 +66,9 @@ abstract class RTFParser extends AbstractFilter {
 
     // For fcharset control word
     protected CharsetDecoder decoder;
-    private final byte[] ba = new byte[2];
-    protected final ByteBuffer decoderBB = ByteBuffer.wrap(ba);
-    private final char[] ca = new char[1];
-    private final CharBuffer decoderCB = CharBuffer.wrap(ca);
+    protected final ByteBuffer decoderBB = ByteBuffer.wrap(new byte[2]);
+    private final char[] decoderCA = new char[1];
+    private final CharBuffer decoderCB = CharBuffer.wrap(decoderCA);
 
     /** Implemented by subclasses to interpret a parameter-less RTF keyword.
      *  The keyword is passed without the leading '/' or any delimiting
@@ -377,7 +376,7 @@ abstract class RTFParser extends AbstractFilter {
                 decoder.reset();
                 decoderBB.clear();
                 decoderBB.limit(1);
-                return ca[0];
+                return decoderCA[0];
             } else {
                 // Detected lead byte
                 decoder.reset();

--- a/modules/jfx.incubator.richtext/src/main/java/com/sun/jfx/incubator/scene/control/richtext/rtf/RTFReader.java
+++ b/modules/jfx.incubator.richtext/src/main/java/com/sun/jfx/incubator/scene/control/richtext/rtf/RTFReader.java
@@ -1252,7 +1252,7 @@ public class RTFReader extends RTFParser {
 
             switch (keyword) {
             case "fs":
-                characterAttributes.addAttribute(StyleAttributeMap.FONT_SIZE, (parameter / 2));
+                characterAttributes.addAttribute(StyleAttributeMap.FONT_SIZE, (parameter / 2.0));
                 return true;
             }
 

--- a/modules/jfx.incubator.richtext/src/main/java/com/sun/jfx/incubator/scene/control/richtext/rtf/RTFReader.java
+++ b/modules/jfx.incubator.richtext/src/main/java/com/sun/jfx/incubator/scene/control/richtext/rtf/RTFReader.java
@@ -31,6 +31,8 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.StreamTokenizer;
 import java.io.StringReader;
+import java.nio.charset.Charset;
+import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -116,8 +118,34 @@ public class RTFReader extends RTFParser {
      *  for those keywords which simply insert some text. */
     private static final HashMap<String, String> textKeywords = initTextKeywords();
     private static final HashMap<String, char[]> characterSets = initCharacterSets();
+    /** maps String font charset to String code page. */
+    private static HashMap<String, String> fcharsetToCP = initFCharsetToCP();
+    /** maps Integer font numbers to Charset font charset. */
+    private HashMap<Integer, Charset> fcharsetTable = new HashMap<>();
 
-    /* TODO: per-font font encodings ( \fcharset control word ) ? */
+    // Windows charsets
+    private static final int ANSI_CHARSET        = 0;
+    private static final int DEFAULT_CHARSET     = 1;
+    private static final int SYMBOL_CHARSET      = 2;
+    private static final int MAC_CHARSET         = 77;
+    private static final int SHIFTJIS_CHARSET    = 128;
+    private static final int HANGUL_CHARSET      = 129;
+    private static final int JOHAB_CHARSET       = 130;
+    private static final int GB2312_CHARSET      = 134;
+    private static final int CHINESEBIG5_CHARSET = 136;
+    private static final int GREEK_CHARSET       = 161;
+    private static final int TURKISH_CHARSET     = 162;
+    private static final int VIETNAMESE_CHARSET  = 163;
+    private static final int HEBREW_CHARSET      = 177;
+    private static final int ARABIC_CHARSET      = 178;
+    private static final int BALTIC_CHARSET      = 186;
+    private static final int RUSSIAN_CHARSET     = 204;
+    private static final int THAI_CHARSET        = 222;
+    private static final int EASTEUROPE_CHARSET  = 238;
+    private static final int OEM_CHARSET         = 255;
+
+    // Defined for replacement character
+    private static final String REPLACEMENT_CHAR = "\uFFFD";
 
     /**
      * Creates a new RTFReader instance.
@@ -125,7 +153,6 @@ public class RTFReader extends RTFParser {
      */
     public RTFReader(String text) {
         this.text = text;
-        //System.err.println(text); // FIX
 
         parserState = new HashMap<>();
         fontTable = new HashMap<Integer, String>();
@@ -158,6 +185,7 @@ public class RTFReader extends RTFParser {
         m.put("emspace", "\u2003");
         m.put("endash", "\u2013");
         m.put("enspace", "\u2002");
+        m.put("line", "\n");
         m.put("ldblquote", "\u201C");
         m.put("lquote", "\u2018");
         m.put("ltrmark", "\u200E");
@@ -170,6 +198,26 @@ public class RTFReader extends RTFParser {
         // There is no Unicode equivalent to an optional hyphen, as far as I can tell.
         // TODO optional hyphen
         m.put("-", "\u2027");
+        return m;
+    }
+
+    private static HashMap<String, String> initFCharsetToCP() {
+        HashMap<String, String> m = new HashMap<String, String>();
+        m.put("fcharset" + ANSI_CHARSET, "windows-1252");
+        m.put("fcharset" + SHIFTJIS_CHARSET, "ms932");
+        m.put("fcharset" + HANGUL_CHARSET, "ms949");
+        m.put("fcharset" + JOHAB_CHARSET, "ms1361");
+        m.put("fcharset" + GB2312_CHARSET, "ms936");
+        m.put("fcharset" + CHINESEBIG5_CHARSET, "ms950");
+        m.put("fcharset" + GREEK_CHARSET, "windows-1253");
+        m.put("fcharset" + TURKISH_CHARSET, "windows-1254");
+        m.put("fcharset" + VIETNAMESE_CHARSET, "windows-1258");
+        m.put("fcharset" + HEBREW_CHARSET, "windows-1255");
+        m.put("fcharset" + ARABIC_CHARSET, "windows-1256");
+        m.put("fcharset" + BALTIC_CHARSET, "windows-1257");
+        m.put("fcharset" + RUSSIAN_CHARSET, "windows-1251");
+        m.put("fcharset" + THAI_CHARSET, "ms874");
+        m.put("fcharset" + EASTEUROPE_CHARSET, "windows-1250");
         return m;
     }
 
@@ -703,6 +751,25 @@ public class RTFReader extends RTFParser {
                 nextFontNumber = parameter;
                 return true;
             }
+            // For fcharset control word
+            if (keyword.equals("fcharset")) {
+                String fcharset = keyword + parameter;
+                String csName = fcharsetToCP.get(fcharset);
+                Charset cs;
+                if (csName != null) {
+                    try {
+                        cs = Charset.forName(csName);
+                    } catch (IllegalArgumentException iae) {
+                        // Fallback, should not be called
+                        cs = StandardCharsets.ISO_8859_1;
+                    }
+                } else {
+                    // Fallback, fcharset control word number is not defined
+                    cs = StandardCharsets.ISO_8859_1;
+                }
+                fcharsetTable.put(nextFontNumber, cs);
+                return true;
+            }
             return false;
         }
     }
@@ -1063,6 +1130,24 @@ public class RTFReader extends RTFParser {
             switch (keyword) {
             case "f":
                 parserState.put(keyword, Integer.valueOf(parameter));
+                // Check lead byte is stored or not
+                if (decoderBB.position() == 1) {
+                    handleText(REPLACEMENT_CHAR);
+                }
+                // Reset decoder byte buffer
+                decoderBB.clear();
+                decoderBB.limit(1);
+                // Check fcharset is used or not
+                Charset cs = fcharsetTable.get(parameter);
+                if (cs != null) {
+                    decoder = cs.newDecoder();
+                    decoder
+                        .onMalformedInput(CodingErrorAction.REPLACE)
+                        .onUnmappableCharacter(CodingErrorAction.REPLACE);
+                } else {
+                    // fcharset is not used, use translationTable
+                    decoder = null;
+                }
                 return true;
             case "cf":
                 parserState.put(keyword, Integer.valueOf(parameter));
@@ -1425,6 +1510,12 @@ public class RTFReader extends RTFParser {
             case "\r":
             case "\n":
             case "par":
+                // Check lead byte is stored or not
+                if (decoderBB.position() == 1) {
+                    handleText(REPLACEMENT_CHAR);
+                    decoderBB.clear();
+                    decoderBB.limit(1);
+                }
                 endParagraph();
                 return true;
             case "sect":


### PR DESCRIPTION
Fixed two issues found in importing RTF text:

- Arabic import
- missing font size

The former was caused by my removal of the character decoder code present in the original JDK RTF parser/reader.  Why did I do that? 