### PR TITLE
8353620: Make some systems tests robust for Ubuntu 24.04

### DIFF
--- a/tests/system/src/test/java/test/robot/javafx/scene/MenuDoubleShortcutTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/MenuDoubleShortcutTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -115,6 +115,7 @@ public class MenuDoubleShortcutTest {
 
     @Test
     void acceleratorOnlyInMenuBar() {
+        Util.sleep(delayMilliseconds);
         testApp.testKey(menuBarOnlyKeyCode);
         Util.sleep(delayMilliseconds);
         TestResult result = testApp.testResult();

--- a/tests/system/src/test/java/test/robot/javafx/stage/KeyEventClosesStageTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/stage/KeyEventClosesStageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -66,6 +66,7 @@ public class KeyEventClosesStageTest {
     @BeforeAll
     public static void initFX() throws Exception {
         Util.launch(startupLatch, TestApp.class);
+        Util.sleep(200);
 
         // When run from the command line Windows does not want to
         // activate the window.

--- a/tests/system/src/test/java/test/robot/javafx/web/TextSelectionTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/web/TextSelectionTest.java
@@ -71,6 +71,7 @@ public class TextSelectionTest extends RobotTestBase {
     @Timeout(value=20)
     public void testTextSelection() {
 
+        Util.sleep(200);
         int x = (int)(scene.getWindow().getX() + scene.getX() + 22);
         int y = (int)(scene.getWindow().getY() + scene.getY() + 15);
 


### PR DESCRIPTION
Under https://bugs.openjdk.org/browse/JDK-8339679 task, we are running full tests and identifying issues for Ubuntu 24.04.

As part of above task it is identified that there are 3 tests which fail intermittently and we need to add appropriate delays to make them more robust. Delays are added between UI launch and processing of UI events, with this change intermittent failures are not seen.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353620](https://bugs.openjdk.org/browse/JDK-8353620): Make some systems tests robust for Ubuntu 24.04 (**Bug** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1761/head:pull/1761` \
`$ git checkout pull/1761`

Update a local copy of the PR: \
`$ git checkout pull/1761` \
`$ git pull https://git.openjdk.org/jfx.git pull/1761/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1761`

View PR using the GUI difftool: \
`$ git pr show -t 1761`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1761.diff">https://git.openjdk.org/jfx/pull/1761.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1761#issuecomment-2776570661)
</details>
