### PR TITLE
8350009: [XWayland] SwingNodePlatformExitCrashTest hangs on Ubuntu 24.04

### DIFF
--- a/tests/system/src/test/java/test/robot/javafx/embed/swing/SwingNodePlatformExitCrashTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/embed/swing/SwingNodePlatformExitCrashTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,7 @@ import javax.swing.SwingUtilities;
 import javafx.application.Platform;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assumptions;
 import test.util.Util;
 
 public class SwingNodePlatformExitCrashTest extends SwingNodeBase {
@@ -53,6 +54,8 @@ public class SwingNodePlatformExitCrashTest extends SwingNodeBase {
 
     @BeforeAll
     public static void skipShutDown() {
+        // This test requires JDK 24 or later on Wayland
+        Assumptions.assumeTrue(!Util.isOnWayland() || Runtime.version().feature() >= 24);
         // Skip shutdown as Toolkit shutdown is already done in Platform.exit
         // and will cause hang if called
         doShutdown = false;


### PR DESCRIPTION
SwingNodePlatformExitCrashTest hangs on Ubuntu 24.04 and wayland when we use < JDK 24.

This is happening because of issue identified in https://bugs.openjdk.org/browse/JDK-8335468 and it is fixed in JDK 24.
So we need to run this test on wayland only when we use JDK 24 or later.
Test is updated and verified that it works appropriately now on Ubuntu 24.04.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350009](https://bugs.openjdk.org/browse/JDK-8350009): [XWayland] SwingNodePlatformExitCrashTest hangs on Ubuntu 24.04 (**Bug** - P3)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1753/head:pull/1753` \
`$ git checkout pull/1753`

Update a local copy of the PR: \
`$ git checkout pull/1753` \
`$ git pull https://git.openjdk.org/jfx.git pull/1753/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1753`

View PR using the GUI difftool: \
`$ git pr show -t 1753`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1753.diff">https://git.openjdk.org/jfx/pull/1753.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1753#issuecomment-2769850865)
</details>
