### PR TITLE
8355413: Re-enable InitializeJavaFXLaunchTests on Xorg

### DIFF
--- a/tests/system/src/test/java/test/com/sun/javafx/application/InitializeJavaFXLaunch1Test.java
+++ b/tests/system/src/test/java/test/com/sun/javafx/application/InitializeJavaFXLaunch1Test.java
@@ -29,16 +29,11 @@ import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import com.sun.javafx.PlatformUtil;
-import test.util.Util;
-
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class InitializeJavaFXLaunch1Test extends InitializeJavaFXLaunchBase {
 
     @BeforeAll
     public static void initialize() throws Exception {
-        assumeTrue(!PlatformUtil.isLinux() || Util.isOnWayland()); // JDK-8353644
         InitializeJavaFXLaunchBase.initializeApplicationLaunch();
     }
 

--- a/tests/system/src/test/java/test/com/sun/javafx/application/InitializeJavaFXLaunch2Test.java
+++ b/tests/system/src/test/java/test/com/sun/javafx/application/InitializeJavaFXLaunch2Test.java
@@ -29,16 +29,11 @@ import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import com.sun.javafx.PlatformUtil;
-import test.util.Util;
-
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class InitializeJavaFXLaunch2Test extends InitializeJavaFXLaunchBase {
 
     @BeforeAll
     public static void initialize() throws Exception {
-        assumeTrue(!PlatformUtil.isLinux() || Util.isOnWayland()); // JDK-8353644
         InitializeJavaFXLaunchBase.initializeApplicationLaunch();
     }
 


### PR DESCRIPTION
As part of https://bugs.openjdk.org/browse/JDK-8353557, InitializeJavaFXLaunchTests were disabled as they were failing in Ubuntu24.04 VM and product issue https://bugs.openjdk.org/browse/JDK-8353644 was created.

But after verifying this test on actual Ubuntu 24.04 hardware it is identified that this test doesn't fail even after multiple iterations. So we need to re-enable these tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8355413](https://bugs.openjdk.org/browse/JDK-8355413): Re-enable InitializeJavaFXLaunchTests on Xorg (**Bug** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1792/head:pull/1792` \
`$ git checkout pull/1792`

Update a local copy of the PR: \
`$ git checkout pull/1792` \
`$ git pull https://git.openjdk.org/jfx.git pull/1792/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1792`

View PR using the GUI difftool: \
`$ git pr show -t 1792`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1792.diff">https://git.openjdk.org/jfx/pull/1792.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1792#issuecomment-2824744012)
</details>
