### PR TITLE
8354794: [TestBug] LocalDateTimeStringConverterTest: Not all Tests needs to be parameterized

### DIFF
--- a/modules/javafx.base/src/test/java/test/javafx/util/converter/LocalDateTimeStringConverterTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/util/converter/LocalDateTimeStringConverterTest.java
@@ -44,6 +44,7 @@ import javafx.util.converter.LocalDateTimeStringConverterShim;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -187,8 +188,7 @@ public class LocalDateTimeStringConverterTest {
         };
     }
 
-    @ParameterizedTest
-    @MethodSource("implementations")
+    @Test
     void converter_with_specified_formatter_and_parser() {
         String formatPattern = "dd MMMM yyyy, HH:mm:ss";
         String parsePattern = "MMMM dd, yyyy, HH:mm:ss";
@@ -199,8 +199,7 @@ public class LocalDateTimeStringConverterTest {
         assertEquals(VALID_LDT_WITH_SECONDS, converter.fromString("January 12, 1985, 12:34:56"));
     }
 
-    @ParameterizedTest
-    @MethodSource("implementations")
+    @Test
     void converter_with_specified_formatter_and_null_parser() {
         String pattern = "dd MMMM yyyy, HH:mm:ss";
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern(pattern);
@@ -209,8 +208,7 @@ public class LocalDateTimeStringConverterTest {
         assertEquals(VALID_LDT_WITH_SECONDS, converter.fromString("12 January 1985, 12:34:56"));
     }
 
-    @ParameterizedTest
-    @MethodSource("implementations")
+    @Test
     void testChronologyConsistency() {
         var converter = new LocalDateTimeStringConverter(FormatStyle.FULL, FormatStyle.MEDIUM,
                 null, JapaneseChronology.INSTANCE);


### PR DESCRIPTION
As discussed in #1778, those test does not need to be parameterized, we therefore can replace `@ParameterizedTest` and `@MethodSource` with `@Test`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354794](https://bugs.openjdk.org/browse/JDK-8354794): [TestBug] LocalDateTimeStringConverterTest: Not all Tests needs to be parameterized (**Enhancement** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1782/head:pull/1782` \
`$ git checkout pull/1782`

Update a local copy of the PR: \
`$ git checkout pull/1782` \
`$ git pull https://git.openjdk.org/jfx.git pull/1782/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1782`

View PR using the GUI difftool: \
`$ git pr show -t 1782`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1782.diff">https://git.openjdk.org/jfx/pull/1782.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1782#issuecomment-2810387657)
</details>
