### PR TITLE
8353163: [XWayland] Disable SwingNodePlatformExitCrashTest on wayland

### DIFF
--- a/tests/system/src/test/java/test/robot/javafx/embed/swing/SwingNodePlatformExitCrashTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/embed/swing/SwingNodePlatformExitCrashTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,7 @@ import javax.swing.SwingUtilities;
 import javafx.application.Platform;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assumptions;
 import test.util.Util;
 
 public class SwingNodePlatformExitCrashTest extends SwingNodeBase {
@@ -53,6 +54,7 @@ public class SwingNodePlatformExitCrashTest extends SwingNodeBase {
 
     @BeforeAll
     public static void skipShutDown() {
+        Assumptions.assumeTrue(!Util.isOnWayland());
         // Skip shutdown as Toolkit shutdown is already done in Platform.exit
         // and will cause hang if called
         doShutdown = false;


### PR DESCRIPTION
SwingNodePlatformExitCrashTest hangs while running on wayland, we need to skip this test on wayland until https://bugs.openjdk.org/browse/JDK-8350009 is fixed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353163](https://bugs.openjdk.org/browse/JDK-8353163): [XWayland] Disable SwingNodePlatformExitCrashTest on wayland (**Bug** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1745/head:pull/1745` \
`$ git checkout pull/1745`

Update a local copy of the PR: \
`$ git checkout pull/1745` \
`$ git pull https://git.openjdk.org/jfx.git pull/1745/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1745`

View PR using the GUI difftool: \
`$ git pr show -t 1745`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1745.diff">https://git.openjdk.org/jfx/pull/1745.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1745#issuecomment-2760609614)
</details>
