### PR TITLE
8353632: [Linux] Undefined reference to PlatformSupport::OBSERVED_SETTINGS with C++14

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/gtk/PlatformSupport.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/PlatformSupport.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -80,6 +80,8 @@ namespace
         instance->updatePreferences();
     }
 }
+
+constexpr const char* PlatformSupport::OBSERVED_SETTINGS[];
 
 PlatformSupport::PlatformSupport(JNIEnv* env, jobject application)
         : env(env), application(env->NewGlobalRef(application)), preferences(NULL) {


### PR DESCRIPTION
Fixes a link error that occurs when using C++14 to compile and link JavaFX on Linux.

```
in function `PlatformSupport::PlatformSupport(JNIEnv_*, _jobject*)':
PlatformSupport.cpp:90: undefined reference to `PlatformSupport::OBSERVED_SETTINGS'
```

The solution, proposed by @johanvos, is to define `PlatformSupport::OBSERVED_SETTINGS` in `PlatformSupport.cpp`.

I have tested this using gcc 13.2 and 14.2 using C++17 and it builds and runs as expected. Johan has already tested a variant of this on C++14, but I will wait for his explicit review.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8353632](https://bugs.openjdk.org/browse/JDK-8353632): [Linux] Undefined reference to PlatformSupport::OBSERVED_SETTINGS with C++14 (**Bug** - P4)


### Reviewers
 * [Michael Strauß](https://openjdk.org/census#mstrauss) (@mstr2 - **Reviewer**)
 * [Johan Vos](https://openjdk.org/census#jvos) (@johanvos - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1768/head:pull/1768` \
`$ git checkout pull/1768`

Update a local copy of the PR: \
`$ git checkout pull/1768` \
`$ git pull https://git.openjdk.org/jfx.git pull/1768/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1768`

View PR using the GUI difftool: \
`$ git pr show -t 1768`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1768.diff">https://git.openjdk.org/jfx/pull/1768.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1768#issuecomment-2794409983)
</details>
