### PR TITLE
8354795: DialogPane show details button wipes out base style class "hyperlink"

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/DialogPane.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/DialogPane.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,6 @@ import java.util.WeakHashMap;
 import com.sun.javafx.scene.control.skin.Utils;
 import com.sun.javafx.scene.control.skin.resources.ControlResources;
 import javafx.beans.DefaultProperty;
-import javafx.beans.InvalidationListener;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleBooleanProperty;
@@ -818,16 +817,15 @@ public class DialogPane extends Pane {
         final Hyperlink detailsButton = new Hyperlink();
         final String moreText = ControlResources.getString("Dialog.detail.button.more"); //$NON-NLS-1$
         final String lessText = ControlResources.getString("Dialog.detail.button.less"); //$NON-NLS-1$
+        final ObservableList<String> styleClasses = detailsButton.getStyleClass();
 
-        InvalidationListener expandedListener = o -> {
-            final boolean isExpanded = isExpanded();
-            detailsButton.setText(isExpanded ? lessText : moreText);
-            detailsButton.getStyleClass().setAll("details-button", (isExpanded ? "less" : "more")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-        };
+        styleClasses.add("details-button");  //$NON-NLS-1$
 
-        // we call the listener immediately to ensure the state is correct at start up
-        expandedListener.invalidated(null);
-        expandedProperty().addListener(expandedListener);
+        expandedProperty().subscribe(expanded -> {
+            styleClasses.remove(expanded ? "more" : "less");  //$NON-NLS-1$ //$NON-NLS-2$
+            styleClasses.add(expanded ? "less" : "more");  //$NON-NLS-1$ //$NON-NLS-2$
+            detailsButton.setText(expanded ? lessText : moreText);
+        });
 
         detailsButton.setOnAction(ae -> setExpanded(!isExpanded()));
         return detailsButton;


### PR DESCRIPTION
The "show details" hyperlink button in an alert dialog that has an expandable detail area wipes out its base style class by overwriting all styles. This means styling in modena.css that targets `.hyperlink` is no longer applied, like the default text fill colors.

The culprit is this code in DialogPane:

        InvalidationListener expandedListener = o -> {
            final boolean isExpanded = isExpanded();
            detailsButton.setText(isExpanded ? lessText : moreText);
            detailsButton.getStyleClass().setAll("details-button", (isExpanded ? "less" : "more")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
        };

Here it uses `setAll` to set styles, wiping out the default `.hyperlink` style from "Hyperlink detailsButton = new HyperLink()"

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8354795](https://bugs.openjdk.org/browse/JDK-8354795): DialogPane show details button wipes out base style class "hyperlink" (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1779/head:pull/1779` \
`$ git checkout pull/1779`

Update a local copy of the PR: \
`$ git checkout pull/1779` \
`$ git pull https://git.openjdk.org/jfx.git pull/1779/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1779`

View PR using the GUI difftool: \
`$ git pr show -t 1779`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1779.diff">https://git.openjdk.org/jfx/pull/1779.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1779#issuecomment-2808877086)
</details>
