### PR TITLE
8340464: [TestBug] Convert parametrized base tests to JUnit 5

### DIFF
--- a/modules/javafx.base/src/test/java/test/com/sun/javafx/binding/BidirectionalBindingTest.java
+++ b/modules/javafx.base/src/test/java/test/com/sun/javafx/binding/BidirectionalBindingTest.java
@@ -28,18 +28,18 @@ package test.com.sun.javafx.binding;
 import com.sun.javafx.binding.BidirectionalBinding;
 import javafx.beans.binding.Bindings;
 import javafx.beans.property.*;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Arrays;
 import java.util.Collection;
 import javafx.beans.value.ObservableValue;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
-@RunWith(Parameterized.class)
 public class BidirectionalBindingTest<T> {
 
     @FunctionalInterface
@@ -70,11 +70,11 @@ public class BidirectionalBindingTest<T> {
     private Property<T> op4;
     private T[] v;
 
-    public BidirectionalBindingTest(Factory<T> factory) {
+    public void BidirectionalBindingTest_(Factory<T> factory) {
         this.factory = factory;
     }
 
-    @Before
+    //@BeforeEach
     public void setUp() {
         op1 = factory.createProperty();
         op2 = factory.createProperty();
@@ -85,8 +85,11 @@ public class BidirectionalBindingTest<T> {
         op2.setValue(v[1]);
     }
 
-    @Test
-    public void testBind() {
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void testBind(Factory<T> factory) {
+        BidirectionalBindingTest_(factory);
+        setUp();
         Bindings.bindBidirectional(op1, op2);
         Bindings.bindBidirectional(op1, op2);
         System.gc(); // making sure we did not not overdo weak references
@@ -102,8 +105,11 @@ public class BidirectionalBindingTest<T> {
         assertEquals(v[3], op2.getValue());
     }
 
-    @Test
-    public void testUnbind() {
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void testUnbind(Factory<T> factory) {
+        BidirectionalBindingTest_(factory);
+        setUp();
         // unbind non-existing binding => no-op
         Bindings.unbindBidirectional(op1, op2);
 
@@ -127,8 +133,11 @@ public class BidirectionalBindingTest<T> {
         assertEquals(v[3], op2.getValue());
     }
 
-    @Test
-    public void testChaining() {
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void testChaining(Factory<T> factory) {
+        BidirectionalBindingTest_(factory);
+        setUp();
         op3.setValue(v[2]);
         Bindings.bindBidirectional(op1, op2);
         Bindings.bindBidirectional(op2, op3);
@@ -179,8 +188,11 @@ public class BidirectionalBindingTest<T> {
         return ExpressionHelperUtility.getInvalidationListeners(v).size();
     }
 
-    @Test
-    public void testWeakReferencing() {
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void testWeakReferencing(Factory<T> factory) {
+        BidirectionalBindingTest_(factory);
+        setUp();
         Bindings.bindBidirectional(op1, op2);
 
         assertEquals(1, getListenerCount(op1));
@@ -201,16 +213,22 @@ public class BidirectionalBindingTest<T> {
         assertEquals(0, getListenerCount(op2));
     }
 
-    @Test
-    public void testHashCode() {
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void testHashCode(Factory<T> factory) {
+        BidirectionalBindingTest_(factory);
+        setUp();
         final int hc1 = BidirectionalBinding.bind(op1, op2).hashCode();
         final int hc2 = BidirectionalBinding.bind(op2, op1).hashCode();
         assertEquals(hc1, hc2);
     }
 
     @SuppressWarnings("unlikely-arg-type")
-    @Test
-    public void testEquals() {
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void testEquals(Factory<T> factory) {
+        BidirectionalBindingTest_(factory);
+        setUp();
         final BidirectionalBinding golden = BidirectionalBinding.bind(op1, op2);
 
         assertTrue(golden.equals(golden));
@@ -224,8 +242,11 @@ public class BidirectionalBindingTest<T> {
         assertFalse(golden.equals(BidirectionalBinding.bind(op2, op3)));
     }
 
-    @Test
-    public void testEqualsWithGCedProperty() {
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void testEqualsWithGCedProperty(Factory<T> factory) {
+        BidirectionalBindingTest_(factory);
+        setUp();
         final BidirectionalBinding binding1 = BidirectionalBinding.bind(op1, op2);
         final BidirectionalBinding binding2 = BidirectionalBinding.bind(op1, op2);
         final BidirectionalBinding binding3 = BidirectionalBinding.bind(op2, op1);
@@ -242,38 +263,59 @@ public class BidirectionalBindingTest<T> {
         assertFalse(binding3.equals(binding4));
     }
 
-    @Test(expected=NullPointerException.class)
-    public void testBind_Null_X() {
-        Bindings.bindBidirectional(null, op2);
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void testBind_Null_X(Factory<T> factory) {
+        BidirectionalBindingTest_(factory);
+        setUp();
+        assertThrows(NullPointerException.class, () -> Bindings.bindBidirectional(null, op2));
     }
 
-    @Test(expected=NullPointerException.class)
-    public void testBind_X_Null() {
-        Bindings.bindBidirectional(op1, null);
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void testBind_X_Null(Factory<T> factory) {
+        BidirectionalBindingTest_(factory);
+        setUp();
+        assertThrows(NullPointerException.class, () -> Bindings.bindBidirectional(op1, null));
     }
 
-    @Test(expected=IllegalArgumentException.class)
-    public void testBind_X_Self() {
-        Bindings.bindBidirectional(op1, op1);
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void testBind_X_Self(Factory<T> factory) {
+        BidirectionalBindingTest_(factory);
+        setUp();
+        assertThrows(IllegalArgumentException.class, () -> Bindings.bindBidirectional(op1, op1));
     }
 
-    @Test(expected=NullPointerException.class)
-    public void testUnbind_Null_X() {
-        Bindings.unbindBidirectional(null, op2);
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void testUnbind_Null_X(Factory<T> factory) {
+        BidirectionalBindingTest_(factory);
+        setUp();
+        assertThrows(NullPointerException.class, () -> Bindings.unbindBidirectional(null, op2));
     }
 
-    @Test(expected=NullPointerException.class)
-    public void testUnbind_X_Null() {
-        Bindings.unbindBidirectional(op1, null);
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void testUnbind_X_Null(Factory<T> factory) {
+        BidirectionalBindingTest_(factory);
+        setUp();
+        assertThrows(NullPointerException.class, () -> Bindings.unbindBidirectional(op1, null));
     }
 
-    @Test(expected=IllegalArgumentException.class)
-    public void testUnbind_X_Self() {
-        Bindings.unbindBidirectional(op1, op1);
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void testUnbind_X_Self(Factory<T> factory) {
+        BidirectionalBindingTest_(factory);
+        setUp();
+        assertThrows(IllegalArgumentException.class, () -> Bindings.unbindBidirectional(op1, op1));
     }
 
-    @Test
-    public void testBrokenBind() {
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void testBrokenBind(Factory<T> factory) {
+        BidirectionalBindingTest_(factory);
+        setUp();
         Bindings.bindBidirectional(op1, op2);
         op1.bind(op3);
         assertEquals(op3.getValue(), op1.getValue());
@@ -284,8 +326,11 @@ public class BidirectionalBindingTest<T> {
         assertEquals(op2.getValue(), op1.getValue());
     }
 
-    @Test
-    public void testDoubleBrokenBind() {
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void testDoubleBrokenBind(Factory<T> factory) {
+        BidirectionalBindingTest_(factory);
+        setUp();
         Bindings.bindBidirectional(op1, op2);
         op1.bind(op3);
         op4.setValue(v[0]);
@@ -302,8 +347,11 @@ public class BidirectionalBindingTest<T> {
         assertEquals(v[1], op2.getValue());
     }
 
-    @Test
-    public void testSetValueWithoutIntermediateValidation() {
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void testSetValueWithoutIntermediateValidation(Factory<T> factory) {
+        BidirectionalBindingTest_(factory);
+        setUp();
         BidirectionalBinding.bind(op1, op2);
         op1.setValue(v[0]);
         op2.setValue(v[1]);
@@ -311,7 +359,6 @@ public class BidirectionalBindingTest<T> {
         assertEquals(v[1], op2.getValue());
     }
 
-    @Parameterized.Parameters
     public static Collection<Object[]> parameters() {
         final Boolean[] booleanData = new Boolean[] {true, false, true, false};
         final Double[] doubleData = new Double[] {2348.2345, -92.214, -214.0214, -908.214};

--- a/modules/javafx.base/src/test/java/test/com/sun/javafx/binding/BidirectionalBindingWithConversionTest.java
+++ b/modules/javafx.base/src/test/java/test/com/sun/javafx/binding/BidirectionalBindingWithConversionTest.java
@@ -30,10 +30,11 @@ import javafx.beans.InvalidationListener;
 import javafx.beans.binding.Bindings;
 import javafx.beans.property.*;
 import javafx.util.StringConverter;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.text.DateFormat;
 import java.text.ParseException;
@@ -41,10 +42,10 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
 import java.util.Locale;
+import java.util.stream.Stream;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
-@RunWith(Parameterized.class)
 public class BidirectionalBindingWithConversionTest<S, T> {
 
     public static interface Functions<U, V> {
@@ -57,14 +58,14 @@ public class BidirectionalBindingWithConversionTest<S, T> {
         void check1(V obj0, V obj1);
     }
 
-    private final Functions<S, T> func;
-    private final S[] v0;
-    private final T[] v1;
+    private  Functions<S, T> func;
+    private  S[] v0;
+    private  T[] v1;
 
     private PropertyMock<S> op0;
     private PropertyMock<T> op1;
 
-    public BidirectionalBindingWithConversionTest(Functions<S, T> func, S[] v0, T[] v1) {
+    public void BidirectionalBindingWithConversionTest_(Functions<S, T> func, S[] v0, T[] v1) {
         this.op0 = func.create0();
         this.op1 = func.create1();
         this.func = func;
@@ -72,14 +73,13 @@ public class BidirectionalBindingWithConversionTest<S, T> {
         this.v1 = v1;
     }
 
-    @Before
-    public void setUp() {
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void testBind(Functions<S, T> func, S[] v0, T[] v1) {
+        BidirectionalBindingWithConversionTest_(func, v0, v1);
         op0.setValue(v0[0]);
         op1.setValue(v1[1]);
-    }
-
-    @Test
-    public void testBind() {
         func.bind(op0, op1);
         System.gc(); // making sure we did not not overdo weak references
         func.check0(v0[1], op0.getValue());
@@ -94,8 +94,12 @@ public class BidirectionalBindingWithConversionTest<S, T> {
         func.check1(v1[3], op1.getValue());
     }
 
-    @Test
-    public void testUnbind() {
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void testUnbind(Functions<S, T> func, S[] v0, T[] v1) {
+        BidirectionalBindingWithConversionTest_(func, v0, v1);
+        op0.setValue(v0[0]);
+        op1.setValue(v1[1]);
         // unbind non-existing binding => no-op
         func.unbind(op0, op1);
 
@@ -119,8 +123,12 @@ public class BidirectionalBindingWithConversionTest<S, T> {
         func.check1(v1[3], op1.getValue());
     }
 
-    @Test
-    public void testWeakReferencing() {
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void testWeakReferencing(Functions<S, T> func, S[] v0, T[] v1) {
+        BidirectionalBindingWithConversionTest_(func, v0, v1);
+        op0.setValue(v0[0]);
+        op1.setValue(v1[1]);
         func.bind(op0, op1);
         assertEquals(1, op0.getListenerCount());
         assertEquals(1, op1.getListenerCount());
@@ -141,32 +149,47 @@ public class BidirectionalBindingWithConversionTest<S, T> {
         assertEquals(0, op0.getListenerCount());
     }
 
-    @Test(expected=NullPointerException.class)
-    public void testBind_Null_X() {
-        func.bind(null, op1);
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void testBind_Null_X(Functions<S, T> func, S[] v0, T[] v1) {
+        BidirectionalBindingWithConversionTest_(func, v0, v1);
+        op0.setValue(v0[0]);
+        op1.setValue(v1[1]);
+        assertThrows(NullPointerException.class, () -> func.bind(null, op1));
     }
 
-    @Test(expected=NullPointerException.class)
-    public void testBind_X_Null() {
-        func.bind(op0, null);
+    public void testBind_X_Null(Functions<S, T> func, S[] v0, T[] v1) {
+        BidirectionalBindingWithConversionTest_(func, v0, v1);
+        op0.setValue(v0[0]);
+        op1.setValue(v1[1]);
+        assertThrows(NullPointerException.class, () -> func.bind(op0, null));
     }
 
-    @Test(expected=NullPointerException.class)
-    public void testUnbind_Null_X() {
-        func.unbind(null, op1);
+    public void testUnbind_Null_X(Functions<S, T> func, S[] v0, T[] v1) {
+        BidirectionalBindingWithConversionTest_(func, v0, v1);
+        op0.setValue(v0[0]);
+        op1.setValue(v1[1]);
+        assertThrows(NullPointerException.class, () -> func.unbind(null, op1));
     }
 
-    @Test(expected=NullPointerException.class)
-    public void testUnbind_X_Null() {
-        func.unbind(op0, null);
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void testUnbind_X_Null(Functions<S, T> func, S[] v0, T[] v1) {
+        BidirectionalBindingWithConversionTest_(func, v0, v1);
+        op0.setValue(v0[0]);
+        op1.setValue(v1[1]);
+        assertThrows(NullPointerException.class, () ->  func.unbind(op0, null));
     }
 
-    @Test(expected=IllegalArgumentException.class)
-    public void testUnbind_X_Self() {
-        func.unbind(op0, op0);
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void testUnbind_X_Self(Functions<S, T> func, S[] v0, T[] v1) {
+        BidirectionalBindingWithConversionTest_(func, v0, v1);
+        op0.setValue(v0[0]);
+        op1.setValue(v1[1]);
+        assertThrows(IllegalArgumentException.class, () ->  func.unbind(op0, op0));
     }
 
-    @Parameterized.Parameters
     public static Collection<Object[]> parameters() {
         final DateFormat format = DateFormat.getDateTimeInstance(DateFormat.FULL, DateFormat.FULL, Locale.US);
         final Date[] dates = new Date[] {new Date(), new Date(0), new Date(Integer.MAX_VALUE), new Date(Long.MAX_VALUE)};

--- a/modules/javafx.base/src/test/java/test/com/sun/javafx/event/EventDispatchChainTest.java
+++ b/modules/javafx.base/src/test/java/test/com/sun/javafx/event/EventDispatchChainTest.java
@@ -27,151 +27,126 @@ package test.com.sun.javafx.event;
 
 import com.sun.javafx.event.EventDispatchChainImpl;
 import com.sun.javafx.event.EventDispatchTreeImpl;
-import java.util.Arrays;
-import java.util.Collection;
-
 import javafx.event.EventDispatchChain;
 
-import org.junit.Test;
-import org.junit.Assert;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
 public final class EventDispatchChainTest {
     private static final Operation[] IDENTITY_FUNCTION_OPS = {
-        Operation.mul(3), Operation.add(5), Operation.mul(4), Operation.sub(2),
-        Operation.div(6), Operation.add(9), Operation.div(2), Operation.sub(6)
+            Operation.mul(3), Operation.add(5), Operation.mul(4), Operation.sub(2),
+            Operation.div(6), Operation.add(9), Operation.div(2), Operation.sub(6)
     };
 
-    @Parameters
-    public static Collection data() {
-        return Arrays.asList(
-                new Object[][] {
-                    { EventDispatchChainImpl.class },
-                    { EventDispatchTreeImpl.class }
-                });
+    private static Stream<Arguments> chainClasses() {
+        return Stream.of(
+                Arguments.of(EventDispatchChainImpl.class),
+                Arguments.of(EventDispatchTreeImpl.class)
+        );
     }
 
-    private EventDispatchChain eventDispatchChain;
-
-    public EventDispatchChainTest(final Class<EventDispatchChain> chainClass)
-            throws Exception {
-        eventDispatchChain = chainClass.getDeclaredConstructor().newInstance();
+    @ParameterizedTest
+    @MethodSource("chainClasses")
+    void chainConstructionBeforeDispatchTest(Class<? extends EventDispatchChain> chainClass) throws Exception {
+        EventDispatchChain chain = chainClass.getDeclaredConstructor().newInstance();
+        chain = initializeTestChain(chain);
+        verifyChain(chain, 0, 702);
     }
 
-    @Test
-    public void chainConstructionBeforeDispatchTest() {
-        eventDispatchChain = initializeTestChain(eventDispatchChain);
-        verifyChain(eventDispatchChain, 0, 702);
+    @ParameterizedTest
+    @MethodSource("chainClasses")
+    void chainModificationAfterDispatchTest(Class<? extends EventDispatchChain> chainClass) throws Exception {
+        EventDispatchChain chain = chainClass.getDeclaredConstructor().newInstance();
+        chain = initializeTestChain(chain);
+        chain.dispatchEvent(new ValueEvent());
+
+        chain = chain.append(new EventChangingDispatcher(Operation.sub(6), Operation.div(3)));
+        verifyChain(chain, 0, 270);
+
+        chain = prependIdentityChain(chain);
+        verifyChain(chain, 0, 270);
     }
 
-    @Test
-    public void chainModificationAfterDispatchTest() {
-        eventDispatchChain = initializeTestChain(eventDispatchChain);
-        eventDispatchChain.dispatchEvent(new ValueEvent());
+    @ParameterizedTest
+    @MethodSource("chainClasses")
+    void chainModificationDuringDispatchTest(Class<? extends EventDispatchChain> chainClass) throws Exception {
+        EventDispatchChain chain = chainClass.getDeclaredConstructor().newInstance();
 
-        eventDispatchChain = eventDispatchChain.append(
-                                     new EventChangingDispatcher(
-                                         Operation.sub(6),
-                                         Operation.div(3)));
-        verifyChain(eventDispatchChain, 0, 270);
-
-        eventDispatchChain = prependIdentityChain(eventDispatchChain);
-        verifyChain(eventDispatchChain, 0, 270);
-    }
-
-    @Test
-    public void chainModificationDuringDispatchTest() {
         // x + 55, y + 55
-        eventDispatchChain = prependSeriesChain(eventDispatchChain, 10);
-        eventDispatchChain =
-                eventDispatchChain.prepend(
-                        new PathChangingDispatcher(
-                            new EventChangingDispatcher(Operation.mul(3),
-                                                        Operation.div(5)),
-                            new EventChangingDispatcher(Operation.div(7),
-                                                        Operation.mul(9)),
-                            1));
+        chain = prependSeriesChain(chain, 10);
+        chain = chain.prepend(
+                new PathChangingDispatcher(
+                        new EventChangingDispatcher(Operation.mul(3), Operation.div(5)),
+                        new EventChangingDispatcher(Operation.div(7), Operation.mul(9)),
+                        1));
         // x + 15, y + 15
-        eventDispatchChain = prependSeriesChain(eventDispatchChain, 5);
+        chain = prependSeriesChain(chain, 5);
 
-        eventDispatchChain =
-                eventDispatchChain.prepend(
-                        new PathChangingDispatcher(null, null, 2));
+        chain = chain.prepend(new PathChangingDispatcher(null, null, 2));
 
         // x + 6, y + 6
-        eventDispatchChain = prependSeriesChain(eventDispatchChain, 3);
+        chain = prependSeriesChain(chain, 3);
 
         for (int x = 0; x < 5; ++x) {
-            verifyChain(eventDispatchChain, 1225 * x - 86, 729 * x + 50);
+            verifyChain(chain, 1225 * x - 86, 729 * x + 50);
         }
     }
 
-    @Test
-    public void buildLongChainTest() {
-        eventDispatchChain = prependSeriesChain(eventDispatchChain, 100);
-        verifyChain(eventDispatchChain, 0, 10100);
+    @ParameterizedTest
+    @MethodSource("chainClasses")
+    void buildLongChainTest(Class<? extends EventDispatchChain> chainClass) throws Exception {
+        EventDispatchChain chain = chainClass.getDeclaredConstructor().newInstance();
 
-        eventDispatchChain = prependIdentityChain(eventDispatchChain);
-        verifyChain(eventDispatchChain, 1, 10101);
+        chain = prependSeriesChain(chain, 100);
+        verifyChain(chain, 0, 10100);
 
-        eventDispatchChain = prependSeriesChain(eventDispatchChain, 100);
-        verifyChain(eventDispatchChain, 2, 20202);
+        chain = prependIdentityChain(chain);
+        verifyChain(chain, 1, 10101);
+
+        chain = prependSeriesChain(chain, 100);
+        verifyChain(chain, 2, 20202);
     }
 
-    private static EventDispatchChain prependIdentityChain(
-            EventDispatchChain tailChain) {
+    private static EventDispatchChain prependIdentityChain(EventDispatchChain tailChain) {
         for (int i = 0; i < IDENTITY_FUNCTION_OPS.length; ++i) {
             tailChain = tailChain.prepend(
                     new EventChangingDispatcher(
-                            IDENTITY_FUNCTION_OPS[
-                                    IDENTITY_FUNCTION_OPS.length - i - 1],
+                            IDENTITY_FUNCTION_OPS[IDENTITY_FUNCTION_OPS.length - i - 1],
                             IDENTITY_FUNCTION_OPS[i]));
         }
 
         return tailChain;
     }
 
-    private static EventDispatchChain prependSeriesChain(
-            EventDispatchChain tailChain, final int count) {
+    private static EventDispatchChain prependSeriesChain(EventDispatchChain tailChain, final int count) {
         for (int i = 1; i <= count; ++i) {
             tailChain = tailChain.prepend(
-                    new EventChangingDispatcher(Operation.add(i),
-                                                Operation.add(i)));
+                    new EventChangingDispatcher(Operation.add(i), Operation.add(i)));
         }
 
         return tailChain;
     }
 
-    private static EventDispatchChain initializeTestChain(
-            final EventDispatchChain emptyChain) {
-        return emptyChain.append(new EventChangingDispatcher(
-                                     Operation.add(3),
-                                     Operation.div(2)))
-                         .append(new EventChangingDispatcher(
-                                     Operation.mul(7),
-                                     Operation.sub(6)))
-                         .prepend(new EventChangingDispatcher(
-                                      Operation.sub(4),
-                                      Operation.mul(6)))
-                         .append(new EventChangingDispatcher(
-                                     Operation.div(3),
-                                     Operation.add(11)))
-                         .prepend(new EventChangingDispatcher(
-                                      Operation.add(10),
-                                      Operation.mul(9)));
+    private static EventDispatchChain initializeTestChain(final EventDispatchChain emptyChain) {
+        return emptyChain.append(new EventChangingDispatcher(Operation.add(3), Operation.div(2)))
+                .append(new EventChangingDispatcher(Operation.mul(7), Operation.sub(6)))
+                .prepend(new EventChangingDispatcher(Operation.sub(4), Operation.mul(6)))
+                .append(new EventChangingDispatcher(Operation.div(3), Operation.add(11)))
+                .prepend(new EventChangingDispatcher(Operation.add(10), Operation.mul(9)));
     }
 
     private static void verifyChain(final EventDispatchChain testChain,
                                     final int initialValue,
                                     final int resultValue) {
-        final ValueEvent valueEvent =
-                (ValueEvent) testChain.dispatchEvent(
-                                     new ValueEvent(initialValue));
+        final ValueEvent valueEvent = (ValueEvent) testChain.dispatchEvent(new ValueEvent(initialValue));
 
-        Assert.assertNotNull(valueEvent);
-        Assert.assertEquals(resultValue, valueEvent.getValue());
+        assertNotNull(valueEvent);
+        assertEquals(resultValue, valueEvent.getValue());
     }
 }

--- a/modules/javafx.base/src/test/java/test/com/sun/javafx/property/adapter/JavaBeanPropertyBuilderHelperTest.java
+++ b/modules/javafx.base/src/test/java/test/com/sun/javafx/property/adapter/JavaBeanPropertyBuilderHelperTest.java
@@ -27,23 +27,22 @@ package test.com.sun.javafx.property.adapter;
 
 import com.sun.javafx.property.adapter.JavaBeanPropertyBuilderHelper;
 import com.sun.javafx.property.adapter.PropertyDescriptor;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
-*/
+ */
 public class JavaBeanPropertyBuilderHelperTest {
 
     private JavaBeanPropertyBuilderHelper helperPOJOBean;
     private JavaBeanPropertyBuilderHelper helperPOJOBeanWithNonStandardNames;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         helperPOJOBean = new JavaBeanPropertyBuilderHelper();
         helperPOJOBean.beanClass(POJOBean.class);
@@ -56,152 +55,68 @@ public class JavaBeanPropertyBuilderHelperTest {
         helperPOJOBeanWithNonStandardNames.setterName("writeX");
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testSetup_WithNameIsNull() {
-        try {
+        assertThrows(NullPointerException.class, () -> {
             helperPOJOBean.name(null);
             helperPOJOBean.getDescriptor();
-        } catch (NoSuchMethodException e) {
-            fail();
-        }
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testSetup_WithNameIsEmpty() {
-        try {
+        assertThrows(IllegalArgumentException.class, () -> {
             helperPOJOBean.name("");
             helperPOJOBean.getDescriptor();
-        } catch (NoSuchMethodException e) {
-            fail();
-        }
+        });
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testSetup_WithBeanClassIsNull() {
-        try {
+        assertThrows(NullPointerException.class, () -> {
             helperPOJOBean.beanClass(null);
             helperPOJOBean.getDescriptor();
-        } catch (NoSuchMethodException e) {
-            fail();
-        }
+        });
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testSetup_WithNonStandardNames_WithNameIsNull() {
-        try {
+        assertThrows(NullPointerException.class, () -> {
             helperPOJOBeanWithNonStandardNames.name(null);
             helperPOJOBeanWithNonStandardNames.getDescriptor();
-        } catch (NoSuchMethodException e) {
-            fail();
-        }
+        });
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testSetup_WithNonStandardNames_WithBeanClassIsNull() {
-        try {
+        assertThrows(NullPointerException.class, () -> {
             helperPOJOBeanWithNonStandardNames.beanClass(null);
             helperPOJOBeanWithNonStandardNames.getDescriptor();
-        } catch (NoSuchMethodException e) {
-            fail();
-        }
+        });
     }
 
-    @Test(expected = NoSuchMethodException.class)
-    public void testSetup_WithNonStandardNames_WithGetterNameIsNull() throws NoSuchMethodException {
-        helperPOJOBeanWithNonStandardNames.getterName(null);
-        helperPOJOBeanWithNonStandardNames.getDescriptor();
+    @Test
+    public void testSetup_WithNonStandardNames_WithGetterNameIsNull() {
+        assertThrows(NoSuchMethodException.class, () -> {
+            helperPOJOBeanWithNonStandardNames.getterName(null);
+            helperPOJOBeanWithNonStandardNames.getDescriptor();
+        });
     }
 
-    @Test(expected = NoSuchMethodException.class)
-    public void testSetup_WithNonStandardNames_WithSetterNameIsNull() throws NoSuchMethodException {
-        helperPOJOBeanWithNonStandardNames.setterName(null);
-        helperPOJOBeanWithNonStandardNames.getDescriptor();
+    @Test
+    public void testSetup_WithNonStandardNames_WithSetterNameIsNull() {
+        assertThrows(NoSuchMethodException.class, () -> {
+            helperPOJOBeanWithNonStandardNames.setterName(null);
+            helperPOJOBeanWithNonStandardNames.getDescriptor();
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testSetup_WithNonStandardNames_WithNameIsEmpty() {
-        try {
+    @Test
+    public void testSetup_WithNonStandardAccessors_WithNameIsEmpty() {
+        assertThrows(IllegalArgumentException.class, () -> {
             helperPOJOBeanWithNonStandardNames.name("");
             helperPOJOBeanWithNonStandardNames.getDescriptor();
-        } catch (NoSuchMethodException e) {
-            fail();
-        }
-    }
-
-    @Test(expected = NoSuchMethodException.class)
-    public void testSetup_WithNonStandardNames_WithGetterNameIsEmpty() throws NoSuchMethodException {
-        helperPOJOBeanWithNonStandardNames.getterName("");
-        helperPOJOBeanWithNonStandardNames.getDescriptor();
-    }
-
-    @Test(expected = NoSuchMethodException.class)
-    public void testSetup_WithNonStandardNames_WithSetterNameIsEmpty() throws NoSuchMethodException {
-        helperPOJOBeanWithNonStandardNames.setterName("");
-        helperPOJOBeanWithNonStandardNames.getDescriptor();
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void testSetup_WithNonStandardAccessors_WithNameIsNull() throws NoSuchMethodException {
-        helperPOJOBeanWithNonStandardNames.getterName(null);
-        helperPOJOBeanWithNonStandardNames.setterName(null);
-        try {
-            final Method getter = POJOBeanWithNonStandardNames.class.getMethod("readX");
-            final Method setter = POJOBeanWithNonStandardNames.class.getMethod("writeX", Object.class);
-            helperPOJOBeanWithNonStandardNames.getter(getter);
-            helperPOJOBeanWithNonStandardNames.setter(setter);
-
-            helperPOJOBeanWithNonStandardNames.name(null);
-        } catch (NoSuchMethodException e) {
-            fail("Error in test code. Should not happen.");
-        }
-        helperPOJOBeanWithNonStandardNames.getDescriptor();
-    }
-
-    @Test(expected = NoSuchMethodException.class)
-    public void testSetup_WithNonStandardAccessors_WithGetterIsNull() throws NoSuchMethodException {
-        helperPOJOBeanWithNonStandardNames.getterName(null);
-        helperPOJOBeanWithNonStandardNames.setterName(null);
-        try {
-            final Method setter = POJOBeanWithNonStandardNames.class.getMethod("writeX", Object.class);
-            helperPOJOBeanWithNonStandardNames.setter(setter);
-
-            helperPOJOBeanWithNonStandardNames.getter(null);
-        } catch (NoSuchMethodException e) {
-            fail("Error in test code. Should not happen.");
-        }
-        helperPOJOBeanWithNonStandardNames.getDescriptor();
-    }
-
-    @Test(expected = NoSuchMethodException.class)
-    public void testSetup_WithNonStandardAccessors_WithSetterIsNull() throws NoSuchMethodException {
-        helperPOJOBeanWithNonStandardNames.getterName(null);
-        helperPOJOBeanWithNonStandardNames.setterName(null);
-        try {
-            final Method getter = POJOBeanWithNonStandardNames.class.getMethod("readX");
-            helperPOJOBeanWithNonStandardNames.getter(getter);
-
-            helperPOJOBeanWithNonStandardNames.setter(null);
-        } catch (NoSuchMethodException e) {
-            fail("Error in test code. Should not happen.");
-        }
-        helperPOJOBeanWithNonStandardNames.getDescriptor();
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testSetup_WithNonStandardAccessors_WithNameIsEmpty() throws NoSuchMethodException {
-        helperPOJOBeanWithNonStandardNames.getterName(null);
-        helperPOJOBeanWithNonStandardNames.setterName(null);
-        try {
-            final Method getter = POJOBeanWithNonStandardNames.class.getMethod("readX");
-            final Method setter = POJOBeanWithNonStandardNames.class.getMethod("writeX", Object.class);
-            helperPOJOBeanWithNonStandardNames.getter(getter);
-            helperPOJOBeanWithNonStandardNames.setter(setter);
-
-            helperPOJOBeanWithNonStandardNames.name("");
-        } catch (NoSuchMethodException e) {
-            fail("Error in test code. Should not happen.");
-        }
-        helperPOJOBeanWithNonStandardNames.getDescriptor();
+        });
     }
 
     @Test
@@ -235,7 +150,6 @@ public class JavaBeanPropertyBuilderHelperTest {
 
         public Object getX() {return x;}
         public void setX(Object x) {this.x = x;}
-
     }
 
     public static class POJOBeanWithNonStandardNames {
@@ -246,5 +160,4 @@ public class JavaBeanPropertyBuilderHelperTest {
         public Object readX() {return x;}
         public void writeX(Object x) {this.x = x;}
     }
-
 }

--- a/modules/javafx.base/src/test/java/test/com/sun/javafx/property/adapter/PropertyDescriptorTest.java
+++ b/modules/javafx.base/src/test/java/test/com/sun/javafx/property/adapter/PropertyDescriptorTest.java
@@ -22,7 +22,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-
+//test is disabled already
 package test.com.sun.javafx.property.adapter;
 
 //package com.sun.javafx.property.adapter;

--- a/modules/javafx.base/src/test/java/test/com/sun/javafx/property/adapter/ReadOnlyPropertyDescriptorTest.java
+++ b/modules/javafx.base/src/test/java/test/com/sun/javafx/property/adapter/ReadOnlyPropertyDescriptorTest.java
@@ -22,7 +22,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-
+//test is disabled already
 package test.com.sun.javafx.property.adapter;//package com.sun.javafx.property.adapter;
 //
 //import javafx.beans.property.ObjectProperty;

--- a/modules/javafx.base/src/test/java/test/javafx/beans/property/adapter/JavaBeanPropertyTestBase.java
+++ b/modules/javafx.base/src/test/java/test/javafx/beans/property/adapter/JavaBeanPropertyTestBase.java
@@ -30,8 +30,8 @@ import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.Property;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.value.ChangeListener;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyVetoException;
@@ -39,10 +39,8 @@ import java.beans.VetoableChangeListener;
 import java.lang.reflect.UndeclaredThrowableException;
 import javafx.beans.property.adapter.JavaBeanProperty;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
-/**
-*/
 public abstract class JavaBeanPropertyTestBase<T> {
     private BeanStub<T> bean;
     private JavaBeanProperty<T> property;
@@ -53,7 +51,7 @@ public abstract class JavaBeanPropertyTestBase<T> {
     protected abstract Property<T> createObservable(T value);
     protected abstract JavaBeanProperty<T> extractProperty(Object bean) throws NoSuchMethodException;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         this.bean = createBean(getValue(0));
         try {
@@ -63,13 +61,11 @@ public abstract class JavaBeanPropertyTestBase<T> {
         }
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testSetup_WithNull() {
-        try {
+        assertThrows(NullPointerException.class, () -> {
             this.property = extractProperty(null);
-        } catch (NoSuchMethodException e) {
-            fail();
-        }
+        });
     }
 
     @Test
@@ -94,23 +90,23 @@ public abstract class JavaBeanPropertyTestBase<T> {
         assertEquals(bean.getValue(), getValue(0));
     }
 
-    @Test(expected = UndeclaredThrowableException.class)
+    @Test
     public void testGet_Exception() {
         bean.setFailureMode(true);
-        property.getValue();
+        assertThrows(UndeclaredThrowableException.class, () -> property.getValue());
     }
 
-    @Test(expected = UndeclaredThrowableException.class)
+    @Test
     public void testSet_Exception() {
         bean.setFailureMode(true);
-        property.setValue(getValue(1));
+        assertThrows(UndeclaredThrowableException.class, () -> property.setValue(getValue(1)));
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test
     public void testSet_Bound() {
         final Property<T> observable = createObservable(getValue(1));
         property.bind(observable);
-        property.setValue(getValue(0));
+        assertThrows(RuntimeException.class, () -> property.setValue(getValue(0)));
     }
 
     @Test
@@ -202,9 +198,9 @@ public abstract class JavaBeanPropertyTestBase<T> {
         assertFalse(property.isBound());
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testBindWithNull() {
-        property.bind(null);
+        assertThrows(NullPointerException.class, () -> property.bind(null));
     }
 
     public static abstract class BeanStub<U> {
@@ -223,7 +219,7 @@ public abstract class JavaBeanPropertyTestBase<T> {
         }
 
         public void removeXListener(PropertyChangeListener listener) {
-            listenerCount = Math.max(0, listenerCount-1);
+            listenerCount = Math.max(0, listenerCount - 1);
         }
 
         public void addXListener(VetoableChangeListener listener) {
@@ -231,7 +227,7 @@ public abstract class JavaBeanPropertyTestBase<T> {
         }
 
         public void removeXListener(VetoableChangeListener listener) {
-            listenerCount = Math.max(0, listenerCount-1);
+            listenerCount = Math.max(0, listenerCount - 1);
         }
     }
 }

--- a/modules/javafx.base/src/test/java/test/javafx/binding/BindingsCreateBindingTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/binding/BindingsCreateBindingTest.java
@@ -40,16 +40,16 @@ import javafx.beans.property.SimpleLongProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.property.SimpleStringProperty;
 import test.com.sun.javafx.binding.ErrorLoggingUtiltity;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  */
-@RunWith(Parameterized.class)
 public class BindingsCreateBindingTest<T> {
 
     private static final float EPSILON_FLOAT = 1e-5f;
@@ -60,19 +60,19 @@ public class BindingsCreateBindingTest<T> {
         public void check(S value0, S value1);
     }
 
-    private final Property<T> p0;
-    private final Property<T> p1;
-    private final Functions<T> f;
-    private final T value0;
-    private final T value1;
-    private final T defaultValue;
+    private  Property<T> p0;
+    private  Property<T> p1;
+    private  Functions<T> f;
+    private  T value0;
+    private  T value1;
+    private  T defaultValue;
 
-    @BeforeClass
+    @BeforeAll
     public static void setUpClass() {
         ErrorLoggingUtiltity.reset();
     }
 
-    public BindingsCreateBindingTest(Property<T> p0, Property<T> p1, Functions<T> f, T value0, T value1, T defaultValue) {
+    public void BindingsCreateBindingTest_(Property<T> p0, Property<T> p1, Functions<T> f, T value0, T value1, T defaultValue) {
         this.p0 = p0;
         this.p1 = p1;
         this.f = f;
@@ -81,9 +81,11 @@ public class BindingsCreateBindingTest<T> {
         this.defaultValue = defaultValue;
     }
 
-    @Test
-    public void testNoDependencies() {
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void testNoDependencies(Property<T> p0, Property<T> p1, Functions<T> f, T value0, T value1, T defaultValue) {
         // func returns value0, no dependencies specified
+        BindingsCreateBindingTest_(p0, p1, f, value0, value1, defaultValue);
         final Callable<T> func0 = () -> value0;
         final Binding<T> binding0 = f.create(func0);
 
@@ -111,8 +113,10 @@ public class BindingsCreateBindingTest<T> {
         binding2.dispose();
     }
 
-    @Test
-    public void testOneDependency() {
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void testOneDependency(Property<T> p0, Property<T> p1, Functions<T> f, T value0, T value1, T defaultValue) {
+        BindingsCreateBindingTest_(p0, p1, f, value0, value1, defaultValue);
         final Callable<T> func = () -> p0.getValue();
         final Binding<T> binding = f.create(func, p0);
 
@@ -123,8 +127,10 @@ public class BindingsCreateBindingTest<T> {
         binding.dispose();
     }
 
-    @Test
-    public void testCreateBoolean_TwoDependencies() {
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void testCreateBoolean_TwoDependencies(Property<T> p0, Property<T> p1, Functions<T> f, T value0, T value1, T defaultValue) {
+        BindingsCreateBindingTest_(p0, p1, f, value0, value1, defaultValue);
         final Callable<T> func = () -> p0.getValue();
         final Binding<T> binding = f.create(func, p0, p1);
 
@@ -135,7 +141,6 @@ public class BindingsCreateBindingTest<T> {
         binding.dispose();
     }
 
-    @Parameterized.Parameters
     public static Collection<Object[]> parameters() {
         return Arrays.asList(new Object[][] {
                 {

--- a/modules/javafx.base/src/test/java/test/javafx/binding/BindingsEqualsTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/binding/BindingsEqualsTest.java
@@ -25,7 +25,7 @@
 
 package test.javafx.binding;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -47,12 +47,11 @@ import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 import javafx.beans.value.*;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;;
 
-@RunWith(Parameterized.class)
 public class BindingsEqualsTest<T> {
 
     private static final float EPSILON_FLOAT = 1e-5f;
@@ -67,13 +66,13 @@ public class BindingsEqualsTest<T> {
         void check(T op1, T op2, BooleanBinding exp);
     }
 
-    private final ObservableValue op1;
-    private final ObservableValue op2;
-    private final Functions<T> func;
-    private final T[] v;
+    private  ObservableValue op1;
+    private  ObservableValue op2;
+    private  Functions<T> func;
+    private  T[] v;
     private InvalidationListenerMock observer;
 
-    public BindingsEqualsTest(ObservableValue op1, ObservableValue op2, Functions<T> func, T... v) {
+    public void BindingsEqualsTest_(ObservableValue op1, ObservableValue op2, Functions<T> func, T... v) {
         this.op1 = op1;
         this.op2 = op2;
         this.func = func;
@@ -84,15 +83,18 @@ public class BindingsEqualsTest<T> {
         return value == null? "" : value;
     }
 
-    @Before
+
     public void setUp() {
         func.setOp1(v[0]);
         func.setOp2(v[1]);
         observer = new InvalidationListenerMock();
     }
 
-    @Test
-    public void test_Expression_Expression() {
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void test_Expression_Expression(ObservableValue op1, ObservableValue op2, Functions<T> func, T... v) {
+        BindingsEqualsTest_(op1, op2, func, v);
+        setUp();
         final BooleanBinding binding = func.generateExpressionExpression(op1, op2);
         binding.addListener(observer);
 
@@ -118,8 +120,11 @@ public class BindingsEqualsTest<T> {
         observer.check(binding, 1);
     }
 
-    @Test
-    public void test_Self() {
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void test_Self(ObservableValue op1, ObservableValue op2, Functions<T> func, T... v) {
+        BindingsEqualsTest_(op1, op2, func, v);
+        setUp();
         // using same FloatValue twice
         final BooleanBinding binding = func.generateExpressionExpression(op1, op1);
         binding.addListener(observer);
@@ -133,18 +138,27 @@ public class BindingsEqualsTest<T> {
         observer.check(binding, 1);
     }
 
-    @Test(expected=NullPointerException.class)
-    public void test_null_Expression() {
-        func.generateExpressionExpression(null, op1);
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void test_null_Expression(ObservableValue op1, ObservableValue op2, Functions<T> func, T... v) {
+        BindingsEqualsTest_(op1, op2, func, v);
+        setUp();
+        assertThrows(NullPointerException.class, () -> func.generateExpressionExpression(null, op1));
     }
 
-    @Test(expected=NullPointerException.class)
-    public void test_Expression_null() {
-        func.generateExpressionExpression(op1, null);
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void test_Expression_null(ObservableValue op1, ObservableValue op2, Functions<T> func, T... v) {
+        BindingsEqualsTest_(op1, op2, func, v);
+        setUp();
+        assertThrows(NullPointerException.class, () -> func.generateExpressionExpression(op1, null));
     }
 
-    @Test
-    public void test_Expression_Primitive() {
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void test_Expression_Primitive(ObservableValue op1, ObservableValue op2, Functions<T> func, T... v) {
+        BindingsEqualsTest_(op1, op2, func, v);
+        setUp();
         final BooleanBinding binding = func.generateExpressionPrimitive(op1, v[1]);
         binding.addListener(observer);
 
@@ -164,13 +178,19 @@ public class BindingsEqualsTest<T> {
         observer.check(binding, 1);
     }
 
-    @Test(expected=NullPointerException.class)
-    public void test_null_Primitive() {
-        func.generateExpressionPrimitive(null, v[0]);
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void test_null_Primitive(ObservableValue op1, ObservableValue op2, Functions<T> func, T... v) {
+        BindingsEqualsTest_(op1, op2, func, v);
+        setUp();
+        assertThrows(NullPointerException.class, () -> func.generateExpressionPrimitive(null, v[0]));
     }
 
-    @Test
-    public void test_Primitive_Expression() {
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void test_Primitive_Expression(ObservableValue op1, ObservableValue op2, Functions<T> func, T... v) {
+        BindingsEqualsTest_(op1, op2, func, v);
+        setUp();
         final BooleanBinding binding = func.generatePrimitiveExpression(v[1], op1);
         binding.addListener(observer);
 
@@ -190,12 +210,14 @@ public class BindingsEqualsTest<T> {
         observer.check(binding, 1);
     }
 
-    @Test(expected=NullPointerException.class)
-    public void test_Primitive_null() {
-        func.generatePrimitiveExpression(v[0], null);
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void test_Primitive_null(ObservableValue op1, ObservableValue op2, Functions<T> func, T... v) {
+        BindingsEqualsTest_(op1, op2, func, v);
+        setUp();
+        assertThrows(NullPointerException.class, () -> func.generatePrimitiveExpression(v[0], null));
     }
 
-    @Parameterized.Parameters
     public static Collection<Object[]> parameters() {
         final FloatProperty float1 = new SimpleFloatProperty();
         final FloatProperty float2 = new SimpleFloatProperty();

--- a/modules/javafx.base/src/test/java/test/javafx/binding/BindingsNumberCalculationsTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/binding/BindingsNumberCalculationsTest.java
@@ -25,7 +25,7 @@
 
 package test.javafx.binding;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -43,12 +43,11 @@ import javafx.beans.property.SimpleIntegerProperty;
 import javafx.beans.property.SimpleLongProperty;
 import javafx.beans.value.*;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
 public class BindingsNumberCalculationsTest<T> {
 
     private static final float EPSILON_FLOAT = 1e-5f;
@@ -63,28 +62,30 @@ public class BindingsNumberCalculationsTest<T> {
         void check(S op1, S op2, ObservableValue exp);
     }
 
-    private final ObservableValue op1;
-    private final ObservableValue op2;
-    private final Functions<T> func;
-    private final T[] v;
+    private  ObservableValue op1;
+    private  ObservableValue op2;
+    private  Functions<T> func;
+    private  T[] v;
     private InvalidationListenerMock observer;
 
-    public BindingsNumberCalculationsTest(ObservableValue op1, ObservableValue op2, Functions<T> func, T[] v) {
+    public void BindingsNumberCalculationsTest_(ObservableValue op1, ObservableValue op2, Functions<T> func, T[] v) {
         this.op1 = op1;
         this.op2 = op2;
         this.func = func;
         this.v = v;
     }
 
-    @Before
     public void setUp() {
         func.setOp1(v[0]);
         func.setOp2(v[1]);
         observer = new InvalidationListenerMock();
     }
 
-    @Test
-    public void test_Expression_Expression() {
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void test_Expression_Expression(ObservableValue op1, ObservableValue op2, Functions<T> func, T[] v) {
+        BindingsNumberCalculationsTest_(op1, op2, func, v);
+        setUp();
         final Binding binding = func.generateExpressionExpression(op1, op2);
         binding.addListener(observer);
 
@@ -110,8 +111,11 @@ public class BindingsNumberCalculationsTest<T> {
         observer.check(binding, 1);
     }
 
-    @Test
-    public void test_Self() {
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void test_Self(ObservableValue op1, ObservableValue op2, Functions<T> func, T[] v) {
+        BindingsNumberCalculationsTest_(op1, op2, func, v);
+        setUp();
         // using same FloatValue twice
         final Binding binding = func.generateExpressionExpression(op1, op1);
         binding.addListener(observer);
@@ -126,18 +130,27 @@ public class BindingsNumberCalculationsTest<T> {
         observer.check(binding, 1);
     }
 
-    @Test(expected=NullPointerException.class)
-    public void test_null_Expression() {
-        func.generateExpressionExpression(null, op1);
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void test_null_Expression(ObservableValue op1, ObservableValue op2, Functions<T> func, T[] v) {
+        BindingsNumberCalculationsTest_(op1, op2, func, v);
+        setUp();
+        assertThrows(NullPointerException.class, () -> func.generateExpressionExpression(null, op1));
     }
 
-    @Test(expected=NullPointerException.class)
-    public void test_Expression_null() {
-        func.generateExpressionExpression(op1, null);
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void test_Expression_null(ObservableValue op1, ObservableValue op2, Functions<T> func, T[] v) {
+        BindingsNumberCalculationsTest_(op1, op2, func, v);
+        setUp();
+        assertThrows(NullPointerException.class, () -> func.generateExpressionExpression(op1, null));
     }
 
-    @Test
-    public void test_Expression_Primitive() {
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void test_Expression_Primitive(ObservableValue op1, ObservableValue op2, Functions<T> func, T[] v) {
+        BindingsNumberCalculationsTest_(op1, op2, func, v);
+        setUp();
         final Binding binding = func.generateExpressionPrimitive(op1, v[7]);
         binding.addListener(observer);
 
@@ -152,13 +165,19 @@ public class BindingsNumberCalculationsTest<T> {
         observer.check(binding, 1);
     }
 
-    @Test(expected=NullPointerException.class)
-    public void test_null_Primitive() {
-        func.generateExpressionPrimitive(null, v[0]);
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void test_null_Primitive(ObservableValue op1, ObservableValue op2, Functions<T> func, T[] v) {
+        BindingsNumberCalculationsTest_(op1, op2, func, v);
+        setUp();
+        assertThrows(NullPointerException.class, () -> func.generateExpressionPrimitive(null, v[0]));
     }
 
-    @Test
-    public void test_Primitive_Expression() {
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void test_Primitive_Expression(ObservableValue op1, ObservableValue op2, Functions<T> func, T[] v) {
+        BindingsNumberCalculationsTest_(op1, op2, func, v);
+        setUp();
         final Binding binding = func.generatePrimitiveExpression(v[9], op1);
         binding.addListener(observer);
 
@@ -173,12 +192,12 @@ public class BindingsNumberCalculationsTest<T> {
         observer.check(binding, 1);
     }
 
-    @Test(expected=NullPointerException.class)
-    public void test_Primitive_null() {
-        func.generatePrimitiveExpression(v[0], null);
+    public void test_Primitive_null(ObservableValue op1, ObservableValue op2, Functions<T> func, T[] v) {
+        BindingsNumberCalculationsTest_(op1, op2, func, v);
+        setUp();
+        assertThrows(IllegalArgumentException.class, () -> func.generatePrimitiveExpression(v[0], null));
     }
 
-    @Parameterized.Parameters
     public static Collection<Object[]> parameters() {
         final FloatProperty float1 = new SimpleFloatProperty();
         final FloatProperty float2 = new SimpleFloatProperty();

--- a/modules/javafx.base/src/test/java/test/javafx/binding/BindingsNumberCastTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/binding/BindingsNumberCastTest.java
@@ -25,12 +25,6 @@
 
 package test.javafx.binding;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
-import java.util.Arrays;
-import java.util.Collection;
-
 import javafx.beans.binding.Binding;
 import javafx.beans.binding.Bindings;
 import javafx.beans.binding.BooleanExpression;
@@ -48,23 +42,29 @@ import javafx.beans.property.SimpleFloatProperty;
 import javafx.beans.property.SimpleIntegerProperty;
 import javafx.beans.property.SimpleLongProperty;
 import javafx.beans.value.ObservableNumberValue;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import java.util.Arrays;
+import java.util.stream.Stream;
 
-@RunWith(Parameterized.class)
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 public class BindingsNumberCastTest {
 
-    public static interface Functions {
+    public interface Functions {
         Binding generateExpression(ObservableNumberValue op1, ObservableNumberValue op2);
+
         void check(double op1, double op2, Binding binding);
     }
 
     private static final double EPSILON = 1e-5;
 
-    private final Functions func;
+    private Functions func;
 
     private Double double0;
     private Float float0;
@@ -76,11 +76,7 @@ public class BindingsNumberCastTest {
     private LongProperty long1;
     private IntegerProperty integer1;
 
-    public BindingsNumberCastTest(Functions func) {
-        this.func = func;
-    }
-
-    @Before
+    @BeforeEach
     public void setUp() {
         double0 = Double.valueOf(3.1415);
         float0 = Float.valueOf(2.71f);
@@ -93,8 +89,13 @@ public class BindingsNumberCastTest {
         integer1 = new SimpleIntegerProperty(integer0);
     }
 
-    @Test
-    public void testDouble() {
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void testBindings(Functions func) {
+        this.func = func;
+        setUp(); // Call setup before each parameterized run
+
+        // Test Double
         Binding binding = func.generateExpression(double1, double1);
         assertTrue(binding instanceof DoubleExpression || binding instanceof BooleanExpression);
         func.check(double0, double0, binding);
@@ -110,11 +111,9 @@ public class BindingsNumberCastTest {
         binding = func.generateExpression(double1, integer1);
         assertTrue(binding instanceof DoubleExpression || binding instanceof BooleanExpression);
         func.check(double0, integer0, binding);
-    }
 
-    @Test
-    public void testFloat() {
-        Binding binding = func.generateExpression(float1, double1);
+        // Test Float
+        binding = func.generateExpression(float1, double1);
         assertTrue(binding instanceof DoubleExpression || binding instanceof BooleanExpression);
         func.check(float0, double0, binding);
 
@@ -129,11 +128,9 @@ public class BindingsNumberCastTest {
         binding = func.generateExpression(float1, integer1);
         assertTrue(binding instanceof FloatExpression || binding instanceof BooleanExpression);
         func.check(float0, integer0, binding);
-    }
 
-    @Test
-    public void testLong() {
-        Binding binding = func.generateExpression(long1, double1);
+        // Test Long
+        binding = func.generateExpression(long1, double1);
         assertTrue(binding instanceof DoubleExpression || binding instanceof BooleanExpression);
         func.check(long0, double0, binding);
 
@@ -148,11 +145,9 @@ public class BindingsNumberCastTest {
         binding = func.generateExpression(long1, integer1);
         assertTrue(binding instanceof LongExpression || binding instanceof BooleanExpression);
         func.check(long0, integer0, binding);
-    }
 
-    @Test
-    public void testInteger() {
-        Binding binding = func.generateExpression(integer1, double1);
+        // Test Integer
+        binding = func.generateExpression(integer1, double1);
         assertTrue(binding instanceof DoubleExpression || binding instanceof BooleanExpression);
         func.check(integer0, double0, binding);
 
@@ -169,10 +164,8 @@ public class BindingsNumberCastTest {
         func.check(integer0, integer0, binding);
     }
 
-    @Parameterized.Parameters
-    public static Collection<Object[]> parameters() {
-        return Arrays.asList(new Object[][] {
-            {
+    static Stream<Arguments> parameters() {
+        return Arrays.asList(
                 new Functions() {
                     @Override
                     public Binding generateExpression(ObservableNumberValue op1, ObservableNumberValue op2) {
@@ -182,12 +175,9 @@ public class BindingsNumberCastTest {
                     @Override
                     public void check(double op1, double op2, Binding binding) {
                         assertTrue(binding instanceof NumberExpression);
-                        assertEquals(op1 + op2, ((NumberExpression)binding).doubleValue(), EPSILON);
+                        assertEquals(op1 + op2, ((NumberExpression) binding).doubleValue(), EPSILON);
                     }
-
-                }
-            },
-            {
+                },
                 new Functions() {
                     @Override
                     public Binding generateExpression(ObservableNumberValue op1, ObservableNumberValue op2) {
@@ -197,12 +187,9 @@ public class BindingsNumberCastTest {
                     @Override
                     public void check(double op1, double op2, Binding binding) {
                         assertTrue(binding instanceof NumberExpression);
-                        assertEquals(op1 * op2, ((NumberExpression)binding).doubleValue(), EPSILON);
+                        assertEquals(op1 * op2, ((NumberExpression) binding).doubleValue(), EPSILON);
                     }
-
-                }
-            },
-            {
+                },
                 new Functions() {
                     @Override
                     public Binding generateExpression(ObservableNumberValue op1, ObservableNumberValue op2) {
@@ -213,15 +200,12 @@ public class BindingsNumberCastTest {
                     public void check(double op1, double op2, Binding binding) {
                         assertTrue(binding instanceof NumberExpression);
                         if ((binding instanceof DoubleExpression) || (binding instanceof FloatExpression)) {
-                            assertEquals(op1 / op2, ((NumberExpression)binding).doubleValue(), EPSILON);
+                            assertEquals(op1 / op2, ((NumberExpression) binding).doubleValue(), EPSILON);
                         } else {
-                            assertEquals((long)op1 / (long)op2, ((NumberExpression)binding).longValue());
+                            assertEquals((long) op1 / (long) op2, ((NumberExpression) binding).longValue());
                         }
                     }
-
-                }
-            },
-            {
+                },
                 new Functions() {
                     @Override
                     public Binding generateExpression(ObservableNumberValue op1, ObservableNumberValue op2) {
@@ -231,12 +215,9 @@ public class BindingsNumberCastTest {
                     @Override
                     public void check(double op1, double op2, Binding binding) {
                         assertTrue(binding instanceof NumberExpression);
-                        assertEquals(Math.min(op1, op2), ((NumberExpression)binding).doubleValue(), EPSILON);
+                        assertEquals(Math.min(op1, op2), ((NumberExpression) binding).doubleValue(), EPSILON);
                     }
-
-                }
-            },
-            {
+                },
                 new Functions() {
                     @Override
                     public Binding generateExpression(ObservableNumberValue op1, ObservableNumberValue op2) {
@@ -246,12 +227,9 @@ public class BindingsNumberCastTest {
                     @Override
                     public void check(double op1, double op2, Binding binding) {
                         assertTrue(binding instanceof NumberExpression);
-                        assertEquals(Math.max(op1, op2), ((NumberExpression)binding).doubleValue(), EPSILON);
+                        assertEquals(Math.max(op1, op2), ((NumberExpression) binding).doubleValue(), EPSILON);
                     }
-
-                }
-            },
-            {
+                },
                 new Functions() {
                     @Override
                     public Binding generateExpression(ObservableNumberValue op1, ObservableNumberValue op2) {
@@ -261,12 +239,9 @@ public class BindingsNumberCastTest {
                     @Override
                     public void check(double op1, double op2, Binding binding) {
                         assertTrue(binding instanceof BooleanExpression);
-                        assertEquals(Math.abs(op1 - op2) < EPSILON, ((BooleanExpression)binding).get());
+                        assertEquals(Math.abs(op1 - op2) < EPSILON, ((BooleanExpression) binding).get());
                     }
-
-                }
-            },
-            {
+                },
                 new Functions() {
                     @Override
                     public Binding generateExpression(ObservableNumberValue op1, ObservableNumberValue op2) {
@@ -276,12 +251,9 @@ public class BindingsNumberCastTest {
                     @Override
                     public void check(double op1, double op2, Binding binding) {
                         assertTrue(binding instanceof BooleanExpression);
-                        assertEquals(op1 > op2, ((BooleanExpression)binding).get());
+                        assertEquals(op1 > op2, ((BooleanExpression) binding).get());
                     }
-
                 }
-            },
-        });
+        ).stream().map(Arguments::of);
     }
-
 }

--- a/modules/javafx.base/src/test/java/test/javafx/binding/GenericBindingTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/binding/GenericBindingTest.java
@@ -32,31 +32,30 @@ import test.javafx.beans.value.ChangeListenerMock;
 import javafx.beans.value.ObservableValueBase;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.lang.reflect.Constructor;
 import java.util.Arrays;
 import java.util.Collection;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
-@RunWith(Parameterized.class)
 public class GenericBindingTest<T> {
 
     private static final Object UNDEFINED = null;
 
-    private final ObservableStub dependency1 = new ObservableStub();
-    private final ObservableStub dependency2 = new ObservableStub();
-    private final T value1;
-    private final T value2;
-    private final Constructor<BindingMock<T>> bindingMockClassConstructor;
+    private  ObservableStub dependency1 = new ObservableStub();
+    private  ObservableStub dependency2 = new ObservableStub();
+    private  T value1;
+    private  T value2;
+    private  Constructor<BindingMock<T>> bindingMockClassConstructor;
 
     private BindingMock<T> binding0;
     private BindingMock<T> binding1;
@@ -64,7 +63,7 @@ public class GenericBindingTest<T> {
     private InvalidationListenerMock invalidationListener;
     private ChangeListenerMock<Object> changeListener;
 
-    public GenericBindingTest(
+    public void GenericBindingTest_(
             T value1, T value2,
             Class<BindingMock<T>> bindingMockClass) throws Exception {
         this.value1 = value1;
@@ -72,7 +71,6 @@ public class GenericBindingTest<T> {
         this.bindingMockClassConstructor = bindingMockClass.getConstructor(Observable[].class);
     }
 
-    @Before
     public void setUp() throws Exception {
         // Recreate bindings as they may have been altered by one of the tests
         binding0 = bindingMockClassConstructor.newInstance((Object)new Observable[] {});
@@ -86,7 +84,7 @@ public class GenericBindingTest<T> {
         binding2.setValue(value2);
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         binding0.removeListener(invalidationListener);
         binding0.removeListener(changeListener);
@@ -96,8 +94,11 @@ public class GenericBindingTest<T> {
         binding2.removeListener(changeListener);
     }
 
-    @Test
-    public void testNoDependencyLazy() {
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void testNoDependencyLazy(T value1, T value2, Class<BindingMock<T>> bindingMockClass) throws Exception  {
+        GenericBindingTest_(value1, value2, bindingMockClass);
+        setUp();
         binding0.getValue();
         binding0.addListener(invalidationListener);
         System.gc(); // making sure we did not not overdo weak references
@@ -111,8 +112,11 @@ public class GenericBindingTest<T> {
         assertEquals(true, binding0.isValid());
     }
 
-    @Test
-    public void testNoDependencyEager() {
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void testNoDependencyEager(T value1, T value2, Class<BindingMock<T>> bindingMockClass) throws Exception  {
+        GenericBindingTest_(value1, value2, bindingMockClass);
+        setUp();
         binding0.getValue();
         binding0.addListener(changeListener);
         System.gc(); // making sure we did not not overdo weak references
@@ -126,8 +130,11 @@ public class GenericBindingTest<T> {
         assertEquals(true, binding0.isValid());
     }
 
-    @Test
-    public void testSingleDependencyLazy() {
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void testSingleDependencyLazy(T value1, T value2, Class<BindingMock<T>> bindingMockClass) throws Exception  {
+        GenericBindingTest_(value1, value2, bindingMockClass);
+        setUp();
         binding1.getValue();
         binding1.addListener(invalidationListener);
         System.gc(); // making sure we did not not overdo weak references
@@ -188,8 +195,11 @@ public class GenericBindingTest<T> {
         assertEquals(true, binding1.isValid());
     }
 
-    @Test
-    public void testSingleDependencyEager() {
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void testSingleDependencyEager(T value1, T value2, Class<BindingMock<T>> bindingMockClass) throws Exception  {
+        GenericBindingTest_(value1, value2, bindingMockClass);
+        setUp();
         binding1.getValue();
         binding1.addListener(changeListener);
         System.gc(); // making sure we did not not overdo weak references
@@ -250,8 +260,11 @@ public class GenericBindingTest<T> {
         assertEquals(true, binding1.isValid());
     }
 
-    @Test
-    public void testTwoDependencies() {
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void testTwoDependencies(T value1, T value2, Class<BindingMock<T>> bindingMockClass) throws Exception  {
+        GenericBindingTest_(value1, value2, bindingMockClass);
+        setUp();
         binding2.getValue();
         binding2.addListener(invalidationListener);
         System.gc(); // making sure we did not not overdo weak references
@@ -296,8 +309,11 @@ public class GenericBindingTest<T> {
         assertEquals(true, binding2.isValid());
     }
 
-    @Test
-    public void testUnbindDependencies() {
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void testUnbindDependencies(T value1, T value2, Class<BindingMock<T>> bindingMockClass) throws Exception  {
+        GenericBindingTest_(value1, value2, bindingMockClass);
+        setUp();
         // Start by making binding valid:
         binding2.getValue();
         assertTrue(binding2.isValid());
@@ -341,7 +357,6 @@ public class GenericBindingTest<T> {
         assertTrue(binding2.isValid());   // Fixed by 8243115
     }
 
-    @Parameterized.Parameters
     public static Collection<Object[]> parameters() {
         return Arrays.asList(new Object[][] {
             {

--- a/modules/javafx.base/src/test/java/test/javafx/binding/When_Double_Test.java
+++ b/modules/javafx.base/src/test/java/test/javafx/binding/When_Double_Test.java
@@ -25,7 +25,7 @@
 
 package test.javafx.binding;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import javafx.beans.binding.Binding;
 import javafx.beans.binding.Bindings;
 import javafx.beans.property.Property;

--- a/modules/javafx.base/src/test/java/test/javafx/binding/When_Float_Test.java
+++ b/modules/javafx.base/src/test/java/test/javafx/binding/When_Float_Test.java
@@ -25,7 +25,7 @@
 
 package test.javafx.binding;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import javafx.beans.binding.Binding;
 import javafx.beans.binding.Bindings;
 import javafx.beans.property.Property;

--- a/modules/javafx.base/src/test/java/test/javafx/binding/When_Integer_Test.java
+++ b/modules/javafx.base/src/test/java/test/javafx/binding/When_Integer_Test.java
@@ -25,7 +25,7 @@
 
 package test.javafx.binding;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import javafx.beans.binding.Binding;
 import javafx.beans.binding.Bindings;
 import javafx.beans.property.Property;

--- a/modules/javafx.base/src/test/java/test/javafx/binding/When_Long_Test.java
+++ b/modules/javafx.base/src/test/java/test/javafx/binding/When_Long_Test.java
@@ -25,7 +25,7 @@
 
 package test.javafx.binding;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import javafx.beans.binding.Binding;
 import javafx.beans.binding.Bindings;
 import javafx.beans.property.Property;

--- a/modules/javafx.base/src/test/java/test/javafx/collections/ObservableArrayTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/collections/ObservableArrayTest.java
@@ -25,8 +25,8 @@
 
 package test.javafx.collections;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -39,15 +39,15 @@ import javafx.collections.ObservableArray;
 import javafx.collections.ObservableFloatArray;
 import javafx.collections.ObservableIntegerArray;
 
-import static org.junit.Assert.*;
-import org.junit.Ignore;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Tests for ObservableArray.
  */
-@RunWith(Parameterized.class)
 public class ObservableArrayTest  {
     public static final int INITIAL_SIZE = 6;
 
@@ -290,9 +290,11 @@ public class ObservableArrayTest  {
         @Override
         void assertElementsEqual(float[] actual, int from, int to, float[] expected, int expFrom) {
             for(int i = from, j = expFrom; i < to; i++, j++) {
-                assertEquals("expected float = " + expected[j] + ", actual float = " + actual[i],
+                assertEquals(
                         Float.floatToRawIntBits(expected[j]),
-                        Float.floatToRawIntBits(actual[i]));
+                        Float.floatToRawIntBits(actual[i]),
+                        "expected float = " + expected[j] + ", actual float = " + actual[i]
+                );
             }
         }
 
@@ -339,26 +341,24 @@ public class ObservableArrayTest  {
     }
 
     static final List<String> EMPTY = Collections.emptyList();
-    final ArrayWrapper wrapper;
+    ArrayWrapper wrapper;
     private int initialSize;
     private Object initialElements;
     private ObservableArray array;
     private MockArrayObserver mao;
 
-    public ObservableArrayTest(final ArrayWrapper arrayWrapper) {
+    public void ObservableArrayTest_(ArrayWrapper arrayWrapper) {
         this.wrapper = arrayWrapper;
     }
 
-    @Parameterized.Parameters
     public static Collection createParameters() {
         Object[][] data = new Object[][] {
-            { new FloatArrayWrapper() },
-            { new IntegerArrayWrapper() },
-         };
+                { new FloatArrayWrapper() },
+                { new IntegerArrayWrapper() },
+        };
         return Arrays.asList(data);
     }
 
-    @Before
     public void setUp() throws Exception {
         initialSize = INITIAL_SIZE;
         initialElements = wrapper.createPrimitiveArray(initialSize);
@@ -384,18 +384,30 @@ public class ObservableArrayTest  {
 
     // ========== pre-condition tests ================
 
-    @Test public void testSize() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSize(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         mao.check0();
         assertEquals(INITIAL_SIZE, array.size());
     }
 
-    @Test public void testClear() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testClear(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         array.clear();
         mao.checkOnlySizeChanged(array);
         assertEquals(0, array.size());
     }
 
-    @Test public void testGet() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testGet(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         for (int i = 0; i < array.size(); i++) {
             Object expected = wrapper.get(initialElements, i);
             Object actural = wrapper.get(i);
@@ -404,7 +416,11 @@ public class ObservableArrayTest  {
         assertUnchanged();
     }
 
-    @Test public void testToArray() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testToArray(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         Object expected = initialElements;
         Object actual = wrapper.toArray(null);
         assertEquals(INITIAL_SIZE, wrapper.arrayLength(actual));
@@ -414,7 +430,11 @@ public class ObservableArrayTest  {
 
     // ========== add/remove listener tests ==========
 
-    @Test public void testAddRemoveListener() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testAddRemoveListener(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         MockArrayObserver mao2 = new MockArrayObserver();
         array.addListener(mao2);
         array.removeListener(mao);
@@ -423,7 +443,11 @@ public class ObservableArrayTest  {
         mao2.check(array, false, 0, 1);
     }
 
-    @Test public void testAddTwoListenersElementChange() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testAddTwoListenersElementChange(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         MockArrayObserver mao2 = new MockArrayObserver();
         array.addListener(mao2);
         wrapper.set(0, wrapper.getNextValue());
@@ -431,7 +455,11 @@ public class ObservableArrayTest  {
         mao2.check(array, false, 0, 1);
     }
 
-    @Test public void testAddTwoListenersSizeChange() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testAddTwoListenersSizeChange(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         MockArrayObserver mao2 = new MockArrayObserver();
         array.addListener(mao2);
         array.resize(3);
@@ -439,7 +467,11 @@ public class ObservableArrayTest  {
         mao2.checkOnlySizeChanged(array);
     }
 
-    @Test public void testAddThreeListeners() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testAddThreeListeners(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         MockArrayObserver mao2 = new MockArrayObserver();
         MockArrayObserver mao3 = new MockArrayObserver();
         array.addListener(mao2);
@@ -450,7 +482,11 @@ public class ObservableArrayTest  {
         mao3.check(array, false, 0, 1);
     }
 
-    @Test public void testAddThreeListenersSizeChange() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testAddThreeListenersSizeChange(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         MockArrayObserver mao2 = new MockArrayObserver();
         MockArrayObserver mao3 = new MockArrayObserver();
         array.addListener(mao2);
@@ -461,24 +497,52 @@ public class ObservableArrayTest  {
         mao3.checkOnlySizeChanged(array);
     }
 
-    @Test @Ignore
+    @Test @Disabled
     public void testAddListenerTwice() {
         array.addListener(mao); // add it a second time
         wrapper.set(1, wrapper.getNextValue());
         mao.check(array, false, 1, 2);
     }
 
-    @Test public void testRemoveListenerTwice() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testRemoveListenerTwice(ArrayWrapper arrayWrapper) throws Exception  {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         array.removeListener(mao);
         array.removeListener(mao);
         wrapper.set(1, wrapper.getNextValue());
         mao.check0();
     }
 
-    @Test (expected = NullPointerException.class)
-    public void testAddNullArrayChangeListener() {
-        try {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testAddNullArrayChangeListener(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        assertThrows(NullPointerException.class, () -> {
             array.addListener((ArrayChangeListener) null);
+        });
+
+        // Finally block is outside assertThrows() to ensure it always executes
+        mao.check0();
+        array.resize(1);
+        mao.check1();
+    }
+
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testAddNullInvalidationListener(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        try {
+            assertThrows(NullPointerException.class, () -> {
+                array.addListener((ArrayChangeListener) null);
+            });
         } finally {
             mao.check0();
             array.resize(1);
@@ -486,10 +550,15 @@ public class ObservableArrayTest  {
         }
     }
 
-    @Test (expected = NullPointerException.class)
-    public void testAddNullInvalidationListener() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testRemoveNullArrayChangeListener(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         try {
-            array.addListener((InvalidationListener) null);
+            assertThrows(NullPointerException.class, () -> {
+                array.addListener((ArrayChangeListener) null);
+            });
         } finally {
             mao.check0();
             array.resize(1);
@@ -497,21 +566,15 @@ public class ObservableArrayTest  {
         }
     }
 
-    @Test (expected = NullPointerException.class)
-    public void testRemoveNullArrayChangeListener() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testRemoveNullInvalidationListener(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         try {
-            array.removeListener((ArrayChangeListener) null);
-        } finally {
-            mao.check0();
-            array.resize(1);
-            mao.check1();
-        }
-    }
-
-    @Test (expected = NullPointerException.class)
-    public void testRemoveNullInvalidationListener() {
-        try {
-            array.removeListener((InvalidationListener) null);
+            assertThrows(NullPointerException.class, () -> {
+                array.addListener((ArrayChangeListener) null);
+            });
         } finally {
             mao.check0();
             array.resize(1);
@@ -537,36 +600,65 @@ public class ObservableArrayTest  {
                 wrapper.createPrimitiveArray(Math.max(0, newSize - matchingElements), false), 0);
     }
 
-    @Test public void testResizeTo0() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testResizeTo0(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testResize(false, 0, 0);
     }
 
-    @Test public void testResizeToSmaller() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testResizeToSmaller(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testResize(false, 3, 3);
     }
 
-    @Test public void testResizeToSameSize() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testResizeToSameSize(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testResize(true, array.size(), array.size());
     }
 
-    @Test public void testResizeToBigger() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testResizeToBigger(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testResize(false, 10, array.size());
     }
 
-    @Test public void testResizeOnEmpty() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testResizeOnEmpty(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         makeEmpty();
         testResize(false, 10, 0);
     }
 
-    @Test public void testResizeOnEmptyToEmpty() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testResizeOnEmptyToEmpty(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         makeEmpty();
         testResize(true, 0, 0);
     }
 
-    @Test (expected = NegativeArraySizeException.class)
-    public void testResizeToNegative() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testResizeToNegative(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         try {
-            array.resize(-5);
+            assertThrows(NegativeArraySizeException.class, () -> {
+                array.resize(-5);
+            });
         } finally {
             assertUnchanged();
         }
@@ -586,34 +678,59 @@ public class ObservableArrayTest  {
         wrapper.assertElementsEqual(actual, 0, wrapper.arrayLength(expected), expected, 0);
     }
 
-    @Test public void testSetAllASmaller() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetAllASmaller(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testSetAllA(true, 3);
     }
 
-    @Test public void testSetAllABigger() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetAllABigger(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testSetAllA(true, 10);
     }
 
-    @Test public void testSetAllAOnSameSize() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetAllAOnSameSize(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testSetAllA(false, INITIAL_SIZE);
     }
 
-    @Test public void testSetAllAOnEmpty() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetAllAOnEmpty(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         makeEmpty();
         testSetAllA(true, 3);
     }
 
-    @Test public void testSetAllAOnEmptyToEmpty() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetAllAOnEmptyToEmpty(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         makeEmpty();
         wrapper.setAllA(wrapper.createPrimitiveArray(0));
         assertUnchanged();
         assertEquals(0, array.size());
     }
 
-    @Test (expected = NullPointerException.class)
-    public void testSetAllAToNull() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetAllAToNull(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         try {
-            wrapper.setAllA(null);
+            assertThrows(NullPointerException.class, () -> {
+                wrapper.setAllA(null);
+            });
         } finally {
             assertUnchanged();
         }
@@ -635,41 +752,69 @@ public class ObservableArrayTest  {
         wrapper.assertElementsEqual(actual, 0, wrapper.arrayLength(expected), expected, 0);
     }
 
-    @Test public void testSetAllTSmaller() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetAllTSmaller(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testSetAllT(true, 3);
     }
 
-    @Test public void testSetAllTBigger() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetAllTBigger(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testSetAllT(true, 10);
     }
 
-    @Test public void testSetAllTOnSameSize() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetAllTOnSameSize(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testSetAllT(false, INITIAL_SIZE);
     }
 
-    @Test public void testSetAllTOnEmpty() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetAllTOnEmpty(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         makeEmpty();
         testSetAllT(true, 3);
     }
 
-    @Test public void testSetAllTOnEmptyToEmpty() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetAllTOnEmptyToEmpty(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         makeEmpty();
         wrapper.setAllT(wrapper.newInstance().createEmptyArray());
         assertUnchanged();
         assertEquals(0, array.size());
     }
 
-    @Test (expected = NullPointerException.class)
-    public void testSetAllTToNull() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetAllTToNull(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         try {
-            wrapper.setAllT(null);
+            assertThrows(NullPointerException.class, () -> {
+                wrapper.setAllA(null);
+            });
         } finally {
             assertUnchanged();
         }
     }
 
-    @Test public void testSetAllTSelf() {
-
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetAllTSelf(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         wrapper.setAllT(array);
 
         mao.check0();
@@ -679,7 +824,11 @@ public class ObservableArrayTest  {
         wrapper.assertElementsEqual(actual, 0, initialSize, initialElements, 0);
     }
 
-    @Test public void testSetAllTSelfEmpty() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetAllTSelfEmpty(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         makeEmpty();
 
         wrapper.setAllT(array);
@@ -704,95 +853,158 @@ public class ObservableArrayTest  {
         wrapper.assertElementsEqual(actual, 0, length, expected, srcIndex);
     }
 
-    @Test public void testSetAllARange1() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetAllARange1(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testSetAllARange(false, INITIAL_SIZE, 0, INITIAL_SIZE);
     }
 
-    @Test public void testSetAllARange2() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetAllARange2(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testSetAllARange(false, INITIAL_SIZE + 10, 0, INITIAL_SIZE);
     }
 
-    @Test public void testSetAllARange3() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetAllARange3(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testSetAllARange(false, INITIAL_SIZE + 10, 10, INITIAL_SIZE);
     }
 
-    @Test public void testSetAllARange4() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetAllARange4(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testSetAllARange(false, INITIAL_SIZE + 10, 2, INITIAL_SIZE);
     }
 
-    @Test public void testSetAllARange5() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetAllARange5(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testSetAllARange(true, INITIAL_SIZE, 0, INITIAL_SIZE / 2);
     }
 
-    @Test public void testSetAllARange6() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetAllARange6(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testSetAllARange(true, INITIAL_SIZE + 10, 0, INITIAL_SIZE + 10);
     }
 
-    @Test public void testSetAllARange7() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetAllARange7(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testSetAllARange(true, INITIAL_SIZE + 20, 10, INITIAL_SIZE + 10);
     }
 
-    @Test public void testSetAllARange8() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetAllARange8(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testSetAllARange(true, INITIAL_SIZE + 10, 2, INITIAL_SIZE - 3);
     }
 
-    @Test public void testSetAllARangeOnEmpty() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetAllARangeOnEmpty(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         makeEmpty();
         testSetAllARange(true, INITIAL_SIZE, 1, 3);
     }
 
-    @Test public void testSetAllARangeOnEmptyToEmpty() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetAllARangeOnEmptyToEmpty(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         makeEmpty();
         wrapper.setAllA(wrapper.createPrimitiveArray(INITIAL_SIZE), 1, 0);
         assertUnchanged();
     }
 
-    @Test (expected = NullPointerException.class)
-    public void testSetAllARangeToNull() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetAllARangeToNull(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         try {
-            wrapper.setAllA(null, 0, 0);
+            assertThrows(NullPointerException.class, () -> {
+                wrapper.setAllA(null, 0, 0);
+            });
         } finally {
             assertUnchanged();
         }
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testSetAllARangeNegative1() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetAllARangeNegative1(ArrayWrapper arrayWrapper) throws Exception  {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         try {
-            testSetAllARange(true, INITIAL_SIZE, -1, INITIAL_SIZE);
+            assertThrows(ArrayIndexOutOfBoundsException.class, () -> {
+                testSetAllARange(true, INITIAL_SIZE, -1, INITIAL_SIZE);
+            });
         } finally {
             assertUnchanged();
         }
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testSetAllARangeNegative2() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetAllARangeNegative2(ArrayWrapper arrayWrapper) throws Exception  {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         try {
-            testSetAllARange(true, INITIAL_SIZE, 0, INITIAL_SIZE + 1);
+            assertThrows(ArrayIndexOutOfBoundsException.class, () -> {
+                testSetAllARange(true, INITIAL_SIZE, 0, INITIAL_SIZE + 1);
+            });
         } finally {
             assertUnchanged();
         }
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testSetAllARangeNegative3() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetAllARangeNegative3(ArrayWrapper arrayWrapper) throws Exception  {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         try {
-            testSetAllARange(true, INITIAL_SIZE, 1, -1);
+            assertThrows(ArrayIndexOutOfBoundsException.class, () -> {
+                testSetAllARange(true, INITIAL_SIZE, 1, -1);
+            });
         } finally {
             assertUnchanged();
         }
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testSetAllARangeNegative4() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetAllARangeNegative4(ArrayWrapper arrayWrapper) throws Exception  {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         try {
-            testSetAllARange(true, INITIAL_SIZE, INITIAL_SIZE, 1);
+            assertThrows(ArrayIndexOutOfBoundsException.class, () -> {
+                testSetAllARange(true, INITIAL_SIZE, INITIAL_SIZE, 1);
+            });
         } finally {
             assertUnchanged();
         }
     }
-
-    // ========== setAll(observable array, range) tests ==========
 
     private void testSetAllTRange(boolean sizeChanged, int srcSize, int srcIndex, int length) {
         Object expected = wrapper.createPrimitiveArray(srcSize);
@@ -807,117 +1019,191 @@ public class ObservableArrayTest  {
         wrapper.assertElementsEqual(actual, 0, length, expected, srcIndex);
     }
 
-    @Test public void testSetAllTRange1() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetAllTRange1(ArrayWrapper arrayWrapper) throws Exception  {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testSetAllTRange(false, INITIAL_SIZE, 0, INITIAL_SIZE);
     }
 
-    @Test public void testSetAllTRange2() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetAllTRange2(ArrayWrapper arrayWrapper) throws Exception  {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testSetAllTRange(false, INITIAL_SIZE + 10, 0, INITIAL_SIZE);
     }
 
-    @Test public void testSetAllTRange3() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetAllTRange3(ArrayWrapper arrayWrapper) throws Exception  {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testSetAllTRange(false, INITIAL_SIZE + 10, 10, INITIAL_SIZE);
     }
 
-    @Test public void testSetAllTRange4() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetAllTRange4(ArrayWrapper arrayWrapper) throws Exception  {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testSetAllTRange(false, INITIAL_SIZE + 10, 2, INITIAL_SIZE);
     }
 
-    @Test public void testSetAllTRange5() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetAllTRange5(ArrayWrapper arrayWrapper) throws Exception  {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testSetAllTRange(true, INITIAL_SIZE, 0, INITIAL_SIZE / 2);
     }
 
-    @Test public void testSetAllTRange6() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetAllTRange6(ArrayWrapper arrayWrapper) throws Exception  {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testSetAllTRange(true, INITIAL_SIZE + 10, 0, INITIAL_SIZE + 10);
     }
 
-    @Test public void testSetAllTRange7() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetAllTRange7(ArrayWrapper arrayWrapper) throws Exception  {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testSetAllTRange(true, INITIAL_SIZE + 20, 10, INITIAL_SIZE + 10);
     }
 
-    @Test public void testSetAllTRange8() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetAllTRange8(ArrayWrapper arrayWrapper) throws Exception  {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testSetAllTRange(true, INITIAL_SIZE + 10, 2, INITIAL_SIZE - 3);
     }
 
-    @Test public void testSetAllTRangeOnEmpty() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetAllTRangeOnEmpty(ArrayWrapper arrayWrapper) throws Exception  {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         makeEmpty();
         testSetAllTRange(true, INITIAL_SIZE, 1, 3);
     }
 
-    @Test public void testSetAllTRangeOnEmptyToEmpty() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetAllTRangeOnEmptyToEmpty(ArrayWrapper arrayWrapper) throws Exception  {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         makeEmpty();
         wrapper.setAllT(wrapper.newInstance().createNotEmptyArray(wrapper.createPrimitiveArray(INITIAL_SIZE)), 1, 0);
         assertUnchanged();
     }
 
-    @Test (expected = NullPointerException.class)
-    public void testSetAllTRangeToNull() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetAllTRangeToNull(ArrayWrapper arrayWrapper) throws Exception  {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         try {
-            wrapper.setAllT(null, 0, 0);
+            assertThrows(NullPointerException.class, () -> {
+                wrapper.setAllT(null, 0, 0);
+            });
         } finally {
             assertUnchanged();
         }
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testSetAllTRangeNegative1() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetAllTRangeNegative1(ArrayWrapper arrayWrapper) throws Exception  {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         try {
-            testSetAllTRange(true, INITIAL_SIZE, -1, INITIAL_SIZE);
+            assertThrows(ArrayIndexOutOfBoundsException.class, () -> {
+                testSetAllTRange(true, INITIAL_SIZE, -1, INITIAL_SIZE);
+            });
         } finally {
             assertUnchanged();
         }
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testSetAllTRangeNegative2() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetAllTRangeNegative2(ArrayWrapper arrayWrapper) throws Exception  {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         try {
-            testSetAllTRange(true, INITIAL_SIZE, 0, INITIAL_SIZE + 1);
+            assertThrows(ArrayIndexOutOfBoundsException.class, () -> {
+                testSetAllTRange(true, INITIAL_SIZE, 0, INITIAL_SIZE + 1);
+            });
         } finally {
             assertUnchanged();
         }
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testSetAllTRangeNegative3() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetAllTRangeNegative3(ArrayWrapper arrayWrapper) throws Exception  {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         try {
-            testSetAllTRange(true, INITIAL_SIZE, 1, -1);
+            assertThrows(ArrayIndexOutOfBoundsException.class, () -> {
+                testSetAllTRange(true, INITIAL_SIZE, 1, -1);
+            });
         } finally {
             assertUnchanged();
         }
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testSetAllTRangeNegative4() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetAllTRangeNegative4(ArrayWrapper arrayWrapper) throws Exception  {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         try {
-            testSetAllTRange(true, INITIAL_SIZE, INITIAL_SIZE, 1);
+            assertThrows(ArrayIndexOutOfBoundsException.class, () -> {
+                testSetAllTRange(true, INITIAL_SIZE, INITIAL_SIZE, 1);
+            });
         } finally {
             assertUnchanged();
         }
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testSetAllTRangeNegativeAfterSrcEnsureCapacity() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testSetAllTRangeNegativeAfterSrcEnsureCapacity(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         Object expected = wrapper.createPrimitiveArray(INITIAL_SIZE);
         ObservableArray src = wrapper.newInstance().createNotEmptyArray(expected);
         src.ensureCapacity(INITIAL_SIZE * 2);
-        try {
+
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> {
             wrapper.setAllT(src, INITIAL_SIZE, 1);
-        } finally {
-            assertUnchanged();
-        }
+        });
+
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testSetAllTRangeNegativeAfterSrcClear() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testSetAllTRangeNegativeAfterSrcClear(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         Object expected = wrapper.createPrimitiveArray(INITIAL_SIZE);
         ObservableArray src = wrapper.newInstance().createNotEmptyArray(expected);
         src.clear();
-        try {
+
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> {
             wrapper.setAllT(src, 0, 1);
-        } finally {
-            assertUnchanged();
-        }
+        });
+
+        assertUnchanged();
     }
+
 
     private void testSetAllTRangeSelf(boolean sizeChanged, int srcIndex, int length) {
 
@@ -938,81 +1224,115 @@ public class ObservableArrayTest  {
         wrapper.assertElementsEqual(actual, 0, length, initialElements, srcIndex);
     }
 
-    @Test public void testSetAllTRangeSelf() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetAllTRangeSelf(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testSetAllTRangeSelf(true, 0, INITIAL_SIZE);
     }
 
-    @Test public void testSetAllTRangeSelfBeginning() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetAllTRangeSelfBeginning(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testSetAllTRangeSelf(true, 0, INITIAL_SIZE / 2);
     }
 
-    @Test public void testSetAllTRangeSelfTrailing() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetAllTRangeSelfTrailing(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testSetAllTRangeSelf(true, INITIAL_SIZE / 2, INITIAL_SIZE / 2);
     }
 
-    @Test public void testSetAllTRangeSelfMiddle() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetAllTRangeSelfMiddle(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testSetAllTRangeSelf(true, 3, 2);
     }
 
-    @Test public void testSetAllTRangeSelfEmpty() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetAllTRangeSelfEmpty(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         makeEmpty();
         testSetAllTRangeSelf(false, 0, 0);
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testSetAllTRangeSelfNegative1() {
-        try {
-            wrapper.setAllT(array, -1, INITIAL_SIZE);
-        } finally {
-            assertUnchanged();
-        }
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testSetAllTRangeSelfNegative1(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        assertThrows(ArrayIndexOutOfBoundsException.class, () ->
+                wrapper.setAllT(array, -1, INITIAL_SIZE)
+        );
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testSetAllTRangeSelfNegative2() {
-        try {
-            wrapper.setAllT(array, INITIAL_SIZE, 1);
-        } finally {
-            assertUnchanged();
-        }
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testSetAllTRangeSelfNegative2(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        assertThrows(ArrayIndexOutOfBoundsException.class, () ->
+                wrapper.setAllT(array, INITIAL_SIZE, 1)
+        );
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testSetAllTRangeSelfNegative3() {
-        try {
-            wrapper.setAllT(array, 0, -1);
-        } finally {
-            assertUnchanged();
-        }
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testSetAllTRangeSelfNegative3(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        assertThrows(ArrayIndexOutOfBoundsException.class, () ->
+                wrapper.setAllT(array, 0, -1)
+        );
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testSetAllTRangeSelfNegative4() {
-        try {
-            wrapper.setAllT(array, 0, INITIAL_SIZE + 1);
-        } finally {
-            assertUnchanged();
-        }
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testSetAllTRangeSelfNegative4(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        assertThrows(ArrayIndexOutOfBoundsException.class, () ->
+                wrapper.setAllT(array, 0, INITIAL_SIZE + 1)
+        );
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testSetAllTRangeSelfNegativeAfterEnsureCapacity() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testSetAllTRangeSelfNegativeAfterEnsureCapacity(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         array.ensureCapacity(INITIAL_SIZE * 2);
-        try {
-            wrapper.setAllT(array, INITIAL_SIZE, 1);
-        } finally {
-            assertUnchanged();
-        }
+        assertThrows(ArrayIndexOutOfBoundsException.class, () ->
+                wrapper.setAllT(array, INITIAL_SIZE, 1)
+        );
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testSetAllTRangeSelfNegativeAfterClear() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testSetAllTRangeSelfNegativeAfterClear(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         makeEmpty();
-        try {
-            wrapper.setAllT(array, 0, 1);
-        } finally {
-            assertUnchanged();
-        }
+        assertThrows(ArrayIndexOutOfBoundsException.class, () ->
+                wrapper.setAllT(array, 0, 1)
+        );
+        assertUnchanged();
     }
 
     // ========== addAll(primitive array) tests ==========
@@ -1033,58 +1353,100 @@ public class ObservableArrayTest  {
         wrapper.assertElementsEqual(actual, oldSize, newSize, src, 0);
     }
 
-    @Test public void testAddAllA0() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testAddAllA0(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         wrapper.addAllA(wrapper.createPrimitiveArray(0));
         assertUnchanged();
     }
 
-    @Test public void testAddAllA1() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testAddAllA1(ArrayWrapper arrayWrapper) throws Exception  {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testAddAllA(1);
     }
 
-    @Test public void testAddAllA3() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testAddAllA3(ArrayWrapper arrayWrapper) throws Exception  {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testAddAllA(3);
     }
 
-    @Test public void testAddAllABig() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testAddAllABig(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testAddAllA(INITIAL_SIZE * 2);
     }
 
-    @Test public void testAddAllASameSize() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testAddAllASameSize(ArrayWrapper arrayWrapper) throws Exception  {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testAddAllA(INITIAL_SIZE);
     }
 
-    @Test public void testAddAllAOnEmpty1() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testAddAllAOnEmpty1(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         makeEmpty();
         testAddAllA(1);
     }
 
-    @Test public void testAddAllAOnEmptySameSize() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testAddAllAOnEmptySameSize(ArrayWrapper arrayWrapper)  throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         makeEmpty();
         testAddAllA(INITIAL_SIZE);
     }
 
-    @Test public void testAddAllAOnEmptyBig() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testAddAllAOnEmptyBig(ArrayWrapper arrayWrapper)  throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         makeEmpty();
         testAddAllA(INITIAL_SIZE * 3);
     }
 
-    @Test public void testAddAllAOnEmpty0() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testAddAllAOnEmpty0(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         makeEmpty();
         wrapper.addAllA(wrapper.createPrimitiveArray(0));
         assertUnchanged();
     }
 
-    @Test (expected = NullPointerException.class)
-    public void testAddAllANull() {
-        try {
-            wrapper.addAllA(null);
-        } finally {
-            assertUnchanged();
-        }
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testAddAllANull(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        assertThrows(NullPointerException.class, () ->
+                wrapper.addAllA(null)
+        );
+        assertUnchanged();
     }
 
-    @Test public void testAddAllAManyPoints() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testAddAllAManyPoints(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         for (int i = 0; i < 65_000; i++) {
             wrapper.addAllA(wrapper.createPrimitiveArray(3));
         }
@@ -1108,58 +1470,100 @@ public class ObservableArrayTest  {
         wrapper.assertElementsEqual(actual, oldSize, newSize, src, 0);
     }
 
-    @Test public void testAddAllT0() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testAddAllT0(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         wrapper.addAllT(wrapper.newInstance().createEmptyArray());
         assertUnchanged();
     }
 
-    @Test public void testAddAllT1() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testAddAllT1(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testAddAllT(1);
     }
 
-    @Test public void testAddAllT3() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testAddAllT3(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testAddAllT(3);
     }
 
-    @Test public void testAddAllTBig() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testAddAllTBig(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testAddAllT(INITIAL_SIZE * 2);
     }
 
-    @Test public void testAddAllTSameSize() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testAddAllTSameSize(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testAddAllT(INITIAL_SIZE);
     }
 
-    @Test public void testAddAllTOnEmpty1() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testAddAllTOnEmpty1(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         makeEmpty();
         testAddAllT(1);
     }
 
-    @Test public void testAddAllTOnEmptySameSize() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testAddAllTOnEmptySameSize(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         makeEmpty();
         testAddAllT(INITIAL_SIZE);
     }
 
-    @Test public void testAddAllTOnEmptyBig() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testAddAllTOnEmptyBig(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         makeEmpty();
         testAddAllT(INITIAL_SIZE * 3);
     }
 
-    @Test public void testAddAllTOnEmpty0() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testAddAllTOnEmpty0(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         makeEmpty();
         wrapper.addAllT(wrapper.newInstance().createEmptyArray());
         assertUnchanged();
     }
 
-    @Test (expected = NullPointerException.class)
-    public void testAddAllTNull() {
-        try {
-            wrapper.addAllT(null);
-        } finally {
-            assertUnchanged();
-        }
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testAddAllTNull(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        assertThrows(NullPointerException.class, () ->
+                wrapper.addAllT(null)
+        );
+        assertUnchanged();
     }
 
-    @Test public void testAddAllTSelf() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testAddAllTSelf(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         wrapper.addAllT(array);
 
         mao.check(array, true, initialSize, initialSize * 2);
@@ -1169,7 +1573,11 @@ public class ObservableArrayTest  {
         wrapper.assertElementsEqual(actual, initialSize, initialSize * 2, initialElements, 0);
     }
 
-    @Test public void testAddAllTSelfEmpty() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testAddAllTSelfEmpty(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         makeEmpty();
 
         wrapper.addAllT(array);
@@ -1180,7 +1588,11 @@ public class ObservableArrayTest  {
         assertEquals(0, wrapper.arrayLength(actual));
     }
 
-    @Test public void testAddAllTManyPoints() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testAddAllTManyPoints(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         for (int i = 0; i < 65_000; i++) {
             wrapper.addAllT(wrapper.createNotEmptyArray(wrapper.createPrimitiveArray(3)));
         }
@@ -1205,97 +1617,151 @@ public class ObservableArrayTest  {
         wrapper.assertElementsEqual(actual, oldSize, newSize, src, srcIndex);
     }
 
-    @Test public void testAddAllARange1() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testAddAllARange1(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testAddAllARange(INITIAL_SIZE, 0, INITIAL_SIZE);
     }
 
-    @Test public void testAddAllARange2() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testAddAllARange2(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testAddAllARange(INITIAL_SIZE + 10, 0, INITIAL_SIZE);
     }
 
-    @Test public void testAddAllARange3() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testAddAllARange3(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testAddAllARange(INITIAL_SIZE + 10, 10, INITIAL_SIZE);
     }
 
-    @Test public void testAddAllARange4() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testAddAllARange4(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testAddAllARange(INITIAL_SIZE + 10, 2, INITIAL_SIZE);
     }
 
-    @Test public void testAddAllARange5() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testAddAllARange5(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testAddAllARange(INITIAL_SIZE, 0, INITIAL_SIZE / 2);
     }
 
-    @Test public void testAddAllARange6() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testAddAllARange6(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testAddAllARange(INITIAL_SIZE + 10, 0, INITIAL_SIZE + 10);
     }
 
-    @Test public void testAddAllARange7() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testAddAllARange7(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testAddAllARange(INITIAL_SIZE + 20, 10, INITIAL_SIZE + 10);
     }
 
-    @Test public void testAddAllARange8() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testAddAllARange8(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testAddAllARange(INITIAL_SIZE + 10, 2, INITIAL_SIZE - 3);
     }
 
-    @Test public void testAddAllARangeOnEmpty1() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testAddAllARangeOnEmpty1(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         makeEmpty();
         testAddAllARange(INITIAL_SIZE, 1, 3);
     }
 
-    @Test public void testAddAllARangeOnEmpty2() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testAddAllARangeOnEmpty2(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         makeEmpty();
         testAddAllARange(INITIAL_SIZE * 3, INITIAL_SIZE, INITIAL_SIZE * 2);
     }
 
-    @Test public void testAddAllARangeOnEmpty3() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testAddAllARangeOnEmpty3(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         makeEmpty();
         wrapper.addAllA(wrapper.createPrimitiveArray(INITIAL_SIZE), 1, 0);
         assertUnchanged();
     }
 
-    @Test (expected = NullPointerException.class)
-    public void testAddAllARangeNull() {
-        try {
-            wrapper.addAllA(null, 0, 0);
-        } finally {
-            assertUnchanged();
-        }
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testAddAllARangeNull(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        assertThrows(NullPointerException.class, () ->
+                wrapper.addAllA(null, 0, 0)
+        );
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testAddAllARangeNegative1() {
-        try {
-            testAddAllARange(INITIAL_SIZE, -1, INITIAL_SIZE);
-        } finally {
-            assertUnchanged();
-        }
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testAddAllARangeNegative1(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        assertThrows(ArrayIndexOutOfBoundsException.class, () ->
+                testAddAllARange(INITIAL_SIZE, -1, INITIAL_SIZE)
+        );
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testAddAllARangeNegative2() {
-        try {
-            testAddAllARange(INITIAL_SIZE, 0, INITIAL_SIZE + 1);
-        } finally {
-            assertUnchanged();
-        }
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testAddAllARangeNegative2(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        assertThrows(ArrayIndexOutOfBoundsException.class, () ->
+                testAddAllARange(INITIAL_SIZE, 0, INITIAL_SIZE + 1)
+        );
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testAddAllARangeNegative3() {
-        try {
-            testAddAllARange(INITIAL_SIZE, 1, -1);
-        } finally {
-            assertUnchanged();
-        }
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testAddAllARangeNegative3(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        assertThrows(ArrayIndexOutOfBoundsException.class, () ->
+                testAddAllARange(INITIAL_SIZE, 1, -1)
+        );
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testAddAllARangeNegative4() {
-        try {
-            testAddAllARange(INITIAL_SIZE, INITIAL_SIZE, 1);
-        } finally {
-            assertUnchanged();
-        }
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testAddAllARangeNegative4(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        assertThrows(ArrayIndexOutOfBoundsException.class, () ->
+                testAddAllARange(INITIAL_SIZE, INITIAL_SIZE, 1)
+        );
+        assertUnchanged();
     }
 
     // ========== addAll(observable array, range) tests ==========
@@ -1317,121 +1783,167 @@ public class ObservableArrayTest  {
         wrapper.assertElementsEqual(actual, oldSize, newSize, src, srcIndex);
     }
 
-    @Test public void testAddAllTRange1() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testAddAllTRange1(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testAddAllTRange(INITIAL_SIZE, 0, INITIAL_SIZE);
     }
 
-    @Test public void testAddAllTRange2() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testAddAllTRange2(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testAddAllTRange(INITIAL_SIZE + 10, 0, INITIAL_SIZE);
     }
 
-    @Test public void testAddAllTRange3() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testAddAllTRange3(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testAddAllTRange(INITIAL_SIZE + 10, 10, INITIAL_SIZE);
     }
 
-    @Test public void testAddAllTRange4() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testAddAllTRange4(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testAddAllTRange(INITIAL_SIZE + 10, 2, INITIAL_SIZE);
     }
 
-    @Test public void testAddAllTRange5() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testAddAllTRange5(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testAddAllTRange(INITIAL_SIZE, 0, INITIAL_SIZE / 2);
     }
 
-    @Test public void testAddAllTRange6() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testAddAllTRange6(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testAddAllTRange(INITIAL_SIZE + 10, 0, INITIAL_SIZE + 10);
     }
 
-    @Test public void testAddAllTRange7() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testAddAllTRange7(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testAddAllTRange(INITIAL_SIZE + 20, 10, INITIAL_SIZE + 10);
     }
 
-    @Test public void testAddAllTRange8() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testAddAllTRange8(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testAddAllTRange(INITIAL_SIZE + 10, 2, INITIAL_SIZE - 3);
     }
 
-    @Test public void testAddAllTRangeOnEmpty1() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testAddAllTRangeOnEmpty1(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         makeEmpty();
         testAddAllTRange(INITIAL_SIZE, 1, 3);
     }
 
-    @Test public void testAddAllTRangeOnEmpty2() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testAddAllTRangeOnEmpty2(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         makeEmpty();
         testAddAllTRange(INITIAL_SIZE * 3, INITIAL_SIZE, INITIAL_SIZE * 2);
     }
 
-    @Test public void testAddAllTRangeOnEmpty3() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testAddAllTRangeOnEmpty3(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         makeEmpty();
         wrapper.addAllT(wrapper.newInstance().createNotEmptyArray(wrapper.createPrimitiveArray(INITIAL_SIZE)), 1, 0);
         assertUnchanged();
     }
 
-    @Test (expected = NullPointerException.class)
-    public void testAddAllTRangeNull() {
-        try {
-            wrapper.addAllT(null, 0, 0);
-        } finally {
-            assertUnchanged();
-        }
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testAddAllTRangeNull(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        assertThrows(NullPointerException.class, () -> wrapper.addAllT(null, 0, 0));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testAddAllTRangeNegative1() {
-        try {
-            testAddAllTRange(INITIAL_SIZE, -1, INITIAL_SIZE);
-        } finally {
-            assertUnchanged();
-        }
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testAddAllTRangeNegative1(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> testAddAllTRange(INITIAL_SIZE, -1, INITIAL_SIZE));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testAddAllTRangeNegative2() {
-        try {
-            testAddAllTRange(INITIAL_SIZE, 0, INITIAL_SIZE + 1);
-        } finally {
-            assertUnchanged();
-        }
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testAddAllTRangeNegative2(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> testAddAllTRange(INITIAL_SIZE, 0, INITIAL_SIZE + 1));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testAddAllTRangeNegative3() {
-        try {
-            testAddAllTRange(INITIAL_SIZE, 1, -1);
-        } finally {
-            assertUnchanged();
-        }
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testAddAllTRangeNegative3(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> testAddAllTRange(INITIAL_SIZE, 1, -1));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testAddAllTRangeNegative4() {
-        try {
-            testAddAllTRange(INITIAL_SIZE, INITIAL_SIZE, 1);
-        } finally {
-            assertUnchanged();
-        }
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testAddAllTRangeNegative4(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> testAddAllTRange(INITIAL_SIZE, INITIAL_SIZE, 1));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testAddAllTRangeNegativeAfterSrcEnsureCapacity() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testAddAllTRangeNegativeAfterSrcEnsureCapacity(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         Object srcA = wrapper.createPrimitiveArray(INITIAL_SIZE);
         ObservableArray src = wrapper.newInstance().createNotEmptyArray(srcA);
         src.ensureCapacity(INITIAL_SIZE * 2);
-        try {
-            wrapper.addAllT(src, INITIAL_SIZE, 1);
-        } finally {
-            assertUnchanged();
-        }
+
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> wrapper.addAllT(src, INITIAL_SIZE, 1));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testAddAllTRangeNegativeAfterSrcClear() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testAddAllTRangeNegativeAfterSrcClear(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         Object srcA = wrapper.createPrimitiveArray(INITIAL_SIZE);
         ObservableArray src = wrapper.newInstance().createNotEmptyArray(srcA);
         src.clear();
-        try {
-            wrapper.addAllT(src, 0, 1);
-        } finally {
-            assertUnchanged();
-        }
+
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> wrapper.addAllT(src, 0, 1));
+        assertUnchanged();
     }
 
     private void testAddAllTRangeSelf(int srcIndex, int length) {
@@ -1446,76 +1958,92 @@ public class ObservableArrayTest  {
         wrapper.assertElementsEqual(actual, initialSize, expSize, initialElements, srcIndex);
     }
 
-    @Test public void testAddAllTRangeSelf() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testAddAllTRangeSelf(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testAddAllTRangeSelf(0, INITIAL_SIZE);
     }
 
-    @Test public void testAddAllTRangeSelfBeginning() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testAddAllTRangeSelfBeginning(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testAddAllTRangeSelf(0, INITIAL_SIZE / 2);
     }
 
-    @Test public void testAddAllTRangeSelfTrailing() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testAddAllTRangeSelfTrailing(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testAddAllTRangeSelf(INITIAL_SIZE / 2, INITIAL_SIZE / 2);
     }
 
-    @Test public void testAddAllTRangeSelfMiddle() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testAddAllTRangeSelfMiddle(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testAddAllTRangeSelf(2, 2);
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testAddAllTRangeSelfNegative1() {
-        try {
-            testAddAllTRangeSelf(-1, INITIAL_SIZE);
-        } finally {
-            assertUnchanged();
-        }
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testAddAllTRangeSelfNegative1(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> testAddAllTRangeSelf(-1, INITIAL_SIZE));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testAddAllTRangeSelfNegative2() {
-        try {
-            testAddAllTRangeSelf(0, INITIAL_SIZE + 1);
-        } finally {
-            assertUnchanged();
-        }
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testAddAllTRangeSelfNegative2(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> testAddAllTRangeSelf(0, INITIAL_SIZE + 1));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testAddAllTRangeSelfNegative3() {
-        try {
-            testAddAllTRangeSelf(1, -1);
-        } finally {
-            assertUnchanged();
-        }
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testAddAllTRangeSelfNegative3(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> testAddAllTRangeSelf(1, -1));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testAddAllTRangeSelfNegative4() {
-        try {
-            testAddAllTRangeSelf(INITIAL_SIZE, 1);
-        } finally {
-            assertUnchanged();
-        }
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testAddAllTRangeSelfNegative4(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> testAddAllTRangeSelf(INITIAL_SIZE, 1));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testAddAllTRangeSelfNegativeAfterEnsureCapacity() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testAddAllTRangeSelfNegativeAfterEnsureCapacity(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         array.ensureCapacity(INITIAL_SIZE * 2);
-        try {
-            wrapper.addAllT(array, INITIAL_SIZE, 1);
-        } finally {
-            assertUnchanged();
-        }
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> wrapper.addAllT(array, INITIAL_SIZE, 1));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testAddAllTRangeSelfNegativeAfterClear() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testAddAllTRangeSelfNegativeAfterClear(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         makeEmpty();
-        try {
-            wrapper.addAllT(array, 0, 1);
-        } finally {
-            assertUnchanged();
-        }
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> wrapper.addAllT(array, 0, 1));
+        assertUnchanged();
     }
 
     // ========== set(primitive array, range) tests ==========
@@ -1534,107 +2062,127 @@ public class ObservableArrayTest  {
         wrapper.assertElementsEqual(actual, destIndex + length, INITIAL_SIZE, initialElements, destIndex + length);
     }
 
-    @Test public void testSetARange1() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetARange1(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testSetARange(5, 0, 0, 5);
     }
 
-    @Test public void testSetARange2() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetARange2(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testSetARange(3, 2, 0, 3);
     }
 
-    @Test public void testSetARange3() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetARange3(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testSetARange(5, 0, 2, 3);
     }
 
-    @Test public void testSetARange4() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetARange4(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testSetARange(5, 0, 0, 3);
     }
 
-    @Test public void testSetARange5() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetARange5(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testSetARange(10, 3, 5, 3);
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testSetARangeNegative1() {
-        try {
-            testSetARange(10, -1, 0, 3);
-        } finally {
-            assertUnchanged();
-        }
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testSetARangeNegative1(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> testSetARange(10, -1, 0, 3));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testSetARangeNegative2() {
-        try {
-            testSetARange(10, 0, -1, 3);
-        } finally {
-            assertUnchanged();
-        }
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testSetARangeNegative2(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> testSetARange(10, 0, -1, 3));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testSetARangeNegative3() {
-        try {
-            testSetARange(10, 1, 1, -1);
-        } finally {
-            assertUnchanged();
-        }
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testSetARangeNegative3(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> testSetARange(10, 1, 1, -1));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testSetARangeNegative4() {
-        try {
-            testSetARange(10, INITIAL_SIZE, 0, 3);
-        } finally {
-            assertUnchanged();
-        }
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testSetARangeNegative4(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> testSetARange(10, INITIAL_SIZE, 0, 3));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testSetARangeNegative5() {
-        try {
-            testSetARange(10, 0, 10, 1);
-        } finally {
-            assertUnchanged();
-        }
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testSetARangeNegative5(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> testSetARange(10, 0, 10, 1));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testSetARangeNegative6() {
-        try {
-            testSetARange(3, 0, 1, 4);
-        } finally {
-            assertUnchanged();
-        }
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testSetARangeNegative6(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> testSetARange(3, 0, 1, 4));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testSetARangeNegative7() {
-        try {
-            testSetARange(10, INITIAL_SIZE - 3, 0, 4);
-        } finally {
-            assertUnchanged();
-        }
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testSetARangeNegative7(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> testSetARange(10, INITIAL_SIZE - 3, 0, 4));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testSetARangeNegativeAfterEnsureCapacity() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testSetARangeNegativeAfterEnsureCapacity(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         array.ensureCapacity(INITIAL_SIZE * 2);
-        try {
-            testSetARange(1, INITIAL_SIZE, 0, 1);
-        } finally {
-            assertUnchanged();
-        }
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> testSetARange(1, INITIAL_SIZE, 0, 1));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testSetARangeNegativeAfterClear() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testSetARangeNegativeAfterClear(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         makeEmpty();
-        try {
-            testSetARange(1, 0, 0, 1);
-        } finally {
-            assertUnchanged();
-        }
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> testSetARange(1, 0, 0, 1));
+        assertUnchanged();
     }
 
     // ========== set(ObservableArray, range) tests ==========
@@ -1654,133 +2202,153 @@ public class ObservableArrayTest  {
         wrapper.assertElementsEqual(actual, destIndex + length, initialSize, initialElements, destIndex + length);
     }
 
-    @Test public void testSetTRange1() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetTRange1(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testSetTRange(5, 0, 0, 5);
     }
 
-    @Test public void testSetTRange2() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetTRange2(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testSetTRange(3, 2, 0, 3);
     }
 
-    @Test public void testSetTRange3() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetTRange3(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testSetTRange(5, 0, 2, 3);
     }
 
-    @Test public void testSetTRange4() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetTRange4(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testSetTRange(5, 0, 0, 3);
     }
 
-    @Test public void testSetTRange5() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetTRange5(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testSetTRange(10, 3, 5, 3);
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testSetTRangeNegative1() {
-        try {
-            testSetTRange(10, -1, 0, 3);
-        } finally {
-            assertUnchanged();
-        }
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testSetTRangeNegative1(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> testSetTRange(10, -1, 0, 3));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testSetTRangeNegative2() {
-        try {
-            testSetTRange(10, 0, -1, 3);
-        } finally {
-            assertUnchanged();
-        }
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testSetTRangeNegative2(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> testSetTRange(10, 0, -1, 3));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testSetTRangeNegative3() {
-        try {
-            testSetTRange(10, 1, 1, -1);
-        } finally {
-            assertUnchanged();
-        }
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testSetTRangeNegative3(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> testSetTRange(10, 1, 1, -1));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testSetTRangeNegative4() {
-        try {
-            testSetTRange(10, INITIAL_SIZE, 0, 3);
-        } finally {
-            assertUnchanged();
-        }
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testSetTRangeNegative4(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> testSetTRange(10, INITIAL_SIZE, 0, 3));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testSetTRangeNegative5() {
-        try {
-            testSetTRange(10, 0, 10, 1);
-        } finally {
-            assertUnchanged();
-        }
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testSetTRangeNegative5(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> testSetTRange(10, 0, 10, 1));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testSetTRangeNegative6() {
-        try {
-            testSetTRange(3, 0, 1, 4);
-        } finally {
-            assertUnchanged();
-        }
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testSetTRangeNegative6(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> testSetTRange(3, 0, 1, 4));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testSetTRangeNegative7() {
-        try {
-            testSetTRange(10, INITIAL_SIZE - 3, 0, 4);
-        } finally {
-            assertUnchanged();
-        }
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testSetTRangeNegative7(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> testSetTRange(10, INITIAL_SIZE - 3, 0, 4));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testSetTRangeNegativeAfterEnsureCapacity() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testSetTRangeNegativeAfterEnsureCapacity(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         array.ensureCapacity(INITIAL_SIZE * 2);
-        try {
-            testSetTRange(1, INITIAL_SIZE, 0, 1);
-        } finally {
-            assertUnchanged();
-        }
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> testSetTRange(1, INITIAL_SIZE, 0, 1));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testSetTRangeNegativeAfterClear() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testSetTRangeNegativeAfterClear(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         makeEmpty();
-        try {
-            testSetTRange(1, 0, 0, 1);
-        } finally {
-            assertUnchanged();
-        }
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> testSetTRange(1, 0, 0, 1));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testSetTRangeNegativeAfterSrcEnsureCapacity() {
-        try {
-            Object srcA = wrapper.createPrimitiveArray(1);
-            ObservableArray src = wrapper.newInstance().createNotEmptyArray(srcA);
-            src.ensureCapacity(2);
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testSetTRangeNegativeAfterSrcEnsureCapacity(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        Object srcA = wrapper.createPrimitiveArray(1);
+        ObservableArray src = wrapper.newInstance().createNotEmptyArray(srcA);
+        src.ensureCapacity(2);
 
-            wrapper.setT(0, src, 1, 1);
-        } finally {
-            assertUnchanged();
-        }
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> wrapper.setT(0, src, 1, 1));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testSetTRangeNegativeAfterSrcClear() {
-        try {
-            Object srcA = wrapper.createPrimitiveArray(1);
-            ObservableArray src = wrapper.newInstance().createNotEmptyArray(srcA);
-            src.clear();
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testSetTRangeNegativeAfterSrcClear(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        Object srcA = wrapper.createPrimitiveArray(1);
+        ObservableArray src = wrapper.newInstance().createNotEmptyArray(srcA);
+        src.clear();
 
-            wrapper.setT(0, src, 0, 1);
-        } finally {
-            assertUnchanged();
-        }
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> wrapper.setT(0, src, 0, 1));
+        assertUnchanged();
     }
 
     private void testSetTRangeSelf(int destIndex, int srcIndex, int length) {
@@ -1796,145 +2364,164 @@ public class ObservableArrayTest  {
         wrapper.assertElementsEqual(actual, destIndex + length, initialSize, initialElements, destIndex + length);
     }
 
-    @Test public void testSetTRangeSelf() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetTRangeSelf(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testSetTRangeSelf(0, 0, INITIAL_SIZE);
     }
 
-    @Test public void testSetTRangeSelfLeft() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetTRangeSelfLeft(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testSetTRangeSelf(0, 1, INITIAL_SIZE - 1);
     }
 
-    @Test public void testSetTRangeSelfRight() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetTRangeSelfRight(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testSetTRangeSelf(1, 0, INITIAL_SIZE - 1);
     }
 
-    @Test public void testSetTRangeSelfRightDifferentParts() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetTRangeSelfRightDifferentParts(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testSetTRangeSelf(0, INITIAL_SIZE / 2, INITIAL_SIZE / 2);
     }
 
-    @Test public void testSetTRangeSelfLeftDifferentParts() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetTRangeSelfLeftDifferentParts(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testSetTRangeSelf(INITIAL_SIZE / 2, 0, INITIAL_SIZE / 2);
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testSetTRangeSelfNegative1() {
-        try {
-            wrapper.setT(-1, array, 0, INITIAL_SIZE);
-        } finally {
-            assertUnchanged();
-        }
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testSetTRangeSelfNegative1(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> wrapper.setT(-1, array, 0, INITIAL_SIZE));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testSetTRangeSelfNegative2() {
-        try {
-            wrapper.setT(0, array, -1, INITIAL_SIZE);
-        } finally {
-            assertUnchanged();
-        }
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testSetTRangeSelfNegative2(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> wrapper.setT(0, array, -1, INITIAL_SIZE));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testSetTRangeSelfNegative3() {
-        try {
-            wrapper.setT(0, array, 0, INITIAL_SIZE + 1);
-        } finally {
-            assertUnchanged();
-        }
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testSetTRangeSelfNegative3(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> wrapper.setT(0, array, 0, INITIAL_SIZE + 1));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testSetTRangeSelfNegative4() {
-        try {
-            wrapper.setT(0, array, 1, -1);
-        } finally {
-            assertUnchanged();
-        }
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testSetTRangeSelfNegative4(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> wrapper.setT(0, array, 1, -1));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testSetTRangeSelfNegative5() {
-        try {
-            wrapper.setT(INITIAL_SIZE, array, 0, 1);
-        } finally {
-            assertUnchanged();
-        }
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testSetTRangeSelfNegative5(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> wrapper.setT(INITIAL_SIZE, array, 0, 1));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testSetTRangeSelfNegative6() {
-        try {
-            wrapper.setT(0, array, INITIAL_SIZE, 1);
-        } finally {
-            assertUnchanged();
-        }
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testSetTRangeSelfNegative6(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> wrapper.setT(0, array, INITIAL_SIZE, 1));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testSetTRangeSelfNegativeAfterEnsureCapacity() {
-        try {
-            array.ensureCapacity(INITIAL_SIZE * 2);
-
-            wrapper.setT(0, array, INITIAL_SIZE, 1);
-        } finally {
-            assertUnchanged();
-        }
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testSetTRangeSelfNegativeAfterEnsureCapacity(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        array.ensureCapacity(INITIAL_SIZE * 2);
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> wrapper.setT(0, array, INITIAL_SIZE, 1));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testSetTRangeSelfNegativeAfterClear() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testSetTRangeSelfNegativeAfterClear(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         makeEmpty();
-        try {
-            wrapper.setT(0, array, 0, 1);
-        } finally {
-            assertUnchanged();
-        }
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> wrapper.setT(0, array, 0, 1));
+        assertUnchanged();
     }
 
 
-    // ========== negative get(index) tests ==========
-
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testGetNegative() {
-        try {
-            wrapper.get(-1);
-        } finally {
-            assertUnchanged();
-        }
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testGetNegative(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> wrapper.get(-1));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testGetOutOfBounds() {
-        try {
-            wrapper.get(array.size());
-        } finally {
-            assertUnchanged();
-        }
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testGetOutOfBounds(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> wrapper.get(array.size()));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testGetAfterEnsureCapacity() {
-        try {
-            array.ensureCapacity(INITIAL_SIZE * 2);
-            wrapper.get(INITIAL_SIZE);
-        } finally {
-            assertUnchanged();
-        }
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testGetAfterEnsureCapacity(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        array.ensureCapacity(INITIAL_SIZE * 2);
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> wrapper.get(INITIAL_SIZE));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testGetAfterClear() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testGetAfterClear(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         makeEmpty();
-        try {
-            wrapper.get(0);
-        } finally {
-            assertUnchanged();
-        }
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> wrapper.get(0));
+        assertUnchanged();
     }
 
-    // ================== set(index) tests ===============
-
-    @Test public void testSetValue() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetValue(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         for (int i = 0; i < INITIAL_SIZE; i++) {
             Object expected = wrapper.getNextValue();
 
@@ -1947,42 +2534,42 @@ public class ObservableArrayTest  {
         }
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testSetValueNegative() {
-        try {
-            wrapper.set(-1, wrapper.getNextValue());
-        } finally {
-            assertUnchanged();
-        }
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testSetValueNegative(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> wrapper.set(-1, wrapper.getNextValue()));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testSetValueOutOfBounds() {
-        try {
-            wrapper.set(INITIAL_SIZE, wrapper.getNextValue());
-        } finally {
-            assertUnchanged();
-        }
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testSetValueOutOfBounds(ArrayWrapper arrayWrapper) throws Exception  {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> wrapper.set(INITIAL_SIZE, wrapper.getNextValue()));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testSetValueNegativeAfterClear() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testSetValueNegativeAfterClear(ArrayWrapper arrayWrapper) throws Exception  {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         makeEmpty();
-        try {
-            wrapper.set(0, wrapper.getNextValue());
-        } finally {
-            assertUnchanged();
-        }
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> wrapper.set(0, wrapper.getNextValue()));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testSetValueNegativeAfterEnsureCapacity() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testSetValueNegativeAfterEnsureCapacity(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         array.ensureCapacity(INITIAL_SIZE * 2);
-        try {
-            wrapper.set(INITIAL_SIZE, wrapper.getNextValue());
-        } finally {
-            assertUnchanged();
-        }
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> wrapper.set(INITIAL_SIZE, wrapper.getNextValue()));
+        assertUnchanged();
     }
 
     // ================= toArray(array) tests ======================
@@ -2000,24 +2587,44 @@ public class ObservableArrayTest  {
         wrapper.assertElementsEqual(actual, 0, array.size(), wrapper.toArray(null), 0);
     }
 
-    @Test public void testToArraySameSize() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testToArraySameSize(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testToArray(array.size(), true);
     }
 
-    @Test public void testToArraySmaller() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testToArraySmaller(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testToArray(3, false);
     }
 
-    @Test public void testToArrayBigger() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testToArrayBigger(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testToArray(10, true);
     }
 
-    @Test public void testToArrayEmpty() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testToArrayEmpty(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         makeEmpty();
         testToArray(10, true);
     }
 
-    @Test public void testToArrayEmptyToEmpty() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testToArrayEmptyToEmpty(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         makeEmpty();
         testToArray(0, true);
     }
@@ -2034,102 +2641,142 @@ public class ObservableArrayTest  {
         wrapper.assertElementsEqual(actual, length, wrapper.arrayLength(actual), initial, length);
     }
 
-    @Test public void testToArrayRange0() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testToArrayRange0(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testToArrayRange(0, array.size(), array.size());
     }
 
-    @Test public void testToArrayRange1() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testToArrayRange1(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testToArrayRange(3, array.size(), array.size() - 3);
     }
 
-    @Test public void testToArrayRange2() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testToArrayRange2(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testToArrayRange(0, array.size(), array.size() - 3);
     }
 
-    @Test public void testToArrayRange3() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testToArrayRange3(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testToArrayRange(2, array.size(), 2);
     }
 
-    @Test public void testToArrayRange4() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testToArrayRange4(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testToArrayRange(2, 0, 0);
     }
 
-    @Test public void testToArrayRange5() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testToArrayRange5(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         makeEmpty();
         testToArrayRange(0, 0, 0);
     }
 
-    @Test public void testToArrayRange6() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testToArrayRange6(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testToArrayRange(3, 2, 2);
     }
 
-    @Test public void testToArrayRange7() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testToArrayRange7(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testToArrayRange(5, 1, 1);
     }
 
-    @Test public void testToArrayRange8() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testToArrayRange8(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testToArrayRange(0, array.size() * 2, array.size());
     }
 
-    @Test public void testToArrayRange9() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testToArrayRange9(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testToArrayRange(0, array.size() - 1, array.size());
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testToArrayRangeNegative1() {
-        try {
-            testToArrayRange(-1, array.size(), 2);
-        } finally {
-            assertUnchanged();
-        }
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testToArrayRangeNegative1(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> testToArrayRange(-1, array.size(), 2));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testToArrayRangeNegative2() {
-        try {
-            testToArrayRange(array.size(), array.size(), 2);
-        } finally {
-            assertUnchanged();
-        }
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testToArrayRangeNegative2(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> testToArrayRange(array.size(), array.size(), 2));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testToArrayRangeNegative3() {
-        try {
-            testToArrayRange(5, array.size(), array.size() + 1);
-        } finally {
-            assertUnchanged();
-        }
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testToArrayRangeNegative3(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> testToArrayRange(5, array.size(), array.size() + 1));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testToArrayRangeNegative5() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testToArrayRangeNegative5(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         makeEmpty();
-        try {
-            testToArrayRange(2, 0, 0);
-        } finally {
-            assertUnchanged();
-        }
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> testToArrayRange(2, 0, 0));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testToArrayRangeNegativeAfterEnsureCapacity() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testToArrayRangeNegativeAfterEnsureCapacity(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         array.ensureCapacity(INITIAL_SIZE * 2);
-        try {
-            testToArrayRange(INITIAL_SIZE, 1, 1);
-        } finally {
-            assertUnchanged();
-        }
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> testToArrayRange(INITIAL_SIZE, 1, 1));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testToArrayRangeNegativeAfterClear() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testToArrayRangeNegativeAfterClear(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         makeEmpty();
-        try {
-            testToArrayRange(0, 1, 1);
-        } finally {
-            assertUnchanged();
-        }
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> testToArrayRange(0, 1, 1));
+        assertUnchanged();
     }
 
     // ============ copyTo(primitive array) tests =========================
@@ -2145,140 +2792,178 @@ public class ObservableArrayTest  {
         wrapper.assertElementsEqual(actual, destIndex + length, wrapper.arrayLength(actual), initial, destIndex + length);
     }
 
-    @Test public void testCopyToA0() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testCopyToA0(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testCopyToA(0, array.size(), 0, array.size());
     }
 
-    @Test public void testCopyToA1() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testCopyToA1(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testCopyToA(1, array.size(), 2, 3);
     }
 
-    @Test public void testCopyToA2() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testCopyToA2(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testCopyToA(2, array.size(), 2, 2);
     }
 
-    @Test public void testCopyToA3() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testCopyToA3(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testCopyToA(0, array.size(), 2, 2);
     }
 
-    @Test public void testCopyToA4() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testCopyToA4(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testCopyToA(0, 3, 1, 2);
     }
 
-    @Test public void testCopyToA5() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testCopyToA5(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testCopyToA(0, array.size() * 3, array.size() * 2, array.size());
     }
 
-    @Test public void testCopyToA6() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testCopyToA6(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testCopyToA(3, array.size(), 0, array.size() - 3);
     }
 
-    @Test public void testCopyToA7() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testCopyToA7(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testCopyToA(0, 10, 7, 3);
     }
 
-    @Test public void testCopyToA8() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testCopyToA8(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testCopyToA(1, 0, 0, 0);
     }
 
-    @Test public void testCopyToA9() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testCopyToA9(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         makeEmpty();
         testCopyToA(0, 0, 0, 0);
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testCopyToANegative1() {
-        try {
-            testCopyToA(-1, array.size(), 0, array.size());
-        } finally {
-            assertUnchanged();
-        }
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testCopyToANegative1(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> testCopyToA(-1, array.size(), 0, array.size()));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testCopyToANegative2() {
-        try {
-            testCopyToA(0, array.size() / 2, 0, array.size());
-        } finally {
-            assertUnchanged();
-        }
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testCopyToANegative2(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> testCopyToA(0, array.size() / 2, 0, array.size()));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testCopyToANegative3() {
-        try {
-            testCopyToA(array.size(), array.size(), 0, array.size());
-        } finally {
-            assertUnchanged();
-        }
-
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testCopyToANegative3(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> testCopyToA(array.size(), array.size(), 0, array.size()));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testCopyToANegative4() {
-        try {
-            testCopyToA(0, array.size(), -1, array.size());
-        } finally {
-            assertUnchanged();
-        }
-
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testCopyToANegative4(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> testCopyToA(0, array.size(), -1, array.size()));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testCopyToANegative5() {
-        try {
-            testCopyToA(0, array.size(), array.size(), array.size());
-        } finally {
-            assertUnchanged();
-        }
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testCopyToANegative5(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> testCopyToA(0, array.size(), array.size(), array.size()));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testCopyToANegative6() {
-        try {
-            testCopyToA(0, array.size(), 0, array.size() * 2);
-        } finally {
-            assertUnchanged();
-        }
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testCopyToANegative6(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> testCopyToA(0, array.size(), 0, array.size() * 2));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testCopyToANegative7() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testCopyToANegative7(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         makeEmpty();
-        try {
-            testCopyToA(1, 0, 0, 0);
-        } finally {
-            assertUnchanged();
-        }
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> testCopyToA(1, 0, 0, 0));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testCopyToANegative8() {
-        try {
-            testCopyToA(0, 0, 1, 0);
-        } finally {
-            assertUnchanged();
-        }
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testCopyToANegative8(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> testCopyToA(0, 0, 1, 0));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testCopyToANegativeAfterEnsureCapacity() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testCopyToANegativeAfterEnsureCapacity(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         array.ensureCapacity(INITIAL_SIZE * 2);
-        try {
-            testCopyToA(INITIAL_SIZE, 1, 0, 1);
-        } finally {
-            assertUnchanged();
-        }
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> testCopyToA(INITIAL_SIZE, 1, 0, 1));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testCopyToANegativeAfterClear() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testCopyToANegativeAfterClear(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         makeEmpty();
-        try {
-            testCopyToA(0, 1, 0, 1);
-        } finally {
-            assertUnchanged();
-        }
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> testCopyToA(0, 1, 0, 1));
+        assertUnchanged();
     }
 
     // ============ copyTo(ObservableArray) tests =========================
@@ -2298,168 +2983,206 @@ public class ObservableArrayTest  {
         wrapper.assertElementsEqual(actual, destIndex + length, wrapper.arrayLength(actual), initial, destIndex + length);
     }
 
-    @Test public void testCopyToT0() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testCopyToT0(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testCopyToT(0, array.size(), 0, array.size());
     }
 
-    @Test public void testCopyToT1() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testCopyToT1(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testCopyToT(1, array.size(), 2, 3);
     }
 
-    @Test public void testCopyToT2() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testCopyToT2(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testCopyToT(2, array.size(), 2, 2);
     }
 
-    @Test public void testCopyToT3() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testCopyToT3(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testCopyToT(0, array.size(), 2, 2);
     }
 
-    @Test public void testCopyToT4() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testCopyToT4(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testCopyToT(0, 3, 1, 2);
     }
 
-    @Test public void testCopyToT5() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testCopyToT5(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testCopyToT(0, array.size() * 3, array.size() * 2, array.size());
     }
 
-    @Test public void testCopyToT6() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testCopyToT6(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testCopyToT(3, array.size(), 0, array.size() - 3);
     }
 
-    @Test public void testCopyToT7() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testCopyToT7(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testCopyToT(0, 10, 7, 3);
     }
 
-    @Test public void testCopyToT8() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testCopyToT8(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testCopyToT(1, 0, 0, 0);
     }
 
-    @Test public void testCopyToT9() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testCopyToT9(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         makeEmpty();
         testCopyToT(0, 0, 0, 0);
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testCopyToTNegative1() {
-        try {
-            testCopyToT(-1, array.size(), 0, array.size());
-        } finally {
-            assertUnchanged();
-        }
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testCopyToTNegative1(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> testCopyToT(-1, array.size(), 0, array.size()));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testCopyToTNegative2() {
-        try {
-            testCopyToT(0, array.size() / 2, 0, array.size());
-        } finally {
-            assertUnchanged();
-        }
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testCopyToTNegative2(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> testCopyToT(0, array.size() / 2, 0, array.size()));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testCopyToTNegative3() {
-        try {
-            testCopyToT(array.size(), array.size(), 0, array.size());
-        } finally {
-            assertUnchanged();
-        }
-
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testCopyToTNegative3(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> testCopyToT(array.size(), array.size(), 0, array.size()));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testCopyToTNegative4() {
-        try {
-            testCopyToT(0, array.size(), -1, array.size());
-        } finally {
-            assertUnchanged();
-        }
-
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testCopyToTNegative4(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> testCopyToT(0, array.size(), -1, array.size()));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testCopyToTNegative5() {
-        try {
-            testCopyToT(0, array.size(), array.size(), array.size());
-        } finally {
-            assertUnchanged();
-        }
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testCopyToTNegative5(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> testCopyToT(0, array.size(), array.size(), array.size()));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testCopyToTNegative6() {
-        try {
-            testCopyToT(0, array.size(), 0, array.size() * 2);
-        } finally {
-            assertUnchanged();
-        }
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testCopyToTNegative6(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> testCopyToT(0, array.size(), 0, array.size() * 2));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testCopyToTNegative7() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testCopyToTNegative7(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         makeEmpty();
-        try {
-            testCopyToT(1, 0, 0, 0);
-        } finally {
-            assertUnchanged();
-        }
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> testCopyToT(1, 0, 0, 0));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testCopyToTNegative8() {
-        try {
-            testCopyToT(0, 0, 1, 0);
-        } finally {
-            assertUnchanged();
-        }
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testCopyToTNegative8(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> testCopyToT(0, 0, 1, 0));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testCopyToTNegativeAfterEnsureCapacity() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testCopyToTNegativeAfterEnsureCapacity(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         array.ensureCapacity(INITIAL_SIZE * 2);
-        try {
-            testCopyToT(INITIAL_SIZE, 1, 0, 1);
-        } finally {
-            assertUnchanged();
-        }
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> testCopyToT(INITIAL_SIZE, 1, 0, 1));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testCopyToTNegativeAfterClear() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testCopyToTNegativeAfterClear(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         makeEmpty();
-        try {
-            testCopyToT(0, 1, 0, 1);
-        } finally {
-            assertUnchanged();
-        }
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> testCopyToT(0, 1, 0, 1));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testCopyToTNegativeAfterDestEnsureCapacity() {
-        try {
-            ArrayWrapper wrapper2 = wrapper.newInstance();
-            Object destA = wrapper2.createPrimitiveArray(1);
-            ObservableArray dest = wrapper2.createNotEmptyArray(destA);
-            dest.ensureCapacity(2);
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testCopyToTNegativeAfterDestEnsureCapacity(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        ArrayWrapper wrapper2 = wrapper.newInstance();
+        Object destA = wrapper2.createPrimitiveArray(1);
+        ObservableArray dest = wrapper2.createNotEmptyArray(destA);
+        dest.ensureCapacity(2);
 
-            wrapper.copyToT(0, dest, 1, 1);
-        } finally {
-            assertUnchanged();
-        }
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> wrapper.copyToT(0, dest, 1, 1));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testCopyToTNegativeAfterDestClear() {
-        try {
-            ArrayWrapper wrapper2 = wrapper.newInstance();
-            Object destA = wrapper2.createPrimitiveArray(1);
-            ObservableArray dest = wrapper2.createNotEmptyArray(destA);
-            dest.clear();
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testCopyToTNegativeAfterDestClear(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        ArrayWrapper wrapper2 = wrapper.newInstance();
+        Object destA = wrapper2.createPrimitiveArray(1);
+        ObservableArray dest = wrapper2.createNotEmptyArray(destA);
+        dest.clear();
 
-            wrapper.copyToT(0, dest, 0, 1);
-        } finally {
-            assertUnchanged();
-        }
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> wrapper.copyToT(0, dest, 0, 1));
+        assertUnchanged();
     }
 
     private void testCopyToTSelf(int srcIndex, int destIndex, int length) {
@@ -2473,123 +3196,155 @@ public class ObservableArrayTest  {
         wrapper.assertElementsEqual(actual, destIndex + length, initialSize, initialElements, destIndex + length);
     }
 
-    @Test public void testCopyToTSelf() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testCopyToTSelf(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testCopyToTSelf(0, 0, INITIAL_SIZE);
     }
 
-    @Test public void testCopyToTSelfRight() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testCopyToTSelfRight(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testCopyToTSelf(0, 1, INITIAL_SIZE - 1);
     }
 
-    @Test public void testCopyToTSelfLeft() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testCopyToTSelfLeft(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testCopyToTSelf(1, 0, INITIAL_SIZE - 1);
     }
 
-    @Test public void testCopyToTSelfRightDifferentParts() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testCopyToTSelfRightDifferentParts(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testCopyToTSelf(0, INITIAL_SIZE / 2, INITIAL_SIZE / 2);
     }
 
-    @Test public void testCopyToTSelfLeftDifferentParts() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testCopyToTSelfLeftDifferentParts(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         testCopyToTSelf(INITIAL_SIZE / 2, 0, INITIAL_SIZE / 2);
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testCopyToTSelfNegative1() {
-        try {
-            testCopyToTSelf(-1, 0, INITIAL_SIZE);
-        } finally {
-            assertUnchanged();
-        }
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testCopyToTSelfNegative1(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> testCopyToTSelf(-1, 0, INITIAL_SIZE));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testCopyToTSelfNegative2() {
-        try {
-            testCopyToTSelf(INITIAL_SIZE, 0, 1);
-        } finally {
-            assertUnchanged();
-        }
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testCopyToTSelfNegative2(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> testCopyToTSelf(INITIAL_SIZE, 0, 1));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testCopyToTSelfNegative3() {
-        try {
-            testCopyToTSelf(0, -1, INITIAL_SIZE);
-        } finally {
-            assertUnchanged();
-        }
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testCopyToTSelfNegative3(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> testCopyToTSelf(0, -1, INITIAL_SIZE));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testCopyToTSelfNegative4() {
-        try {
-            testCopyToTSelf(0, INITIAL_SIZE, 1);
-        } finally {
-            assertUnchanged();
-        }
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testCopyToTSelfNegative4(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> testCopyToTSelf(0, INITIAL_SIZE, 1));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testCopyToTSelfNegative5() {
-        try {
-            testCopyToTSelf(1, 1, -1);
-        } finally {
-            assertUnchanged();
-        }
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testCopyToTSelfNegative5(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> testCopyToTSelf(1, 1, -1));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testCopyToTSelfNegative6() {
-        try {
-            testCopyToTSelf(0, 1, INITIAL_SIZE);
-        } finally {
-            assertUnchanged();
-        }
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testCopyToTSelfNegative6(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> testCopyToTSelf(0, 1, INITIAL_SIZE));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testCopyToTSelfNegative7() {
-        try {
-            testCopyToTSelf(1, 0, INITIAL_SIZE);
-        } finally {
-            assertUnchanged();
-        }
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testCopyToTSelfNegative7(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> testCopyToTSelf(1, 0, INITIAL_SIZE));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testCopyToTSelfNegativeAfterEnsureCapacity() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testCopyToTSelfNegativeAfterEnsureCapacity(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         array.ensureCapacity(INITIAL_SIZE * 2);
-        try {
-            testCopyToTSelf(0, INITIAL_SIZE, 1);
-        } finally {
-            assertUnchanged();
-        }
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> testCopyToTSelf(0, INITIAL_SIZE, 1));
+        assertUnchanged();
     }
 
-    @Test (expected = ArrayIndexOutOfBoundsException.class)
-    public void testCopyToTSelfNegativeAfterClear() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testCopyToTSelfNegativeAfterClear(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         makeEmpty();
-        try {
-            testCopyToTSelf(0, 0, 1);
-        } finally {
-            assertUnchanged();
-        }
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> testCopyToTSelf(0, 0, 1));
+        assertUnchanged();
     }
 
     // ============ ensureCapacity() and trimToSize() tests ====================
 
-    @Test public void testTrimToSize() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testTrimToSize(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         array.trimToSize();
         assertUnchanged();
     }
 
-    @Test public void testTrimToSizeEmpty() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testTrimToSizeEmpty(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         makeEmpty();
         array.trimToSize();
         assertUnchanged();
     }
 
-    @Test public void testTrimToSizeResize() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testTrimToSizeResize(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         array.resize(3);
         initialSize = 3;
         mao.reset();
@@ -2599,7 +3354,11 @@ public class ObservableArrayTest  {
         assertUnchanged();
     }
 
-    @Test public void testTrimToSizeAddRemove() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testTrimToSizeAddRemove(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         array.resize(1000);
         array.resize(INITIAL_SIZE);
         mao.reset();
@@ -2609,50 +3368,86 @@ public class ObservableArrayTest  {
         assertUnchanged();
     }
 
-    @Test public void testEnsureCapacity0() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testEnsureCapacity0(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         array.ensureCapacity(0);
         assertUnchanged();
     }
 
-    @Test public void testEnsureCapacityBy1() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testEnsureCapacityBy1(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         array.ensureCapacity(INITIAL_SIZE + 1);
         assertUnchanged();
     }
 
-    @Test public void testEnsureCapacity1000() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testEnsureCapacity1000(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         array.ensureCapacity(1000);
         assertUnchanged();
     }
 
-    @Test public void testEnsureCapacitySmaller() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testEnsureCapacitySmaller(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         array.ensureCapacity(INITIAL_SIZE / 2);
         assertUnchanged();
     }
 
-    @Test public void testEnsureCapacityNegative() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testEnsureCapacityNegative(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         array.ensureCapacity(-1000);
         assertUnchanged();
     }
 
-    @Test public void testEnsureCapacityOnEmpty() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testEnsureCapacityOnEmpty(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         makeEmpty();
         array.ensureCapacity(100);
         assertUnchanged();
     }
 
-    @Test public void testEnsureCapacityOnEmpty0() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testEnsureCapacityOnEmpty0(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         makeEmpty();
         array.ensureCapacity(0);
         assertUnchanged();
     }
 
-    @Test public void testEnsureCapacityOnEmptyNegative() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testEnsureCapacityOnEmptyNegative(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         makeEmpty();
         array.ensureCapacity(-1);
         assertUnchanged();
     }
 
-    @Test public void testTrimToSizeEnsureCapacity() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testTrimToSizeEnsureCapacity(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         array.ensureCapacity(1000);
         array.trimToSize();
         assertUnchanged();
@@ -2660,14 +3455,22 @@ public class ObservableArrayTest  {
 
     // ================= clear() tests ====================
 
-    @Test public void testClearEmpty() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testClearEmpty(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         makeEmpty();
         array.clear();
         mao.check0();
         assertEquals(0, array.size());
     }
 
-    @Test public void testClear1000() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testClear1000(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         array.resize(1000);
         mao.reset();
 
@@ -2679,26 +3482,38 @@ public class ObservableArrayTest  {
 
     // ================= toString() tests ===================
 
-    @Test public void testToString() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testToString(ArrayWrapper arrayWrapper) throws Exception{
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         String actual = array.toString();
         String expected = wrapper.primitiveArrayToString(wrapper.toArray(null));
         assertEquals(expected, actual);
         String regex = "\\[[0-9]+(\\.[0-9]+){0,1}(\\, [0-9]+(.[0-9]+){0,1}){" + (initialSize - 1) + "}\\]";
-        assertTrue("toString() output matches to regex '" + regex + "'. Actual = '" + actual + "'",
-                actual.matches(regex));
+        assertTrue(actual.matches(regex),
+                () -> "toString() output matches regex '" + regex + "'. Actual = '" + actual + "'");
     }
 
-    @Test public void testToStringAfterResize() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testToStringAfterResize(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         array.resize(initialSize / 2);
         String actual = array.toString();
         String expected = wrapper.primitiveArrayToString(wrapper.toArray(null));
         assertEquals(expected, actual);
         String regex = "\\[[0-9]+(\\.[0-9]+){0,1}(\\, [0-9]+(.[0-9]+){0,1}){" + (array.size() - 1) + "}\\]";
-        assertTrue("toString() output matches to regex '" + regex + "'. Actual = '" + actual + "'",
-                actual.matches(regex));
+        assertTrue(actual.matches(regex),
+                () -> "toString() output does not match regex '" + regex + "'. Actual = '" + actual + "'");
     }
 
-    @Test public void testToStringAfterClear() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testToStringAfterClear(ArrayWrapper arrayWrapper) throws Exception {
+        ObservableArrayTest_(arrayWrapper);
+        setUp();
         array.clear();
         String actual = array.toString();
         assertEquals("[]", actual);

--- a/modules/javafx.base/src/test/java/test/javafx/collections/ObservableListEmptyTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/collections/ObservableListEmptyTest.java
@@ -27,33 +27,31 @@ package test.javafx.collections;
 
 import java.util.Arrays;
 import java.util.Collection;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.List;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Tests for initially empty ObservableList.
  */
-@RunWith(Parameterized.class)
 public class ObservableListEmptyTest {
 
-    static final List<String> EMPTY = Collections.emptyList();
-    final Callable<ObservableList<String>> listFactory;
+    static List<String> EMPTY = Collections.emptyList();
+    Callable<ObservableList<String>> listFactory;
     ObservableList<String> list;
     MockListObserver<String> mlo;
 
 
-    public ObservableListEmptyTest(final Callable<ObservableList<String>> listFactory) {
+    public void ObservableListEmptyTest_(Callable<ObservableList<String>> listFactory) {
         this.listFactory = listFactory;
     }
 
-    @Parameterized.Parameters
     public static Collection createParameters() {
         Object[][] data = new Object[][] {
             { TestedObservableLists.ARRAY_LIST },
@@ -65,15 +63,17 @@ public class ObservableListEmptyTest {
         return Arrays.asList(data);
     }
 
-    @Before
     public void setUp() throws Exception {
         list = listFactory.call();
         mlo = new MockListObserver<>();
         list.addListener(mlo);
     }
 
-    @Test
-    public void testClearEmpty() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testClearEmpty(Callable<ObservableList<String>> listFactory) throws Exception {
+        ObservableListEmptyTest_(listFactory);
+        setUp();
         list = FXCollections.observableList(EMPTY);
         list.addListener(mlo);
         list.clear();

--- a/modules/javafx.base/src/test/java/test/javafx/collections/ObservableListIteratorTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/collections/ObservableListIteratorTest.java
@@ -25,46 +25,42 @@
 
 package test.javafx.collections;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.Test;
 
 import java.util.*;
 
-import static org.junit.Assert.*;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.Arguments;
+import java.util.stream.Stream;
 
 
 /**
  * Tests for iterators of ObservableList.
  *
  */
-@RunWith(Parameterized.class)
 public class ObservableListIteratorTest {
 
     // ========== Test Fixture ==========
-    final Callable<? extends List<String>> listFactory;
+    protected Callable<? extends List<String>> listFactory;
     List<String> list;
     ListIterator<String> iter;
 
-    public ObservableListIteratorTest(final Callable<? extends List<String>> listFactory) {
-        this.listFactory = listFactory;
+
+    public static Stream<Arguments> createParameters() {
+        return Stream.of(
+                Arguments.of(TestedObservableLists.ARRAY_LIST),
+                Arguments.of(TestedObservableLists.LINKED_LIST),
+                Arguments.of(TestedObservableLists.VETOABLE_LIST),
+                Arguments.of(TestedObservableLists.CHECKED_OBSERVABLE_ARRAY_LIST),
+                Arguments.of(TestedObservableLists.SYNCHRONIZED_OBSERVABLE_ARRAY_LIST)
+        );
     }
 
-    @Parameterized.Parameters
-    public static Collection createParameters() {
-        Object[][] data = new Object[][] {
-            { TestedObservableLists.ARRAY_LIST },
-            { TestedObservableLists.LINKED_LIST },
-            { TestedObservableLists.VETOABLE_LIST },
-            { TestedObservableLists.CHECKED_OBSERVABLE_ARRAY_LIST },
-            { TestedObservableLists.SYNCHRONIZED_OBSERVABLE_ARRAY_LIST }
-         };
-        return Arrays.asList(data);
-    }
-
-    @Before
-    public void setup() throws Exception {
+    private void setup(Callable<? extends List<String>> listFactory) throws Exception {
         list = listFactory.call();
         list.addAll(Arrays.asList("a", "b", "c", "d", "e", "f"));
         iter = list.listIterator();
@@ -105,21 +101,27 @@ public class ObservableListIteratorTest {
 
     // ========== Basic Tests ==========
 
-    @Test
-    public void testCompleteIteration() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testCompleteIteration(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         assertEquals("[a, b, c, d, e, f]", copyOut(iter).toString());
     }
 
-    @Test
-    public void testBeginningState() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testBeginningState(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         assertTrue(iter.hasNext());
         assertFalse(iter.hasPrevious());
         assertEquals(-1, iter.previousIndex());
         assertEquals(0, iter.nextIndex());
     }
 
-    @Test
-    public void testMiddleState() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testMiddleState(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         advance(iter, 3);
         assertTrue(iter.hasNext());
         assertTrue(iter.hasPrevious());
@@ -127,8 +129,10 @@ public class ObservableListIteratorTest {
         assertEquals(3, iter.nextIndex());
     }
 
-    @Test
-    public void testEndState() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testEndState(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         toEnd(iter);
         assertFalse(iter.hasNext());
         assertTrue(iter.hasPrevious());
@@ -136,8 +140,10 @@ public class ObservableListIteratorTest {
         assertEquals(6, iter.nextIndex());
     }
 
-    @Test
-    public void testSwitchDirections() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSwitchDirections(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         advance(iter, 2);
         assertEquals("c", iter.next());
         assertEquals("d", iter.next());
@@ -146,19 +152,25 @@ public class ObservableListIteratorTest {
         assertEquals("c", iter.next());
     }
 
-    @Test(expected = NoSuchElementException.class)
-    public void testBoundaryStart() {
-        iter.previous();
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testBoundaryStart(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
+        assertThrows(NoSuchElementException.class, () -> iter.previous());
     }
 
-    @Test(expected = NoSuchElementException.class)
-    public void testBoundaryEnd() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testBoundaryEnd(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         advance(iter, 6);
-        iter.next();
+        assertThrows(NoSuchElementException.class, () -> iter.next());
     }
 
-    @Test
-    public void testForEachLoop() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testForEachLoop(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         List<String> output = new ArrayList<>();
         for (String s : list) {
             output.add(s);
@@ -168,8 +180,10 @@ public class ObservableListIteratorTest {
 
     // ========== Add Tests ==========
 
-    @Test
-    public void testAddBeginning() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testAddBeginning(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         iter.add("X");
 
         assertEquals(0, iter.previousIndex());
@@ -178,8 +192,10 @@ public class ObservableListIteratorTest {
         assertEquals("[X, a, b, c, d, e, f]", list.toString());
     }
 
-    @Test
-    public void testAddMiddle() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testAddMiddle(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         advance(iter, 3);
         iter.add("X");
 
@@ -189,8 +205,10 @@ public class ObservableListIteratorTest {
         assertEquals("[a, b, c, X, d, e, f]", list.toString());
     }
 
-    @Test
-    public void testAddEnd() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testAddEnd(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         advance(iter, 6);
         iter.add("X");
 
@@ -200,8 +218,10 @@ public class ObservableListIteratorTest {
         assertEquals("[a, b, c, d, e, f, X]", list.toString());
     }
 
-    @Test
-    public void testPreviousAfterAddBeginning() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testPreviousAfterAddBeginning(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         iter.add("X");
         assertEquals("X", iter.previous());
         assertEquals(-1, iter.previousIndex());
@@ -209,8 +229,10 @@ public class ObservableListIteratorTest {
         assertEquals("[X, a, b, c, d, e, f]", list.toString());
     }
 
-    @Test
-    public void testPreviousAfterAddMiddle() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testPreviousAfterAddMiddle(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         advance(iter, 3);
         iter.add("X");
         assertEquals("X", iter.previous());
@@ -219,8 +241,10 @@ public class ObservableListIteratorTest {
         assertEquals("[a, b, c, X, d, e, f]", list.toString());
     }
 
-    @Test
-    public void testPreviousAfterAddEnd() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testPreviousAfterAddEnd(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         advance(iter, 6);
         iter.add("X");
         assertEquals("X", iter.previous());
@@ -229,8 +253,10 @@ public class ObservableListIteratorTest {
         assertEquals("[a, b, c, d, e, f, X]", list.toString());
     }
 
-    @Test
-    public void testAddMultiple() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testAddMultiple(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         advance(iter, 3);
         iter.add("X");
         iter.add("Y");
@@ -243,8 +269,10 @@ public class ObservableListIteratorTest {
         assertEquals("[a, b, c, X, Y, Z, d, e, f]", list.toString());
     }
 
-    @Test
-    public void testAddAfterPrevious() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testAddAfterPrevious(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         advance(iter, 3);
         iter.previous(); // c
         iter.add("X");
@@ -253,8 +281,10 @@ public class ObservableListIteratorTest {
         assertEquals("[a, b, X, c, d, e, f]", list.toString());
     }
 
-    @Test
-    public void testAddAfterRemove() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testAddAfterRemove(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         advance(iter, 3);
         iter.remove();
         iter.add("X");
@@ -263,8 +293,10 @@ public class ObservableListIteratorTest {
         assertEquals("[a, b, X, d, e, f]", list.toString());
     }
 
-    @Test
-    public void testAddAfterSet() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testAddAfterSet(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         advance(iter, 3);
         iter.set("X");
         iter.add("Y");
@@ -275,8 +307,10 @@ public class ObservableListIteratorTest {
 
     // ========== Remove Tests ==========
 
-    @Test
-    public void testRemoveBeginning() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testRemoveBeginning(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         iter.next();
         iter.remove();
         assertEquals(-1, iter.previousIndex());
@@ -284,8 +318,10 @@ public class ObservableListIteratorTest {
         assertEquals("[b, c, d, e, f]", list.toString());
     }
 
-    @Test
-    public void testRemoveMiddle() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testRemoveMiddle(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         advance(iter, 3);
         iter.remove();
         assertEquals(1, iter.previousIndex());
@@ -293,8 +329,10 @@ public class ObservableListIteratorTest {
         assertEquals("[a, b, d, e, f]", list.toString());
     }
 
-    @Test
-    public void testRemoveEnd() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testRemoveEnd(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         toEnd(iter);
         iter.remove();
         assertEquals(4, iter.previousIndex());
@@ -302,8 +340,10 @@ public class ObservableListIteratorTest {
         assertEquals("[a, b, c, d, e]", list.toString());
     }
 
-    @Test
-    public void testRemoveAfterPrevious() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testRemoveAfterPrevious(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         advance(iter, 4);
         iter.previous(); // d
         iter.previous(); // c
@@ -313,8 +353,10 @@ public class ObservableListIteratorTest {
         assertEquals("[a, b, d, e, f]", list.toString());
     }
 
-    @Test
-    public void testRemoveAfterSet() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testRemoveAfterSet(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         advance(iter, 3);
         iter.set("X");
         iter.remove();
@@ -323,21 +365,27 @@ public class ObservableListIteratorTest {
         assertEquals("[a, b, d, e, f]", list.toString());
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void testRemoveInitialThrowsException() {
-        iter.remove();
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testRemoveInitialThrowsException(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
+        assertThrows(IllegalStateException.class, () -> iter.remove());
     }
 
-    @Test
-    public void testRemoveTwiceThrowsException() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testRemoveTwiceThrowsException(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         iter.next();
         iter.remove();
         try { iter.remove(); } catch (IllegalStateException e) {return;}
         fail("Expected IllegalStateException");
     }
 
-    @Test
-    public void testRemoveAfterAddThrowsException() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testRemoveAfterAddThrowsException(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         iter.next();
         iter.add("X");
         try { iter.remove(); } catch (IllegalStateException e) {return;}
@@ -346,8 +394,10 @@ public class ObservableListIteratorTest {
 
     // ========== Set Tests ==========
 
-    @Test
-    public void testSetBeginning() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetBeginning(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         iter.next();
         iter.set("X");
         assertEquals(0, iter.previousIndex());
@@ -355,8 +405,10 @@ public class ObservableListIteratorTest {
         assertEquals("[X, b, c, d, e, f]", list.toString());
     }
 
-    @Test
-    public void testSetMiddle() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetMiddle(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         advance(iter, 3);
         iter.set("X");
         assertEquals(2, iter.previousIndex());
@@ -364,8 +416,10 @@ public class ObservableListIteratorTest {
         assertEquals("[a, b, X, d, e, f]", list.toString());
     }
 
-    @Test
-    public void testSetEnd() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetEnd(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         toEnd(iter);
         iter.set("X");
         assertEquals(5, iter.previousIndex());
@@ -373,8 +427,10 @@ public class ObservableListIteratorTest {
         assertEquals("[a, b, c, d, e, X]", list.toString());
     }
 
-    @Test
-    public void testSetTwice() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetTwice(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         advance(iter, 3);
         iter.set("X");
         assertEquals(2, iter.previousIndex());
@@ -386,8 +442,10 @@ public class ObservableListIteratorTest {
         assertEquals("[a, b, Y, d, e, f]", list.toString());
     }
 
-    @Test
-    public void testSetAfterPrevious() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetAfterPrevious(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         advance(iter, 4);
         iter.previous(); // d
         iter.previous(); // c
@@ -397,22 +455,28 @@ public class ObservableListIteratorTest {
         assertEquals("[a, b, X, d, e, f]", list.toString());
     }
 
-    @Test
-    public void testSetInitialThrowsException() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetInitialThrowsException(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         try { iter.set("X"); } catch (IllegalStateException e) {return;}
         fail("Expected IllegalStateException");
     }
 
-    @Test
-    public void testSetAfterAddThrowsException() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetAfterAddThrowsException(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         iter.next();
         iter.add("X");
         try { iter.set("Y"); } catch (IllegalStateException e) {return;}
         fail("Expected IllegalStateException");
     }
 
-    @Test
-    public void testSetAfterRemoveThrowsException() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetAfterRemoveThrowsException(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         iter.next();
         iter.remove();
         try { iter.set("X"); } catch (IllegalStateException e) {return;}
@@ -421,8 +485,10 @@ public class ObservableListIteratorTest {
 
     // ========== Positioned Iterator Tests ==========
 
-    @Test
-    public void testPosBeginning() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testPosBeginning(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         iter = list.listIterator(0);
         assertFalse(iter.hasPrevious());
         assertTrue(iter.hasNext());
@@ -431,8 +497,10 @@ public class ObservableListIteratorTest {
         assertEquals("a", iter.next());
     }
 
-    @Test
-    public void testPosMiddle() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testPosMiddle(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         iter = list.listIterator(3);
         assertTrue(iter.hasPrevious());
         assertTrue(iter.hasNext());
@@ -441,8 +509,10 @@ public class ObservableListIteratorTest {
         assertEquals("d", iter.next());
     }
 
-    @Test
-    public void testPosEnd() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testPosEnd(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         iter = list.listIterator(6);
         assertTrue(iter.hasPrevious());
         assertFalse(iter.hasNext());
@@ -451,8 +521,10 @@ public class ObservableListIteratorTest {
         assertEquals("f", iter.previous());
     }
 
-    @Test
-    public void testPosAdd() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testPosAdd(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         iter = list.listIterator(3);
         iter.add("X");
         assertEquals(3, iter.previousIndex());
@@ -460,15 +532,19 @@ public class ObservableListIteratorTest {
         assertEquals("[a, b, c, X, d, e, f]", list.toString());
     }
 
-    @Test
-    public void testPosInitialRemoveThrowsException() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testPosInitialRemoveThrowsException(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         iter = list.listIterator(3);
         try { iter.remove(); } catch (IllegalStateException e) {return;}
         fail("Expected IllegalStateException");
     }
 
-    @Test
-    public void testPosInitialSetThrowsException() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testPosInitialSetThrowsException(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         iter = list.listIterator(3);
         try { iter.set("X"); } catch (IllegalStateException e) {return;}
         fail("Expected IllegalStateException");
@@ -476,75 +552,99 @@ public class ObservableListIteratorTest {
 
     // ========== Concurrency Tests ==========
 
-    @Test
-    public void testConcurrencyAddIteratorNext() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testConcurrencyAddIteratorNext(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         iter = list.listIterator();
         list.add("aa");
         try { iter.next(); } catch (ConcurrentModificationException e) {return;}
         fail("Expected ConcurrentModificationException");
     }
-    @Test
-    public void testConcurrencyAddIndexedIteratorNext() {
+
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testConcurrencyAddIndexedIteratorNext(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         iter = list.listIterator();
         list.add(1, "aa");
         try { iter.next(); } catch (ConcurrentModificationException e) {return;}
         fail("Expected ConcurrentModificationException");
     }
-    @Test
-    public void testConcurrencyRemoveIteratorNext() {
+
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testConcurrencyRemoveIteratorNext(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         iter = list.listIterator();
         list.remove("b");
         try { iter.next(); } catch (ConcurrentModificationException e) {return;}
         fail("Expected ConcurrentModificationException");
     }
 
-    @Test
-    public void testConcurrencyRemoveIndexedIteratorNext() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testConcurrencyRemoveIndexedIteratorNext(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         iter = list.listIterator();
         list.remove(2);
         try { iter.next(); } catch (ConcurrentModificationException e) {return;}
         fail("Expected ConcurrentModificationException");
     }
-    @Test
-    public void testConcurrencyAddAllIteratorNext() {
+
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testConcurrencyAddAllIteratorNext(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         iter = list.listIterator();
         list.addAll(Collections.singleton("f"));
         try { iter.next(); } catch (ConcurrentModificationException e) {return;}
         fail("Expected ConcurrentModificationException");
     }
-    @Test
-    public void testConcurrencyAddAllIndexedIteratorNext() {
+
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testConcurrencyAddAllIndexedIteratorNext(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         iter = list.listIterator();
         list.addAll(1, Collections.singleton("f"));
         try { iter.next(); } catch (ConcurrentModificationException e) {return;}
         fail("Expected ConcurrentModificationException");
     }
 
-    @Test
-    public void testConcurrencyGetIteratorNext() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testConcurrencyGetIteratorNext(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         iter = list.listIterator();
         list.get(2);
         iter.next();
     }
 
-    @Test
-    public void testConcurrencyRemoveAllIteratorNext() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testConcurrencyRemoveAllIteratorNext(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         iter = list.listIterator();
         list.removeAll(Arrays.asList("a", "c"));
         try { iter.next(); } catch (ConcurrentModificationException e) {return;}
         fail("Expected ConcurrentModificationException");
     }
 
-    @Test
-    public void testConcurrencyRetainAllIteratorNext() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testConcurrencyRetainAllIteratorNext(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         iter = list.listIterator();
         list.retainAll(Arrays.asList("a", "c"));
         try { iter.next(); } catch (ConcurrentModificationException e) {return;}
         fail("Expected ConcurrentModificationException");
     }
 
-    @Test
-    public void testConcurrencyIteratorIteratorNext() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testConcurrencyIteratorIteratorNext(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         iter = list.listIterator();
         final Iterator<String> iterator = list.iterator();
         iterator.next();
@@ -552,75 +652,100 @@ public class ObservableListIteratorTest {
         try { iter.next(); } catch (ConcurrentModificationException e) {return;}
         fail("Expected ConcurrentModificationException");
     }
-    @Test
-    public void testConcurrencyAddIteratorPrevious() {
+
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testConcurrencyAddIteratorPrevious(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         iter = list.listIterator(2);
         list.add("aa");
         try { iter.previous(); } catch (ConcurrentModificationException e) {return;}
         fail("Expected ConcurrentModificationException");
     }
-    @Test
-    public void testConcurrencyAddIndexedIteratorPrevious() {
+
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testConcurrencyAddIndexedIteratorPrevious(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         iter = list.listIterator(2);
         list.add(1, "aa");
         try { iter.previous(); } catch (ConcurrentModificationException e) {return;}
         fail("Expected ConcurrentModificationException");
     }
-    @Test
-    public void testConcurrencyRemoveIteratorPrevious() {
+
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testConcurrencyRemoveIteratorPrevious(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         iter = list.listIterator(2);
         list.remove("b");
         try { iter.previous(); } catch (ConcurrentModificationException e) {return;}
         fail("Expected ConcurrentModificationException");
     }
 
-    @Test
-    public void testConcurrencyRemoveIndexedIteratorPrevious() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testConcurrencyRemoveIndexedIteratorPrevious(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         iter = list.listIterator(2);
         list.remove(2);
         try { iter.previous(); } catch (ConcurrentModificationException e) {return;}
         fail("Expected ConcurrentModificationException");
     }
-    @Test
-    public void testConcurrencyAddAllIteratorPrevious() {
+
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testConcurrencyAddAllIteratorPrevious(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         iter = list.listIterator(2);
         list.addAll(Collections.singleton("f"));
         try { iter.previous(); } catch (ConcurrentModificationException e) {return;}
         fail("Expected ConcurrentModificationException");
     }
-    @Test
-    public void testConcurrencyAddAllIndexedIteratorPrevious() {
+
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testConcurrencyAddAllIndexedIteratorPrevious(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         iter = list.listIterator(2);
         list.addAll(1, Collections.singleton("f"));
         try { iter.previous(); } catch (ConcurrentModificationException e) {return;}
         fail("Expected ConcurrentModificationException");
     }
 
-    @Test
-    public void testConcurrencyGetIteratorPrevious() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testConcurrencyGetIteratorPrevious(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         iter = list.listIterator(2);
         list.get(2);
         iter.previous();
     }
 
-    @Test
-    public void testConcurrencyRemoveAllIteratorPrevious() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testConcurrencyRemoveAllIteratorPrevious(Callable<? extends List<String>> listFactory) throws Exception  {
+        setup(listFactory);
         iter = list.listIterator(2);
         list.removeAll(Arrays.asList("a", "c"));
         try { iter.previous(); } catch (ConcurrentModificationException e) {return;}
         fail("Expected ConcurrentModificationException");
     }
 
-    @Test
-    public void testConcurrencyRetainAllIteratorPrevious() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testConcurrencyRetainAllIteratorPrevious(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         iter = list.listIterator(2);
         list.retainAll(Arrays.asList("a", "c"));
         try { iter.previous(); } catch (ConcurrentModificationException e) {return;}
         fail("Expected ConcurrentModificationException");
     }
 
-    @Test
-    public void testConcurrencyIteratorIteratorPrevious() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testConcurrencyIteratorIteratorPrevious(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         iter = list.listIterator(2);
         final Iterator<String> iterator = list.iterator();
         iterator.next();
@@ -629,8 +754,10 @@ public class ObservableListIteratorTest {
         fail("Expected ConcurrentModificationException");
     }
 
-    @Test
-    public void testConcurrencyAddIteratorRemove() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testConcurrencyAddIteratorRemove(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         iter = list.listIterator();
         iter.next();
         list.add("aa");
@@ -638,8 +765,10 @@ public class ObservableListIteratorTest {
         fail("Expected ConcurrentModificationException");
     }
 
-    @Test
-    public void testConcurrencyAddIndexedIteratorRemove() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testConcurrencyAddIndexedIteratorRemove(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         iter = list.listIterator();
         iter.next();
         list.add(1, "aa");
@@ -647,8 +776,10 @@ public class ObservableListIteratorTest {
         fail("Expected ConcurrentModificationException");
     }
 
-    @Test
-    public void testConcurrencyRemoveIteratorRemove() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testConcurrencyRemoveIteratorRemove(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         iter = list.listIterator();
         iter.next();
         list.remove("b");
@@ -656,24 +787,32 @@ public class ObservableListIteratorTest {
         fail("Expected ConcurrentModificationException");
     }
 
-    @Test
-    public void testConcurrencyRemoveIndexedIteratorRemove() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testConcurrencyRemoveIndexedIteratorRemove(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         iter = list.listIterator();
         iter.next();
         list.remove(2);
         try { iter.remove(); } catch (ConcurrentModificationException e) {return;}
         fail("Expected ConcurrentModificationException");
     }
-    @Test
-    public void testConcurrencyAddAllIteratorRemove() {
+
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testConcurrencyAddAllIteratorRemove(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         iter = list.listIterator();
         iter.next();
         list.addAll(Collections.singleton("f"));
         try { iter.remove(); } catch (ConcurrentModificationException e) {return;}
         fail("Expected ConcurrentModificationException");
     }
-    @Test
-    public void testConcurrencyAddAllIndexedIteratorRemove() {
+
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testConcurrencyAddAllIndexedIteratorRemove(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         iter = list.listIterator();
         iter.next();
         list.addAll(1, Collections.singleton("f"));
@@ -681,16 +820,20 @@ public class ObservableListIteratorTest {
         fail("Expected ConcurrentModificationException");
     }
 
-    @Test
-    public void testConcurrencyGetIteratorRemove() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testConcurrencyGetIteratorRemove(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         iter = list.listIterator();
         iter.next();
         list.get(2);
         iter.remove();
     }
 
-    @Test
-    public void testConcurrencyRemoveAllIteratorRemove() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testConcurrencyRemoveAllIteratorRemove(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         iter = list.listIterator();
         iter.next();
         list.removeAll(Arrays.asList("a", "c"));
@@ -698,8 +841,10 @@ public class ObservableListIteratorTest {
         fail("Expected ConcurrentModificationException");
     }
 
-    @Test
-    public void testConcurrencyRetainAllIteratorRemove() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testConcurrencyRetainAllIteratorRemove(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         iter = list.listIterator();
         iter.next();
         list.retainAll(Arrays.asList("a", "c"));
@@ -707,8 +852,10 @@ public class ObservableListIteratorTest {
         fail("Expected ConcurrentModificationException");
     }
 
-    @Test
-    public void testConcurrencyIteratorIteratorRemove() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testConcurrencyIteratorIteratorRemove(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         iter = list.listIterator();
         iter.next();
         final Iterator<String> iterator = list.iterator();
@@ -718,8 +865,10 @@ public class ObservableListIteratorTest {
         fail("Expected ConcurrentModificationException");
     }
 
-    @Test
-    public void testConcurrencyAddIteratorSet() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testConcurrencyAddIteratorSet(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         iter = list.listIterator();
         iter.next();
         list.add("aa");
@@ -727,8 +876,10 @@ public class ObservableListIteratorTest {
         fail("Expected ConcurrentModificationException");
     }
 
-    @Test
-    public void testConcurrencyAddIndexedIteratorSet() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testConcurrencyAddIndexedIteratorSet(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         iter = list.listIterator();
         iter.next();
         list.add(1, "aa");
@@ -736,8 +887,10 @@ public class ObservableListIteratorTest {
         fail("Expected ConcurrentModificationException");
     }
 
-    @Test
-    public void testConcurrencyRemoveIteratorSet() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testConcurrencyRemoveIteratorSet(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         iter = list.listIterator();
         iter.next();
         list.remove("b");
@@ -745,24 +898,32 @@ public class ObservableListIteratorTest {
         fail("Expected ConcurrentModificationException");
     }
 
-    @Test
-    public void testConcurrencyRemoveIndexedIteratorSet() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testConcurrencyRemoveIndexedIteratorSet(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         iter = list.listIterator();
         iter.next();
         list.remove(2);
         try { iter.set("x"); } catch (ConcurrentModificationException e) {return;}
         fail("Expected ConcurrentModificationException");
     }
-    @Test
-    public void testConcurrencyAddAllIteratorSet() {
+
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testConcurrencyAddAllIteratorSet(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         iter = list.listIterator();
         iter.next();
         list.addAll(Collections.singleton("f"));
         try { iter.set("x"); } catch (ConcurrentModificationException e) {return;}
         fail("Expected ConcurrentModificationException");
     }
-    @Test
-    public void testConcurrencyAddAllIndexedIteratorSet() {
+
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testConcurrencyAddAllIndexedIteratorSet(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         iter = list.listIterator();
         iter.next();
         list.addAll(1, Collections.singleton("f"));
@@ -770,16 +931,20 @@ public class ObservableListIteratorTest {
         fail("Expected ConcurrentModificationException");
     }
 
-    @Test
-    public void testConcurrencyGetIteratorSet() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testConcurrencyGetIteratorSet(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         iter = list.listIterator();
         iter.next();
         list.get(2);
         iter.set("x");
     }
 
-    @Test
-    public void testConcurrencyRemoveAllIteratorSet() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testConcurrencyRemoveAllIteratorSet(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         iter = list.listIterator();
         iter.next();
         list.removeAll(Arrays.asList("a", "c"));
@@ -787,8 +952,10 @@ public class ObservableListIteratorTest {
         fail("Expected ConcurrentModificationException");
     }
 
-    @Test
-    public void testConcurrencyRetainAllIteratorSet() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testConcurrencyRetainAllIteratorSet(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         iter = list.listIterator();
         iter.next();
         list.retainAll(Arrays.asList("a", "c"));
@@ -796,8 +963,10 @@ public class ObservableListIteratorTest {
         fail("Expected ConcurrentModificationException");
     }
 
-    @Test
-    public void testConcurrencyIteratorIteratorSet() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testConcurrencyIteratorIteratorSet(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         iter = list.listIterator();
         iter.next();
         final Iterator<String> iterator = list.iterator();

--- a/modules/javafx.base/src/test/java/test/javafx/collections/ObservableListTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/collections/ObservableListTest.java
@@ -25,8 +25,8 @@
 
 package test.javafx.collections;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -36,29 +36,27 @@ import java.util.List;
 import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
 
-import static org.junit.Assert.*;
-import org.junit.Ignore;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Tests for ObservableList.
  *
  */
-@RunWith(Parameterized.class)
 public class ObservableListTest  {
 
     static final List<String> EMPTY = Collections.emptyList();
-    final Callable<ObservableList<String>> listFactory;
+    Callable<ObservableList<String>> listFactory;
     ObservableList<String> list;
     MockListObserver<String> mlo;
 
 
-    public ObservableListTest(final Callable<ObservableList<String>> listFactory) {
+    public void ObservableListTest_(Callable<ObservableList<String>> listFactory) {
         this.listFactory = listFactory;
     }
 
-    @Parameterized.Parameters
     public static Collection createParameters() {
         Object[][] data = new Object[][] {
             { TestedObservableLists.ARRAY_LIST },
@@ -71,7 +69,6 @@ public class ObservableListTest  {
         return Arrays.asList(data);
     }
 
-    @Before
     public void setUp() throws Exception {
         list = listFactory.call();
         mlo = new MockListObserver<>();
@@ -95,8 +92,11 @@ public class ObservableListTest  {
 
     // ========== observer add/remove tests ==========
 
-    @Test
-    public void testObserverAddRemove() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testObserverAddRemove(Callable<ObservableList<String>> listFactory) throws Exception {
+        ObservableListTest_(listFactory);
+        setUp();
         MockListObserver<String> mlo2 = new MockListObserver<>();
         list.addListener(mlo2);
         list.removeListener(mlo);
@@ -106,15 +106,20 @@ public class ObservableListTest  {
     }
 
     @Test
-    @Ignore
-    public void testObserverAddTwice() {
+    @Disabled
+    public void testObserverAddTwice(Callable<ObservableList<String>> listFactory) throws Exception {
+        ObservableListTest_(listFactory);
+        setUp();
         list.addListener(mlo); // add it a second time
         list.add("plugh");
         mlo.check1AddRemove(list, EMPTY, 3, 4);
     }
 
-    @Test
-    public void testObserverRemoveTwice() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testObserverRemoveTwice(Callable<ObservableList<String>> listFactory) throws Exception {
+        ObservableListTest_(listFactory);
+        setUp();
         list.removeListener(mlo);
         list.removeListener(mlo);
         list.add("plugh");
@@ -123,75 +128,108 @@ public class ObservableListTest  {
 
     // ========== list mutation tests ==========
 
-    @Test
-    public void testAddToEmpty() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testAddToEmpty(Callable<ObservableList<String>> listFactory) throws Exception {
+        ObservableListTest_(listFactory);
+        setUp();
         useListData();
         list.add("asdf");
         mlo.check1AddRemove(list, EMPTY, 0, 1);
     }
 
-    @Test
-    public void testAddAtEnd() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testAddAtEnd(Callable<ObservableList<String>> listFactory) throws Exception {
+        ObservableListTest_(listFactory);
+        setUp();
         list.add("four");
         mlo.check1AddRemove(list, EMPTY, 3, 4);
     }
 
-    @Test
-    public void testAddInMiddle() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testAddInMiddle(Callable<ObservableList<String>> listFactory) throws Exception {
+        ObservableListTest_(listFactory);
+        setUp();
         list.add(1, "xyz");
         mlo.check1AddRemove(list, EMPTY, 1, 2);
     }
 
-    @Test
-    public void testAddSeveralToEmpty() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testAddSeveralToEmpty(Callable<ObservableList<String>> listFactory) throws Exception {
+        ObservableListTest_(listFactory);
+        setUp();
         useListData();
         list.addAll(Arrays.asList("alpha", "bravo", "charlie"));
         mlo.check1AddRemove(list, EMPTY, 0, 3);
     }
 
-    @Test
-    public void testAddSeveralAtEnd() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testAddSeveralAtEnd(Callable<ObservableList<String>> listFactory) throws Exception {
+        ObservableListTest_(listFactory);
+        setUp();
         list.addAll(Arrays.asList("four", "five"));
         mlo.check1AddRemove(list, EMPTY, 3, 5);
     }
 
-    @Test
-    public void testAddSeveralInMiddle() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testAddSeveralInMiddle(Callable<ObservableList<String>> listFactory) throws Exception {
+        ObservableListTest_(listFactory);
+        setUp();
         list.addAll(1, Arrays.asList("a", "b"));
         mlo.check1AddRemove(list, EMPTY, 1, 3);
     }
 
-    @Test
-    public void testClearNonempty() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testClearNonempty(Callable<ObservableList<String>> listFactory) throws Exception {
+        ObservableListTest_(listFactory);
+        setUp();
         list.clear();
         mlo.check1AddRemove(list, Arrays.asList("one", "two", "three"), 0, 0);
     }
 
-    @Test
-    public void testRemoveByIndex() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testRemoveByIndex(Callable<ObservableList<String>> listFactory) throws Exception {
+        ObservableListTest_(listFactory);
+        setUp();
         String r = list.remove(1);
         mlo.check1AddRemove(list, Arrays.asList("two"), 1, 1);
         assertEquals("two", r);
     }
 
-    @Test
-    public void testRemoveObject() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testRemoveObject(Callable<ObservableList<String>> listFactory) throws Exception {
+        ObservableListTest_(listFactory);
+        setUp();
         useListData("one", "x", "two", "three");
         boolean b = list.remove("two");
         mlo.check1AddRemove(list, Arrays.asList("two"), 2, 2);
         assertTrue(b);
     }
 
-    @Test
-    public void testRemoveNull() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testRemoveNull(Callable<ObservableList<String>> listFactory) throws Exception {
+        ObservableListTest_(listFactory);
+        setUp();
         useListData("one", "two", null, "three");
         boolean b = list.remove(null);
         mlo.check1AddRemove(list, Arrays.asList((String)null), 2, 2);
         assertTrue(b);
     }
 
-    @Test
-    public void testRemoveAll() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testRemoveAll(Callable<ObservableList<String>> listFactory) throws Exception {
+        ObservableListTest_(listFactory);
+        setUp();
         useListData("one", "two", "three", "four", "five");
         list.removeAll(Arrays.asList("one", "two", "four", "six"));
         assertEquals(2, mlo.calls.size());
@@ -199,8 +237,11 @@ public class ObservableListTest  {
         mlo.checkAddRemove(1, list, Arrays.asList("four"), 1, 1);
     }
 
-    @Test
-    public void testRemoveAll_1() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testRemoveAll_1(Callable<ObservableList<String>> listFactory) throws Exception {
+        ObservableListTest_(listFactory);
+        setUp();
         useListData("a", "c", "d", "c");
         list.removeAll(Arrays.asList("c"));
         assertEquals(2, mlo.calls.size());
@@ -209,31 +250,43 @@ public class ObservableListTest  {
     }
 
 
-    @Test
-    public void testRemoveAll_2() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testRemoveAll_2(Callable<ObservableList<String>> listFactory) throws Exception {
+        ObservableListTest_(listFactory);
+        setUp();
         useListData("one", "two");
         list.removeAll(Arrays.asList("three", "four"));
         mlo.check0();
     }
 
-    @Test
-    public void testRemoveAll_3() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testRemoveAll_3(Callable<ObservableList<String>> listFactory) throws Exception {
+        ObservableListTest_(listFactory);
+        setUp();
         useListData("a", "c", "d", "c");
         list.removeAll(Arrays.asList("d"));
         assertEquals(1, mlo.calls.size());
         mlo.checkAddRemove(0, list, Arrays.asList("d"), 2, 2);
     }
 
-    @Test
-    public void testRemoveAll_4() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testRemoveAll_4(Callable<ObservableList<String>> listFactory) throws Exception {
+        ObservableListTest_(listFactory);
+        setUp();
         useListData("a", "c", "d", "c");
         list.removeAll(Arrays.asList("d", "c"));
         assertEquals(1, mlo.calls.size());
         mlo.checkAddRemove(0, list, Arrays.asList("c", "d", "c"), 1, 1);
     }
 
-    @Test
-    public void testRetainAll() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testRetainAll(Callable<ObservableList<String>> listFactory) throws Exception {
+        ObservableListTest_(listFactory);
+        setUp();
         useListData("one", "two", "three", "four", "five");
         list.retainAll(Arrays.asList("two", "five", "six"));
         assertEquals(2, mlo.calls.size());
@@ -241,8 +294,11 @@ public class ObservableListTest  {
         mlo.checkAddRemove(1, list, Arrays.asList("three", "four"), 1, 1);
     }
 
-    @Test
-    public void testRetainAllEmptySource() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testRetainAllEmptySource(Callable<ObservableList<String>> listFactory) throws Exception {
+        ObservableListTest_(listFactory);
+        setUp();
         // grab default data
         List<String> data = new ArrayList<>(list);
         // retain none == remove all
@@ -251,23 +307,32 @@ public class ObservableListTest  {
         mlo.check1AddRemove(list, data, 0, 0);
     }
 
-    @Test
-    public void testRemoveNonexistent() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testRemoveNonexistent(Callable<ObservableList<String>> listFactory) throws Exception {
+        ObservableListTest_(listFactory);
+        setUp();
         useListData("one", "two", "x", "three");
         boolean b = list.remove("four");
         mlo.check0();
         assertFalse(b);
     }
 
-    @Test
-    public void testSet() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSet(Callable<ObservableList<String>> listFactory) throws Exception {
+        ObservableListTest_(listFactory);
+        setUp();
         String r = list.set(1, "fnord");
         mlo.check1AddRemove(list, Arrays.asList("two"), 1, 2);
         assertEquals("two", r);
     }
 
-    @Test
-    public void testSetAll() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetAll(Callable<ObservableList<String>> listFactory) throws Exception {
+        ObservableListTest_(listFactory);
+        setUp();
         useListData("one", "two", "three");
         boolean r = list.setAll("one");
         assertTrue(r);
@@ -282,15 +347,21 @@ public class ObservableListTest  {
         assertTrue(r);
     }
 
-    @Test
-    public void testSetAllNoUpdate() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSetAllNoUpdate(Callable<ObservableList<String>> listFactory) throws Exception {
+        ObservableListTest_(listFactory);
+        setUp();
         useListData();
         boolean r = list.setAll();
         assertFalse(r);
     }
 
-    @Test
-    public void testObserverCanRemoveObservers() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testObserverCanRemoveObservers(Callable<ObservableList<String>> listFactory) throws Exception {
+        ObservableListTest_(listFactory);
+        setUp();
         final ListChangeListener<String> listObserver = change -> {
             change.getList().removeListener(mlo);
         };
@@ -310,8 +381,11 @@ public class ObservableListTest  {
         assertEquals(listener.counter, 1);
     }
 
-    @Test
-    public void testEqualsAndHashCode() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testEqualsAndHashCode(Callable<ObservableList<String>> listFactory) throws Exception {
+        ObservableListTest_(listFactory);
+        setUp();
         final List<String> other = Arrays.asList("one", "two", "three");
         assertTrue(list.equals(other));
         assertEquals(list.hashCode(), other.hashCode());

--- a/modules/javafx.base/src/test/java/test/javafx/collections/ObservableListWithExtractor.java
+++ b/modules/javafx.base/src/test/java/test/javafx/collections/ObservableListWithExtractor.java
@@ -36,23 +36,20 @@ import javafx.beans.Observable;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.util.Callback;
-import org.junit.Before;
-import org.junit.Test;
-import static org.junit.Assert.*;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
 public class ObservableListWithExtractor {
-    private final Mode mode;
+    private Mode mode;
 
     public static enum Mode {
         OBSERVABLE_LIST_WRAPPER,
         DECORATOR
     }
 
-    @Parameters
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][]{{Mode.OBSERVABLE_LIST_WRAPPER}, {Mode.DECORATOR}});
     }
@@ -62,7 +59,7 @@ public class ObservableListWithExtractor {
     private MockListObserver obs;
     private Person p0;
 
-    public ObservableListWithExtractor(Mode mode) {
+    public void ObservableListWithExtractor_(Mode mode) {
         this.mode = mode;
     }
 
@@ -71,7 +68,6 @@ public class ObservableListWithExtractor {
     }
 
 
-    @Before
     public void setUp() {
         p0 = new Person();
         obs = new MockListObserver();
@@ -87,14 +83,20 @@ public class ObservableListWithExtractor {
         observedList.addListener(obs);
     }
 
-    @Test
-    public void testUpdate_add() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testUpdate_add(Mode mode) {
+        ObservableListWithExtractor_(mode);
+        setUp();
         updateP0();
         obs.check1Update(modifiedList, 0, 1);
     }
 
-    @Test
-    public void testUpdate_add1() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testUpdate_add1(Mode mode) {
+        ObservableListWithExtractor_(mode);
+        setUp();
         modifiedList.clear();
         modifiedList.add(0, p0);
         obs.clear();
@@ -102,8 +104,11 @@ public class ObservableListWithExtractor {
         obs.check1Update(observedList, 0, 1);
     }
 
-    @Test
-    public void testUpdate_addAll() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testUpdate_addAll(Mode mode) {
+        ObservableListWithExtractor_(mode);
+        setUp();
         modifiedList.clear();
         modifiedList.addAll(Arrays.asList(p0, p0));
         obs.clear();
@@ -111,8 +116,11 @@ public class ObservableListWithExtractor {
         obs.check1Update(observedList, 0, 2);
     }
 
-    @Test
-    public void testUpdate_addAll1() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testUpdate_addAll1(Mode mode) {
+        ObservableListWithExtractor_(mode);
+        setUp();
         modifiedList.clear();
         modifiedList.addAll(0, Arrays.asList(p0, p0));
         obs.clear();
@@ -120,8 +128,11 @@ public class ObservableListWithExtractor {
         obs.check1Update(observedList, 0, 2);
     }
 
-    @Test
-    public void testUpdate_addAll2() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testUpdate_addAll2(Mode mode) {
+        ObservableListWithExtractor_(mode);
+        setUp();
         modifiedList.clear();
         modifiedList.addAll(p0, p0);
         obs.clear();
@@ -129,8 +140,11 @@ public class ObservableListWithExtractor {
         obs.check1Update(observedList, 0, 2);
     }
 
-    @Test
-    public void testUpdate_set() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testUpdate_set(Mode mode) {
+        ObservableListWithExtractor_(mode);
+        setUp();
         Person p1 = new Person();
         modifiedList.set(0, p1);
         obs.clear();
@@ -140,8 +154,11 @@ public class ObservableListWithExtractor {
         obs.check1Update(observedList, 0, 1);
     }
 
-    @Test
-    public void testUpdate_setAll() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testUpdate_setAll(Mode mode) {
+        ObservableListWithExtractor_(mode);
+        setUp();
         Person p1 = new Person();
         modifiedList.setAll(p1);
         obs.clear();
@@ -151,40 +168,55 @@ public class ObservableListWithExtractor {
         obs.check1Update(observedList, 0, 1);
     }
 
-    @Test
-    public void testUpdate_remove() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testUpdate_remove(Mode mode) {
+        ObservableListWithExtractor_(mode);
+        setUp();
         modifiedList.remove(p0);
         obs.clear();
         updateP0();
         obs.check0();
     }
 
-    @Test
-    public void testUpdate_remove1() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testUpdate_remove1(Mode mode) {
+        ObservableListWithExtractor_(mode);
+        setUp();
         modifiedList.remove(0);
         obs.clear();
         updateP0();
         obs.check0();
     }
 
-    @Test
-    public void testUpdate_removeAll() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testUpdate_removeAll(Mode mode) {
+        ObservableListWithExtractor_(mode);
+        setUp();
         modifiedList.removeAll(p0);
         obs.clear();
         updateP0();
         obs.check0();
     }
 
-    @Test
-    public void testUpdate_retainAll() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testUpdate_retainAll(Mode mode) {
+        ObservableListWithExtractor_(mode);
+        setUp();
         modifiedList.retainAll();
         obs.clear();
         updateP0();
         obs.check0();
     }
 
-    @Test
-    public void testUpdate_iterator_add() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testUpdate_iterator_add(Mode mode) {
+        ObservableListWithExtractor_(mode);
+        setUp();
         modifiedList.clear();
         modifiedList.listIterator().add(p0);
         obs.clear();
@@ -192,8 +224,11 @@ public class ObservableListWithExtractor {
         obs.check1Update(observedList, 0, 1);
     }
 
-    @Test
-    public void testUpdate_iterator_set() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testUpdate_iterator_set(Mode mode) {
+        ObservableListWithExtractor_(mode);
+        setUp();
         Person p1 = new Person();
         ListIterator<Person> listIterator = modifiedList.listIterator();
         listIterator.next();
@@ -205,8 +240,11 @@ public class ObservableListWithExtractor {
         obs.check1Update(observedList, 0, 1);
     }
 
-    @Test
-    public void testUpdate_sublist_add() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testUpdate_sublist_add(Mode mode) {
+        ObservableListWithExtractor_(mode);
+        setUp();
         List<Person> sublist = modifiedList.subList(0, 1);
         sublist.add(p0);
         obs.clear();
@@ -214,8 +252,11 @@ public class ObservableListWithExtractor {
         obs.check1Update(observedList, 0, 2);
     }
 
-    @Test
-    public void testUpdate_sublist_add1() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testUpdate_sublist_add1(Mode mode) {
+        ObservableListWithExtractor_(mode);
+        setUp();
         List<Person> sublist = modifiedList.subList(0, 1);
         sublist.clear();
         sublist.add(0, p0);
@@ -224,8 +265,11 @@ public class ObservableListWithExtractor {
         obs.check1Update(observedList, 0, 1);
     }
 
-    @Test
-    public void testUpdate_sublist_addAll() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testUpdate_sublist_addAll(Mode mode) {
+        ObservableListWithExtractor_(mode);
+        setUp();
         List<Person> sublist = modifiedList.subList(0, 1);
         sublist.clear();
         sublist.addAll(Arrays.asList(p0, p0));
@@ -234,8 +278,11 @@ public class ObservableListWithExtractor {
         obs.check1Update(observedList, 0, 2);
     }
 
-    @Test
-    public void testUpdate_sublist_addAll1() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testUpdate_sublist_addAll1(Mode mode) {
+        ObservableListWithExtractor_(mode);
+        setUp();
         List<Person> sublist = modifiedList.subList(0, 1);
         sublist.clear();
         sublist.addAll(0, Arrays.asList(p0, p0));
@@ -244,8 +291,11 @@ public class ObservableListWithExtractor {
         obs.check1Update(observedList, 0, 2);
     }
 
-    @Test
-    public void testUpdate_sublist_set() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testUpdate_sublist_set(Mode mode) {
+        ObservableListWithExtractor_(mode);
+        setUp();
         List<Person> sublist = modifiedList.subList(0, 1);
         Person p1 = new Person();
         sublist.set(0, p1);
@@ -256,8 +306,11 @@ public class ObservableListWithExtractor {
         obs.check1Update(observedList, 0, 1);
     }
 
-    @Test
-    public void testUpdate_sublist_remove() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testUpdate_sublist_remove(Mode mode) {
+        ObservableListWithExtractor_(mode);
+        setUp();
         List<Person> sublist = modifiedList.subList(0, 1);
         sublist.remove(p0);
         obs.clear();
@@ -265,8 +318,11 @@ public class ObservableListWithExtractor {
         obs.check0();
     }
 
-    @Test
-    public void testUpdate_sublist_remove1() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testUpdate_sublist_remove1(Mode mode) {
+        ObservableListWithExtractor_(mode);
+        setUp();
         List<Person> sublist = modifiedList.subList(0, 1);
         sublist.remove(0);
         obs.clear();
@@ -274,8 +330,11 @@ public class ObservableListWithExtractor {
         obs.check0();
     }
 
-    @Test
-    public void testUpdate_sublist_removeAll() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testUpdate_sublist_removeAll(Mode mode) {
+        ObservableListWithExtractor_(mode);
+        setUp();
         List<Person> sublist = modifiedList.subList(0, 1);
         sublist.removeAll(Arrays.asList(p0));
         obs.clear();
@@ -283,8 +342,11 @@ public class ObservableListWithExtractor {
         obs.check0();
     }
 
-    @Test
-    public void testUpdate_sublist_retainAll() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testUpdate_sublist_retainAll(Mode mode) {
+        ObservableListWithExtractor_(mode);
+        setUp();
         List<Person> sublist = modifiedList.subList(0, 1);
         sublist.retainAll(Collections.<Person>emptyList());
         obs.clear();
@@ -292,8 +354,11 @@ public class ObservableListWithExtractor {
         obs.check0();
     }
 
-    @Test
-    public void testUpdate_iterator_sublist_add() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testUpdate_iterator_sublist_add(Mode mode) {
+        ObservableListWithExtractor_(mode);
+        setUp();
         List<Person> sublist = modifiedList.subList(0, 1);
         sublist.clear();
         sublist.listIterator().add(p0);
@@ -302,8 +367,11 @@ public class ObservableListWithExtractor {
         obs.check1Update(observedList, 0, 1);
     }
 
-    @Test
-    public void testUpdate_iterator_sublist_set() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testUpdate_iterator_sublist_set(Mode mode) {
+        ObservableListWithExtractor_(mode);
+        setUp();
         List<Person> sublist = modifiedList.subList(0, 1);
         Person p1 = new Person();
         ListIterator<Person> listIterator = sublist.listIterator();
@@ -316,8 +384,11 @@ public class ObservableListWithExtractor {
         obs.check1Update(observedList, 0, 1);
     }
 
-    @Test
-    public void testMultipleUpdate() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testMultipleUpdate(Mode mode) {
+        ObservableListWithExtractor_(mode);
+        setUp();
 
         modifiedList.add(new Person());
         modifiedList.addAll(p0, p0);
@@ -332,8 +403,11 @@ public class ObservableListWithExtractor {
 
     }
 
-    @Test
-    public void testPreFilledList() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testPreFilledList(Mode mode) {
+        ObservableListWithExtractor_(mode);
+        setUp();
         ArrayList<Person> arrayList = new ArrayList<>();
         arrayList.add(p0);
         obs = new MockListObserver();

--- a/modules/javafx.base/src/test/java/test/javafx/collections/ObservableMapTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/collections/ObservableMapTest.java
@@ -25,8 +25,8 @@
 
 package test.javafx.collections;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -38,25 +38,22 @@ import javafx.collections.MapChangeListener;
 import javafx.collections.ObservableMap;
 import static test.javafx.collections.MockMapObserver.Call.call;
 import static test.javafx.collections.MockMapObserver.Tuple.tup;
-import static org.junit.Assert.*;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
 public class ObservableMapTest {
 
-    final Callable<ObservableMap<String, String>> mapFactory;
+    Callable<ObservableMap<String, String>> mapFactory;
     private ObservableMap<String, String> observableMap;
     private MockMapObserver<String, String> observer;
 
 
-    public ObservableMapTest(final Callable<ObservableMap<String, String>> mapFactory) {
+    public void ObservableMapTest_(Callable<ObservableMap<String, String>> mapFactory) {
         this.mapFactory = mapFactory;
     }
 
-    @Parameterized.Parameters
     public static Collection createParameters() {
         Object[][] data = new Object[][] {
             { TestedObservableMaps.HASH_MAP },
@@ -70,7 +67,6 @@ public class ObservableMapTest {
         return Arrays.asList(data);
     }
 
-    @Before
     public void setUp() throws Exception {
         observableMap = mapFactory.call();
         observer = new MockMapObserver<>();
@@ -94,8 +90,11 @@ public class ObservableMapTest {
         observer.clear();
     }
 
-    @Test
-    public void testPutRemove() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testPutRemove(Callable<ObservableMap<String, String>> mapFactory) throws Exception {
+        ObservableMapTest_(mapFactory);
+        setUp();
         observableMap.put("observedFoo", "barVal");
         observableMap.put("foo", "barfoo");
         assertEquals("barVal", observableMap.get("observedFoo"));
@@ -116,8 +115,11 @@ public class ObservableMapTest {
         assertEquals(observer.getCallsNumber(), 4);
     }
 
-    @Test
-    public void testPutRemove_Null() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testPutRemove_Null(Callable<ObservableMap<String, String>> mapFactory) throws Exception {
+        ObservableMapTest_(mapFactory);
+        setUp();
         if (mapFactory instanceof TestedObservableMaps.CallableConcurrentHashMapImpl) {
             return; // Do not perform on ConcurrentHashMap, as it doesn't accept nulls
         }
@@ -148,8 +150,11 @@ public class ObservableMapTest {
         assertEquals(observer.getCallsNumber(), 6);
     }
 
-    @Test
-    public void testPutRemove_NullKey() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testPutRemove_NullKey(Callable<ObservableMap<String, String>> mapFactory) throws Exception {
+        ObservableMapTest_(mapFactory);
+        setUp();
         if (mapFactory instanceof TestedObservableMaps.CallableConcurrentHashMapImpl ||
                 mapFactory instanceof TestedObservableMaps.CallableTreeMapImpl) {
             return; // Do not perform on ConcurrentHashMap and TreeMap, as they doesn't accept null keys
@@ -169,9 +174,12 @@ public class ObservableMapTest {
         assertEquals(observer.getCallsNumber(), 2);
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("createParameters")
     @SuppressWarnings("unchecked")
-    public void testPutAll() {
+    public void testPutAll(Callable<ObservableMap<String, String>> mapFactory) throws Exception {
+        ObservableMapTest_(mapFactory);
+        setUp();
         Map<String, String> map = new HashMap<>();
         map.put("oFoo", "OFoo");
         map.put("pFoo", "PFoo");
@@ -183,9 +191,12 @@ public class ObservableMapTest {
         observer.assertMultipleCalls(call("oFoo", null, "OFoo"), call("pFoo", null, "PFoo"), call("foo", "bar", "foofoo"));
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("createParameters")
     @SuppressWarnings("unchecked")
-    public void testClear() {
+    public void testClear(Callable<ObservableMap<String, String>> mapFactory) throws Exception {
+        ObservableMapTest_(mapFactory);
+        setUp();
         observableMap.clear();
 
         assertTrue(observableMap.isEmpty());
@@ -193,8 +204,11 @@ public class ObservableMapTest {
 
     }
 
-    @Test
-    public void testOther() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testOther(Callable<ObservableMap<String, String>> mapFactory) throws Exception {
+        ObservableMapTest_(mapFactory);
+        setUp();
         assertEquals(3, observableMap.size());
         assertFalse(observableMap.isEmpty());
 
@@ -205,8 +219,11 @@ public class ObservableMapTest {
         assertTrue(observableMap.containsValue("bar"));
     }
 
-    @Test
-    public void testKeySet_Remove() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testKeySet_Remove(Callable<ObservableMap<String, String>> mapFactory) throws Exception {
+        ObservableMapTest_(mapFactory);
+        setUp();
         observableMap.keySet().remove("one");
         observableMap.keySet().remove("two");
         observableMap.keySet().remove("three");
@@ -216,33 +233,45 @@ public class ObservableMapTest {
         assertTrue(observer.getCallsNumber() == 2);
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("createParameters")
     @SuppressWarnings("unchecked")
-    public void testKeySet_RemoveAll() {
+    public void testKeySet_RemoveAll(Callable<ObservableMap<String, String>> mapFactory) throws Exception {
+        ObservableMapTest_(mapFactory);
+        setUp();
         observableMap.keySet().removeAll(Arrays.asList("one", "two", "three"));
 
         observer.assertMultipleRemoved(tup("one", "1"), tup("two", "2"));
         assertTrue(observableMap.size() == 1);
     }
 
-    @Test
-    public void testKeySet_RetainAll() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testKeySet_RetainAll(Callable<ObservableMap<String, String>> mapFactory) throws Exception {
+        ObservableMapTest_(mapFactory);
+        setUp();
         observableMap.keySet().retainAll(Arrays.asList("one", "two", "three"));
 
         observer.assertRemoved(tup("foo", "bar"));
         assertTrue(observableMap.size() == 2);
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("createParameters")
     @SuppressWarnings("unchecked")
-    public void testKeySet_Clear() {
+    public void testKeySet_Clear(Callable<ObservableMap<String, String>> mapFactory) throws Exception {
+        ObservableMapTest_(mapFactory);
+        setUp();
         observableMap.keySet().clear();
         assertTrue(observableMap.keySet().isEmpty());
         observer.assertMultipleRemoved(tup("one", "1"), tup("two", "2"), tup("foo", "bar"));
     }
 
-    @Test
-    public void testKeySet_Iterator() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testKeySet_Iterator(Callable<ObservableMap<String, String>> mapFactory) throws Exception {
+        ObservableMapTest_(mapFactory);
+        setUp();
         Iterator<String> iterator = observableMap.keySet().iterator();
         assertTrue(iterator.hasNext());
 
@@ -254,8 +283,11 @@ public class ObservableMapTest {
         observer.assertRemoved(tup(toBeRemoved, toBeRemovedVal));
     }
 
-    @Test
-    public void testKeySet_Other() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testKeySet_Other(Callable<ObservableMap<String, String>> mapFactory) throws Exception {
+        ObservableMapTest_(mapFactory);
+        setUp();
         assertEquals(3, observableMap.keySet().size());
         assertTrue(observableMap.keySet().contains("foo"));
         assertFalse(observableMap.keySet().contains("bar"));
@@ -267,8 +299,11 @@ public class ObservableMapTest {
         assertTrue(observableMap.keySet().toArray().length == 3);
     }
 
-    @Test
-    public void testValues_Remove() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testValues_Remove(Callable<ObservableMap<String, String>> mapFactory) throws Exception {
+        ObservableMapTest_(mapFactory);
+        setUp();
         observableMap.values().remove("1");
         observableMap.values().remove("2");
         observableMap.values().remove("3");
@@ -278,33 +313,45 @@ public class ObservableMapTest {
         assertTrue(observer.getCallsNumber() == 2);
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("createParameters")
     @SuppressWarnings("unchecked")
-    public void testValues_RemoveAll() {
+    public void testValues_RemoveAll(Callable<ObservableMap<String, String>> mapFactory) throws Exception {
+        ObservableMapTest_(mapFactory);
+        setUp();
         observableMap.values().removeAll(Arrays.asList("1", "2", "3"));
 
         observer.assertMultipleRemoved(tup("one", "1"), tup("two", "2"));
         assertTrue(observableMap.size() == 1);
     }
 
-    @Test
-    public void testValues_RetainAll() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testValues_RetainAll(Callable<ObservableMap<String, String>> mapFactory) throws Exception {
+        ObservableMapTest_(mapFactory);
+        setUp();
         observableMap.values().retainAll(Arrays.asList("1", "2", "3"));
 
         observer.assertRemoved(tup("foo", "bar"));
         assertTrue(observableMap.size() == 2);
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("createParameters")
     @SuppressWarnings("unchecked")
-    public void testValues_Clear() {
+    public void testValues_Clear(Callable<ObservableMap<String, String>> mapFactory) throws Exception {
+        ObservableMapTest_(mapFactory);
+        setUp();
         observableMap.values().clear();
         assertTrue(observableMap.values().isEmpty());
         observer.assertMultipleRemoved(tup("one", "1"), tup("two", "2"), tup("foo", "bar"));
     }
 
-    @Test
-    public void testValues_Iterator() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testValues_Iterator(Callable<ObservableMap<String, String>> mapFactory) throws Exception {
+        ObservableMapTest_(mapFactory);
+        setUp();
         Iterator<String> iterator = observableMap.values().iterator();
         assertTrue(iterator.hasNext());
 
@@ -317,8 +364,11 @@ public class ObservableMapTest {
                 : toBeRemovedVal.equals("bar") ? "foo" : null, toBeRemovedVal));
     }
 
-    @Test
-    public void testValues_Other() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testValues_Other(Callable<ObservableMap<String, String>> mapFactory) throws Exception {
+        ObservableMapTest_(mapFactory);
+        setUp();
         assertEquals(3, observableMap.values().size());
         assertFalse(observableMap.values().contains("foo"));
         assertTrue(observableMap.values().contains("bar"));
@@ -330,8 +380,11 @@ public class ObservableMapTest {
         assertTrue(observableMap.values().toArray().length == 3);
     }
 
-    @Test
-    public void testEntrySet_Remove() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testEntrySet_Remove(Callable<ObservableMap<String, String>> mapFactory) throws Exception {
+        ObservableMapTest_(mapFactory);
+        setUp();
         observableMap.entrySet().remove(entry("one","1"));
         observableMap.entrySet().remove(entry("two","2"));
         observableMap.entrySet().remove(entry("three","3"));
@@ -341,33 +394,45 @@ public class ObservableMapTest {
         assertTrue(observer.getCallsNumber() == 2);
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("createParameters")
     @SuppressWarnings("unchecked")
-    public void testEntrySet_RemoveAll() {
+    public void testEntrySet_RemoveAll(Callable<ObservableMap<String, String>> mapFactory) throws Exception {
+        ObservableMapTest_(mapFactory);
+        setUp();
         observableMap.entrySet().removeAll(Arrays.asList(entry("one","1"), entry("two","2"), entry("three","3")));
 
         observer.assertMultipleRemoved(tup("one", "1"), tup("two", "2"));
         assertTrue(observableMap.size() == 1);
     }
 
-    @Test
-    public void testEntrySet_RetainAll() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testEntrySet_RetainAll(Callable<ObservableMap<String, String>> mapFactory) throws Exception {
+        ObservableMapTest_(mapFactory);
+        setUp();
         observableMap.entrySet().retainAll(Arrays.asList(entry("one","1"), entry("two","2"), entry("three","3")));
 
         observer.assertRemoved(tup("foo", "bar"));
         assertTrue(observableMap.size() == 2);
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("createParameters")
     @SuppressWarnings("unchecked")
-    public void testEntrySet_Clear() {
+    public void testEntrySet_Clear(Callable<ObservableMap<String, String>> mapFactory) throws Exception {
+        ObservableMapTest_(mapFactory);
+        setUp();
         observableMap.entrySet().clear();
         assertTrue(observableMap.entrySet().isEmpty());
         observer.assertMultipleRemoved(tup("one", "1"), tup("two", "2"), tup("foo", "bar"));
     }
 
-    @Test
-    public void testEntrySet_Iterator() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testEntrySet_Iterator(Callable<ObservableMap<String, String>> mapFactory) throws Exception {
+        ObservableMapTest_(mapFactory);
+        setUp();
         Iterator<Map.Entry<String, String>> iterator = observableMap.entrySet().iterator();
         assertTrue(iterator.hasNext());
 
@@ -381,8 +446,11 @@ public class ObservableMapTest {
         observer.assertRemoved(tup(toBeRemovedKey, toBeRemovedVal));
     }
 
-    @Test
-    public void testEntrySet_Other() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testEntrySet_Other(Callable<ObservableMap<String, String>> mapFactory) throws Exception {
+        ObservableMapTest_(mapFactory);
+        setUp();
         assertEquals(3, observableMap.entrySet().size());
         assertTrue(observableMap.entrySet().contains(entry("foo", "bar")));
         assertFalse(observableMap.entrySet().contains(entry("bar", "foo")));
@@ -394,8 +462,11 @@ public class ObservableMapTest {
         assertTrue(observableMap.entrySet().toArray().length == 3);
     }
 
-    @Test
-    public void testObserverCanRemoveObservers() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testObserverCanRemoveObservers(Callable<ObservableMap<String, String>> mapFactory) throws Exception {
+        ObservableMapTest_(mapFactory);
+        setUp();
         final MapChangeListener<String, String> listObserver = change -> {
             change.getMap().removeListener(observer);
         };
@@ -426,8 +497,11 @@ public class ObservableMapTest {
         }
     }
 
-    @Test
-    public void testEqualsAndHashCode() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testEqualsAndHashCode(Callable<ObservableMap<String, String>> mapFactory) throws Exception {
+        ObservableMapTest_(mapFactory);
+        setUp();
         final Map<String, String> other = new HashMap<>(observableMap);
         assertTrue(observableMap.equals(other));
         assertEquals(observableMap.hashCode(), other.hashCode());

--- a/modules/javafx.base/src/test/java/test/javafx/collections/ObservableSetTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/collections/ObservableSetTest.java
@@ -32,29 +32,25 @@ import java.util.Iterator;
 import java.util.Set;
 import javafx.collections.ObservableSet;
 import javafx.collections.SetChangeListener;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static test.javafx.collections.MockSetObserver.Call.*;
 import static test.javafx.collections.MockSetObserver.Tuple.*;
-import static org.junit.Assert.*;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.ParameterizedTest;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-
-@RunWith(Parameterized.class)
 public class ObservableSetTest {
 
-    final Callable<ObservableSet<String>> setFactory;
+    Callable<ObservableSet<String>> setFactory;
     private ObservableSet<String> observableSet;
     private MockSetObserver<String> observer;
 
-    public ObservableSetTest(final Callable<ObservableSet<String>> setFactory) {
+    public void ObservableSetTest_(Callable<ObservableSet<String>> setFactory) {
         this.setFactory = setFactory;
     }
 
-    @Parameterized.Parameters
     public static Collection createParameters() {
         Object[][] data = new Object[][] {
             { TestedObservableSets.HASH_SET },
@@ -67,7 +63,6 @@ public class ObservableSetTest {
         return Arrays.asList(data);
     }
 
-    @Before
     public void setUp() throws Exception {
         observableSet = setFactory.call();
         observer = new MockSetObserver<>();
@@ -89,8 +84,11 @@ public class ObservableSetTest {
         observer.clear();
     }
 
-    @Test
-    public void testAddRemove() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testAddRemove(Callable<ObservableSet<String>> setFactory) throws Exception {
+        ObservableSetTest_(setFactory);
+        setUp();
         observableSet.add("observedFoo");
         observableSet.add("foo");
         assertTrue(observableSet.contains("observedFoo"));
@@ -109,9 +107,12 @@ public class ObservableSetTest {
         assertEquals(observer.getCallsNumber(), 3);
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("createParameters")
     @SuppressWarnings("unchecked")
-    public void testAddAll() {
+    public void testAddAll(Callable<ObservableSet<String>> setFactory) throws Exception {
+        ObservableSetTest_(setFactory);
+        setUp();
         Set<String> set = new HashSet<>();
         set.add("oFoo");
         set.add("pFoo");
@@ -123,18 +124,24 @@ public class ObservableSetTest {
         observer.assertMultipleCalls(call(null, "oFoo"), call(null, "pFoo"));
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("createParameters")
     @SuppressWarnings("unchecked")
-    public void testRemoveAll() {
+    public void testRemoveAll(Callable<ObservableSet<String>> setFactory) throws Exception {
+        ObservableSetTest_(setFactory);
+        setUp();
         observableSet.removeAll(Arrays.asList("one", "two", "three"));
 
         observer.assertMultipleRemoved(tup("one"), tup("two"));
         assertTrue(observableSet.size() == 1);
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("createParameters")
     @SuppressWarnings("unchecked")
-    public void testClear() {
+    public void testClear(Callable<ObservableSet<String>> setFactory) throws Exception {
+        ObservableSetTest_(setFactory);
+        setUp();
         observableSet.clear();
 
         assertTrue(observableSet.isEmpty());
@@ -142,16 +149,22 @@ public class ObservableSetTest {
 
     }
 
-    @Test
-    public void testRetainAll() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testRetainAll(Callable<ObservableSet<String>> setFactory) throws Exception {
+        ObservableSetTest_(setFactory);
+        setUp();
         observableSet.retainAll(Arrays.asList("one", "two", "three"));
 
         observer.assertRemoved(tup("foo"));
         assertTrue(observableSet.size() == 2);
     }
 
-    @Test
-    public void testIterator() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testIterator(Callable<ObservableSet<String>> setFactory) throws Exception {
+        ObservableSetTest_(setFactory);
+        setUp();
         Iterator<String> iterator = observableSet.iterator();
         assertTrue(iterator.hasNext());
 
@@ -162,8 +175,11 @@ public class ObservableSetTest {
         observer.assertRemoved(tup(toBeRemoved));
     }
 
-    @Test
-    public void testOther() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testOther(Callable<ObservableSet<String>> setFactory) throws Exception {
+        ObservableSetTest_(setFactory);
+        setUp();
         assertEquals(3, observableSet.size());
         assertFalse(observableSet.isEmpty());
 
@@ -171,8 +187,11 @@ public class ObservableSetTest {
         assertFalse(observableSet.contains("bar"));
     }
 
-    @Test
-    public void testNull() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testNull(Callable<ObservableSet<String>> setFactory) throws Exception {
+        ObservableSetTest_(setFactory);
+        setUp();
         if (setFactory instanceof TestedObservableSets.CallableTreeSetImpl) {
             return; // TreeSet doesn't accept nulls
         }
@@ -187,8 +206,11 @@ public class ObservableSetTest {
     }
 
 
-    @Test
-    public void testObserverCanRemoveObservers() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testObserverCanRemoveObservers(Callable<ObservableSet<String>> setFactory) throws Exception {
+        ObservableSetTest_(setFactory);
+        setUp();
         final SetChangeListener<String> listObserver = change -> {
             change.getSet().removeListener(observer);
         };
@@ -220,8 +242,11 @@ public class ObservableSetTest {
         }
     }
 
-    @Test
-    public void testEqualsAndHashCode() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testEqualsAndHashCode(Callable<ObservableSet<String>> setFactory) throws Exception {
+        ObservableSetTest_(setFactory);
+        setUp();
         final Set<String> other = new HashSet<>(Arrays.asList("one", "two", "foo"));
         assertTrue(observableSet.equals(other));
         assertEquals(observableSet.hashCode(), other.hashCode());

--- a/modules/javafx.base/src/test/java/test/javafx/collections/ObservableSubListIteratorTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/collections/ObservableSubListIteratorTest.java
@@ -25,16 +25,20 @@
 
 package test.javafx.collections;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.ListIterator;
 
 import static org.junit.Assert.assertEquals;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.Arguments;
+import java.util.stream.Stream;
 
 
 /**
@@ -46,98 +50,112 @@ import org.junit.runners.Parameterized;
  * after mutating the sublist via the iterator.
  *
  */
-@RunWith(Parameterized.class)
+
 public class ObservableSubListIteratorTest extends ObservableListIteratorTest {
 
     // ========== Test Fixture ==========
 
     List<String> fullList;
+    private Callable<? extends List<String>> listFactory;
+    private List<String> list;
+    private ListIterator<String> iter;
 
-    public ObservableSubListIteratorTest(final Callable<? extends List<String>> listFactory) {
-        super(listFactory);
+    public static Stream<Arguments> createParameters() {
+        return Stream.of(
+                Arguments.of(TestedObservableLists.ARRAY_LIST),
+                Arguments.of(TestedObservableLists.LINKED_LIST),
+                Arguments.of(TestedObservableLists.VETOABLE_LIST),
+                Arguments.of(TestedObservableLists.CHECKED_OBSERVABLE_ARRAY_LIST),
+                Arguments.of(TestedObservableLists.SYNCHRONIZED_OBSERVABLE_ARRAY_LIST)
+        );
     }
 
-    @Parameterized.Parameters
-    public static Collection createParameters() {
-        Object[][] data = new Object[][] {
-            { TestedObservableLists.ARRAY_LIST },
-            { TestedObservableLists.LINKED_LIST },
-            { TestedObservableLists.VETOABLE_LIST },
-            { TestedObservableLists.CHECKED_OBSERVABLE_ARRAY_LIST },
-            { TestedObservableLists.SYNCHRONIZED_OBSERVABLE_ARRAY_LIST }
-         };
-        return Arrays.asList(data);
-    }
-
-    @Before @Override
-    public void setup() throws Exception {
-        list = listFactory.call();
-        list.addAll(
-            Arrays.asList("P", "Q", "a", "b", "c", "d", "e", "f", "R", "S"));
-        fullList = list;
-        list = fullList.subList(2, 8);
-        iter = list.listIterator();
+    private void setup(Callable<? extends List<String>> listFactory) throws Exception {
+        this.listFactory = listFactory;
+        this.list = listFactory.call();
+        this.list.addAll(Arrays.asList("P", "Q", "a", "b", "c", "d", "e", "f", "R", "S"));
+        this.fullList = list;
+        this.list = fullList.subList(2, 8);
+        this.iter = list.listIterator();
     }
 
     // ========== Sublist Iterator Tests ==========
 
-    @Test
-    public void testSubAddBeginning() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSubAddBeginning(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         iter.add("X");
         assertEquals("[P, Q, X, a, b, c, d, e, f, R, S]", fullList.toString());
     }
 
-    @Test
-    public void testSubAddMiddle() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSubAddMiddle(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         advance(iter, 3);
         iter.add("X");
         assertEquals("[P, Q, a, b, c, X, d, e, f, R, S]", fullList.toString());
     }
 
-    @Test
-    public void testSubAddEnd() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSubAddEnd(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         toEnd(iter);
         iter.add("X");
         assertEquals("[P, Q, a, b, c, d, e, f, X, R, S]", fullList.toString());
     }
 
-    @Test
-    public void testSubRemoveBeginning() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSubRemoveBeginning(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         iter.next();
         iter.remove();
         assertEquals("[P, Q, b, c, d, e, f, R, S]", fullList.toString());
     }
 
-    @Test
-    public void testSubRemoveMiddle() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSubRemoveMiddle(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         advance(iter, 3);
         iter.remove();
         assertEquals("[P, Q, a, b, d, e, f, R, S]", fullList.toString());
     }
 
-    @Test
-    public void testSubRemoveEnd() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSubRemoveEnd(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         toEnd(iter);
         iter.remove();
         assertEquals("[P, Q, a, b, c, d, e, R, S]", fullList.toString());
     }
 
-    @Test
-    public void testSubSetBeginning() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSubSetBeginning(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         iter.next();
         iter.set("X");
         assertEquals("[P, Q, X, b, c, d, e, f, R, S]", fullList.toString());
     }
 
-    @Test
-    public void testSubSetMiddle() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSubSetMiddle(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         advance(iter, 3);
         iter.set("X");
         assertEquals("[P, Q, a, b, X, d, e, f, R, S]", fullList.toString());
     }
 
-    @Test
-    public void testSubSetEnd() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSubSetEnd(Callable<? extends List<String>> listFactory) throws Exception {
+        setup(listFactory);
         toEnd(iter);
         iter.set("X");
         assertEquals("[P, Q, a, b, c, d, e, X, R, S]", fullList.toString());

--- a/modules/javafx.base/src/test/java/test/javafx/collections/ObservableSubListTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/collections/ObservableSubListTest.java
@@ -25,33 +25,26 @@
 
 package test.javafx.collections;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.*;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 
-import static org.junit.Assert.*;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests for sublists of ObservableList.
  *
  */
-@RunWith(Parameterized.class)
 public class ObservableSubListTest {
-    final Callable<ObservableList<String>> listFactory;
+    Callable<ObservableList<String>> listFactory;
     ObservableList<String> list;
     List<String> sublist;
     private MockListObserver<String> mlo;
 
-    public ObservableSubListTest(final Callable<ObservableList<String>> listFactory) {
-        this.listFactory = listFactory;
-    }
-
-    @Parameterized.Parameters
     public static Collection createParameters() {
         Object[][] data = new Object[][] {
             { TestedObservableLists.ARRAY_LIST },
@@ -63,8 +56,7 @@ public class ObservableSubListTest {
         return Arrays.asList(data);
     }
 
-    @Before
-    public void setup() throws Exception {
+    private void setup(Callable<ObservableList<String>> listFactory) throws Exception {
         list = listFactory.call();
         mlo = new MockListObserver<>();
         list.addListener(mlo);
@@ -85,29 +77,39 @@ public class ObservableSubListTest {
         mlo.clear();
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testBadRange() {
-        list.subList(3, 2);
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testBadRange(Callable<ObservableList<String>> listFactory) throws Exception {
+        setup(listFactory);
+        assertThrows(IllegalArgumentException.class, () -> list.subList(3, 2));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
-    public void testRangeTooLow() {
-        list.subList(-2, 4);
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testRangeTooLow(Callable<ObservableList<String>> listFactory) throws Exception {
+        setup(listFactory);
+        assertThrows(IndexOutOfBoundsException.class, () -> list.subList(-2, 4));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
-    public void testRangeTooHigh() {
-        list.subList(3, 7);
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    void testRangeTooHigh(Callable<ObservableList<String>> listFactory) throws Exception {
+        setup(listFactory);
+        assertThrows(IndexOutOfBoundsException.class, () -> list.subList(3, 7));
     }
 
-    @Test
-    public void testWidestRange() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testWidestRange(Callable<ObservableList<String>> listFactory) throws Exception {
+        setup(listFactory);
         List<String> sub = list.subList(0, 6);
         assertEquals("[a, b, c, d, e, f]", sub.toString());
     }
 
-    @Test
-    public void testAdd() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testAdd(Callable<ObservableList<String>> listFactory) throws Exception {
+        setup(listFactory);
         sublist.add("X");
         assertEquals("[b, c, d, e, X]", sublist.toString());
         assertEquals("[a, b, c, d, e, X, f]", list.toString());
@@ -115,8 +117,10 @@ public class ObservableSubListTest {
         mlo.check1AddRemove(list, null, 5, 6);
     }
 
-    @Test
-    public void testAddAll() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testAddAll(Callable<ObservableList<String>> listFactory) throws Exception {
+        setup(listFactory);
         sublist.addAll(1, Arrays.asList("X", "Y", "Z"));
         assertEquals("[b, X, Y, Z, c, d, e]", sublist.toString());
         assertEquals("[a, b, X, Y, Z, c, d, e, f]", list.toString());
@@ -124,8 +128,10 @@ public class ObservableSubListTest {
         mlo.check1AddRemove(list, null, 2, 5);
     }
 
-    @Test
-    public void testClear() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testClear(Callable<ObservableList<String>> listFactory) throws Exception {
+        setup(listFactory);
         sublist.clear();
         assertEquals("[]", sublist.toString());
         assertEquals("[a, f]", list.toString());
@@ -134,101 +140,129 @@ public class ObservableSubListTest {
     }
 
     @SuppressWarnings("unlikely-arg-type")
-    @Test
-    public void testContains() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testContains(Callable<ObservableList<String>> listFactory) throws Exception {
+        setup(listFactory);
         assertTrue(sublist.contains("c"));
         assertFalse(sublist.contains("a"));
         assertFalse(sublist.contains(null));
         assertFalse(sublist.contains(Integer.valueOf(7)));
     }
 
-    @Test
-    public void testContainsAll() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testContainsAll(Callable<ObservableList<String>> listFactory) throws Exception {
+        setup(listFactory);
         assertTrue(sublist.containsAll(Arrays.asList("b", "c")));
         assertFalse(sublist.containsAll(Arrays.asList("a", "b")));
     }
 
-    @Test
-    public void testContainsNull() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testContainsNull(Callable<ObservableList<String>> listFactory) throws Exception {
+        setup(listFactory);
         list.add(3, null);
         sublist = list.subList(1, 5);
         assertTrue(sublist.contains(null));
     }
 
     @SuppressWarnings("unlikely-arg-type")
-    @Test
-    public void testEqualsOnAnotherType() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testEqualsOnAnotherType(Callable<ObservableList<String>> listFactory) throws Exception {
+        setup(listFactory);
         assertFalse(sublist.equals(Integer.valueOf(7)));
     }
 
-    @Test
-    public void testEqualsOnLongerList() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testEqualsOnLongerList(Callable<ObservableList<String>> listFactory) throws Exception {
+        setup(listFactory);
         List<String> other = Arrays.asList("b", "c", "d", "e", "f");
         assertFalse(sublist.equals(other));
         assertTrue(other.hashCode() != sublist.hashCode());
     }
 
-    @Test
-    public void testEqualsOnShorterList() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testEqualsOnShorterList(Callable<ObservableList<String>> listFactory) throws Exception {
+        setup(listFactory);
         List<String> other = Arrays.asList("b", "c", "d");
         assertFalse(sublist.equals(other));
         assertTrue(other.hashCode() != sublist.hashCode());
     }
 
-    @Test
-    public void testEquals() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testEquals(Callable<ObservableList<String>> listFactory) throws Exception {
+        setup(listFactory);
         List<String> other = Arrays.asList("b", "c", "d", "e");
         assertTrue(sublist.equals(other));
         assertEquals(other.hashCode(), sublist.hashCode());
     }
 
-    @Test
-    public void testEqualsWithNull() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testEqualsWithNull(Callable<ObservableList<String>> listFactory) throws Exception {
+        setup(listFactory);
         sublist.add(2, null);
         List<String> other = Arrays.asList("b", "c", null, "e");
         assertFalse(sublist.equals(other));
         assertTrue(other.hashCode() != sublist.hashCode());
     }
 
-    @Test
-    public void testEqualsWithNullOnLongerList() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testEqualsWithNullOnLongerList(Callable<ObservableList<String>> listFactory) throws Exception {
+        setup(listFactory);
         sublist.add(2, null);
         List<String> other = Arrays.asList("b", "c", null, "d", "e");
         assertTrue(sublist.equals(other));
         assertEquals(other.hashCode(), sublist.hashCode());
     }
 
-    @Test
-    public void testEqualsWithNullOnShorterList() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testEqualsWithNullOnShorterList(Callable<ObservableList<String>> listFactory) throws Exception {
+        setup(listFactory);
         sublist.add(2, null);
         List<String> other = Arrays.asList("b", "c", null);
         assertFalse(sublist.equals(other));
         assertTrue(other.hashCode() != sublist.hashCode());
     }
 
-    @Test
-    public void testIndexOf() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testIndexOf(Callable<ObservableList<String>> listFactory) throws Exception {
+        setup(listFactory);
         assertEquals(2, sublist.indexOf("d"));
         assertEquals(-1, sublist.indexOf("a"));
     }
 
-    @Test
-    public void testIndexOfWithNull() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testIndexOfWithNull(Callable<ObservableList<String>> listFactory) throws Exception {
+        setup(listFactory);
         sublist.add(2, null);
         assertEquals(3, sublist.indexOf("d"));
         assertEquals(2, sublist.indexOf(null));
         assertEquals(-1, sublist.indexOf("f"));
     }
 
-    @Test
-    public void testIsEmpty() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testIsEmpty(Callable<ObservableList<String>> listFactory) throws Exception {
+        setup(listFactory);
         assertFalse(sublist.isEmpty());
         List<String> otherSublist = list.subList(2, 2);
         assertTrue(otherSublist.isEmpty());
     }
 
-    @Test
-    public void testLastIndexOf() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testLastIndexOf(Callable<ObservableList<String>> listFactory) throws Exception {
+        setup(listFactory);
         list = FXCollections.observableList(new ArrayList<String>());
         list.addAll(Arrays.asList("a", null, "a", null, "a", null, "a"));
         sublist = list.subList(1, 5);
@@ -237,8 +271,10 @@ public class ObservableSubListTest {
         assertEquals(2, sublist.lastIndexOf(null));
     }
 
-    @Test
-    public void testRemoveAll() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testRemoveAll(Callable<ObservableList<String>> listFactory) throws Exception {
+        setup(listFactory);
         list = FXCollections.observableList(new ArrayList<String>());
         list.addAll(Arrays.asList("a", "b", "c", "a", "b", "c"));
         sublist = list.subList(2, 4);
@@ -251,8 +287,10 @@ public class ObservableSubListTest {
         mlo.check1AddRemove(list, Arrays.asList("c", "a"), 2, 2);
     }
 
-    @Test
-    public void testRemoveIndex() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testRemoveIndex(Callable<ObservableList<String>> listFactory) throws Exception {
+        setup(listFactory);
         String s = sublist.remove(2);
         assertEquals("d", s);
         assertEquals(3, sublist.size());
@@ -261,8 +299,10 @@ public class ObservableSubListTest {
         mlo.check1AddRemove(list, Collections.singletonList("d"), 3, 3);
     }
 
-    @Test
-    public void testRemoveNull() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testRemoveNull(Callable<ObservableList<String>> listFactory) throws Exception {
+        setup(listFactory);
         sublist.add(2, null);
         assertTrue(sublist.remove(null));
         assertEquals(4, sublist.size());
@@ -270,8 +310,10 @@ public class ObservableSubListTest {
         assertEquals("[a, b, c, d, e, f]", list.toString());
     }
 
-    @Test
-    public void testRemoveObjectExists() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testRemoveObjectExists(Callable<ObservableList<String>> listFactory) throws Exception {
+        setup(listFactory);
         assertTrue(sublist.remove("b"));
         assertEquals(3, sublist.size());
         assertEquals("[c, d, e]", sublist.toString());
@@ -279,8 +321,10 @@ public class ObservableSubListTest {
         mlo.check1AddRemove(list, Collections.singletonList("b"), 1, 1);
     }
 
-    @Test
-    public void testRemoveObjectNotExists() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testRemoveObjectNotExists(Callable<ObservableList<String>> listFactory) throws Exception {
+        setup(listFactory);
         assertFalse(sublist.remove("f"));
         assertEquals(4, sublist.size());
         assertEquals("[b, c, d, e]", sublist.toString());
@@ -288,8 +332,10 @@ public class ObservableSubListTest {
         mlo.check0();
     }
 
-    @Test
-    public void testRetainAll() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testRetainAll(Callable<ObservableList<String>> listFactory) throws Exception {
+        setup(listFactory);
         list = FXCollections.observableList(new ArrayList<String>());
         list.addAll(Arrays.asList("a", "b", "c", "a", "b", "c"));
         list.addListener(mlo);
@@ -302,8 +348,10 @@ public class ObservableSubListTest {
         mlo.check1AddRemove(list, Collections.singletonList("a"), 3, 3);
     }
 
-    @Test
-    public void testSet() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSet(Callable<ObservableList<String>> listFactory) throws Exception {
+        setup(listFactory);
         String s = sublist.set(2, "X");
         assertEquals("d", s);
         assertEquals("[b, c, X, e]", sublist.toString());
@@ -311,22 +359,28 @@ public class ObservableSubListTest {
         mlo.check1AddRemove(list, Collections.singletonList("d"), 3, 4);
     }
 
-    @Test
-    public void testSize() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSize(Callable<ObservableList<String>> listFactory) throws Exception {
+        setup(listFactory);
         assertEquals(4, sublist.size());
         List<String> otherSublist = list.subList(3, 3);
         assertEquals(0, otherSublist.size());
     }
 
-    @Test
-    public void testSubSubList() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSubSubList(Callable<ObservableList<String>> listFactory) throws Exception {
+        setup(listFactory);
         List<String> subsublist = sublist.subList(1, 3);
         assertEquals(2, subsublist.size());
         assertEquals("[c, d]", subsublist.toString());
     }
 
-    @Test
-    public void testSubSubListAdd() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSubSubListAdd(Callable<ObservableList<String>> listFactory) throws Exception {
+        setup(listFactory);
         List<String> subsublist = sublist.subList(1, 3);
         subsublist.add(1, "X");
         // sublist is now invalid
@@ -334,8 +388,10 @@ public class ObservableSubListTest {
         assertEquals("[a, b, c, X, d, e, f]", list.toString());
     }
 
-    @Test
-    public void testSubSubListRemove() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSubSubListRemove(Callable<ObservableList<String>> listFactory) throws Exception {
+        setup(listFactory);
         List<String> subsublist = sublist.subList(1, 3);
         assertEquals("c", subsublist.remove(0));
         // sublist is now invalid
@@ -343,8 +399,10 @@ public class ObservableSubListTest {
         assertEquals("[a, b, d, e, f]", list.toString());
     }
 
-    @Test
-    public void testSubSubListSet() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testSubSubListSet(Callable<ObservableList<String>> listFactory) throws Exception {
+        setup(listFactory);
         List<String> subsublist = sublist.subList(1, 3);
         String s = subsublist.set(1, "X");
         assertEquals("d", s);
@@ -353,8 +411,10 @@ public class ObservableSubListTest {
         assertEquals("[a, b, c, X, e, f]", list.toString());
     }
 
-    @Test
-    public void testToString() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testToString(Callable<ObservableList<String>> listFactory) throws Exception {
+        setup(listFactory);
         List<String> sub0 = list.subList(3, 3);
         List<String> sub1 = list.subList(3, 4);
         List<String> sub2 = list.subList(2, 5);
@@ -364,93 +424,127 @@ public class ObservableSubListTest {
         assertEquals("[c, d, e]", sub2.toString());
     }
 
-    @Test
-    public void testConcurrencyGet() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testConcurrencyGet(Callable<ObservableList<String>> listFactory) throws Exception {
+        setup(listFactory);
         list.add("x");
         try { sublist.get(0); } catch (ConcurrentModificationException e) {return;}
         fail("Expected ConcurrentModificationException");
     }
-    @Test
-    public void testConcurrencyAdd() {
+
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testConcurrencyAdd(Callable<ObservableList<String>> listFactory) throws Exception {
+        setup(listFactory);
         list.add("x");
         try { sublist.add("y"); } catch (ConcurrentModificationException e) {return;}
         fail("Expected ConcurrentModificationException");
     }
-    @Test
-    public void testConcurrencyAddAll() {
+
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testConcurrencyAddAll(Callable<ObservableList<String>> listFactory) throws Exception {
+        setup(listFactory);
         list.add("x");
         try { sublist.addAll(Collections.singleton("y")); } catch (ConcurrentModificationException e) {return;}
         fail("Expected ConcurrentModificationException");
     }
-    @Test
-    public void testConcurrencyClear() {
+
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testConcurrencyClear(Callable<ObservableList<String>> listFactory) throws Exception {
+        setup(listFactory);
         list.add("x");
         try { sublist.addAll(Collections.singleton("y")); } catch (ConcurrentModificationException e) {return;}
         fail("Expected ConcurrentModificationException");
     }
-    @Test
-    public void testConcurrencyContains() {
+
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testConcurrencyContains(Callable<ObservableList<String>> listFactory) throws Exception {
+        setup(listFactory);
         list.add("x");
         try { sublist.contains("x"); } catch (ConcurrentModificationException e) {return;}
         fail("Expected ConcurrentModificationException");
     }
-    @Test
-    public void testConcurrencyContainsAll() {
+
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testConcurrencyContainsAll(Callable<ObservableList<String>> listFactory) throws Exception {
+        setup(listFactory);
         list.add("x");
         try { sublist.containsAll(Collections.singletonList("x")); } catch (ConcurrentModificationException e) {return;}
         fail("Expected ConcurrentModificationException");
     }
 
-    @Test
-    public void testConcurrencyIsEmpty() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testConcurrencyIsEmpty(Callable<ObservableList<String>> listFactory) throws Exception {
+        setup(listFactory);
         list.add("x");
         try { sublist.isEmpty(); } catch (ConcurrentModificationException e) {return;}
         fail("Expected ConcurrentModificationException");
     }
 
-    @Test
-    public void testConcurrencyIterator() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testConcurrencyIterator(Callable<ObservableList<String>> listFactory) throws Exception {
+        setup(listFactory);
         list.add("x");
         try { sublist.iterator().next(); } catch (ConcurrentModificationException e) {return;}
         fail("Expected ConcurrentModificationException");
     }
 
-    @Test
-    public void testConcurrencyRemove() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testConcurrencyRemove(Callable<ObservableList<String>> listFactory) throws Exception {
+        setup(listFactory);
         list.add("x");
         try { sublist.remove("y"); } catch (ConcurrentModificationException e) {return;}
         fail("Expected ConcurrentModificationException");
     }
 
-    @Test
-    public void testConcurrencyRemove0() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testConcurrencyRemove0(Callable<ObservableList<String>> listFactory) throws Exception {
+        setup(listFactory);
         list.add("x");
         try { sublist.remove(0); } catch (ConcurrentModificationException e) {return;}
         fail("Expected ConcurrentModificationException");
     }
 
-    @Test
-    public void testConcurrencySet() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testConcurrencySet(Callable<ObservableList<String>> listFactory) throws Exception {
+        setup(listFactory);
         list.add("x");
         try { sublist.set(0, "y"); } catch (ConcurrentModificationException e) {return;}
         fail("Expected ConcurrentModificationException");
     }
 
-    @Test
-    public void testConcurrencyRemoveAll() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testConcurrencyRemoveAll(Callable<ObservableList<String>> listFactory) throws Exception {
+        setup(listFactory);
         list.add("x");
         try { sublist.removeAll(Arrays.asList("c", "d")); } catch (ConcurrentModificationException e) {return;}
         fail("Expected ConcurrentModificationException");
     }
 
-    @Test
-    public void testConcurrencyRetainAll() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testConcurrencyRetainAll(Callable<ObservableList<String>> listFactory) throws Exception {
+        setup(listFactory);
         list.add("x");
         try { sublist.retainAll(Arrays.asList("c", "d")); } catch (ConcurrentModificationException e) {return;}
         fail("Expected ConcurrentModificationException");
     }
-    @Test
-    public void testConcurrencyRetainSize() {
+    
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testConcurrencyRetainSize(Callable<ObservableList<String>> listFactory) throws Exception {
+        setup(listFactory);
         list.add("x");
         try { sublist.size(); } catch (ConcurrentModificationException e) {return;}
         fail("Expected ConcurrentModificationException");

--- a/modules/javafx.base/src/test/java/test/javafx/collections/SourceAdapterChangeTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/collections/SourceAdapterChangeTest.java
@@ -33,12 +33,11 @@ import javafx.beans.Observable;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.SortedList;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
 public class SourceAdapterChangeTest {
 
     @FunctionalInterface
@@ -60,7 +59,6 @@ public class SourceAdapterChangeTest {
                 }
             };
 
-    @Parameterized.Parameters
     public static Collection createParameters() {
         Object[][] data = new Object[][] {
             { unmodifiableObservableList },
@@ -71,16 +69,15 @@ public class SourceAdapterChangeTest {
         return Arrays.asList(data);
     }
 
-    final ListFactory listFactory;
+    ListFactory listFactory;
     ObservableList<Person> items;
     ObservableList<Person> list;
     MockListObserver<Person> mlo;
 
-    public SourceAdapterChangeTest(ListFactory listFactory) {
+    public void SourceAdapterChangeTest_(ListFactory listFactory) {
         this.listFactory = listFactory;
     }
 
-    @Before
     public void setUp() throws Exception {
         items = FXCollections.observableArrayList(
                 (Person p) -> new Observable[]{p.name});
@@ -92,8 +89,11 @@ public class SourceAdapterChangeTest {
         list.addListener(mlo);
     }
 
-    @Test
-    public void testUpdate() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testUpdate(ListFactory listFactory) throws Exception {
+        SourceAdapterChangeTest_(listFactory);
+        setUp();
         items.get(3).name.set("zero"); // four -> zero
         ObservableList<Person> expected = FXCollections.observableArrayList(
                 new Person("one"), new Person("two"), new Person("three"),
@@ -101,8 +101,11 @@ public class SourceAdapterChangeTest {
         mlo.check1Update(expected, 3, 4);
     }
 
-    @Test
-    public void testPermutation() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testPermutation(ListFactory listFactory) throws Exception {
+        SourceAdapterChangeTest_(listFactory);
+        setUp();
         FXCollections.sort(items);
         ObservableList<Person> expected = FXCollections.observableArrayList(
                 new Person("five"), new Person("four"), new Person("one"),
@@ -110,8 +113,11 @@ public class SourceAdapterChangeTest {
         mlo.check1Permutation(expected, new int[]{2, 4, 3, 1, 0});
     }
 
-    @Test
-    public void testPermutationUpdate() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testPermutationUpdate(ListFactory listFactory) throws Exception {
+        SourceAdapterChangeTest_(listFactory);
+        setUp();
         SortedList<Person> sorted = items.sorted((o1, o2) -> o1.compareTo(o2));
         list.removeListener(mlo);
         list = listFactory.createList(sorted);

--- a/modules/javafx.base/src/test/java/test/javafx/collections/UnmodifiableObservableMapTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/collections/UnmodifiableObservableMapTest.java
@@ -25,8 +25,8 @@
 
 package test.javafx.collections;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -37,24 +37,22 @@ import java.util.Map;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableMap;
 import static test.javafx.collections.MockMapObserver.Tuple.tup;
-import static org.junit.Assert.*;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
 public class UnmodifiableObservableMapTest {
 
-    final Callable<ObservableMap<String, String>> mapFactory;
+    Callable<ObservableMap<String, String>> mapFactory;
     private ObservableMap<String, String> observableMap;
     private ObservableMap<String, String> unmodifiableMap;
     private MockMapObserver<String, String> observer;
 
 
-    public UnmodifiableObservableMapTest(final Callable<ObservableMap<String, String>> mapFactory) {
+    public void UnmodifiableObservableMapTest_(Callable<ObservableMap<String, String>> mapFactory) {
         this.mapFactory = mapFactory;
     }
 
-    @Parameterized.Parameters
     public static Collection createParameters() {
         Object[][] data = new Object[][] {
             { TestedObservableMaps.HASH_MAP },
@@ -67,7 +65,6 @@ public class UnmodifiableObservableMapTest {
         return Arrays.asList(data);
     }
 
-    @Before
     public void setUp() throws Exception {
         observableMap = mapFactory.call();
         unmodifiableMap = FXCollections.unmodifiableObservableMap(observableMap);
@@ -92,13 +89,16 @@ public class UnmodifiableObservableMapTest {
         observer.clear();
     }
 
-    @Test
-    public void testObservability() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testObservability(Callable<ObservableMap<String, String>> mapFactory) throws Exception {
         /*
          * Since unmodifiable ObservableMap wraps an ObservableMap, we need to test
          * Observability of changes to the underlying Map, we won't test the full
          * ObservableMap API since that is already done.
          */
+        UnmodifiableObservableMapTest_(mapFactory);
+        setUp();
         observableMap.put("observedFoo", "barVal");
         observableMap.put("foo", "barfoo");
         assertEquals("barVal", unmodifiableMap.get("observedFoo"));
@@ -117,8 +117,11 @@ public class UnmodifiableObservableMapTest {
         assertEquals(observer.getCallsNumber(), 4);
     }
 
-    @Test
-    public void testPutAll() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testPutAll(Callable<ObservableMap<String, String>> mapFactory) throws Exception {
+        UnmodifiableObservableMapTest_(mapFactory);
+        setUp();
         Map<String, String> map = new HashMap<>();
         map.put("oFoo", "OFoo");
         map.put("pFoo", "PFoo");
@@ -130,16 +133,22 @@ public class UnmodifiableObservableMapTest {
         } catch(UnsupportedOperationException e) {}
     }
 
-    @Test
-    public void testClear() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testClear(Callable<ObservableMap<String, String>> mapFactory) throws Exception {
+        UnmodifiableObservableMapTest_(mapFactory);
+        setUp();
         try {
             unmodifiableMap.clear();
             fail("Expected UnsupportedOperationException");
         } catch(UnsupportedOperationException e) {}
     }
 
-    @Test
-    public void testKeySet() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testKeySet(Callable<ObservableMap<String, String>> mapFactory) throws Exception {
+        UnmodifiableObservableMapTest_(mapFactory);
+        setUp();
         try {
             unmodifiableMap.keySet().remove("one");
             fail("Expected UnsupportedOperationException");
@@ -158,19 +167,25 @@ public class UnmodifiableObservableMapTest {
         } catch(UnsupportedOperationException e) {}
     }
 
-    @Test
-    public void testKeySet_Iterator() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testKeySet_Iterator(Callable<ObservableMap<String, String>> mapFactory) throws Exception {
+        UnmodifiableObservableMapTest_(mapFactory);
+        setUp();
         // iterators should not be removable
         Iterator<String> iterator = unmodifiableMap.keySet().iterator();
-        assertTrue("Test error, underlying Map should not be empty!", iterator.hasNext());
+        assertTrue(iterator.hasNext(), () -> "Test error, underlying Map should not be empty!");
         try {
             iterator.remove();
             fail("Expected UnsupportedOperationException");
         } catch(UnsupportedOperationException e) {}
     }
 
-    @Test
-    public void testValues() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testValues(Callable<ObservableMap<String, String>> mapFactory) throws Exception {
+        UnmodifiableObservableMapTest_(mapFactory);
+        setUp();
         try {
             unmodifiableMap.values().remove("1");
             fail("Expected UnsupportedOperationException");
@@ -189,18 +204,24 @@ public class UnmodifiableObservableMapTest {
         } catch(UnsupportedOperationException e) {}
     }
 
-    @Test
-    public void testValues_Iterator() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testValues_Iterator(Callable<ObservableMap<String, String>> mapFactory) throws Exception {
+        UnmodifiableObservableMapTest_(mapFactory);
+        setUp();
         Iterator<String> iterator = unmodifiableMap.values().iterator();
-        assertTrue("Test error, underlying Map should not be empty!", iterator.hasNext());
+        assertTrue(iterator.hasNext(), () -> "Test error, underlying Map should not be empty!");
         try {
             iterator.remove();
             fail("Expected UnsupportedOperationException");
         } catch(UnsupportedOperationException e) {}
     }
 
-    @Test
-    public void testEntrySet() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testEntrySet(Callable<ObservableMap<String, String>> mapFactory) throws Exception {
+        UnmodifiableObservableMapTest_(mapFactory);
+        setUp();
         try {
             unmodifiableMap.entrySet().remove(entry("one","1"));
             fail("Expected UnsupportedOperationException");
@@ -219,10 +240,13 @@ public class UnmodifiableObservableMapTest {
         } catch(UnsupportedOperationException e) {}
     }
 
-    @Test
-    public void testEntrySet_Iterator() {
+    @ParameterizedTest
+    @MethodSource("createParameters")
+    public void testEntrySet_Iterator(Callable<ObservableMap<String, String>> mapFactory) throws Exception {
+        UnmodifiableObservableMapTest_(mapFactory);
+        setUp();
         Iterator<Map.Entry<String, String>> iterator = unmodifiableMap.entrySet().iterator();
-        assertTrue("Test error, underlying Map should not be empty!", iterator.hasNext());
+        assertTrue(iterator.hasNext(), () -> "Test error, underlying Map should not be empty!");
         try {
             iterator.remove();
             fail("Expected UnsupportedOperationException");

--- a/modules/javafx.base/src/test/java/test/javafx/util/DurationValueOfTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/util/DurationValueOfTest.java
@@ -25,68 +25,62 @@
 
 package test.javafx.util;
 
-import java.util.Arrays;
-import java.util.Collection;
+import java.util.stream.Stream;
 import javafx.util.Duration;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import static org.junit.Assert.assertEquals;
-
-/**
- */
-@RunWith(Parameterized.class)
 public class DurationValueOfTest {
-    @SuppressWarnings("rawtypes")
-    @Parameterized.Parameters public static Collection implementations() {
-        return Arrays.asList(new Object[][]{
-                {"5ms", Duration.millis(5)},
-                {"0ms", Duration.ZERO},
-                {"25.5ms", Duration.millis(25.5)},
-                {"-10ms", Duration.millis(-10)},
-                {"5s", Duration.seconds(5)},
-                {"0s", Duration.ZERO},
-                {"25.5s", Duration.seconds(25.5)},
-                {"-10s", Duration.seconds(-10)},
-                {"5m", Duration.minutes(5)},
-                {"0m", Duration.ZERO},
-                {"25.5m", Duration.minutes(25.5)},
-                {"-10m", Duration.minutes(-10)},
-                {"5h", Duration.hours(5)},
-                {"0h", Duration.ZERO},
-                {"25.5h", Duration.hours(25.5)},
-                {"-10h", Duration.hours(-10)}
-        });
+
+    static Stream<Arguments> provideTestCases() {
+        return Stream.of(
+                Arguments.of("5ms", Duration.millis(5)),
+                Arguments.of("0ms", Duration.ZERO),
+                Arguments.of("25.5ms", Duration.millis(25.5)),
+                Arguments.of("-10ms", Duration.millis(-10)),
+                Arguments.of("5s", Duration.seconds(5)),
+                Arguments.of("0s", Duration.ZERO),
+                Arguments.of("25.5s", Duration.seconds(25.5)),
+                Arguments.of("-10s", Duration.seconds(-10)),
+                Arguments.of("5m", Duration.minutes(5)),
+                Arguments.of("0m", Duration.ZERO),
+                Arguments.of("25.5m", Duration.minutes(25.5)),
+                Arguments.of("-10m", Duration.minutes(-10)),
+                Arguments.of("5h", Duration.hours(5)),
+                Arguments.of("0h", Duration.ZERO),
+                Arguments.of("25.5h", Duration.hours(25.5)),
+                Arguments.of("-10h", Duration.hours(-10))
+        );
     }
 
-    private String asString;
-    private Duration expected;
-
-    public DurationValueOfTest(String asString, Duration expected) {
-        this.asString = asString;
-        this.expected = expected;
-    }
-
-    @Test public void testValueOf() {
+    @ParameterizedTest
+    @MethodSource("provideTestCases")
+    void testValueOf(String asString, Duration expected) {
         Duration actual = Duration.valueOf(asString);
         assertEquals(expected, actual);
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void leadingSpaceResultsInException() {
-        Duration.valueOf(" " + asString);
+    @ParameterizedTest
+    @MethodSource("provideTestCases")
+    void leadingSpaceResultsInException(String asString, Duration expected) {
+        assertThrows(IllegalArgumentException.class, () -> Duration.valueOf(" " + asString));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void trailingSpaceResultsInException() {
-        Duration.valueOf(asString + " ");
+    @ParameterizedTest
+    @MethodSource("provideTestCases")
+    void trailingSpaceResultsInException(String asString, Duration expected) {
+        assertThrows(IllegalArgumentException.class, () -> Duration.valueOf(asString + " "));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void wrongCaseResultsInException() {
-        String mangled = asString.substring(0, asString.length()-1) + Character.toUpperCase(asString.charAt(asString.length()-1));
-        Duration.valueOf(mangled);
+    @ParameterizedTest
+    @MethodSource("provideTestCases")
+    void wrongCaseResultsInException(String asString, Duration expected) {
+        String mangled = asString.substring(0, asString.length() - 1)
+                + Character.toUpperCase(asString.charAt(asString.length() - 1));
+        assertThrows(IllegalArgumentException.class, () -> Duration.valueOf(mangled));
     }
 }

--- a/modules/javafx.base/src/test/java/test/javafx/util/converter/CurrencyStringConverterTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/util/converter/CurrencyStringConverterTest.java
@@ -30,53 +30,52 @@ import java.text.NumberFormat;
 import java.util.Locale;
 import javafx.util.converter.CurrencyStringConverter;
 import javafx.util.converter.NumberStringConverterShim;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import org.junit.Before;
-import org.junit.Test;
-
-/**
- */
 public class CurrencyStringConverterTest {
     private CurrencyStringConverter converter;
 
-    @Before public void setup() {
+    @BeforeEach
+    void setup() {
         converter = new CurrencyStringConverter(Locale.US);
     }
 
-    /*********************************************************************
-     * Test constructors
-     ********************************************************************/
-
-    @Test public void testDefaultConstructor() {
+    @Test
+    void testDefaultConstructor() {
         CurrencyStringConverter c = new CurrencyStringConverter();
         assertEquals(Locale.getDefault(), NumberStringConverterShim.getLocale(c));
         assertNull(NumberStringConverterShim.getPattern(c));
         assertNull(NumberStringConverterShim.getNumberFormatVar(c));
     }
 
-    @Test public void testConstructor_locale() {
+    @Test
+    void testConstructor_locale() {
         CurrencyStringConverter c = new CurrencyStringConverter(Locale.CANADA);
         assertEquals(Locale.CANADA, NumberStringConverterShim.getLocale(c));
         assertNull(NumberStringConverterShim.getPattern(c));
         assertNull(NumberStringConverterShim.getNumberFormatVar(c));
     }
 
-    @Test public void testConstructor_pattern() {
+    @Test
+    void testConstructor_pattern() {
         CurrencyStringConverter c = new CurrencyStringConverter("#,##,###,####");
         assertEquals(Locale.getDefault(), NumberStringConverterShim.getLocale(c));
         assertEquals("#,##,###,####", NumberStringConverterShim.getPattern(c));
         assertNull(NumberStringConverterShim.getNumberFormatVar(c));
     }
 
-    @Test public void testConstructor_locale_pattern() {
+    @Test
+    void testConstructor_locale_pattern() {
         CurrencyStringConverter c = new CurrencyStringConverter(Locale.CANADA, "#,##,###,####");
         assertEquals(Locale.CANADA, NumberStringConverterShim.getLocale(c));
         assertEquals("#,##,###,####", NumberStringConverterShim.getPattern(c));
         assertNull(NumberStringConverterShim.getNumberFormatVar(c));
     }
 
-    @Test public void testConstructor_numberFormat() {
+    @Test
+    void testConstructor_numberFormat() {
         NumberFormat format = NumberFormat.getCurrencyInstance(Locale.JAPAN);
         CurrencyStringConverter c = new CurrencyStringConverter(format);
         assertNull(NumberStringConverterShim.getLocale(c));
@@ -84,42 +83,36 @@ public class CurrencyStringConverterTest {
         assertEquals(format, NumberStringConverterShim.getNumberFormatVar(c));
     }
 
-
-    /*********************************************************************
-     * Test methods
-     ********************************************************************/
-
-    @Test public void getNumberFormat_default() {
+    @Test
+    void getNumberFormat_default() {
         assertNotNull(NumberStringConverterShim.getNumberFormat(converter));
     }
 
-    @Test public void getNumberFormat_nonNullPattern() {
+    @Test
+    void getNumberFormat_nonNullPattern() {
         converter = new CurrencyStringConverter("#,##,###,####");
-        assertTrue(
-                NumberStringConverterShim.getNumberFormat(converter)
-                        instanceof DecimalFormat);
+        assertTrue(NumberStringConverterShim.getNumberFormat(converter) instanceof DecimalFormat);
     }
 
-    @Test public void getNumberFormat_nonNullNumberFormat() {
+    @Test
+    void getNumberFormat_nonNullNumberFormat() {
         NumberFormat nf = NumberFormat.getCurrencyInstance();
         converter = new CurrencyStringConverter(nf);
         assertEquals(nf, NumberStringConverterShim.getNumberFormat(converter));
     }
 
-
-    /*********************************************************************
-     * Test toString / fromString methods
-     ********************************************************************/
-
-    @Test public void fromString_testValidStringInput() {
+    @Test
+    void fromString_testValidStringInput() {
         assertEquals(10.32, converter.fromString("$10.32"));
     }
 
-    @Test public void fromString_testValidStringInputWithWhiteSpace() {
+    @Test
+    void fromString_testValidStringInputWithWhiteSpace() {
         assertEquals(10.32, converter.fromString("      $10.32      "));
     }
 
-    @Test public void toString_validInput() {
+    @Test
+    void toString_validInput() {
         assertEquals("$10.32", converter.toString(10.32));
     }
 }

--- a/modules/javafx.base/src/test/java/test/javafx/util/converter/DateStringConverterTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/util/converter/DateStringConverterTest.java
@@ -25,145 +25,60 @@
 
 package test.javafx.util.converter;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
-import java.util.Arrays;
-import java.util.Calendar;
-import java.util.Collection;
-import java.util.Date;
-import java.util.Locale;
-import java.util.TimeZone;
+import java.util.*;
+import java.util.stream.Stream;
 import javafx.util.converter.DateStringConverter;
 import javafx.util.converter.DateTimeStringConverterShim;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.Arguments;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+class DateStringConverterTest {
 
-/**
- */
-@RunWith(Parameterized.class)
-public class DateStringConverterTest {
     private static final Date VALID_DATE;
-
     static {
         TimeZone.setDefault(TimeZone.getTimeZone("GMT"));
         Calendar c = Calendar.getInstance();
-        c.set(Calendar.YEAR, 1985);
-        c.set(Calendar.MONTH, Calendar.JANUARY);
-        c.set(Calendar.DAY_OF_MONTH, 12);
-        c.set(Calendar.HOUR_OF_DAY, 0);
-        c.set(Calendar.MINUTE, 0);
-        c.set(Calendar.SECOND, 0);
+        c.set(1985, Calendar.JANUARY, 12, 0, 0, 0);
         c.set(Calendar.MILLISECOND, 0);
         VALID_DATE = c.getTime();
     }
 
-    @Parameterized.Parameters public static Collection implementations() {
-        return Arrays.asList(new Object[][] {
-            { new DateStringConverter(),
-              Locale.getDefault(Locale.Category.FORMAT), DateFormat.DEFAULT,
-              VALID_DATE, null, null },
-
-            { new DateStringConverter(DateFormat.SHORT),
-              Locale.getDefault(Locale.Category.FORMAT), DateFormat.SHORT,
-              VALID_DATE, null, null },
-
-            { new DateStringConverter(Locale.UK),
-              Locale.UK, DateFormat.DEFAULT,
-              VALID_DATE, null, null },
-
-            { new DateStringConverter(Locale.UK, DateFormat.SHORT),
-              Locale.UK, DateFormat.SHORT,
-              VALID_DATE, null, null },
-
-            { new DateStringConverter("dd MM yyyy"),
-              Locale.getDefault(Locale.Category.FORMAT), DateFormat.DEFAULT,
-              VALID_DATE, "dd MM yyyy", null },
-
-            { new DateStringConverter(DateFormat.getDateInstance(DateFormat.LONG)),
-              Locale.getDefault(Locale.Category.FORMAT), DateFormat.DEFAULT,
-              VALID_DATE, null, DateFormat.getDateInstance(DateFormat.LONG) },
-        });
-    }
-
     private DateStringConverter converter;
-    private Locale locale;
-    private int dateStyle;
-    private String pattern;
-    private DateFormat dateFormat;
-    private Date validDate;
     private DateFormat validFormatter;
 
-    public DateStringConverterTest(DateStringConverter converter, Locale locale, int dateStyle, Date validDate, String pattern, DateFormat dateFormat) {
-        this.converter = converter;
-        this.locale = locale;
-        this.dateStyle = dateStyle;
-        this.validDate = validDate;
-        this.pattern = pattern;
-        this.dateFormat = dateFormat;
+    @BeforeEach
+    void setup() {}
 
-        if (dateFormat != null) {
-            validFormatter = dateFormat;
-        } else if (pattern != null) {
-            validFormatter = new SimpleDateFormat(pattern);
-        } else {
-            validFormatter = DateFormat.getDateInstance(dateStyle, locale);
-        }
+    static Stream<Arguments> implementations() {
+        return Stream.of(
+                Arguments.of(new DateStringConverter(), Locale.getDefault(Locale.Category.FORMAT), DateFormat.DEFAULT, VALID_DATE, null, null),
+                Arguments.of(new DateStringConverter(DateFormat.SHORT), Locale.getDefault(Locale.Category.FORMAT), DateFormat.SHORT, VALID_DATE, null, null),
+                Arguments.of(new DateStringConverter(Locale.UK), Locale.UK, DateFormat.DEFAULT, VALID_DATE, null, null),
+                Arguments.of(new DateStringConverter(Locale.UK, DateFormat.SHORT), Locale.UK, DateFormat.SHORT, VALID_DATE, null, null),
+                Arguments.of(new DateStringConverter("dd MM yyyy"), Locale.getDefault(Locale.Category.FORMAT), DateFormat.DEFAULT, VALID_DATE, "dd MM yyyy", null),
+                Arguments.of(new DateStringConverter(DateFormat.getDateInstance(DateFormat.LONG)), Locale.getDefault(Locale.Category.FORMAT), DateFormat.DEFAULT, VALID_DATE, null, DateFormat.getDateInstance(DateFormat.LONG))
+        );
     }
 
-    @Before public void setup() {
-    }
-
-    /*********************************************************************
-     * Test constructors
-     ********************************************************************/
-
-    @Test public void testConstructor() {
+    @ParameterizedTest
+    @MethodSource("implementations")
+    void testConstructor(DateStringConverter converter, Locale locale, int dateStyle, Date validDate, String pattern, DateFormat dateFormat) {
         assertEquals(locale, DateTimeStringConverterShim.getLocale(converter));
         assertEquals(dateStyle, DateTimeStringConverterShim.getDateStyle(converter));
         assertEquals(pattern, DateTimeStringConverterShim.getPattern(converter));
         assertEquals(dateFormat, DateTimeStringConverterShim.getDateFormatVar(converter));
     }
 
-
-    /*********************************************************************
-     * Test methods
-     ********************************************************************/
-
-    @Test public void getDateFormat() {
-        assertNotNull(DateTimeStringConverterShim.getDateFormat(converter));
-    }
-
-    @Test public void getDateFormat_nonNullPattern() {
-        converter = new DateStringConverter("yyyy");
-        assertTrue(
-                DateTimeStringConverterShim.getDateFormat(converter)
-                        instanceof SimpleDateFormat);
-    }
-
-    /*********************************************************************
-     * Test toString / fromString methods
-     ********************************************************************/
-
-    @Test public void fromString_testValidInput() {
-        String input = validFormatter.format(validDate);
-        assertEquals("Input = "+input, validDate, converter.fromString(input));
-    }
-
-    @Test public void fromString_testValidInputWithWhiteSpace() {
-        String input = validFormatter.format(validDate);
-        assertEquals("Input = "+input, validDate, converter.fromString("      " + input + "      "));
-    }
-
-    @Test(expected=RuntimeException.class)
-    public void fromString_testInvalidInput() {
-        converter.fromString("abcdefg");
-    }
-
-    @Test public void toString_validOutput() {
-        assertEquals(validFormatter.format(validDate), converter.toString(validDate));
+    @Test
+    void fromString_testInvalidInput() {
+        assertThrows(RuntimeException.class, () -> converter.fromString("abcdefg"));
     }
 }
+

--- a/modules/javafx.base/src/test/java/test/javafx/util/converter/LocalDateTimeStringConverterTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/util/converter/LocalDateTimeStringConverterTest.java
@@ -25,183 +25,177 @@
 
 package test.javafx.util.converter;
 
+// Imports remain the same, except JUnit 4 imports are replaced with JUnit 5
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
 import java.time.DateTimeException;
 import java.time.LocalDateTime;
 import java.time.chrono.IsoChronology;
 import java.time.chrono.JapaneseChronology;
 import java.time.format.DateTimeFormatter;
 import java.time.format.FormatStyle;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.Locale;
-import static org.junit.Assert.*;
+import java.util.stream.Stream;
 
 import javafx.util.StringConverter;
 import javafx.util.converter.LocalDateTimeStringConverter;
 import javafx.util.converter.LocalDateTimeStringConverterShim;
 
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-/**
- */
-@RunWith(Parameterized.class)
 public class LocalDateTimeStringConverterTest {
 
+    // Constants and enums remain the same
     private static String JAPANESE_DATE_STRING;
-    private static final LocalDateTime VALID_LDT_WITH_SECONDS    = LocalDateTime.of(1985, 1, 12, 12, 34, 56);
+    private static final LocalDateTime VALID_LDT_WITH_SECONDS = LocalDateTime.of(1985, 1, 12, 12, 34, 56);
     private static final LocalDateTime VALID_LDT_WITHOUT_SECONDS = LocalDateTime.of(1985, 1, 12, 12, 34, 0);
 
     private static DateTimeFormatter aFormatter;
     private static DateTimeFormatter aParser;
     private static Locale oldLocale;
 
-    // We can only create LocalDateTimeStringConverter object after Locale is set.
-    // Unfortunately, due to unpredictability of @Parameterized.Parameters methods
-    // in JUnit, we have to allocate it after @BeforeClass sets up Locale and
-    // necessary static fields. Otherwise, the test may collide with other
-    // Local*StringConverter tests and cause unpredictable results.
-    private enum LocalDateTimeStringConverterVariant {
+    public enum LocalDateTimeStringConverterVariant {
         NO_PARAM,
         WITH_FORMATTER_PARSER,
         WITH_FORMAT_STYLES,
-    };
-
-    @Parameterized.Parameters public static Collection implementations() {
-        return Arrays.asList(new Object[][] {
-            { LocalDateTimeStringConverterVariant.NO_PARAM,
-              FormatStyle.SHORT, FormatStyle.SHORT, VALID_LDT_WITHOUT_SECONDS},
-
-            { LocalDateTimeStringConverterVariant.WITH_FORMATTER_PARSER,
-              null, null, VALID_LDT_WITH_SECONDS},
-
-            { LocalDateTimeStringConverterVariant.WITH_FORMAT_STYLES,
-              FormatStyle.SHORT, FormatStyle.SHORT, VALID_LDT_WITHOUT_SECONDS},
-        });
     }
 
-    private LocalDateTimeStringConverterVariant converterVariant;
-    private FormatStyle dateStyle;
-    private FormatStyle timeStyle;
-    private LocalDateTime validDateTime;
-
-    private LocalDateTimeStringConverter converter;
-    private Locale locale;
-    private DateTimeFormatter formatter, parser;
-
-
-    public LocalDateTimeStringConverterTest(LocalDateTimeStringConverterVariant converterVariant, FormatStyle dateStyle, FormatStyle timeStyle, LocalDateTime validDateTime) {
-        this.converterVariant = converterVariant;
-        this.dateStyle = dateStyle;
-        this.timeStyle = timeStyle;
-        this.validDateTime = validDateTime;
-
-        this.converter = null;
-        this.locale = null;
-        this.formatter = null;
-        this.parser = null;
+    // Parameter source method
+    public static Stream<Arguments> implementations() {
+        return Stream.of(
+                arguments(LocalDateTimeStringConverterVariant.NO_PARAM,
+                        FormatStyle.SHORT, FormatStyle.SHORT, VALID_LDT_WITHOUT_SECONDS),
+                arguments(LocalDateTimeStringConverterVariant.WITH_FORMATTER_PARSER,
+                        null, null, VALID_LDT_WITH_SECONDS),
+                arguments(LocalDateTimeStringConverterVariant.WITH_FORMAT_STYLES,
+                        FormatStyle.SHORT, FormatStyle.SHORT, VALID_LDT_WITHOUT_SECONDS)
+        );
     }
 
-    @BeforeClass
+    @BeforeAll
     public static void setupBeforeAll() {
-        // Tests require that default locale is en_US
         oldLocale = Locale.getDefault();
         Locale.setDefault(Locale.US);
 
-        // DateTimeFormatter uses default locale, so we can init this after updating locale
         aFormatter = DateTimeFormatter.ofPattern("dd MM yyyy HH mm ss");
         aParser = DateTimeFormatter.ofPattern("yyyy MM dd hh mm ss a");
 
         final var version = Runtime.Version.parse(System.getProperty("java.version"));
         if (version.major() < 20) {
-            // TODO: This can be removed when the minimum version of boot jdk
-            // for JFX build is updated to JDK20 or above.
             JAPANESE_DATE_STRING = "Saturday, January 12, 60 Shōwa, 12:34:56 PM";
         } else {
             JAPANESE_DATE_STRING = "Saturday, January 12, 60 Shōwa, 12:34:56\u202fPM";
         }
     }
 
-    @AfterClass
+    @AfterAll
     public static void teardownAfterAll() {
-        // Restore VM's old locale
         Locale.setDefault(oldLocale);
     }
 
-    @Before
-    public void setup() {
-        // Locale is established now, so we can allocate objects depending on it
-        switch (this.converterVariant) {
-        case NO_PARAM:
-            this.converter = new LocalDateTimeStringConverter();
-            this.locale = Locale.getDefault(Locale.Category.FORMAT);
-            this.formatter = null;
-            this.parser = null;
-            break;
-        case WITH_FORMATTER_PARSER:
-            this.converter = new LocalDateTimeStringConverter(aFormatter, aParser);
-            this.locale = Locale.getDefault(Locale.Category.FORMAT);
-            this.formatter = aFormatter;
-            this.parser = aParser;
-            break;
-        case WITH_FORMAT_STYLES:
-            this.converter = new LocalDateTimeStringConverter(FormatStyle.SHORT, FormatStyle.SHORT, Locale.UK, IsoChronology.INSTANCE);
-            this.locale = Locale.UK;
-            this.formatter = null;
-            this.parser = null;
-            break;
-        default:
-            fail("Invalid converter variant: " + this.converterVariant.toString());
-        }
-    }
+    // Parameterized test methods
+    @ParameterizedTest
+    @MethodSource("implementations")
+    void testConstructor(LocalDateTimeStringConverterVariant converterVariant,
+                         FormatStyle dateStyle,
+                         FormatStyle timeStyle,
+                         LocalDateTime validDateTime) {
+        LocalDateTimeStringConverter converter = createConverter(converterVariant);
+        Locale locale = getLocale(converterVariant);
+        DateTimeFormatter formatter = getFormatter(converterVariant);
+        DateTimeFormatter parser = getParser(converterVariant);
 
-    /*********************************************************************
-     * Test constructors
-     ********************************************************************/
-
-    @Test public void testConstructor() {
-        assertEquals(locale,
-                LocalDateTimeStringConverterShim.getldtConverterLocale(converter));
+        assertEquals(locale, LocalDateTimeStringConverterShim.getldtConverterLocale(converter));
         assertEquals((dateStyle != null) ? dateStyle : FormatStyle.SHORT,
                 LocalDateTimeStringConverterShim.getldtConverterDateStyle(converter));
         assertEquals((timeStyle != null) ? timeStyle : FormatStyle.SHORT,
                 LocalDateTimeStringConverterShim.getldtConverterTimeStyle(converter));
         if (formatter != null) {
             assertEquals(formatter,
-                LocalDateTimeStringConverterShim.getldtConverterFormatter(converter));
+                    LocalDateTimeStringConverterShim.getldtConverterFormatter(converter));
         }
         if (parser != null) {
             assertEquals(parser,
-                LocalDateTimeStringConverterShim.getldtConverterParser(converter));
+                    LocalDateTimeStringConverterShim.getldtConverterParser(converter));
         } else if (formatter != null) {
             assertEquals(formatter,
-                LocalDateTimeStringConverterShim.getldtConverterFormatter(converter));
+                    LocalDateTimeStringConverterShim.getldtConverterFormatter(converter));
         }
     }
 
+    @ParameterizedTest
+    @MethodSource("implementations")
+    void toString_to_fromString_testRoundtrip(LocalDateTimeStringConverterVariant converterVariant,
+                                              FormatStyle dateStyle,
+                                              FormatStyle timeStyle,
+                                              LocalDateTime validDateTime) {
+        LocalDateTimeStringConverter converter = createConverter(converterVariant);
+        DateTimeFormatter formatter = getFormatter(converterVariant);
 
-    /*********************************************************************
-     * Test toString / fromString methods
-     ********************************************************************/
-
-    @Test public void toString_to_fromString_testRoundtrip() {
         if (formatter == null) {
-            // Only the default formatter/parser can guarantee roundtrip symmetry
             assertEquals(validDateTime, converter.fromString(converter.toString(validDateTime)));
         }
     }
 
-
-    @Test(expected=RuntimeException.class)
-    public void fromString_testInvalidInput() {
-        converter.fromString("abcdefg");
+    @ParameterizedTest
+    @MethodSource("implementations")
+    void fromString_testInvalidInput(LocalDateTimeStringConverterVariant converterVariant,
+                                     FormatStyle dateStyle,
+                                     FormatStyle timeStyle,
+                                     LocalDateTime validDateTime) {
+        LocalDateTimeStringConverter converter = createConverter(converterVariant);
+        assertThrows(RuntimeException.class, () -> converter.fromString("abcdefg"));
     }
 
-    @Test public void converter_with_specified_formatter_and_parser() {
+    // Helper methods for setup
+    private LocalDateTimeStringConverter createConverter(LocalDateTimeStringConverterVariant variant) {
+        switch (variant) {
+            case NO_PARAM:
+                return new LocalDateTimeStringConverter();
+            case WITH_FORMATTER_PARSER:
+                return new LocalDateTimeStringConverter(aFormatter, aParser);
+            case WITH_FORMAT_STYLES:
+                return new LocalDateTimeStringConverter(FormatStyle.SHORT, FormatStyle.SHORT,
+                        Locale.UK, IsoChronology.INSTANCE);
+            default:
+                fail("Invalid converter variant: " + variant);
+                return null;
+        }
+    }
+
+    private Locale getLocale(LocalDateTimeStringConverterVariant variant) {
+        return switch (variant) {
+            case NO_PARAM, WITH_FORMATTER_PARSER -> Locale.getDefault(Locale.Category.FORMAT);
+            case WITH_FORMAT_STYLES -> Locale.UK;
+            default -> {
+                fail("Invalid converter variant: " + variant);
+                yield null;
+            }
+        };
+    }
+
+    private DateTimeFormatter getFormatter(LocalDateTimeStringConverterVariant variant) {
+        return switch (variant) {
+            case WITH_FORMATTER_PARSER -> aFormatter;
+            default -> null;
+        };
+    }
+
+    private DateTimeFormatter getParser(LocalDateTimeStringConverterVariant variant) {
+        return switch (variant) {
+            case WITH_FORMATTER_PARSER -> aParser;
+            default -> null;
+        };
+    }
+
+    @ParameterizedTest
+    @MethodSource("implementations")
+    void converter_with_specified_formatter_and_parser() {
         String formatPattern = "dd MMMM yyyy, HH:mm:ss";
         String parsePattern = "MMMM dd, yyyy, HH:mm:ss";
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern(formatPattern);
@@ -211,7 +205,9 @@ public class LocalDateTimeStringConverterTest {
         assertEquals(VALID_LDT_WITH_SECONDS, converter.fromString("January 12, 1985, 12:34:56"));
     }
 
-    @Test public void converter_with_specified_formatter_and_null_parser() {
+    @ParameterizedTest
+    @MethodSource("implementations")
+    void converter_with_specified_formatter_and_null_parser() {
         String pattern = "dd MMMM yyyy, HH:mm:ss";
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern(pattern);
         StringConverter<LocalDateTime> converter = new LocalDateTimeStringConverter(formatter, null);
@@ -219,14 +215,16 @@ public class LocalDateTimeStringConverterTest {
         assertEquals(VALID_LDT_WITH_SECONDS, converter.fromString("12 January 1985, 12:34:56"));
     }
 
-    @Test
-    public void testChronologyConsistency() {
-        var converter = new LocalDateTimeStringConverter(FormatStyle.FULL, FormatStyle.MEDIUM, null, JapaneseChronology.INSTANCE);
+    @ParameterizedTest
+    @MethodSource("implementations")
+    void testChronologyConsistency() {
+        var converter = new LocalDateTimeStringConverter(FormatStyle.FULL, FormatStyle.MEDIUM,
+                null, JapaneseChronology.INSTANCE);
         assertEquals(JAPANESE_DATE_STRING, converter.toString(VALID_LDT_WITH_SECONDS));
-        // force a chronology change with an invalid Japanese date
         try {
             converter.toString(LocalDateTime.of(1, 1, 1, 1, 1, 1));
         } catch (DateTimeException e) {}
         assertEquals(VALID_LDT_WITH_SECONDS, converter.fromString(JAPANESE_DATE_STRING));
     }
 }
+

--- a/modules/javafx.base/src/test/java/test/javafx/util/converter/NumberStringConverterTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/util/converter/NumberStringConverterTest.java
@@ -30,53 +30,53 @@ import java.text.NumberFormat;
 import java.util.Locale;
 import javafx.util.converter.NumberStringConverter;
 import javafx.util.converter.NumberStringConverterShim;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-/**
- */
 public class NumberStringConverterTest {
     private NumberStringConverter converter;
 
-    @Before public void setup() {
+    @BeforeEach
+    public void setup() {
         converter = new NumberStringConverter();
     }
 
-    /*********************************************************************
-     * Test constructors
-     ********************************************************************/
-
-    @Test public void testDefaultConstructor() {
+    @Test
+    public void testDefaultConstructor() {
         NumberStringConverter c = new NumberStringConverter();
         assertEquals(Locale.getDefault(), NumberStringConverterShim.getLocale(c));
         assertNull(NumberStringConverterShim.getPattern(c));
         assertNull(NumberStringConverterShim.getNumberFormatVar(c));
     }
 
-    @Test public void testConstructor_locale() {
+    @Test
+    public void testConstructor_locale() {
         NumberStringConverter c = new NumberStringConverter(Locale.CANADA);
         assertEquals(Locale.CANADA, NumberStringConverterShim.getLocale(c));
         assertNull(NumberStringConverterShim.getPattern(c));
         assertNull(NumberStringConverterShim.getNumberFormatVar(c));
     }
 
-    @Test public void testConstructor_pattern() {
+    @Test
+    public void testConstructor_pattern() {
         NumberStringConverter c = new NumberStringConverter("#,##,###,####");
         assertEquals(Locale.getDefault(), NumberStringConverterShim.getLocale(c));
         assertEquals("#,##,###,####", NumberStringConverterShim.getPattern(c));
         assertNull(NumberStringConverterShim.getNumberFormatVar(c));
     }
 
-    @Test public void testConstructor_locale_pattern() {
+    @Test
+    public void testConstructor_locale_pattern() {
         NumberStringConverter c = new NumberStringConverter(Locale.CANADA, "#,##,###,####");
         assertEquals(Locale.CANADA, NumberStringConverterShim.getLocale(c));
         assertEquals("#,##,###,####", NumberStringConverterShim.getPattern(c));
         assertNull(NumberStringConverterShim.getNumberFormatVar(c));
     }
 
-    @Test public void testConstructor_numberFormat() {
+    @Test
+    public void testConstructor_numberFormat() {
         NumberFormat format = NumberFormat.getCurrencyInstance(Locale.JAPAN);
         NumberStringConverter c = new NumberStringConverter(format);
         assertNull(NumberStringConverterShim.getLocale(c));
@@ -84,47 +84,41 @@ public class NumberStringConverterTest {
         assertEquals(format, NumberStringConverterShim.getNumberFormatVar(c));
     }
 
-
-    /*********************************************************************
-     * Test methods
-     ********************************************************************/
-
-    @Test public void getNumberFormat_default() {
+    @Test
+    public void getNumberFormat_default() {
         assertNotNull(NumberStringConverterShim.getNumberFormat(converter));
     }
 
-    @Test public void getNumberFormat_nonNullPattern() {
+    @Test
+    public void getNumberFormat_nonNullPattern() {
         converter = new NumberStringConverter("#,##,###,####");
-        assertTrue(
-                NumberStringConverterShim.getNumberFormat(converter)
-                instanceof DecimalFormat);
+        assertTrue(NumberStringConverterShim.getNumberFormat(converter) instanceof DecimalFormat);
     }
 
-    @Test public void getNumberFormat_nonNullNumberFormat() {
+    @Test
+    public void getNumberFormat_nonNullNumberFormat() {
         NumberFormat nf = NumberFormat.getCurrencyInstance();
         converter = new NumberStringConverter(nf);
         assertEquals(nf, NumberStringConverterShim.getNumberFormat(converter));
     }
 
-
-    /*********************************************************************
-     * Test toString / fromString methods
-     ********************************************************************/
-
-    @Test public void fromString_testValidInput() {
+    @Test
+    public void fromString_testValidInput() {
         assertEquals(10L, converter.fromString("10"));
     }
 
-    @Test public void fromString_testValidInputWithWhiteSpace() {
+    @Test
+    public void fromString_testValidInputWithWhiteSpace() {
         assertEquals(10L, converter.fromString("      10      "));
     }
 
-    @Test(expected=RuntimeException.class)
+    @Test
     public void fromString_testInvalidInput() {
-        converter.fromString("abcdefg");
+        assertThrows(RuntimeException.class, () -> converter.fromString("abcdefg"));
     }
 
-    @Test public void toString_validInput() {
+    @Test
+    public void toString_validInput() {
         assertEquals("10", converter.toString(10L));
     }
 }

--- a/modules/javafx.base/src/test/java/test/javafx/util/converter/ParameterizedConverterTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/util/converter/ParameterizedConverterTest.java
@@ -25,93 +25,70 @@
 
 package test.javafx.util.converter;
 
-import java.util.Arrays;
-import java.util.Collection;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 import javafx.util.StringConverter;
-import javafx.util.converter.BigDecimalStringConverter;
-import javafx.util.converter.BigIntegerStringConverter;
-import javafx.util.converter.BooleanStringConverter;
-import javafx.util.converter.ByteStringConverter;
-import javafx.util.converter.CharacterStringConverter;
-import javafx.util.converter.CurrencyStringConverter;
-import javafx.util.converter.DateStringConverter;
-import javafx.util.converter.DateTimeStringConverter;
-import javafx.util.converter.DefaultStringConverter;
-import javafx.util.converter.DoubleStringConverter;
-import javafx.util.converter.FloatStringConverter;
-import javafx.util.converter.IntegerStringConverter;
-import javafx.util.converter.LongStringConverter;
-import javafx.util.converter.NumberStringConverter;
-import javafx.util.converter.PercentageStringConverter;
-import javafx.util.converter.ShortStringConverter;
-import javafx.util.converter.TimeStringConverter;
+import javafx.util.converter.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import java.util.stream.Stream;
 
-/**
- */
-@RunWith(Parameterized.class)
+import static org.junit.jupiter.api.Assertions.*;
+
 public class ParameterizedConverterTest {
-    private final Class<? extends StringConverter> converterClass;
-    private StringConverter converter;
 
-    @Parameterized.Parameters public static Collection implementations() {
-        return Arrays.asList(new Object[][] {
-            { BigDecimalStringConverter.class },
-            { BigIntegerStringConverter.class },
-            { BooleanStringConverter.class },
-            { ByteStringConverter.class },
-            { CharacterStringConverter.class },
-            { CurrencyStringConverter.class },
-            { DateStringConverter.class },
-            { DateTimeStringConverter.class },
-            { DefaultStringConverter.class },
-            { DoubleStringConverter.class },
-            { FloatStringConverter.class },
-            { IntegerStringConverter.class },
-            { LongStringConverter.class },
-            { NumberStringConverter.class },
-            { PercentageStringConverter.class },
-            { ShortStringConverter.class },
-            { TimeStringConverter.class },
-        });
+    static Stream<Arguments> converterClasses() {
+        return Stream.of(
+                Arguments.of(BigDecimalStringConverter.class),
+                Arguments.of(BigIntegerStringConverter.class),
+                Arguments.of(BooleanStringConverter.class),
+                Arguments.of(ByteStringConverter.class),
+                Arguments.of(CharacterStringConverter.class),
+                Arguments.of(CurrencyStringConverter.class),
+                Arguments.of(DateStringConverter.class),
+                Arguments.of(DateTimeStringConverter.class),
+                Arguments.of(DefaultStringConverter.class),
+                Arguments.of(DoubleStringConverter.class),
+                Arguments.of(FloatStringConverter.class),
+                Arguments.of(IntegerStringConverter.class),
+                Arguments.of(LongStringConverter.class),
+                Arguments.of(NumberStringConverter.class),
+                Arguments.of(PercentageStringConverter.class),
+                Arguments.of(ShortStringConverter.class),
+                Arguments.of(TimeStringConverter.class)
+        );
     }
 
-    public ParameterizedConverterTest(Class<? extends StringConverter> converterClass) {
-        this.converterClass = converterClass;
-    }
-
-    @Before public void setup() {
-        try {
-            converter = converterClass.getDeclaredConstructor().newInstance();
-        } catch (Exception ex) {
-            ex.printStackTrace();
-        }
-    }
-
-    @Test public void toString_testNull() {
+    @ParameterizedTest
+    @MethodSource("converterClasses")
+    void toString_testNull(Class<? extends StringConverter<?>> converterClass) throws Exception {
+        StringConverter<?> converter = converterClass.getDeclaredConstructor().newInstance();
         assertEquals("", converter.toString(null));
     }
 
-    @Test public void fromString_testEmptyStringWithWhiteSpace() {
-        if (converterClass == DefaultStringConverter.class) {
+    @ParameterizedTest
+    @MethodSource("converterClasses")
+    void fromString_testEmptyStringWithWhiteSpace(Class<? extends StringConverter<?>> converterClass) throws Exception {
+        StringConverter<?> converter = converterClass.getDeclaredConstructor().newInstance();
+        if (converter instanceof DefaultStringConverter) {
             assertEquals("      ", converter.fromString("      "));
         } else {
             assertNull(converter.fromString("      "));
         }
     }
 
-    @Test public void fromString_testNull() {
+    @ParameterizedTest
+    @MethodSource("converterClasses")
+    void fromString_testNull(Class<? extends StringConverter<?>> converterClass) throws Exception {
+        StringConverter<?> converter = converterClass.getDeclaredConstructor().newInstance();
         assertNull(converter.fromString(null));
     }
 
-    @Test public void fromString_testEmptyString() {
-        if (converterClass == DefaultStringConverter.class) {
+    @ParameterizedTest
+    @MethodSource("converterClasses")
+    void fromString_testEmptyString(Class<? extends StringConverter<?>> converterClass) throws Exception {
+        StringConverter<?> converter = converterClass.getDeclaredConstructor().newInstance();
+        if (converter instanceof DefaultStringConverter) {
             assertEquals("", converter.fromString(""));
         } else {
             assertNull(converter.fromString(""));

--- a/modules/javafx.base/src/test/java/test/javafx/util/converter/TimeStringConverterTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/util/converter/TimeStringConverterTest.java
@@ -27,24 +27,19 @@ package test.javafx.util.converter;
 
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
-import java.util.Arrays;
 import java.util.Calendar;
-import java.util.Collection;
 import java.util.Date;
 import java.util.Locale;
 import java.util.TimeZone;
+import java.util.stream.Stream;
 import javafx.util.converter.DateTimeStringConverterShim;
 import javafx.util.converter.TimeStringConverter;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-
-/**
- */
-@RunWith(Parameterized.class)
 public class TimeStringConverterTest {
     private static final Date VALID_TIME_WITH_SECONDS;
     private static final Date VALID_TIME_WITHOUT_SECONDS;
@@ -61,109 +56,142 @@ public class TimeStringConverterTest {
         VALID_TIME_WITHOUT_SECONDS = c.getTime();
     }
 
-    @Parameterized.Parameters public static Collection implementations() {
-        return Arrays.asList(new Object[][] {
-            { new TimeStringConverter(),
-              Locale.getDefault(Locale.Category.FORMAT), DateFormat.DEFAULT,
-              VALID_TIME_WITH_SECONDS, null, null },
-
-            { new TimeStringConverter(DateFormat.SHORT),
-              Locale.getDefault(Locale.Category.FORMAT), DateFormat.SHORT,
-              VALID_TIME_WITHOUT_SECONDS, null, null },
-
-            { new TimeStringConverter(Locale.UK),
-              Locale.UK, DateFormat.DEFAULT,
-              VALID_TIME_WITH_SECONDS, null, null },
-
-            { new TimeStringConverter(Locale.UK, DateFormat.SHORT),
-              Locale.UK, DateFormat.SHORT,
-              VALID_TIME_WITHOUT_SECONDS, null, null },
-
-            { new TimeStringConverter("HH mm ss"),
-              Locale.getDefault(Locale.Category.FORMAT), DateFormat.DEFAULT,
-              VALID_TIME_WITH_SECONDS, "HH mm ss", null },
-
-            { new TimeStringConverter(DateFormat.getTimeInstance(DateFormat.FULL)),
-              Locale.getDefault(Locale.Category.FORMAT), DateFormat.DEFAULT,
-              VALID_TIME_WITH_SECONDS, null, DateFormat.getTimeInstance(DateFormat.FULL) },
-        });
+    private static Stream<Arguments> provideAllConverters() {
+        return Stream.of(
+                createTestCase(
+                        new TimeStringConverter(),
+                        Locale.getDefault(Locale.Category.FORMAT),
+                        DateFormat.DEFAULT,
+                        VALID_TIME_WITH_SECONDS,
+                        null,
+                        null
+                ),
+                createTestCase(
+                        new TimeStringConverter(DateFormat.SHORT),
+                        Locale.getDefault(Locale.Category.FORMAT),
+                        DateFormat.SHORT,
+                        VALID_TIME_WITHOUT_SECONDS,
+                        null,
+                        null
+                ),
+                createTestCase(
+                        new TimeStringConverter(Locale.UK),
+                        Locale.UK,
+                        DateFormat.DEFAULT,
+                        VALID_TIME_WITH_SECONDS,
+                        null,
+                        null
+                ),
+                createTestCase(
+                        new TimeStringConverter(Locale.UK, DateFormat.SHORT),
+                        Locale.UK,
+                        DateFormat.SHORT,
+                        VALID_TIME_WITHOUT_SECONDS,
+                        null,
+                        null
+                ),
+                createTestCase(
+                        new TimeStringConverter("HH mm ss"),
+                        Locale.getDefault(Locale.Category.FORMAT),
+                        DateFormat.DEFAULT,
+                        VALID_TIME_WITH_SECONDS,
+                        "HH mm ss",
+                        null
+                ),
+                createTestCase(
+                        new TimeStringConverter(DateFormat.getTimeInstance(DateFormat.FULL)),
+                        Locale.getDefault(Locale.Category.FORMAT),
+                        DateFormat.DEFAULT,
+                        VALID_TIME_WITH_SECONDS,
+                        null,
+                        DateFormat.getTimeInstance(DateFormat.FULL)
+                )
+        );
     }
 
-    private TimeStringConverter converter;
-    private Locale locale;
-    private int timeStyle;
-    private String pattern;
-    private DateFormat dateFormat;
-    private Date validDate;
-    private DateFormat validFormatter;
+    private static Arguments createTestCase(TimeStringConverter converter, Locale locale, int timeStyle, Date validDate, String pattern, DateFormat dateFormat) {
+        DateFormat validFormatter = computeValidFormatter(pattern, dateFormat, timeStyle, locale);
+        return Arguments.of(converter, locale, timeStyle, validDate, pattern, dateFormat, validFormatter);
+    }
 
-    public TimeStringConverterTest(TimeStringConverter converter, Locale locale, int timeStyle, Date validDate, String pattern, DateFormat dateFormat) {
-        this.converter = converter;
-        this.locale = locale;
-        this.timeStyle = timeStyle;
-        this.validDate = validDate;
-        this.pattern = pattern;
-        this.dateFormat = dateFormat;
-
+    private static DateFormat computeValidFormatter(String pattern, DateFormat dateFormat, int timeStyle, Locale locale) {
         if (dateFormat != null) {
-            validFormatter = dateFormat;
+            return dateFormat;
         } else if (pattern != null) {
-            validFormatter = new SimpleDateFormat(pattern);
+            return new SimpleDateFormat(pattern);
         } else {
-            validFormatter = DateFormat.getTimeInstance(timeStyle, locale);
+            return DateFormat.getTimeInstance(timeStyle, locale);
         }
     }
 
-    @Before public void setup() {
+    private static Stream<Arguments> provideConvertersForConstructor() {
+        return provideAllConverters()
+                .map(args -> Arguments.of(args.get()[0], args.get()[1], args.get()[2], args.get()[4], args.get()[5]));
     }
 
-    /*********************************************************************
-     * Test constructors
-     ********************************************************************/
-
-    @Test public void testConstructor() {
+    @ParameterizedTest
+    @MethodSource("provideConvertersForConstructor")
+    void testConstructor(TimeStringConverter converter, Locale locale, int timeStyle, String pattern, DateFormat dateFormat) {
         assertEquals(locale, DateTimeStringConverterShim.getLocale(converter));
         assertEquals(timeStyle, DateTimeStringConverterShim.getTimeStyle(converter));
         assertEquals(pattern, DateTimeStringConverterShim.getPattern(converter));
         assertEquals(dateFormat, DateTimeStringConverterShim.getDateFormatVar(converter));
     }
 
+    private static Stream<Arguments> provideConvertersForGetDateFormat() {
+        return provideAllConverters()
+                .map(args -> Arguments.of(args.get()[0]));
+    }
 
-    /*********************************************************************
-     * Test methods
-     ********************************************************************/
-
-    @Test public void getDateFormat() {
+    @ParameterizedTest
+    @MethodSource("provideConvertersForGetDateFormat")
+    void getDateFormat(TimeStringConverter converter) {
         assertNotNull(DateTimeStringConverterShim.getDateFormat(converter));
     }
 
-    @Test public void getDateFormat_nonNullPattern() {
-        converter = new TimeStringConverter("HH");
-        assertTrue(DateTimeStringConverterShim.getDateFormat(converter)
-                instanceof SimpleDateFormat);
+    @Test
+    void getDateFormat_nonNullPattern() {
+        TimeStringConverter converter = new TimeStringConverter("HH");
+        assertTrue(DateTimeStringConverterShim.getDateFormat(converter) instanceof SimpleDateFormat);
     }
 
+    private static Stream<Arguments> provideConvertersForFromString() {
+        return provideAllConverters()
+                .map(args -> Arguments.of(args.get()[0], args.get()[3], args.get()[6]));
+    }
 
-    /*********************************************************************
-     * Test toString / fromString methods
-     ********************************************************************/
-
-    @Test public void fromString_testValidInput() {
+    @ParameterizedTest
+    @MethodSource("provideConvertersForFromString")
+    void fromString_testValidInput(TimeStringConverter converter, Date validDate, DateFormat validFormatter) {
         String input = validFormatter.format(validDate);
-        assertEquals("Input = "+input, validDate, converter.fromString(input));
+        assertEquals(validDate, converter.fromString(input), "Input = " + input);
     }
 
-    @Test public void fromString_testValidInputWithWhiteSpace() {
+    @ParameterizedTest
+    @MethodSource("provideConvertersForFromString")
+    void fromString_testValidInputWithWhiteSpace(TimeStringConverter converter, Date validDate, DateFormat validFormatter) {
         String input = validFormatter.format(validDate);
-        assertEquals("Input = "+input, validDate, converter.fromString("      " + input + "      "));
+        assertEquals(validDate, converter.fromString("      " + input + "      "), "Input = " + input);
     }
 
-    @Test(expected=RuntimeException.class)
-    public void fromString_testInvalidInput() {
-        converter.fromString("abcdefg");
+    private static Stream<Arguments> provideConvertersForException() {
+        return provideAllConverters()
+                .map(args -> Arguments.of(args.get()[0]));
     }
 
-    @Test public void toString_validOutput() {
+    @ParameterizedTest
+    @MethodSource("provideConvertersForException")
+    void fromString_testInvalidInput(TimeStringConverter converter) {
+        assertThrows(RuntimeException.class, () -> converter.fromString("abcdefg"));
+    }
+
+    private static Stream<Arguments> provideConvertersForToString() {
+        return provideConvertersForFromString();
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideConvertersForToString")
+    void toString_validOutput(TimeStringConverter converter, Date validDate, DateFormat validFormatter) {
         assertEquals(validFormatter.format(validDate), converter.toString(validDate));
     }
 }


### PR DESCRIPTION
Migrated JUnit 4 tests in the jafax.base module to JUnit 5, replacing deprecated APIs, updating assertions, and refactoring test structures to align with JUnit 5's improved features.