### PR TITLE
8353845: com.sun.javafx.css.BitSet.equals(null) throws NPE

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/css/BitSet.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/css/BitSet.java
@@ -532,9 +532,7 @@ abstract class BitSet<T> extends AbstractSet<T> implements ObservableSet<T> {
         // the Set contract to interact correctly with sets of other types!
         if (obj == this) {
             return true;
-        }
-
-        if (obj == null) {
+        } else if (obj == null) {
             return false;
         }
 

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/css/BitSet.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/css/BitSet.java
@@ -533,7 +533,12 @@ abstract class BitSet<T> extends AbstractSet<T> implements ObservableSet<T> {
         if (obj == this) {
             return true;
         }
-        if (obj != null && getClass() == obj.getClass()) {  // fast path if other is exact same type of BitSet
+
+        if (obj == null) {
+            return false;
+        }
+
+        if (getClass() == obj.getClass()) {  // fast path if other is exact same type of BitSet
             return equalsBitSet((BitSet<?>) obj);
         }
 

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/css/BitSet.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/css/BitSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -533,7 +533,7 @@ abstract class BitSet<T> extends AbstractSet<T> implements ObservableSet<T> {
         if (obj == this) {
             return true;
         }
-        if (getClass() == obj.getClass()) {  // fast path if other is exact same type of BitSet
+        if (obj != null && getClass() == obj.getClass()) {  // fast path if other is exact same type of BitSet
             return equalsBitSet((BitSet<?>) obj);
         }
 

--- a/modules/javafx.graphics/src/shims/java/com/sun/javafx/css/BitSetShim.java
+++ b/modules/javafx.graphics/src/shims/java/com/sun/javafx/css/BitSetShim.java
@@ -187,6 +187,11 @@ public class BitSetShim<T> {
     }
 
     @Override
+    public int hashCode() {
+        return delegate.hashCode();
+    }
+
+    @Override
     public boolean equals(Object other) {
         return delegate.equals(other);
     }

--- a/modules/javafx.graphics/src/shims/java/com/sun/javafx/css/BitSetShim.java
+++ b/modules/javafx.graphics/src/shims/java/com/sun/javafx/css/BitSetShim.java
@@ -186,6 +186,7 @@ public class BitSetShim<T> {
         return delegate.parallelStream();
     }
 
+    @Override
     public boolean equals(Object other) {
         return delegate.equals(other);
     }

--- a/modules/javafx.graphics/src/shims/java/com/sun/javafx/css/BitSetShim.java
+++ b/modules/javafx.graphics/src/shims/java/com/sun/javafx/css/BitSetShim.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -184,5 +184,9 @@ public class BitSetShim<T> {
 
     public Stream<T> parallelStream() {
         return delegate.parallelStream();
+    }
+
+    public boolean equals(Object other) {
+        return delegate.equals(other);
     }
 }

--- a/modules/javafx.graphics/src/test/java/test/com/sun/javafx/css/BitSetTest.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/javafx/css/BitSetTest.java
@@ -27,6 +27,7 @@ package test.com.sun.javafx.css;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -175,5 +176,13 @@ public class BitSetTest {
 
         assertEquals(Set.of(), new PseudoClassState());
         assertEquals(new PseudoClassState(), Set.of());
+    }
+
+    @Test
+    void bitSetShouldEqualHashSet() {
+        var bitSet = new PseudoClassState();
+        bitSet.addAll(Set.of(a, b, c));
+        var hashSet = new HashSet<>(Set.of(c, a, b));
+        assertEquals(bitSet, hashSet);
     }
 }

--- a/modules/javafx.graphics/src/test/java/test/com/sun/javafx/css/BitSetTest.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/javafx/css/BitSetTest.java
@@ -184,5 +184,6 @@ public class BitSetTest {
         bitSet.addAll(Set.of(a, b, c));
         var hashSet = new HashSet<>(Set.of(c, a, b));
         assertEquals(bitSet, hashSet);
+        assertEquals(hashSet, bitSet);
     }
 }

--- a/modules/javafx.graphics/src/test/java/test/com/sun/javafx/css/BitSetTest.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/javafx/css/BitSetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,9 +25,7 @@
 
 package test.com.sun.javafx.css;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -46,6 +44,11 @@ public class BitSetTest {
     private final PseudoClass a = PseudoClass.getPseudoClass("a");
     private final PseudoClass b = PseudoClass.getPseudoClass("b");
     private final PseudoClass c = PseudoClass.getPseudoClass("c");
+
+    @Test
+    void equalsNullShouldBeFalse() {
+        assertFalse(set.equals(null));
+    }
 
     @Test
     void setShouldProcessAddAndRemoveCorrectly() {


### PR DESCRIPTION
Fixes the bug that `BitSet.equals(null)` throws NPE.

A single reviewer should be sufficient.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8353845](https://bugs.openjdk.org/browse/JDK-8353845): com.sun.javafx.css.BitSet.equals(null) throws NPE (**Bug** - P4)


### Reviewers
 * [John Hendrikx](https://openjdk.org/census#jhendrikx) (@hjohn - **Reviewer**)
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1766/head:pull/1766` \
`$ git checkout pull/1766`

Update a local copy of the PR: \
`$ git checkout pull/1766` \
`$ git pull https://git.openjdk.org/jfx.git pull/1766/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1766`

View PR using the GUI difftool: \
`$ git pr show -t 1766`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1766.diff">https://git.openjdk.org/jfx/pull/1766.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1766#issuecomment-2788568630)
</details>
