### PR TITLE
8347937: Canvas pattern test fails and crashes on WebKit 620.1

### DIFF
--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/ImageFrame.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/ImageFrame.cpp
@@ -37,8 +37,26 @@ ImageFrame::ImageFrame()
 ImageFrame::ImageFrame(Ref<NativeImage>&& nativeImage)
     : m_nativeImage(WTFMove(nativeImage))
 {
+#if PLATFORM(JAVA)
+/* Ref: Webkit 619.1 javafx.web/src/main/native/Source/WebCore/platform/graphics/ImageSource.cpp refactoring in 620.1
+ *
+ * In the case of the canvas pattern using a transform property filled with an SVGMatrix()
+ * created by an SVG element, `frame.m_nativeImage->size()` calls `NativeImage::size()`
+ * from NativeImageJava.cpp.
+ *
+ * In this scenario, `*m_platformImage->getImage().get()` may be invalid,
+ * as the image decoder has already populated `frame.m_size` during image metadata caching.
+ *
+ * To avoid potential invalid accesses and unintended size resets, only update `m_size`
+ * if the frame does not already have a valid native image.
+ */
+    if (!hasNativeImage() && m_nativeImage)
+        m_size = m_nativeImage->size();
+#else
     m_size = m_nativeImage->size();
+#endif
     m_hasAlpha = m_nativeImage->hasAlpha();
+
 }
 
 ImageFrame::~ImageFrame()

--- a/modules/javafx.web/src/test/java/test/javafx/scene/web/CanvasTest.java
+++ b/modules/javafx.web/src/test/java/test/javafx/scene/web/CanvasTest.java
@@ -37,7 +37,6 @@ import netscape.javascript.JSObject;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
-import org.junit.jupiter.api.Disabled;
 
 /**
  * Test the Image to DataURL function
@@ -121,7 +120,6 @@ public class CanvasTest extends TestBase {
     }
 
     // JDK-8234471
-    @Disabled("JDK-8347937")
     @Test public void testCanvasPattern() throws Exception {
         final String htmlCanvasContent = "\n"
             + "<canvas id='canvaspattern' width='100' height='100'></canvas>\n"


### PR DESCRIPTION
Issue: 
Ref: Webkit 619.1 javafx.web/src/main/native/Source/WebCore/platform/graphics/ImageSource.cpp refactoring in 620.1
In the case of the canvas pattern using a transform property filled with an SVGMatrix()
created by an SVG element, `frame.m_nativeImage->size()` calls `NativeImage::size()`
from NativeImageJava.cpp. In this scenario, `*m_platformImage->getImage().get()` may be invalid,
as the image decoder has already populated `frame.m_size` during image metadata caching.

Solution:
To avoid potential invalid accesses and unintended size resets, only update `m_size`
if the frame does not already have a valid native image.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8347937](https://bugs.openjdk.org/browse/JDK-8347937): Canvas pattern test fails and crashes on WebKit 620.1 (**Bug** - P2)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)

### Contributors
 * Gopal Pattnaik `<gopal.pattnaik@oracle.com>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1740/head:pull/1740` \
`$ git checkout pull/1740`

Update a local copy of the PR: \
`$ git checkout pull/1740` \
`$ git pull https://git.openjdk.org/jfx.git pull/1740/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1740`

View PR using the GUI difftool: \
`$ git pr show -t 1740`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1740.diff">https://git.openjdk.org/jfx/pull/1740.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1740#issuecomment-2742653288)
</details>
