### PR TITLE
8340004: [TestBug] Call ModuleLayer.Controller::enableNativeAccess directly rather than via reflection

### DIFF
--- a/tests/system/src/testapp7/java/mymod/myapp7/DataUrlWithModuleLayerLauncher.java
+++ b/tests/system/src/testapp7/java/mymod/myapp7/DataUrlWithModuleLayerLauncher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/tests/system/src/testapp7/java/mymod/myapp7/DataUrlWithModuleLayerLauncher.java
+++ b/tests/system/src/testapp7/java/mymod/myapp7/DataUrlWithModuleLayerLauncher.java
@@ -73,19 +73,13 @@ public class DataUrlWithModuleLayerLauncher {
         Configuration cf = parent.configuration().resolve(finder, ModuleFinder.of(), Set.of("mymod"));
         ClassLoader scl = ClassLoader.getSystemClassLoader();
         ModuleLayer.Controller controller = ModuleLayer.defineModulesWithOneLoader(cf, List.of(parent), scl);
-        // Remove reflection once JDK 22 is minimum. See JDK-8340004.
-        Method enableNativeAccessMethod = ModuleLayer.Controller.class.getMethod("enableNativeAccess", Module.class);
         ModuleLayer layer = controller.layer();
         ClassLoader moduleClassLoader = layer.findLoader("mymod");
         Class appClass = moduleClassLoader.loadClass("javafx.application.Application");
         Class webClass = moduleClassLoader.loadClass("javafx.scene.web.WebView");
-        // Remove reflection once JDK 22 is minimum. See JDK-8340004.
-        //controller.enableNativeAccess(webClass.getModule());
-        enableNativeAccessMethod.invoke(controller, new Object[]{webClass.getModule()});
+        controller.enableNativeAccess(webClass.getModule());
         Class testClass = moduleClassLoader.loadClass("myapp7.DataUrlWithModuleLayer");
-        // Remove reflection once JDK 22 is minimum. See JDK-8340004.
-        //controller.enableNativeAccess(appClass.getModule());
-        enableNativeAccessMethod.invoke(controller, new Object[]{appClass.getModule()});
+        controller.enableNativeAccess(appClass.getModule());
         Method launchMethod = appClass.getMethod("launch", Class.class, String[].class);
         launchMethod.invoke(null, new Object[]{testClass, args});
         System.exit(DataUrlWithModuleLayer.ERROR_UNEXPECTED_EXIT);

--- a/tests/system/src/testapp7/java/mymod/myapp7/LocalStorageAccessWithModuleLayerLauncher.java
+++ b/tests/system/src/testapp7/java/mymod/myapp7/LocalStorageAccessWithModuleLayerLauncher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/tests/system/src/testapp7/java/mymod/myapp7/LocalStorageAccessWithModuleLayerLauncher.java
+++ b/tests/system/src/testapp7/java/mymod/myapp7/LocalStorageAccessWithModuleLayerLauncher.java
@@ -73,18 +73,12 @@ public class LocalStorageAccessWithModuleLayerLauncher {
         Configuration cf = parent.configuration().resolve(finder, ModuleFinder.of(), Set.of("mymod"));
         ClassLoader scl = ClassLoader.getSystemClassLoader();
         ModuleLayer.Controller controller = ModuleLayer.defineModulesWithOneLoader(cf, List.of(parent), scl);
-        // Remove reflection once JDK 22 is minimum. See JDK-8340004.
-        Method enableNativeAccessMethod = ModuleLayer.Controller.class.getMethod("enableNativeAccess", Module.class);
         ModuleLayer layer = controller.layer();
         ClassLoader moduleClassLoader = layer.findLoader("mymod");
         Class webClass = moduleClassLoader.loadClass("javafx.scene.web.WebView");
-        // Remove reflection once JDK 22 is minimum. See JDK-8340004.
-        //controller.enableNativeAccess(webClass.getModule());
-        enableNativeAccessMethod.invoke(controller, new Object[]{webClass.getModule()});
+        controller.enableNativeAccess(webClass.getModule());
         Class appClass = moduleClassLoader.loadClass("javafx.application.Application");
-        // Remove reflection once JDK 22 is minimum. See JDK-8340004.
-        //controller.enableNativeAccess(appClass.getModule());
-        enableNativeAccessMethod.invoke(controller, new Object[]{appClass.getModule()});
+        controller.enableNativeAccess(appClass.getModule());
         Class testClass = moduleClassLoader.loadClass("myapp7.LocalStorageAccessWithModuleLayer");
         Method launchMethod = appClass.getMethod("launch", Class.class, String[].class);
         launchMethod.invoke(null, new Object[]{testClass, args});


### PR DESCRIPTION
With the minimum JDK set to 22, the reflection calls is replaced with direct calls to enableNativeAccess

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340004](https://bugs.openjdk.org/browse/JDK-8340004): [TestBug] Call ModuleLayer.Controller::enableNativeAccess directly rather than via reflection (**Bug** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1743/head:pull/1743` \
`$ git checkout pull/1743`

Update a local copy of the PR: \
`$ git checkout pull/1743` \
`$ git pull https://git.openjdk.org/jfx.git pull/1743/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1743`

View PR using the GUI difftool: \
`$ git pr show -t 1743`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1743.diff">https://git.openjdk.org/jfx/pull/1743.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1743#issuecomment-2752689267)
</details>
