### PR TITLE
8355615: ConcurrentModificationException creating MenuBar on background thread

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/MenuBarSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/MenuBarSkin.java
@@ -202,17 +202,12 @@ public class MenuBarSkin extends SkinBase<MenuBar> {
      *
      * @param control The control that this skin should be installed onto.
      */
-    public MenuBarSkin(MenuBar control) {
+    public MenuBarSkin(final MenuBar control) {
         super(control);
 
         container = new HBox();
         container.getStyleClass().add("container");
         getChildren().add(container);
-    }
-
-    @Override
-    public void install() {
-        MenuBar control = getSkinnable();
 
         menuBarFocusedPropertyListener = (ov, t, t1) -> {
             unSelectMenus();
@@ -657,27 +652,30 @@ public class MenuBarSkin extends SkinBase<MenuBar> {
      *                                                                         *
      **************************************************************************/
 
+    /** {@inheritDoc} */
     @Override
     public void dispose() {
-        if (Platform.isFxApplicationThread()) {
-            if (getSkinnable() == null) {
-                return;
-            }
-
-            if (sceneListenerHelper != null) {
-                sceneListenerHelper.disconnect();
-                sceneListenerHelper = null;
-            }
-
-            cleanUpListeners();
-            cleanUpSystemMenu();
-            getChildren().remove(container);
-
-            // call super.dispose last since it sets control to null
-            super.dispose();
-        } else {
-            Platform.runLater(this::dispose);
+        if (getSkinnable() == null) {
+            return;
         }
+
+        if (sceneListenerHelper != null) {
+            sceneListenerHelper.disconnect();
+            sceneListenerHelper = null;
+        }
+
+        cleanUpListeners();
+
+        if (Platform.isFxApplicationThread()) {
+            cleanUpSystemMenu();
+        } else {
+            Platform.runLater(this::cleanUpSystemMenu);
+        }
+
+        getChildren().remove(container);
+
+        // call super.dispose last since it sets control to null
+        super.dispose();
     }
 
     // Return empty insets when "container" is empty, which happens
@@ -1026,6 +1024,7 @@ public class MenuBarSkin extends SkinBase<MenuBar> {
         getSkinnable().requestLayout();
     }
 
+    // always called in the fx application thread
     private void cleanUpSystemMenu() {
         if (sceneChangeListener != null && getSkinnable() != null) {
             getSkinnable().sceneProperty().removeListener(sceneChangeListener);

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/MenuBarSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/MenuBarSkin.java
@@ -202,12 +202,17 @@ public class MenuBarSkin extends SkinBase<MenuBar> {
      *
      * @param control The control that this skin should be installed onto.
      */
-    public MenuBarSkin(final MenuBar control) {
+    public MenuBarSkin(MenuBar control) {
         super(control);
 
         container = new HBox();
         container.getStyleClass().add("container");
         getChildren().add(container);
+    }
+
+    @Override
+    public void install() {
+        MenuBar control = getSkinnable();
 
         menuBarFocusedPropertyListener = (ov, t, t1) -> {
             unSelectMenus();
@@ -652,24 +657,27 @@ public class MenuBarSkin extends SkinBase<MenuBar> {
      *                                                                         *
      **************************************************************************/
 
-    /** {@inheritDoc} */
     @Override
     public void dispose() {
-        if (getSkinnable() == null) {
-            return;
+        if (Platform.isFxApplicationThread()) {
+            if (getSkinnable() == null) {
+                return;
+            }
+
+            if (sceneListenerHelper != null) {
+                sceneListenerHelper.disconnect();
+                sceneListenerHelper = null;
+            }
+
+            cleanUpListeners();
+            cleanUpSystemMenu();
+            getChildren().remove(container);
+
+            // call super.dispose last since it sets control to null
+            super.dispose();
+        } else {
+            Platform.runLater(this::dispose);
         }
-
-        if (sceneListenerHelper != null) {
-            sceneListenerHelper.disconnect();
-            sceneListenerHelper = null;
-        }
-
-        cleanUpListeners();
-        cleanUpSystemMenu();
-        getChildren().remove(container);
-
-        // call super.dispose last since it sets control to null
-        super.dispose();
     }
 
     // Return empty insets when "container" is empty, which happens

--- a/tests/system/src/test/java/test/robot/javafx/scene/NodeInitializationStressTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/NodeInitializationStressTest.java
@@ -752,9 +752,13 @@ public class NodeInitializationStressTest extends RobotTestBase {
         assumeFalse(SKIP_TEST);
         test(() -> {
             MenuBar c = new MenuBar();
-            // exercise skin installation and disposal code paths
-            c.setSkin(new MenuBarSkin(c));
-            c.setSkin(new MenuBarSkin(c));
+            if (nextBoolean()) {
+                c.setSkin(new MenuBarSkin(c));
+                if (nextBoolean()) {
+                    // exercise skin installation and disposal code paths
+                    c.setSkin(new MenuBarSkin(c));
+                }
+            }
             c.setUseSystemMenuBar(nextBoolean());
             return c;
         }, (c) -> {


### PR DESCRIPTION
Moving MenuBarSkin initialization code to install() which always happens in the FX Application Thread.

Also, ensure that the reverse process also happens in the FX application thread.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8355615](https://bugs.openjdk.org/browse/JDK-8355615): ConcurrentModificationException creating MenuBar on background thread (**Bug** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Ziad El Midaoui](https://openjdk.org/census#zelmidaoui) (@Ziad-Mid - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1795/head:pull/1795` \
`$ git checkout pull/1795`

Update a local copy of the PR: \
`$ git checkout pull/1795` \
`$ git pull https://git.openjdk.org/jfx.git pull/1795/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1795`

View PR using the GUI difftool: \
`$ git pr show -t 1795`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1795.diff">https://git.openjdk.org/jfx/pull/1795.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1795#issuecomment-2835682419)
</details>
