### PR TITLE
8354318: freetype.c: compilation error: 'incompatible pointer type' with gcc 14

### DIFF
--- a/modules/javafx.graphics/src/main/native-font/freetype.c
+++ b/modules/javafx.graphics/src/main/native-font/freetype.c
@@ -520,7 +520,7 @@ static PathData* checkSize(void* user, int coordCount)
         if (info->lenCoords > SIZE_MAX - DEFAULT_LEN_COORDS) goto fail;
         info->lenCoords += DEFAULT_LEN_COORDS;
 
-        jbyte* newPointCoords = (jfloat*)realloc(info->pointCoords, info->lenCoords * sizeof(jfloat));
+        jfloat* newPointCoords = (jfloat*)realloc(info->pointCoords, info->lenCoords * sizeof(jfloat));
         if (newPointCoords == NULL) goto fail;
         info->pointCoords = newPointCoords;
     }


### PR DESCRIPTION
This PR fixes a bug where a local variable was declared to be the wrong type, causing an error at compilation time when compiling with gcc 14. gcc 14 rejects assignments of incompatible pointer types without an explicit cast. In this case, the solution is declare the variable to be of the correct type in the first place.