### PR TITLE
8352982: gradle TEST_SDK_PATH param doesn't work with relative paths

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -725,11 +725,7 @@ if (hasProperty("TEST_SDK_PATH")) {
     if (!IS_TEST_ONLY) {
         fail("TEST_ONLY must be set to true when using an external TEST_SDK_PATH for running tests: include -PTEST_ONLY=true")
     }
-    String testSdkPath = "${TEST_SDK_PATH}"
-    if (testSdkPath.startsWith(".")) {
-        testSdkPath = file(testSdkPath).absolutePath
-    }
-    ext.TEST_SDK_DIR = testSdkPath
+    ext.TEST_SDK_DIR = file("${TEST_SDK_PATH}").absolutePath
     def sdkShimsPath = file("${TEST_SDK_DIR}")
     def sdkPath = file("${TEST_SDK_DIR}/sdk")
     def shimsPath = file("${TEST_SDK_DIR}/shims")
@@ -742,7 +738,6 @@ if (hasProperty("TEST_SDK_PATH")) {
 } else {
     ext.TEST_SDK_DIR = "${rootProject.buildDir}"
 }
-println "TEST_SDK_PATH: " + TEST_SDK_DIR
 
 // Make sure JDK_HOME/bin/java exists
 if (!file(JAVA).exists()) throw new Exception("Missing or incorrect path to 'java': '$JAVA'. Perhaps bad JDK_HOME? $JDK_HOME")
@@ -1503,6 +1498,9 @@ logger.quiet("OS_NAME: $OS_NAME")
 logger.quiet("OS_ARCH: $OS_ARCH")
 logger.quiet("JAVA_HOME: $JAVA_HOME")
 logger.quiet("JDK_HOME: $JDK_HOME")
+if (IS_TEST_SDK) {
+    logger.quiet("TEST_SDK_PATH: ${TEST_SDK_DIR}")
+}
 
 Version javaVersionInfo = Runtime.version()
 logger.quiet("java.runtime.version: " + javaVersionInfo)

--- a/build.gradle
+++ b/build.gradle
@@ -719,22 +719,34 @@ defineProperty("TEST_ONLY", "false")
 ext.IS_TEST_ONLY = Boolean.parseBoolean(TEST_ONLY) || !buildSdkForTest
 
 ext.IS_TEST_SDK = false
+ext.TEST_SDK_DIR = ""
+
 if (hasProperty("TEST_SDK_PATH")) {
     if (!IS_TEST_ONLY) {
         fail("TEST_ONLY must be set to true when using an external TEST_SDK_PATH for running tests: include -PTEST_ONLY=true")
     }
-    def sdkShimsPath = file("${TEST_SDK_PATH}")
-    def sdkPath = file("${TEST_SDK_PATH}/sdk")
-    def shimsPath = file("${TEST_SDK_PATH}/shims")
-    if (!sdkShimsPath.exists() || !sdkShimsPath.isDirectory() ||
-             !sdkPath.exists() || !sdkPath.isDirectory() ||
-           !shimsPath.exists() || !shimsPath.isDirectory()) {
-        fail("The provided TEST_SDK_PATH=${TEST_SDK_PATH} is invalid")
+    String testSdkPath = "${TEST_SDK_PATH}"
+    if (testSdkPath.startsWith("~")) {
+        testSdkPath = testSdkPath.replaceFirst("~", System.getProperty("user.home"))
+    } else if (testSdkPath.startsWith(".")) {
+        testSdkPath = file(testSdkPath).absolutePath
+    }
+    ext.TEST_SDK_DIR = testSdkPath
+    def sdkShimsPath = file("${TEST_SDK_DIR}")
+    def sdkPath = file("${TEST_SDK_DIR}/sdk")
+    def shimsPath = file("${TEST_SDK_DIR}/shims")
+    if (!sdkShimsPath.exists() || !sdkShimsPath.isDirectory()) {
+        fail("The provided TEST_SDK_DIR=${TEST_SDK_DIR} directory does not exist")
+    }
+    if (!sdkPath.exists() || !sdkPath.isDirectory() ||
+        !shimsPath.exists() || !shimsPath.isDirectory()) {
+        fail("The provided TEST_SDK_DIR=${TEST_SDK_DIR} is invalid")
     }
     ext.IS_TEST_SDK = true
 } else {
-    defineProperty("TEST_SDK_PATH", "${rootProject.buildDir}")
+    ext.TEST_SDK_DIR = "${rootProject.buildDir}"
 }
+println "TEST_SDK_PATH: " + TEST_SDK_DIR
 
 // Make sure JDK_HOME/bin/java exists
 if (!file(JAVA).exists()) throw new Exception("Missing or incorrect path to 'java': '$JAVA'. Perhaps bad JDK_HOME? $JDK_HOME")
@@ -992,7 +1004,7 @@ List<String> computeLibraryPath(boolean working) {
     } else {
         def platformPrefix = ""
         def standaloneSdkDirName = "${platformPrefix}sdk"
-        def standaloneSdkDir = "${TEST_SDK_PATH}/${standaloneSdkDirName}"
+        def standaloneSdkDir = "${TEST_SDK_DIR}/${standaloneSdkDirName}"
         def modulesLibName = IS_WINDOWS ? "bin" : "lib"
         def modulesLibsDir = "${standaloneSdkDir}/${modulesLibName}"
         lp << cygpath("${modulesLibsDir}")
@@ -1030,9 +1042,9 @@ List<String> computePatchModuleArgs(List<String> deps, boolean test, boolean inc
                 String moduleName = proj.ext.moduleName
                 File dir;
                 if (test && proj.sourceSets.hasProperty('shims')) {
-                    dir = file("${TEST_SDK_PATH}/shims/${moduleName}")
+                    dir = file("${TEST_SDK_DIR}/shims/${moduleName}")
                 } else {
-                    dir = file("${TEST_SDK_PATH}/sdk/lib/${moduleName}.jar")
+                    dir = file("${TEST_SDK_DIR}/sdk/lib/${moduleName}.jar")
                 }
                 if (mp == null) {
                     mp = dir.path
@@ -2686,7 +2698,7 @@ project(":graphics") {
     processResources.dependsOn processDecoraShaders, processPrismShaders
 
     test {
-        def cssDir = file("${TEST_SDK_PATH}/shims/${moduleName}/javafx")
+        def cssDir = file("${TEST_SDK_DIR}/shims/${moduleName}/javafx")
         jvmArgs enableNativeGraphics
         // FIXME: Remove this when JDK-8334137 is fixed
         if (jdk24OrLater) {
@@ -2779,7 +2791,7 @@ project(":controls") {
     }
 
     test {
-        def cssDir = file("${TEST_SDK_PATH}/shims/${moduleName}/javafx")
+        def cssDir = file("${TEST_SDK_DIR}/shims/${moduleName}/javafx")
         jvmArgs enableNativeGraphics
         // FIXME: Remove this when JDK-8334137 is fixed
         if (jdk24OrLater) {
@@ -5274,7 +5286,7 @@ compileTargets { t ->
     // ============================================================
 
     def standaloneSdkDirName = "${platformPrefix}sdk"
-    def standaloneSdkDir = "${TEST_SDK_PATH}/${standaloneSdkDirName}"
+    def standaloneSdkDir = "${TEST_SDK_DIR}/${standaloneSdkDirName}"
     def standaloneLibDir = "${standaloneSdkDir}/lib"
     def libDest=targetProperties.libDest
     def standaloneNativeDir = "${standaloneSdkDir}/${libDest}"
@@ -5953,9 +5965,9 @@ compileTargets { t ->
                         modnames << project.ext.moduleName
                         File dir;
                         if (project.sourceSets.hasProperty('shims')) {
-                           dir = new File(TEST_SDK_PATH, "shims/${project.ext.moduleName}")
+                           dir = new File(TEST_SDK_DIR, "shims/${project.ext.moduleName}")
                         } else {
-                           dir = new File(TEST_SDK_PATH, "sdk/lib/${project.ext.moduleName}.jar")
+                           dir = new File(TEST_SDK_DIR, "sdk/lib/${project.ext.moduleName}.jar")
                         }
 
                         def dstModuleDir = cygpath(dir.path)

--- a/build.gradle
+++ b/build.gradle
@@ -726,21 +726,17 @@ if (hasProperty("TEST_SDK_PATH")) {
         fail("TEST_ONLY must be set to true when using an external TEST_SDK_PATH for running tests: include -PTEST_ONLY=true")
     }
     String testSdkPath = "${TEST_SDK_PATH}"
-    if (testSdkPath.startsWith("~")) {
-        testSdkPath = testSdkPath.replaceFirst("~", System.getProperty("user.home"))
-    } else if (testSdkPath.startsWith(".")) {
+    if (testSdkPath.startsWith(".")) {
         testSdkPath = file(testSdkPath).absolutePath
     }
     ext.TEST_SDK_DIR = testSdkPath
     def sdkShimsPath = file("${TEST_SDK_DIR}")
     def sdkPath = file("${TEST_SDK_DIR}/sdk")
     def shimsPath = file("${TEST_SDK_DIR}/shims")
-    if (!sdkShimsPath.exists() || !sdkShimsPath.isDirectory()) {
-        fail("The provided TEST_SDK_DIR=${TEST_SDK_DIR} directory does not exist")
-    }
-    if (!sdkPath.exists() || !sdkPath.isDirectory() ||
-        !shimsPath.exists() || !shimsPath.isDirectory()) {
-        fail("The provided TEST_SDK_DIR=${TEST_SDK_DIR} is invalid")
+    if (!sdkShimsPath.exists() || !sdkShimsPath.isDirectory() ||
+             !sdkPath.exists() || !sdkPath.isDirectory() ||
+           !shimsPath.exists() || !shimsPath.isDirectory()) {
+        fail("The provided TEST_SDK_PATH=${TEST_SDK_PATH} is invalid")
     }
     ext.IS_TEST_SDK = true
 } else {


### PR DESCRIPTION
Issue:
The test execution fails when a relative path is specified a relative path for `TEST_SDK_PATH`.
For example:
1. gradle -PTEST_ONLY=true -PTEST_SDK_PATH=**..**/jfx1/build test 
2. gradle -PTEST_ONLY=true -PTEST_SDK_PATH=**~**/jfx1/build test

Solution:
Convert the relative path to an absolute path.

More about fix:
The property TEST_SDK_PATH belongs to the root project rt in build.gradle.
If we modify this property in build.gradle, it does not reflect in the child projects. The child projects for example graphics, controls would still have the value of TEST_SDK_PATH before modification.
To solve this, I Introduced a new variable in build.gradle `TEST_SDK_DIR`. It would hold the modified value of `TEST_SDK_PATH` and gets correctly reflected across all sub-projects.

Verified that both relative paths and absolute path work fine after this change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8352982: gradle TEST_SDK_PATH param doesn't work with relative paths`

### Issue
 * [JDK-8352982](https://bugs.openjdk.org/browse/JDK-8352982): gradle TEST_SDK_PATH param doesn't work with relative paths (**Bug** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1751/head:pull/1751` \
`$ git checkout pull/1751`

Update a local copy of the PR: \
`$ git checkout pull/1751` \
`$ git pull https://git.openjdk.org/jfx.git pull/1751/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1751`

View PR using the GUI difftool: \
`$ git pr show -t 1751`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1751.diff">https://git.openjdk.org/jfx/pull/1751.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1751#issuecomment-2768329277)
</details>
