### PR TITLE
8354797: Parent.needsLayoutProperty() should return read-only getter

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/scene/Parent.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Parent.java
@@ -969,7 +969,7 @@ public abstract non-sealed class Parent extends Node {
         if (needsLayout == null) {
             needsLayout = new ReadOnlyBooleanWrapper(this, "needsLayout", layoutFlag == LayoutFlags.NEEDS_LAYOUT);
         }
-        return needsLayout;
+        return needsLayout.getReadOnlyProperty();
     }
 
     /**

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/ParentTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/ParentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,6 +36,7 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
+import javafx.beans.property.Property;
 import javafx.scene.Group;
 import javafx.scene.GroupShim;
 import javafx.scene.Node;
@@ -510,6 +511,13 @@ public class ParentTest {
         stage.show();
 
         // there are assertions tested down the stack (see JDK-8115729)
+    }
+
+    @Test
+    public void needsLayoutPropertyIsReadOnly() {
+        assertThrows(
+            ClassCastException.class,
+            () -> { var _ = (Property<Boolean>)new Group().needsLayoutProperty(); });
     }
 
     private static class LGroup extends Group {


### PR DESCRIPTION
`Parent.needsLayout` is implemented with a `ReadOnlyBooleanWrapper`. The property getter returns the wrapper itself, but what it should be doing is return the read-only getter instead.

A single reviewer should be sufficient.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354797](https://bugs.openjdk.org/browse/JDK-8354797): Parent.needsLayoutProperty() should return read-only getter (**Bug** - P4)


### Reviewers
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)
 * [John Hendrikx](https://openjdk.org/census#jhendrikx) (@hjohn - **Reviewer**)
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1780/head:pull/1780` \
`$ git checkout pull/1780`

Update a local copy of the PR: \
`$ git checkout pull/1780` \
`$ git pull https://git.openjdk.org/jfx.git pull/1780/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1780`

View PR using the GUI difftool: \
`$ git pr show -t 1780`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1780.diff">https://git.openjdk.org/jfx/pull/1780.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1780#issuecomment-2808902839)
</details>
