### PR TITLE
8245602: Ensemble8: HTMLEditor Toolbar gets scrolled out of view

### DIFF
--- a/apps/samples/Ensemble8/src/samples/java/ensemble/samples/controls/htmleditor/HTMLEditorApp.java
+++ b/apps/samples/Ensemble8/src/samples/java/ensemble/samples/controls/htmleditor/HTMLEditorApp.java
@@ -76,12 +76,9 @@ public class HTMLEditorApp extends Application {
         htmlEditor = new HTMLEditor();
         htmlEditor.setHtmlText(INITIAL_TEXT);
 
-        ScrollPane htmlSP = new ScrollPane();
-        htmlSP.setFitToWidth(true);
-        htmlSP.setPrefWidth(htmlEditor.prefWidth(-1)); // Workaround of JDK-8096877
-        htmlSP.setPrefHeight(245);
-        htmlSP.setVbarPolicy(ScrollBarPolicy.NEVER);
-        htmlSP.setContent(htmlEditor);
+        VBox htmlVB = new VBox();
+        htmlVB.setPrefHeight(245);
+        htmlVB.getChildren().add(htmlEditor);
 
         final Label htmlLabel = new Label();
         htmlLabel.setWrapText(true);
@@ -99,7 +96,7 @@ public class HTMLEditorApp extends Application {
         VBox vRoot = new VBox();
         vRoot.setAlignment(Pos.CENTER);
         vRoot.setSpacing(5);
-        vRoot.getChildren().addAll(htmlSP, showHTMLButton, scrollPane);
+        vRoot.getChildren().addAll(htmlVB, showHTMLButton, scrollPane);
 
         return vRoot;
     }


### PR DESCRIPTION
There was a scrolling issue with multiline edit control with text controls at the top of the edit box [JDK-8245602](https://bugs.openjdk.org/browse/JDK-8245602),

We replaced the ScrollPane with VBox control as the parent of the html edit control.

Verification:
This makes the controls on the top of the edit control, And the texts scroll inside the text area as expected.
Similar kind of behavior is seen in normal web pages with multiline edit controls inside it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8245602](https://bugs.openjdk.org/browse/JDK-8245602): Ensemble8: HTMLEditor Toolbar gets scrolled out of view (**Bug** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1752/head:pull/1752` \
`$ git checkout pull/1752`

Update a local copy of the PR: \
`$ git checkout pull/1752` \
`$ git pull https://git.openjdk.org/jfx.git pull/1752/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1752`

View PR using the GUI difftool: \
`$ git pr show -t 1752`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1752.diff">https://git.openjdk.org/jfx/pull/1752.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1752#issuecomment-2768355484)
</details>
