### PR TITLE
8354336: gstclock.c: compilation error: 'incompatible pointer type' with gcc 14

### DIFF
--- a/modules/javafx.media/src/main/native/gstreamer/gstreamer-lite/gstreamer/gst/gst_private.h
+++ b/modules/javafx.media/src/main/native/gstreamer/gstreamer-lite/gstreamer/gst/gst_private.h
@@ -532,7 +532,11 @@ struct _GstDynamicTypeFactoryClass {
 struct _GstClockEntryImpl
 {
   GstClockEntry entry;
+#if defined (GSTREAMER_LITE) && defined(LINUX)
+  GWeakRef clock;
+#else // GSTREAMER_LITE
   GWeakRef *clock;
+#endif // GSTREAMER_LITE
   GDestroyNotify destroy_entry;
   gpointer padding[21];                 /* padding for allowing e.g. systemclock
                                          * to add data in lieu of overridable

--- a/modules/javafx.media/src/main/native/gstreamer/plugins/av/videodecoder.c
+++ b/modules/javafx.media/src/main/native/gstreamer/plugins/av/videodecoder.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -199,7 +199,7 @@ static void videodecoder_dispose(GObject* object)
 {
     VideoDecoder *decoder = VIDEODECODER(object);
 
-    basedecoder_close_decoder(decoder);
+    basedecoder_close_decoder(BASEDECODER(decoder));
 
     G_OBJECT_CLASS(parent_class)->dispose(object);
 }
@@ -545,7 +545,7 @@ static gboolean videodecoder_convert_frame(VideoDecoder *decoder)
         return FALSE;
 
     int ret = decoder->sws_scale_func(decoder->sws_context,
-                                      base->frame->data,
+                                      (const uint8_t * const*)base->frame->data,
                                       base->frame->linesize,
                                       0,
                                       base->frame->height,


### PR DESCRIPTION
- Fixed gcc 14 compiler errors.

```
../../../gstreamer-lite/gstreamer/gst/gstclock.c: In function 'gst_clock_entry_new':
../../../gstreamer-lite/gstreamer/gst/gstclock.c:178:48: error: passing argument 1 of 'g_weak_ref_init' from incompatible pointer type [-Wincompatible-pointer-types]
  178 | #define GST_CLOCK_ENTRY_CLOCK_WEAK_REF(entry) (&((GstClockEntryImpl *)(entry))->clock)
      | ~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      | |
      | GWeakRef **
../../../gstreamer-lite/gstreamer/gst/gstclock.c:274:20: note: in expansion of macro 'GST_CLOCK_ENTRY_CLOCK_WEAK_REF'
  274 | g_weak_ref_init (GST_CLOCK_ENTRY_CLOCK_WEAK_REF (entry), clock);
```

```
../../../plugins/av/videodecoder.c: In function 'videodecoder_dispose':
../../../plugins/av/videodecoder.c:202:31: error: passing argument 1 of 'basedecoder_close_decoder' from incompatible pointer type [-Wincompatible-pointer-types]
  202 | basedecoder_close_decoder(decoder);
```

```
../../../plugins/av/videodecoder.c: In function 'videodecoder_convert_frame':
../../../plugins/av/videodecoder.c:548:50: error: passing argument 2 of 'decoder->sws_scale_func' from incompatible pointer type [-Wincompatible-pointer-types]
  548 | base->frame->data,
      | ~~~~~~~~~~~^~~~~~
      | |
      | uint8_t ** {aka unsigned char **}
../../../plugins/av/videodecoder.c:548:50: note: expected 'const uint8_t * const*' {aka 'const unsigned char * const*'} but argument is of type 'uint8_t **' {aka 'unsigned char **'}
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8354336](https://bugs.openjdk.org/browse/JDK-8354336): gstclock.c: compilation error: 'incompatible pointer type' with gcc 14 (**Bug** - P3)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1794/head:pull/1794` \
`$ git checkout pull/1794`

Update a local copy of the PR: \
`$ git checkout pull/1794` \
`$ git pull https://git.openjdk.org/jfx.git pull/1794/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1794`

View PR using the GUI difftool: \
`$ git pr show -t 1794`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1794.diff">https://git.openjdk.org/jfx/pull/1794.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1794#issuecomment-2825761009)
</details>
