### PR TITLE
8353557: Skip some system tests on Linux

### DIFF
--- a/tests/system/src/test/java/test/com/sun/javafx/application/InitializeJavaFXLaunch1Test.java
+++ b/tests/system/src/test/java/test/com/sun/javafx/application/InitializeJavaFXLaunch1Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,11 +29,16 @@ import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import com.sun.javafx.PlatformUtil;
+import test.util.Util;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class InitializeJavaFXLaunch1Test extends InitializeJavaFXLaunchBase {
 
     @BeforeAll
     public static void initialize() throws Exception {
+        assumeTrue(!PlatformUtil.isLinux() || Util.isOnWayland()); // JDK-8353644
         InitializeJavaFXLaunchBase.initializeApplicationLaunch();
     }
 

--- a/tests/system/src/test/java/test/com/sun/javafx/application/InitializeJavaFXLaunch2Test.java
+++ b/tests/system/src/test/java/test/com/sun/javafx/application/InitializeJavaFXLaunch2Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,11 +29,16 @@ import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import com.sun.javafx.PlatformUtil;
+import test.util.Util;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class InitializeJavaFXLaunch2Test extends InitializeJavaFXLaunchBase {
 
     @BeforeAll
     public static void initialize() throws Exception {
+        assumeTrue(!PlatformUtil.isLinux() || Util.isOnWayland()); // JDK-8353644
         InitializeJavaFXLaunchBase.initializeApplicationLaunch();
     }
 

--- a/tests/system/src/test/java/test/javafx/scene/RestoreSceneSizeTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/RestoreSceneSizeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -91,7 +91,8 @@ public class RestoreSceneSizeTest {
     @Test
     public void testUnfullscreenSize() throws Exception {
         // Disable on Mac until JDK-8176813 is fixed
-        assumeTrue(!PlatformUtil.isMac());
+        // Disable on Linux until JDK-8353556 is fixed
+        assumeTrue(!(PlatformUtil.isMac() || PlatformUtil.isLinux()));
 
         Thread.sleep(200);
         final double w = (Math.ceil(WIDTH * scaleX)) / scaleX;

--- a/tests/system/src/test/java/test/javafx/scene/web/PageFillTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/web/PageFillTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@ import static javafx.concurrent.Worker.State.SUCCEEDED;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import java.util.concurrent.CountDownLatch;
 import javafx.application.Application;
 import javafx.application.Platform;
@@ -45,6 +46,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import com.sun.webkit.WebPage;
 import com.sun.webkit.WebPageShim;
+import com.sun.javafx.PlatformUtil;
 import test.util.Util;
 
 public class PageFillTest {
@@ -122,6 +124,7 @@ public class PageFillTest {
     }
 
     @Test public void testPageFillRendering() {
+        assumeTrue(!PlatformUtil.isLinux()); // JDK-8353561
         final CountDownLatch webViewStateLatch = new CountDownLatch(1);
 
         Util.runAndWait(() -> {

--- a/tests/system/src/test/java/test/javafx/stage/SizeToSceneTest.java
+++ b/tests/system/src/test/java/test/javafx/stage/SizeToSceneTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,12 +34,14 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import com.sun.javafx.PlatformUtil;
 import test.util.Util;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.function.Consumer;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 class SizeToSceneTest {
 
@@ -118,6 +120,7 @@ class SizeToSceneTest {
 
     @Test
     void testInitialSizeOnMaximizedThenSizeToScene() {
+        assumeTrue(!PlatformUtil.isLinux()); // JDK-8353612
         createAndShowStage(stage -> {
             stage.setMaximized(true);
             stage.sizeToScene();
@@ -129,6 +132,7 @@ class SizeToSceneTest {
 
     @Test
     void testInitialSizeOnFullscreenThenSizeToScene() {
+        assumeTrue(!PlatformUtil.isLinux()); // JDK-8353612
         createAndShowStage(stage -> {
             stage.setFullScreen(true);
             stage.sizeToScene();
@@ -140,6 +144,7 @@ class SizeToSceneTest {
 
     @Test
     void testInitialSizeOnSizeToSceneThenMaximized() {
+        assumeTrue(!PlatformUtil.isLinux()); // JDK-8353612
         createAndShowStage(stage -> {
             stage.sizeToScene();
             stage.setMaximized(true);
@@ -151,6 +156,7 @@ class SizeToSceneTest {
 
     @Test
     void testInitialSizeOnSizeToSceneThenFullscreen() {
+        assumeTrue(!PlatformUtil.isLinux()); // JDK-8353612
         createAndShowStage(stage -> {
             stage.sizeToScene();
             stage.setFullScreen(true);
@@ -162,6 +168,7 @@ class SizeToSceneTest {
 
     @Test
     void testInitialSizeAfterShowSizeToSceneThenFullscreen() {
+        assumeTrue(!PlatformUtil.isLinux()); // JDK-8353612
         createAndShowStage(stage -> {
             stage.show();
 
@@ -174,6 +181,7 @@ class SizeToSceneTest {
 
     @Test
     void testInitialSizeAfterShowSizeToSceneThenMaximized() {
+        assumeTrue(!PlatformUtil.isLinux()); // JDK-8353612
         createAndShowStage(stage -> {
             stage.show();
 
@@ -186,6 +194,7 @@ class SizeToSceneTest {
 
     @Test
     void testInitialSizeAfterShowFullscreenThenSizeToScene() {
+        assumeTrue(!PlatformUtil.isLinux()); // JDK-8353612
         createAndShowStage(stage -> {
             stage.show();
 
@@ -198,6 +207,7 @@ class SizeToSceneTest {
 
     @Test
     void testInitialSizeAfterShowMaximizedThenSizeToScene() {
+        assumeTrue(!PlatformUtil.isLinux()); // JDK-8353612
         createAndShowStage(stage -> {
             stage.show();
 

--- a/tests/system/src/test/java/test/robot/javafx/stage/WrongStageFocusWithApplicationModalityTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/stage/WrongStageFocusWithApplicationModalityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,6 +42,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import test.util.Util;
 
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
 @Timeout(value=25000, unit=TimeUnit.MILLISECONDS)
 public class WrongStageFocusWithApplicationModalityTest {
     private static Robot robot;
@@ -62,6 +64,7 @@ public class WrongStageFocusWithApplicationModalityTest {
 
     @Test
     public void testWindowFocusByClosingAlerts() throws Exception {
+        assumeTrue(!Util.isOnWayland()); // JDK-8353643
         Thread.sleep(3000);
         mouseClick();
         Thread.sleep(1000);


### PR DESCRIPTION
Under https://bugs.openjdk.org/browse/JDK-8339679 task, we are running full tests and identifying issues for Ubuntu 24.04.

As part of above task 6 test failures were identified and looks like these test failures are happening because of product issues in Ubuntu24.04.

Test failures are:
1) RestoreSceneSizeTest and its product issue : [JDK-8353556](https://bugs.openjdk.org/browse/JDK-8353556)
2) PageFillTest  and its product issue : [JDK-8353561](https://bugs.openjdk.org/browse/JDK-8353561)
3) SizeToSceneTest and its product issue : [JDK-8353612](https://bugs.openjdk.org/browse/JDK-8353612)
4) WrongStageFocusWithApplicationModalityTest fails intermittently only in Wayland and its product issue : [JDK-8353643](https://bugs.openjdk.org/browse/JDK-8353643)
5) InitializeJavaFXLaunch1Test & InitializeJavaFXLaunch2Test fails intermittently only in Xorg and its product issue : [JDK-8353644](https://bugs.openjdk.org/browse/JDK-8353644)

As part of test stabilization task these identified test failures will be skipped and we have product issues raised for them.

I tried finding ways to add utility to skip tests only in Ubuntu 24.04. System.Properties doesn't list any item which can be used to identified a specific Linux distro or Ubuntu version. If we need to identify Ubuntu and its version we need to use executable like `lsb_release`. 

So test which are failing in both Wayland & Xorg are skipped for Linux platform and if they fail with specific windowing system(Wayland/Xorg) they are skipped only under them.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353557](https://bugs.openjdk.org/browse/JDK-8353557): Skip some system tests on Linux (**Bug** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1762/head:pull/1762` \
`$ git checkout pull/1762`

Update a local copy of the PR: \
`$ git checkout pull/1762` \
`$ git pull https://git.openjdk.org/jfx.git pull/1762/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1762`

View PR using the GUI difftool: \
`$ git pr show -t 1762`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1762.diff">https://git.openjdk.org/jfx/pull/1762.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1762#issuecomment-2778239668)
</details>
