### PR TITLE
8353587: Spelling errors and dead code

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/MenuBar.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/MenuBar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,25 +25,21 @@
 
 package javafx.scene.control;
 
-import javafx.css.converter.BooleanConverter;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-
 import javafx.beans.DefaultProperty;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.value.ObservableValue;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.css.CssMetaData;
-import javafx.css.StyleableBooleanProperty;
-
-import javafx.scene.control.skin.MenuBarSkin;
-
 import javafx.css.Styleable;
+import javafx.css.StyleableBooleanProperty;
 import javafx.css.StyleableProperty;
+import javafx.css.converter.BooleanConverter;
 import javafx.scene.AccessibleRole;
+import javafx.scene.control.skin.MenuBarSkin;
 
 /**
  * <p>
@@ -161,15 +157,12 @@ public class MenuBar extends Control {
 
                 @Override
                 public void bind(final ObservableValue<? extends Boolean> rawObservable) {
-                    throw new RuntimeException(BIND_MSG);
+                    throw new RuntimeException("cannot uni-directionally bind to the system menu bar - use bindBidrectional instead");
                 }
-
             };
         }
         return useSystemMenuBar;
     }
-    private String BIND_MSG =
-        "cannot uni-directionally bind to the system menu bar - use bindBidrectional instead";
 
     private BooleanProperty useSystemMenuBar;
     public final void setUseSystemMenuBar(boolean value) {
@@ -262,6 +255,4 @@ public class MenuBar extends Control {
     @Override protected Boolean getInitialFocusTraversable() {
         return Boolean.FALSE;
     }
-
 }
-

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/scene/traversal/Heuristic2D.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/scene/traversal/Heuristic2D.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/scene/traversal/Heuristic2D.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/scene/traversal/Heuristic2D.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2015, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,20 +25,24 @@
 
 package com.sun.javafx.scene.traversal;
 
+import static com.sun.javafx.scene.traversal.Direction.DOWN;
+import static com.sun.javafx.scene.traversal.Direction.LEFT;
+import static com.sun.javafx.scene.traversal.Direction.NEXT;
+import static com.sun.javafx.scene.traversal.Direction.NEXT_IN_LINE;
+import static com.sun.javafx.scene.traversal.Direction.PREVIOUS;
+import static com.sun.javafx.scene.traversal.Direction.RIGHT;
+import static com.sun.javafx.scene.traversal.Direction.UP;
 import java.util.List;
 import java.util.Stack;
+import java.util.function.Function;
 import javafx.geometry.BoundingBox;
 import javafx.geometry.Bounds;
 import javafx.geometry.Point2D;
 import javafx.scene.Node;
 
-import static com.sun.javafx.scene.traversal.Direction.*;
-import java.util.function.Function;
+public class Heuristic2D implements Algorithm {
 
-
-public class Hueristic2D implements Algorithm {
-
-    Hueristic2D() {
+    Heuristic2D() {
     }
 
     @Override

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/scene/traversal/TraversalEngine.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/scene/traversal/TraversalEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,7 +47,7 @@ public abstract class TraversalEngine{
     /**
      * This is the default algorithm for the running platform. It's the algorithm that's used in TopMostTraversalEngine
      */
-    static final Algorithm DEFAULT_ALGORITHM = PlatformImpl.isContextual2DNavigation() ? new Hueristic2D() : new ContainerTabOrder();
+    static final Algorithm DEFAULT_ALGORITHM = PlatformImpl.isContextual2DNavigation() ? new Heuristic2D() : new ContainerTabOrder();
 
     private final TraversalContext context = new EngineContext(); // This is the context used in calls to this engine's algorithm
     // This is a special context that's used when invoking select "callbacks" to default algorithm in other contexts

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/Toolkit.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/Toolkit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -382,7 +382,7 @@ public abstract class Toolkit {
 
     public void firePulse() {
         // Stages need to be notified of pulses before scenes so the Stage can resized
-        // and those changes propogated to scene before it gets its pulse to update
+        // and those changes propagated to scene before it gets its pulse to update
 
         // Copy of listener keySet
         final Set<TKPulseListener> stagePulseList = new HashSet<>();

--- a/modules/javafx.media/src/main/java/com/sun/media/jfxmediaimpl/NativeMediaPlayer.java
+++ b/modules/javafx.media/src/main/java/com/sun/media/jfxmediaimpl/NativeMediaPlayer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1456,7 +1456,7 @@ public abstract class NativeMediaPlayer implements MediaPlayer, MarkerStateListe
 
     protected void sendPlayerHaltEvent(String message, double time) {
         // Log the error.  Since these are most likely playback engine message (e.g. GStreamer or PacketVideo),
-        // it makes no sense to propogate it above.
+        // it makes no sense to propagate it above.
         Logger.logMsg(Logger.ERROR, message);
 
         if (eventLoop != null) {

--- a/modules/javafx.media/src/main/java/javafx/scene/media/AudioEqualizer.java
+++ b/modules/javafx.media/src/main/java/javafx/scene/media/AudioEqualizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -135,9 +135,9 @@ public final class AudioEqualizer {
 
             this.jfxEqualizer = jfxEqualizer;
 
-            // Propogate enabled
+            // Propagate enabled
             jfxEqualizer.setEnabled(isEnabled());
-            // Propogate bands
+            // Propagate bands
             for (EqualizerBand band : bands) {
                 if (band.getCenterFrequency() > 0 && band.getBandwidth() > 0) {
                     com.sun.media.jfxmedia.effects.EqualizerBand jfxBand =

--- a/modules/javafx.media/src/main/java/javafx/scene/media/MediaPlayer.java
+++ b/modules/javafx.media/src/main/java/javafx/scene/media/MediaPlayer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1737,7 +1737,7 @@ public final class MediaPlayer {
         Platform.runLater(() -> {
             setError(error);
 
-            // Propogate errors that related to media to media object
+            // Propagate errors that related to media to media object
             if (error.getType() == MediaException.Type.MEDIA_CORRUPTED
                     || error.getType() == MediaException.Type.MEDIA_UNSUPPORTED
                     || error.getType() == MediaException.Type.MEDIA_INACCESSIBLE


### PR DESCRIPTION
Corrects annoying spelling errors in the code:

- propogated
- Hueristic2D

Also fixes unnecessary field in MenuBar:171

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353587](https://bugs.openjdk.org/browse/JDK-8353587): Spelling errors and dead code (**Bug** - P4)


### Reviewers
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1757/head:pull/1757` \
`$ git checkout pull/1757`

Update a local copy of the PR: \
`$ git checkout pull/1757` \
`$ git pull https://git.openjdk.org/jfx.git pull/1757/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1757`

View PR using the GUI difftool: \
`$ git pr show -t 1757`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1757.diff">https://git.openjdk.org/jfx/pull/1757.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1757#issuecomment-2773873348)
</details>
