### PR TITLE
8354702: [TestBug] LocalDateTimeStringConverterTest Workaround can be removed

### DIFF
--- a/modules/javafx.base/src/test/java/test/javafx/util/converter/LocalDateTimeStringConverterTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/util/converter/LocalDateTimeStringConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,7 +50,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 public class LocalDateTimeStringConverterTest {
 
-    private static String JAPANESE_DATE_STRING;
+    private static final String JAPANESE_DATE_STRING = "Saturday, January 12, 60 Shōwa, 12:34:56\u202fPM";;
     private static final LocalDateTime VALID_LDT_WITH_SECONDS = LocalDateTime.of(1985, 1, 12, 12, 34, 56);
     private static final LocalDateTime VALID_LDT_WITHOUT_SECONDS = LocalDateTime.of(1985, 1, 12, 12, 34, 0);
 
@@ -84,15 +84,6 @@ public class LocalDateTimeStringConverterTest {
         // DateTimeFormatter uses default locale, so we can init this after updating locale
         aFormatter = DateTimeFormatter.ofPattern("dd MM yyyy HH mm ss");
         aParser = DateTimeFormatter.ofPattern("yyyy MM dd hh mm ss a");
-
-        final var version = Runtime.Version.parse(System.getProperty("java.version"));
-        if (version.major() < 20) {
-            // TODO: This can be removed when the minimum version of boot jdk
-            // for JFX build is updated to JDK20 or above.
-            JAPANESE_DATE_STRING = "Saturday, January 12, 60 Shōwa, 12:34:56 PM";
-        } else {
-            JAPANESE_DATE_STRING = "Saturday, January 12, 60 Shōwa, 12:34:56\u202fPM";
-        }
     }
 
     @AfterAll
@@ -230,4 +221,3 @@ public class LocalDateTimeStringConverterTest {
         assertEquals(VALID_LDT_WITH_SECONDS, converter.fromString(JAPANESE_DATE_STRING));
     }
 }
-


### PR DESCRIPTION
[JDK-8297316](https://bugs.openjdk.org/browse/JDK-8297316) added a Workaround for the Japanese Date Converter, which is different on JDK20 and newer. Since our Boot JDK is Java 22 as of April 2025, we can remove the workaround.

We should also consider testing and closing: [JDK-8265727](https://bugs.openjdk.org/browse/JDK-8265727) and [JDK-8141350](https://bugs.openjdk.org/browse/JDK-8141350), which seems to work fine for me (German Locale, Test correctly changes that).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354702](https://bugs.openjdk.org/browse/JDK-8354702): [TestBug] LocalDateTimeStringConverterTest Workaround can be removed (**Enhancement** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1778/head:pull/1778` \
`$ git checkout pull/1778`

Update a local copy of the PR: \
`$ git checkout pull/1778` \
`$ git pull https://git.openjdk.org/jfx.git pull/1778/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1778`

View PR using the GUI difftool: \
`$ git pr show -t 1778`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1778.diff">https://git.openjdk.org/jfx/pull/1778.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1778#issuecomment-2807400294)
</details>
