### PR TITLE
8351264: Some images don't load with WebKit 620.1

### DIFF
--- a/modules/javafx.web/src/main/native/Source/WebCore/loader/cache/CachedResourceRequest.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/loader/cache/CachedResourceRequest.cpp
@@ -147,7 +147,10 @@ static String acceptHeaderValueForImageResource()
 {
     static MainThreadNeverDestroyed<String> staticPrefix = [] {
         StringBuilder builder;
+// Java platform failing to decode webp image data already disabled in 619.1
+#if (HAVE(WEBP) || USE(WEBP)) && !PLATFORM(JAVA)
         builder.append("image/webp,"_s);
+#endif
 #if HAVE(AVIF) || USE(AVIF)
         builder.append("image/avif,"_s);
 #endif


### PR DESCRIPTION

Issue: Some images don't load with WebKit 620.1

WebKit Image Decoding Failure Due to Unintended WebP Format Delivery
WebKit encounters image decoding failures when certain servers respond with WebP images instead of the intended JPEG or PNG format. This issue arises due to WebKit's Accept header configuration, which prioritises WebP by default. Consequently, incomplete or malformed WebP data results in decoding errors.

Solution:
Keep the image rendering features and supported formats as webkit 619.1 , and accordingly
update the Accept header to prioritize JPEG/PNG over WebP unless WebP decoding is confirmed stable.

