### PR TITLE
8318985: [macos] Incorrect 3D lighting on macOS 14 and later

### DIFF
--- a/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/specular_none.frag
+++ b/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/specular_none.frag
@@ -54,5 +54,7 @@ uniform sampler2D specularMap;
 
 vec4 apply_specular()
 {
-    return vec4(0.0,0.0,0.0,0.0);
+    // Use 32 which is default for specular power if specular color is not set
+    // Because pow(0, 0) is undefined (https://www.khronos.org/registry/OpenGL-Refpages/es3.0/html/pow.xhtml)
+    return vec4(0.0,0.0,0.0,32.0);
 }

--- a/tests/system/src/test/java/test/robot/test3d/PointLightIlluminationTest.java
+++ b/tests/system/src/test/java/test/robot/test3d/PointLightIlluminationTest.java
@@ -42,7 +42,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import com.sun.javafx.PlatformUtil;
 import test.robot.testharness.VisualTestBase;
 
 /**
@@ -68,36 +67,9 @@ public class PointLightIlluminationTest extends VisualTestBase {
     private static final double COLOR_TOLERANCE    = 0.07;
     private static volatile Scene testScene = null;
 
-    // Used to skip failing tests on macOS 14 or later on aarch64 until JDK-8318985 is fixed
-    private boolean isMacAarch64MacOS14;
-
-    private static int getFirstInt(String input) {
-        String str = input;
-        if (str == null) {
-            return -1;
-        }
-        str = str.trim();
-        if (str.isEmpty() || !Character.isDigit(str.charAt(0))) {
-            return -1;
-        }
-        str = str.split("\\D+")[0];
-        return Integer.parseInt(str);
-    }
-
     @BeforeEach
     public void setupEach() {
         assumeTrue(Platform.isSupported(ConditionalFeature.SCENE3D));
-
-        // JDK-8318985
-        isMacAarch64MacOS14 = false;
-        if (PlatformUtil.isMac() &&
-                "aarch64".equals(System.getProperty("os.arch"))) {
-
-            int majorVer = getFirstInt(System.getProperty("os.version"));
-            if (majorVer >= 14) {
-                isMacAarch64MacOS14 = true;
-            }
-        }
 
         // Use the same test scene for all tests
         if (testScene == null) {
@@ -124,7 +96,6 @@ public class PointLightIlluminationTest extends VisualTestBase {
 
     @Test
     public void sphereUpperLeftPixelColorShouldBeDarkRed() {
-        assumeTrue(!isMacAarch64MacOS14); // JDK-8318985
         runAndWait(() -> {
             Color color = getColor(testScene, LEFT_CORNER_X, UPPER_CORNER_Y);
             assertColorEquals(Color.DARKRED, color, COLOR_TOLERANCE);
@@ -133,7 +104,6 @@ public class PointLightIlluminationTest extends VisualTestBase {
 
     @Test
     public void sphereUpperRightPixelColorShouldBeDarkRed() {
-        assumeTrue(!isMacAarch64MacOS14); // JDK-8318985
         runAndWait(() -> {
             Color color = getColor(testScene, RIGHT_CORNER_X, UPPER_CORNER_Y);
             assertColorEquals(Color.DARKRED, color, COLOR_TOLERANCE);
@@ -142,7 +112,6 @@ public class PointLightIlluminationTest extends VisualTestBase {
 
     @Test
     public void sphereLowerRightPixelColorShouldBeDarkRed() {
-        assumeTrue(!isMacAarch64MacOS14); // JDK-8318985
         runAndWait(() -> {
             Color color = getColor(testScene, RIGHT_CORNER_X, LOWER_CORNER_Y);
             assertColorEquals(Color.DARKRED, color, COLOR_TOLERANCE);
@@ -151,7 +120,6 @@ public class PointLightIlluminationTest extends VisualTestBase {
 
     @Test
     public void sphereLowerLeftPixelColorShouldBeDarkRed() {
-        assumeTrue(!isMacAarch64MacOS14); // JDK-8318985
         runAndWait(() -> {
             Color color = getColor(testScene, LEFT_CORNER_X, LOWER_CORNER_Y);
             assertColorEquals(Color.DARKRED, color, COLOR_TOLERANCE);


### PR DESCRIPTION
When no specular color is set while rendering 3D primitives, 0.0 specular power value is used by default in our shaders.
When same specular power value is used in pow() function in shader it results in undefined behaviour as mentioned at : https://registry.khronos.org/OpenGL-Refpages/es3.0/html/pow.xhtml

By default specular power value should be 32, so now the specular_none.frag file is updated to use this default value to make sure we don't see 3D lighting issues on some platforms. This change is tested with Ensemble8 and fx83dfeatures and i don't see any regressions.

Also one of our system test _PointLightIlluminationTest_ used to fail because of this issue. It passes now with this update and it is re-enabled.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8318985](https://bugs.openjdk.org/browse/JDK-8318985): [macos] Incorrect 3D lighting on macOS 14 and later (**Bug** - P3)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1791/head:pull/1791` \
`$ git checkout pull/1791`

Update a local copy of the PR: \
`$ git checkout pull/1791` \
`$ git pull https://git.openjdk.org/jfx.git pull/1791/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1791`

View PR using the GUI difftool: \
`$ git pr show -t 1791`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1791.diff">https://git.openjdk.org/jfx/pull/1791.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1791#issuecomment-2824101547)
</details>
