### PR TITLE
8329227: Seek might hang with fMP4 H.265/HEVC or H.265/HEVC over HTTP/FILE

### DIFF
--- a/modules/javafx.media/src/main/native/gstreamer/plugins/mfwrapper/mfwrapper.h
+++ b/modules/javafx.media/src/main/native/gstreamer/plugins/mfwrapper/mfwrapper.h
@@ -94,6 +94,7 @@ struct _GstMFWrapper
 
     BYTE *header;
     gsize header_size;
+    gboolean send_header;
 
     guint width;
     guint height;
@@ -103,6 +104,8 @@ struct _GstMFWrapper
     guint defaultStride;
     guint pixel_num;
     guint pixel_den;
+
+    gboolean set_caps;
 };
 
 struct _GstMFWrapperClass

--- a/modules/javafx.media/src/main/native/gstreamer/plugins/mfwrapper/mfwrapper.h
+++ b/modules/javafx.media/src/main/native/gstreamer/plugins/mfwrapper/mfwrapper.h
@@ -77,8 +77,8 @@ struct _GstMFWrapper
     // This flag should be set if decoder calls failed.
     gboolean is_decoder_error;
 
-    gboolean force_discontinuity;
-    gboolean force_output_discontinuity;
+    gboolean is_force_discontinuity;
+    gboolean is_force_output_discontinuity;
 
     HRESULT hr_mfstartup;
 
@@ -94,7 +94,7 @@ struct _GstMFWrapper
 
     BYTE *header;
     gsize header_size;
-    gboolean send_header;
+    gboolean is_send_header;
 
     guint width;
     guint height;
@@ -105,7 +105,7 @@ struct _GstMFWrapper
     guint pixel_num;
     guint pixel_den;
 
-    gboolean set_caps;
+    gboolean is_set_caps;
 };
 
 struct _GstMFWrapperClass


### PR DESCRIPTION
- Fixed by reloading decoder for each seek.
- Tested with all H.265 files for HLS/HTTP/FILE, no issues found.
- Seek performance is not affected or at least I did not notice any performance issues when doing reload for each seek.

This is workaround and no other reasonable solutions were found.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8329227](https://bugs.openjdk.org/browse/JDK-8329227): Seek might hang with fMP4 H.265/HEVC or H.265/HEVC over HTTP/FILE (**Bug** - P2)


### Reviewers
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1775/head:pull/1775` \
`$ git checkout pull/1775`

Update a local copy of the PR: \
`$ git checkout pull/1775` \
`$ git pull https://git.openjdk.org/jfx.git pull/1775/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1775`

View PR using the GUI difftool: \
`$ git pr show -t 1775`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1775.diff">https://git.openjdk.org/jfx/pull/1775.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1775#issuecomment-2798374850)
</details>
