### PR TITLE
8350284: WebKit 620.1 crashes on startup on Windows x86 32-bit

### DIFF
--- a/modules/javafx.web/src/main/native/Source/cmake/WebKitCompilerFlags.cmake
+++ b/modules/javafx.web/src/main/native/Source/cmake/WebKitCompilerFlags.cmake
@@ -151,6 +151,9 @@ if (COMPILER_IS_GCC_OR_CLANG)
         # FIXME: These warnings should be addressed
         WEBKIT_PREPEND_GLOBAL_COMPILER_FLAGS(-Wno-sign-compare
                                              -Wno-deprecated-declarations)
+        if (WTF_CPU_X86 AND NOT CMAKE_CROSSCOMPILING)
+            WEBKIT_APPEND_GLOBAL_COMPILER_FLAGS(-mno-sse)
+        endif ()
     else ()
         WEBKIT_APPEND_GLOBAL_COMPILER_FLAGS(-fno-exceptions)
         WEBKIT_APPEND_GLOBAL_CXX_FLAGS(-fno-rtti)

--- a/modules/javafx.web/src/main/native/Source/cmake/WebKitCompilerFlags.cmake
+++ b/modules/javafx.web/src/main/native/Source/cmake/WebKitCompilerFlags.cmake
@@ -151,6 +151,7 @@ if (COMPILER_IS_GCC_OR_CLANG)
         # FIXME: These warnings should be addressed
         WEBKIT_PREPEND_GLOBAL_COMPILER_FLAGS(-Wno-sign-compare
                                              -Wno-deprecated-declarations)
+        # Disable SSE for 32-bit Windows on JAVA platform
         if (WTF_CPU_X86 AND NOT CMAKE_CROSSCOMPILING)
             WEBKIT_APPEND_GLOBAL_COMPILER_FLAGS(-mno-sse)
         endif ()


### PR DESCRIPTION
All the crashes are on "`movaps`" instructions, like "`movaps xmmword ptr [esi+0x30], xmm0`".

"`movaps`" must operate with aligned addresses as 
> When the source or destination operand is a memory operand, the operand must be aligned on a 16-byte boundary or a general-protection exception (#GP) is generated

written in docs. When crashes, ESI contains value like `0x27DB63A8`, so it doesn’t seem aligned to 16-byte boundary. The line "`siginfo: ExceptionCode=0xc0000005, reading address 0xffffffff`" from `hs_err` file implicitly says it is GP, not a real "reading address 0xffffffff".

It might be related to clang-cl bug, see https://github.com/llvm/llvm-project/issues/55844

The workaround is to disable SSE when building 32bit on Windows. (`-mno-sse`)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8350284](https://bugs.openjdk.org/browse/JDK-8350284): WebKit 620.1 crashes on startup on Windows x86 32-bit (**Bug** - P3)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Jay Bhaskar](https://openjdk.org/census#jbhaskar) (@jaybhaskar - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1764/head:pull/1764` \
`$ git checkout pull/1764`

Update a local copy of the PR: \
`$ git checkout pull/1764` \
`$ git pull https://git.openjdk.org/jfx.git pull/1764/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1764`

View PR using the GUI difftool: \
`$ git pr show -t 1764`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1764.diff">https://git.openjdk.org/jfx/pull/1764.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1764#issuecomment-2785557457)
</details>
