### PR TITLE
8353223: [Linux] - Maximized windows do not retain correct size when resized programmatically

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/gtk/glass_window.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/glass_window.cpp
@@ -1069,6 +1069,17 @@ void WindowContextTop::set_bounds(int x, int y, bool xSet, bool ySet, int w, int
     geometry.gravity_x = gravity_x;
     geometry.gravity_y = gravity_y;
 
+    // When the window is programmatically resized while maximized
+    if (is_maximized) {
+        if (w < 0 && cw < 0) {
+            cw = gdk_window_get_width(gdk_window);
+        }
+
+        if (h < 0 && ch < 0) {
+            ch = gdk_window_get_height(gdk_window);
+        }
+    }
+
     if (w > 0) {
         geometry.final_width.type = BOUNDSTYPE_WINDOW;
         geometry.final_width.value = w;
@@ -1078,7 +1089,9 @@ void WindowContextTop::set_bounds(int x, int y, bool xSet, bool ySet, int w, int
         geometry.final_width.value = cw;
         newW = cw;
     } else {
-        newW = geometry_get_content_width(&geometry);
+        newW = (is_maximized)
+                ? gdk_window_get_width(gdk_window)
+                : geometry_get_content_width(&geometry);
     }
 
     if (h > 0) {
@@ -1092,7 +1105,6 @@ void WindowContextTop::set_bounds(int x, int y, bool xSet, bool ySet, int w, int
     } else {
         newH = geometry_get_content_height(&geometry);
     }
-
 
     if (newW > 0 || newH > 0) {
         // call update_window_constraints() to let gtk_window_resize succeed, because it's bound to geometry constraints

--- a/modules/javafx.graphics/src/main/native-glass/gtk/glass_window.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/glass_window.cpp
@@ -1089,9 +1089,7 @@ void WindowContextTop::set_bounds(int x, int y, bool xSet, bool ySet, int w, int
         geometry.final_width.value = cw;
         newW = cw;
     } else {
-        newW = (is_maximized)
-                ? gdk_window_get_width(gdk_window)
-                : geometry_get_content_width(&geometry);
+        newW = geometry_get_content_width(&geometry);
     }
 
     if (h > 0) {

--- a/modules/javafx.graphics/src/main/native-glass/gtk/glass_window.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/glass_window.cpp
@@ -1104,6 +1104,7 @@ void WindowContextTop::set_bounds(int x, int y, bool xSet, bool ySet, int w, int
         newH = geometry_get_content_height(&geometry);
     }
 
+
     if (newW > 0 || newH > 0) {
         // call update_window_constraints() to let gtk_window_resize succeed, because it's bound to geometry constraints
         update_window_constraints();


### PR DESCRIPTION
When a window is maximized, if only the width or height is programmatically set, the window will retain its current maximized dimension (either height or width) as is, unless the other dimension is also explicitly set.

This is consistent with what Gtk does.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353223](https://bugs.openjdk.org/browse/JDK-8353223): [Linux] - Maximized windows do not retain correct size when resized programmatically (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1748/head:pull/1748` \
`$ git checkout pull/1748`

Update a local copy of the PR: \
`$ git checkout pull/1748` \
`$ git pull https://git.openjdk.org/jfx.git pull/1748/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1748`

View PR using the GUI difftool: \
`$ git pr show -t 1748`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1748.diff">https://git.openjdk.org/jfx/pull/1748.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1748#issuecomment-2763341878)
</details>
