### PR TITLE
8352999: [macOS] Conditional behavior by directly querying the Objective-C call stack

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow+Java.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow+Java.m
@@ -300,23 +300,7 @@ extern NSSize maxScreenDimensions;
 - (void)_setWindowFrameWithRect:(NSRect)rect withDisplay:(jboolean)display withAnimate:(jboolean)animate
 {
     NSRect frame = [self _constrainFrame:rect];
-    NSString *const constantRestorePreZoomRect = @"_restorePreZoomedRect";
-    NSArray *syms = [NSThread  callStackSymbols];
-    NSString *callerMethod;
-
-    bool callFlipFrame = true;
-    if ([syms count] > 1) {
-        callerMethod = [syms objectAtIndex:1];
-        if([callerMethod rangeOfString:constantRestorePreZoomRect].location != NSNotFound){
-            callFlipFrame = false;
-        }
-    }
-    if (callFlipFrame) {
-        [self _setFlipFrame:frame display:(BOOL)display animate:(BOOL)animate];
-    }
-    else {
-        [self->nsWindow setFrame:frame display:(BOOL)display animate:(BOOL)animate];
-    }
+    [self _setFlipFrame:frame display:(BOOL)display animate:(BOOL)animate];
 }
 
 - (void)_setBounds:(jint)x y:(jint)y xSet:(jboolean)xSet ySet:(jboolean)ySet w:(jint)w h:(jint)h cw:(jint)cw ch:(jint)ch
@@ -344,7 +328,8 @@ extern NSSize maxScreenDimensions;
 
 - (void)_restorePreZoomedRect
 {
-    [self _setWindowFrameWithRect:NSMakeRect(self->preZoomedRect.origin.x, self->preZoomedRect.origin.y, self->preZoomedRect.size.width, self->preZoomedRect.size.height) withDisplay:JNI_TRUE withAnimate:JNI_TRUE];
+    NSRect frame = [self _constrainFrame: NSMakeRect(self->preZoomedRect.origin.x, self->preZoomedRect.origin.y, self->preZoomedRect.size.width, self->preZoomedRect.size.height)];
+    [self->nsWindow setFrame:frame display:YES animate:YES];
     [self _sendJavaWindowMoveEventForFrame:[self _flipFrame]];
     [self _sendJavaWindowResizeEvent:com_sun_glass_events_WindowEvent_RESTORE forFrame:[self _flipFrame]];
 }

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow+Java.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow+Java.m
@@ -328,7 +328,7 @@ extern NSSize maxScreenDimensions;
 
 - (void)_restorePreZoomedRect
 {
-    NSRect frame = [self _constrainFrame: NSMakeRect(self->preZoomedRect.origin.x, self->preZoomedRect.origin.y, self->preZoomedRect.size.width, self->preZoomedRect.size.height)];
+    NSRect frame = [self _constrainFrame: self->preZoomedRect];
     [self->nsWindow setFrame:frame display:YES animate:YES];
     [self _sendJavaWindowMoveEventForFrame:[self _flipFrame]];
     [self _sendJavaWindowResizeEvent:com_sun_glass_events_WindowEvent_RESTORE forFrame:[self _flipFrame]];

--- a/tests/system/src/test/java/test/javafx/stage/RestoreStagePositionTest.java
+++ b/tests/system/src/test/java/test/javafx/stage/RestoreStagePositionTest.java
@@ -122,9 +122,6 @@ public class RestoreStagePositionTest {
 
     @Test
     public void testDemaximizedPosition() throws Exception {
-        // Disable on Mac until JDK-8089230 is fixed
-        assumeTrue(!PlatformUtil.isMac());
-
         Thread.sleep(200);
         Assertions.assertTrue(stage.isShowing());
         Assertions.assertFalse(stage.isMaximized());
@@ -133,7 +130,7 @@ public class RestoreStagePositionTest {
         double y = stage.getY();
 
         Platform.runLater(() -> stage.setMaximized(true));
-        Thread.sleep(200);
+        Thread.sleep(500);
         Assertions.assertTrue(stage.isMaximized());
         CountDownLatch latch = new CountDownLatch(2);
 


### PR DESCRIPTION
Before a window is maximized glass records its existing size and location. This rectangle is stored in native screen coordinates. Compared to Java screen coordinates native coordinates are flipped along the Y axis.

When the window is un-maximized that native rectangle is passed to a routine that normally takes Java screen coordinates. To determine whether the rectangle is flipped or not the code inspects the Objective-C stack to figure out which routine called it.

At the risk of re-writing working code this PR takes a more conventional approach to the problem.

I’ve also re-enabled the related system test. I had to increase the animation delay to get it to pass on the Mac. 400 milliseconds is enough but 500 gives us some headroom.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8352999](https://bugs.openjdk.org/browse/JDK-8352999): [macOS] Conditional behavior by directly querying the Objective-C call stack (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1749/head:pull/1749` \
`$ git checkout pull/1749`

Update a local copy of the PR: \
`$ git checkout pull/1749` \
`$ git pull https://git.openjdk.org/jfx.git pull/1749/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1749`

View PR using the GUI difftool: \
`$ git pr show -t 1749`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1749.diff">https://git.openjdk.org/jfx/pull/1749.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1749#issuecomment-2767079057)
</details>
