### PR TITLE
8354478: Improve StageStyle documentation

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/stage/StageStyle.java
+++ b/modules/javafx.graphics/src/main/java/javafx/stage/StageStyle.java
@@ -32,12 +32,16 @@ package javafx.stage;
 public enum StageStyle {
 
     /**
-     * Defines a normal {@code Stage} style with a solid white background and platform decorations.
+     * Defines a normal {@code Stage} style with a solid background and platform decorations.
      */
     DECORATED,
 
     /**
-     * Defines a {@code Stage} style with a solid white background and no decorations.
+     * Defines a {@code Stage} style with no window decorations, such as a title bar,
+     * borders, or window controls.
+     * This style allows window operations such as resize, minimize, maximize
+     * and fullscreen to be either programmatically controlled or achieved through
+     * platform-specific functions, such as key shortcuts or menu options.
      */
     UNDECORATED,
 
@@ -51,8 +55,11 @@ public enum StageStyle {
     TRANSPARENT,
 
     /**
-     * Defines a {@code Stage} style with a solid white background and minimal
-     * platform decorations used for a utility window.
+     * Defines a lightweight {@code Stage} with minimal decorations, intended for
+     * supporting tasks such as tool palettes.
+     * Utility stages may restrict window operations like maximize, minimize,
+     * and fullscreen depending on the platform. They are designed to float above
+     * primary windows without acting as a main application stage.
      */
     UTILITY,
 


### PR DESCRIPTION
Improve StageStyle Documentation

- Update `StageStyle.UTILITY`:
Clarified that UTILITY stages may impose platform-specific restrictions on window states, such as preventing maximize, minimize (iconify), and fullscreen operations.

- Update `StageStyle.UNDECORATED`:
Improved the description to clarify that although UNDECORATED removes standard window decorations (title bar, borders, and controls), window operations like minimize, maximize, and fullscreen may still be allowed programmatically or via platform-specific functions such as key shortcuts or menu options.

- Remove mention of solid white background:
This seems to be not true anymore, even withou a `Scene` (or there's a bug)