### PR TITLE
8352268: RichEditorDemo: Save file doesn't always save

### DIFF
--- a/apps/samples/RichTextAreaDemo/src/com/oracle/demo/richtext/editor/Actions.java
+++ b/apps/samples/RichTextAreaDemo/src/com/oracle/demo/richtext/editor/Actions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:
@@ -273,13 +273,12 @@ public class Actions {
         FileChooser ch = new FileChooser();
         ch.setTitle("Open File");
         ch.getExtensionFilters().addAll(
-            filterAll(),
             filterRich(),
-            filterRtf()
+            filterRtf(),
+            filterAll()
         );
 
-        Window w = FX.getParentWindow(control);
-        File f = ch.showOpenDialog(w);
+        File f = ch.showOpenDialog(parentWindow());
         if (f != null) {
             try {
                 DataFormat fmt = guessFormat(f);
@@ -294,11 +293,12 @@ public class Actions {
         File f = getFile();
         if (f == null) {
             f = chooseFileForSave();
-            if (f != null) {
+            if (f == null) {
                 return;
             }
         }
 
+        file.set(f);
         try {
             writeFile(f);
         } catch (Exception e) {
@@ -309,7 +309,6 @@ public class Actions {
     boolean saveAs() {
         File f = chooseFileForSave();
         if (f != null) {
-            // TODO ask to overwrite if file exists
             file.set(f);
             try {
                 writeFile(f);
@@ -333,10 +332,9 @@ public class Actions {
             filterRich(),
             filterRtf(),
             filterTxt()
-            //filterAll()
         );
-        Window w = FX.getParentWindow(control);
-        return ch.showSaveDialog(w);
+
+        return ch.showSaveDialog(parentWindow());
     }
 
     private void readFile(File f, DataFormat fmt) throws Exception {
@@ -500,7 +498,7 @@ public class Actions {
 
     private UserChoiceToSave askSaveChanges() {
         Dialog<UserChoiceToSave> d = new Dialog<>();
-        d.initOwner(FX.getParentWindow(control));
+        d.initOwner(parentWindow());
         d.setTitle("Save Changes?");
         d.setContentText("Do you want to save changes?");
 
@@ -539,5 +537,9 @@ public class Actions {
             }
         }
         return false;
+    }
+
+    private Window parentWindow() {
+        return FX.getParentWindow(control);
     }
 }


### PR DESCRIPTION
Fixes embarrassing bugs in Rich Editor Demo:

- File -> Save not saving
- File -> Open not emphasizing .rich files

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352268](https://bugs.openjdk.org/browse/JDK-8352268): RichEditorDemo: Save file doesn't always save (**Bug** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1739/head:pull/1739` \
`$ git checkout pull/1739`

Update a local copy of the PR: \
`$ git checkout pull/1739` \
`$ git pull https://git.openjdk.org/jfx.git pull/1739/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1739`

View PR using the GUI difftool: \
`$ git pr show -t 1739`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1739.diff">https://git.openjdk.org/jfx/pull/1739.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1739#issuecomment-2734823052)
</details>
