### PR TITLE
8354337: GHA: Windows build fails with chmod permission error

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -413,6 +413,7 @@ jobs:
           which java
           java -version
           .\gradlew.bat -version
+          # Skip "chmod" task for GHA builds. See JDK-8354337 for details.
           .\gradlew.bat --info -PCHMOD_ARTIFACTS=false all
 
       - name: Run JavaFX headless tests

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -413,7 +413,7 @@ jobs:
           which java
           java -version
           .\gradlew.bat -version
-          .\gradlew.bat --info all
+          .\gradlew.bat --info -PCHMOD_ARTIFACTS=false all
 
       - name: Run JavaFX headless tests
         working-directory: jfx

--- a/build.gradle
+++ b/build.gradle
@@ -601,6 +601,12 @@ ext.DO_JCOV = Boolean.parseBoolean(JCOV)
 defineProperty("USE_CYGWIN", "true")
 ext.IS_USE_CYGWIN = Boolean.parseBoolean(USE_CYGWIN)
 
+// Specifies whether to run "chmod -R artifacts/sdk" as the last step of
+// copying the sdk to the artifacts dir. This is only done on Windows;
+// the flag is ignored on other platforms.
+defineProperty("CHMOD_ARTIFACTS", "true")
+ext.IS_CHMOD_ARTIFACTS = Boolean.parseBoolean(CHMOD_ARTIFACTS)
+
 // Define the number of threads to use when compiling (specifically for native compilation, including webkit)
 defineProperty("NUM_COMPILE_THREADS", "${Runtime.runtime.availableProcessors()}")
 
@@ -4972,9 +4978,13 @@ compileTargets { t ->
         def chmodArtifactsSdkTask = task("chmodArtifactsSdk$t.capital", dependsOn: copyArtifactsSdkTask) {
             if (IS_WINDOWS && IS_USE_CYGWIN) {
                 doLast {
-                    exec {
-                        workingDir(sdkArtifactsDir)
-                        commandLine("chmod", "-R", "755", ".")
+                    if (IS_CHMOD_ARTIFACTS) {
+                        exec {
+                            workingDir(sdkArtifactsDir)
+                            commandLine("chmod", "-R", "755", ".")
+                        }
+                    } else {
+                        println "Skipping 'chmod -R', CHMOD_ARTIFACTS=$CHMOD_ARTIFACTS"
                     }
                 }
             }


### PR DESCRIPTION
After a recent update by GitHub to the GHA Windows Server 2022 runner, we get the following error in all GHA test runs:

```
chmod: changing permissions of '.': Permission denied
chmod: changing permissions of './bin': Permission denied 
...
```

This PR disables running `chmod -R` on the `artifacts/sdk` dir when doing a GHA build.

The `chmod` is only needed when building artifacts for distribution, and we only use the GHA build for sanity testing, so we can avoid this problem by adding a flag that skips the `chmod` if running on GHA. This is a minimally intrusive solution that would restore our ability to run GHA test builds on Windows without affecting the actual JavaFX build.

I've run a CI build as well as a local build to ensure that the chmod is still being executed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8354337](https://bugs.openjdk.org/browse/JDK-8354337): GHA: Windows build fails with chmod permission error (**Bug** - P3)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1770/head:pull/1770` \
`$ git checkout pull/1770`

Update a local copy of the PR: \
`$ git checkout pull/1770` \
`$ git pull https://git.openjdk.org/jfx.git pull/1770/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1770`

View PR using the GUI difftool: \
`$ git pr show -t 1770`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1770.diff">https://git.openjdk.org/jfx/pull/1770.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1770#issuecomment-2795264802)
</details>
