### PR TITLE
8353548: [macOS] DragEvent.getScreenY() returns incorrect value in secondary monitor

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassViewDelegate.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassViewDelegate.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -907,7 +907,7 @@ static jint getSwipeDirFromEvent(NSEvent *theEvent)
     int y = (int)draggingLocation.y;
 
     int xAbs = (int)([info draggingLocation].x + [self->nsView window].frame.origin.x);
-    int yAbs = (int)([[self->nsView window] screen].frame.size.height - [self->nsView window].frame.origin.y
+    int yAbs = (int)([[NSScreen screens] objectAtIndex: 0].frame.size.height - [self->nsView window].frame.origin.y
                      - [info draggingLocation].y);
 
     int mask;


### PR DESCRIPTION
This PR fixes an issue when dragEvents occur in a secondary screen which doesn't have the same height or (macOS) origin as the main screen.

The calculations for `xAbs, yAbs` are defined from the main screen macOS absolute origin, an in order to flip the coordinates defined from the JavaFX origin, the height from the main screen should be used, and not the height from secondary screens, which was the case in `GlassViewDelegate::sendJavaDndEvent`.

The PR doesn't include tests because it needs a complex setup (two monitors), but the change has been tested on macOS 15.3.2 with the test case from https://bugs.openjdk.org/browse/JDK-8353548, using two monitors (built-in Retina and external 4K display), rearranging their layout (left-bottom-right from main screen), and relative resolution.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8353548](https://bugs.openjdk.org/browse/JDK-8353548): [macOS] DragEvent.getScreenY() returns incorrect value in secondary monitor (**Bug** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1756/head:pull/1756` \
`$ git checkout pull/1756`

Update a local copy of the PR: \
`$ git checkout pull/1756` \
`$ git pull https://git.openjdk.org/jfx.git pull/1756/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1756`

View PR using the GUI difftool: \
`$ git pr show -t 1756`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1756.diff">https://git.openjdk.org/jfx/pull/1756.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1756#issuecomment-2773214922)
</details>
