### PR TITLE
8296554: MouseLocationOnScreenTest sometime fails when system is busy

### DIFF
--- a/tests/system/src/test/java/test/robot/javafx/scene/MouseLocationOnScreenTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/MouseLocationOnScreenTest.java
@@ -43,7 +43,7 @@ import test.util.Util;
 public class MouseLocationOnScreenTest {
     static CountDownLatch startupLatch = new CountDownLatch(1);
     static Robot robot;
-    private static int DELAY_TIME = 3;
+    private static int DELAY_TIME = 1;
 
     public static class TestApp extends Application {
 
@@ -118,15 +118,22 @@ public class MouseLocationOnScreenTest {
      * returned by robot are same
      */
     static void validate(Robot robot, int x, int y) {
-        Assertions.assertEquals(x, (int) robot.getMouseX());
-        Assertions.assertEquals(y, (int) robot.getMouseY());
+        try {
+            Util.sleep(DELAY_TIME);
+            Assertions.assertEquals(x, (int) robot.getMouseX());
+            Assertions.assertEquals(y, (int) robot.getMouseY());
+        }
+        catch(AssertionError e) {
+            Util.sleep(DELAY_TIME + 1); // 3 MS Delay
+            Assertions.assertEquals(x, (int) robot.getMouseX());
+            Assertions.assertEquals(y, (int) robot.getMouseY());
+        }
     }
 
     private static void edge(Robot robot, int x1, int y1, int x2, int y2) {
         for (int x = x1; x <= x2; x++) {
             for (int y = y1; y <= y2; y++) {
                 robot.mouseMove(x, y);
-                Util.sleep(DELAY_TIME);
                 validate(robot, x, y);
             }
         }
@@ -138,14 +145,12 @@ public class MouseLocationOnScreenTest {
         double dy = (y1 - y0) / dmax;
 
         robot.mouseMove(x0, y0);
-        Util.sleep(DELAY_TIME);
         validate(robot, x0, y0);
 
         for (int i = 1; i <= dmax; i++) {
             int x = (int) (x0 + dx * i);
             int y = (int) (y0 + dy * i);
             robot.mouseMove(x, y);
-            Util.sleep(DELAY_TIME);
             validate(robot, x, y);
         }
     }

--- a/tests/system/src/test/java/test/robot/javafx/scene/MouseLocationOnScreenTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/MouseLocationOnScreenTest.java
@@ -43,7 +43,7 @@ import test.util.Util;
 public class MouseLocationOnScreenTest {
     static CountDownLatch startupLatch = new CountDownLatch(1);
     static Robot robot;
-    private static int DELAY_TIME = 1;
+    private static int DELAY_TIME = 3;
 
     public static class TestApp extends Application {
 

--- a/tests/system/src/test/java/test/robot/javafx/scene/MouseLocationOnScreenTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/MouseLocationOnScreenTest.java
@@ -44,6 +44,7 @@ public class MouseLocationOnScreenTest {
     static CountDownLatch startupLatch = new CountDownLatch(1);
     static Robot robot;
     private static int DELAY_TIME = 1;
+    private static int VALIDATE_COUNT = 5;
 
     public static class TestApp extends Application {
 
@@ -118,13 +119,24 @@ public class MouseLocationOnScreenTest {
      * returned by robot are same
      */
     static void validate(Robot robot, int x, int y) {
-        try {
-            Util.sleep(DELAY_TIME);
+        Boolean equalValue = false;
+        for (int i = 0; i < VALIDATE_COUNT; i++) {
+            //Making Delay and Check at 1 ms and every 2 ms gap onwards
+            Util.sleep(i == 0 ? DELAY_TIME : DELAY_TIME + 1);
+            if (x == (int)robot.getMouseX() &&
+                y == (int)robot.getMouseY()) {
+                equalValue = true;
+                break;
+            }
+        }
+
+        if(equalValue == true) {
             Assertions.assertEquals(x, (int) robot.getMouseX());
             Assertions.assertEquals(y, (int) robot.getMouseY());
         }
-        catch(AssertionError e) {
-            Util.sleep(DELAY_TIME + 1); // 3 MS Delay
+        else {
+            //Making Delay and Check after 500 ms.
+            Util.sleep(DELAY_TIME * 500);
             Assertions.assertEquals(x, (int) robot.getMouseX());
             Assertions.assertEquals(y, (int) robot.getMouseY());
         }

--- a/tests/system/src/test/java/test/robot/javafx/scene/MouseLocationOnScreenTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/MouseLocationOnScreenTest.java
@@ -121,7 +121,7 @@ public class MouseLocationOnScreenTest {
     static void validate(Robot robot, int x, int y) {
         Boolean equalValue = false;
         for (int i = 0; i < VALIDATE_COUNT; i++) {
-            //Making Delay and Check at 1 ms and every 2 ms gap onwards
+            // Making delay and check at 1 ms and every 2 ms gap onwards
             Util.sleep(i == 0 ? DELAY_TIME : DELAY_TIME + 1);
             if (x == (int)robot.getMouseX() &&
                 y == (int)robot.getMouseY()) {
@@ -130,16 +130,12 @@ public class MouseLocationOnScreenTest {
             }
         }
 
-        if(equalValue == true) {
-            Assertions.assertEquals(x, (int) robot.getMouseX());
-            Assertions.assertEquals(y, (int) robot.getMouseY());
-        }
-        else {
-            //Making Delay and Check after 500 ms.
-            Util.sleep(DELAY_TIME * 500);
-            Assertions.assertEquals(x, (int) robot.getMouseX());
-            Assertions.assertEquals(y, (int) robot.getMouseY());
-        }
+        if (!equalValue) {
+            // Delay for 500ms more
+            Util.sleep(500);
+        }    
+        Assertions.assertEquals(x, (int) robot.getMouseX());
+        Assertions.assertEquals(y, (int) robot.getMouseY());
     }
 
     private static void edge(Robot robot, int x1, int y1, int x2, int y2) {

--- a/tests/system/src/test/java/test/robot/javafx/scene/MouseLocationOnScreenTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/MouseLocationOnScreenTest.java
@@ -119,7 +119,7 @@ public class MouseLocationOnScreenTest {
      * returned by robot are same
      */
     static void validate(Robot robot, int x, int y) {
-        Boolean equalValue = false;
+        boolean equalValue = false;
         for (int i = 0; i < VALIDATE_COUNT; i++) {
             // Making delay and check at 1 ms and every 2 ms gap onwards
             Util.sleep(i == 0 ? DELAY_TIME : DELAY_TIME + 1);
@@ -133,7 +133,7 @@ public class MouseLocationOnScreenTest {
         if (!equalValue) {
             // Delay for 500ms more
             Util.sleep(500);
-        }    
+        }
         Assertions.assertEquals(x, (int) robot.getMouseX());
         Assertions.assertEquals(y, (int) robot.getMouseY());
     }


### PR DESCRIPTION
There was a Assertion fail issue in mouse location test case JDK-8296554,
Reason: We felt the one mili second delay time for the Robot test may be insufficient in few OS.
Solution: We Changed the delay time to three mili second.

Verification:
Tested in Windows 11, and the Assert fail issue is not found.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296554](https://bugs.openjdk.org/browse/JDK-8296554): MouseLocationOnScreenTest sometime fails when system is busy (**Bug** - P5)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1772/head:pull/1772` \
`$ git checkout pull/1772`

Update a local copy of the PR: \
`$ git checkout pull/1772` \
`$ git pull https://git.openjdk.org/jfx.git pull/1772/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1772`

View PR using the GUI difftool: \
`$ git pr show -t 1772`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1772.diff">https://git.openjdk.org/jfx/pull/1772.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1772#issuecomment-2796401103)
</details>
