### PR TITLE
JDK-8260020 Local Markdown files not shown in Webview

### DIFF
--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/MIMETypeRegistry.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/MIMETypeRegistry.cpp
@@ -199,6 +199,9 @@ HashSet<String, ASCIICaseInsensitiveHash>& MIMETypeRegistry::supportedNonImageMI
             "text/xsl"_s,
             "text/plain"_s,
             "text/"_s,
+#if PLATFORM(JAVA)
+            "application/octet-stream"_s,
+#endif
             "application/xml"_s,
             "application/xhtml+xml"_s,
 #if !PLATFORM(IOS_FAMILY)

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/java/MIMETypeRegistryJava.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/java/MIMETypeRegistryJava.cpp
@@ -62,6 +62,9 @@ static const ExtensionMap extensionMap [] = {
     { "xbm"_s, "image/x-xbitmap"_s },
     { "xml"_s, "text/xml"_s },
     { "xsl"_s, "text/xsl"_s },
+#if PLATFORM(JAVA)
+    { "md"_s, "application/octet-stream"_s},
+#endif
     { "xht"_s, "application/xhtml+xml"_s },
     { "xhtml"_s, "application/xhtml+xml"_s },
     { "wml"_s, "text/vnd.wap.wml"_s },


### PR DESCRIPTION
Local markdown file mime type support was missing in open source [JDK-8260020],

Hence, we added a mime type for local Markdown files display.

expected bahaviour: This should display the markdown file content as text in the webview.
Verification:
The test passes with the rendering of local Markdown file.