### PR TITLE
8354631: [macos] OpenURIHandler events not received by AWT when JavaFX is primary toolkit

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
@@ -474,6 +474,21 @@ jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved)
     return YES;
 }
 
+- (void) application:(NSApplication *)theApplication openURLs:(NSArray<NSURL *> *)urls
+{
+    for (NSURL* url in urls) {
+         NSDictionary *userInfo = @{
+            @"name": @"openURL",
+            @"url": url.absoluteString
+        };
+
+        [[NSNotificationCenter defaultCenter]
+                postNotificationName:@"EmbeddedEvent"
+                object:nil
+                userInfo:userInfo];
+    }
+}
+
 - (BOOL)applicationShouldOpenUntitledFile:(NSApplication *)sender
 {
     LOG("GlassApplication:applicationShouldOpenUntitledFile");

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
@@ -78,6 +78,11 @@ static NSString* JavaRunLoopMode = @"AWTRunLoopMode";
 // don't deadlock.
 static NSArray<NSString*> *runLoopModes = nil;
 
+// Custom event that is provided by AWT to allow libraries like
+// JavaFX to forward native events to AWT even if AWT runs in
+// embedded mode.
+static NSString* awtEmbeddedEvent = @"AWTEmbeddedEvent";
+
 #ifdef STATIC_BUILD
 jint JNICALL JNI_OnLoad_glass(JavaVM *vm, void *reserved)
 #else
@@ -483,7 +488,7 @@ jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved)
         };
 
         [[NSNotificationCenter defaultCenter]
-                postNotificationName:@"EmbeddedEvent"
+                postNotificationName:awtEmbeddedEvent
                 object:nil
                 userInfo:userInfo];
     }


### PR DESCRIPTION
When trying to register an open URI handler when using JavaFX with a native menu, this task fails on Mac.
Either the native menu is not shown or the URIs are not received.

This pull request fixes this issue if AWT is registered after JavaFX, so that AWT runs embedded inside JavaFX.
It fixes this by introducing a native event to AWT, which can be used by JavaFX to forward events such as an openURL event.

The test for this pull request is non trivial, as the application needs to be installed on the Mac before it can be tested. Therefore the test is provided in a separate repository and it needs to be discussed if the test is necessary to have inside the JFX repo and if so, how it should be integrated.

JDK Pull Request: https://github.com/openjdk/jdk/pull/24379
Co-Author: @FlorianKirmaier

Link to the test repo: https://github.com/pabulaner/openurifx

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8354631](https://bugs.openjdk.org/browse/JDK-8354631): [macos] OpenURIHandler events not received by AWT when JavaFX is primary toolkit (**Bug** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - no project role)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Contributors
 * Florian Kirmaier `<fkirmaier@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1755/head:pull/1755` \
`$ git checkout pull/1755`

Update a local copy of the PR: \
`$ git checkout pull/1755` \
`$ git pull https://git.openjdk.org/jfx.git pull/1755/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1755`

View PR using the GUI difftool: \
`$ git pr show -t 1755`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1755.diff">https://git.openjdk.org/jfx/pull/1755.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1755#issuecomment-2802979217)
</details>
