### PR TITLE
8176813: Mac: Failure to exit full-screen programmatically in some cases

### DIFF
--- a/tests/system/src/test/java/test/javafx/scene/RestoreSceneSizeTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/RestoreSceneSizeTest.java
@@ -90,9 +90,8 @@ public class RestoreSceneSizeTest {
 
     @Test
     public void testUnfullscreenSize() throws Exception {
-        // Disable on Mac until JDK-8176813 is fixed
         // Disable on Linux until JDK-8353556 is fixed
-        assumeTrue(!(PlatformUtil.isMac() || PlatformUtil.isLinux()));
+        assumeTrue(!PlatformUtil.isLinux());
 
         Thread.sleep(200);
         final double w = (Math.ceil(WIDTH * scaleX)) / scaleX;

--- a/tests/system/src/test/java/test/javafx/stage/RestoreStagePositionTest.java
+++ b/tests/system/src/test/java/test/javafx/stage/RestoreStagePositionTest.java
@@ -92,7 +92,7 @@ public class RestoreStagePositionTest {
         double y = stage.getY();
 
         Platform.runLater(() -> stage.setFullScreen(true));
-        Thread.sleep(400);
+        Thread.sleep(800);
         Assertions.assertTrue(stage.isFullScreen());
         CountDownLatch latch = new CountDownLatch(2);
 

--- a/tests/system/src/test/java/test/javafx/stage/RestoreStagePositionTest.java
+++ b/tests/system/src/test/java/test/javafx/stage/RestoreStagePositionTest.java
@@ -49,7 +49,7 @@ public class RestoreStagePositionTest {
         initFX();
         try {
             RestoreStagePositionTest test = new RestoreStagePositionTest();
-            test.testUfullscreenPosition();
+            test.testUnfullscreenPosition();
             test.testDemaximizedPosition();
         } catch (Throwable e) {
             e.printStackTrace();
@@ -83,7 +83,7 @@ public class RestoreStagePositionTest {
     }
 
     @Test
-    public void testUfullscreenPosition() throws Exception {
+    public void testUnfullscreenPosition() throws Exception {
         Thread.sleep(200);
         Assertions.assertTrue(stage.isShowing());
         Assertions.assertFalse(stage.isFullScreen());
@@ -119,9 +119,6 @@ public class RestoreStagePositionTest {
 
     @Test
     public void testDemaximizedPosition() throws Exception {
-        // Disable on Mac until JDK-8089230 is fixed
-        assumeTrue(!PlatformUtil.isMac());
-
         Thread.sleep(200);
         Assertions.assertTrue(stage.isShowing());
         Assertions.assertFalse(stage.isMaximized());
@@ -130,7 +127,7 @@ public class RestoreStagePositionTest {
         double y = stage.getY();
 
         Platform.runLater(() -> stage.setMaximized(true));
-        Thread.sleep(200);
+        Thread.sleep(500);
         Assertions.assertTrue(stage.isMaximized());
         CountDownLatch latch = new CountDownLatch(2);
 

--- a/tests/system/src/test/java/test/javafx/stage/RestoreStagePositionTest.java
+++ b/tests/system/src/test/java/test/javafx/stage/RestoreStagePositionTest.java
@@ -84,9 +84,6 @@ public class RestoreStagePositionTest {
 
     @Test
     public void testUfullscreenPosition() throws Exception {
-        // Disable on Mac until JDK-8176813 is fixed
-        assumeTrue(!PlatformUtil.isMac());
-
         Thread.sleep(200);
         Assertions.assertTrue(stage.isShowing());
         Assertions.assertFalse(stage.isFullScreen());

--- a/tests/system/src/test/java/test/javafx/stage/RestoreStagePositionTest.java
+++ b/tests/system/src/test/java/test/javafx/stage/RestoreStagePositionTest.java
@@ -119,6 +119,9 @@ public class RestoreStagePositionTest {
 
     @Test
     public void testDemaximizedPosition() throws Exception {
+        // Disable on Mac until JDK-8089230 is fixed
+        assumeTrue(!PlatformUtil.isMac());
+
         Thread.sleep(200);
         Assertions.assertTrue(stage.isShowing());
         Assertions.assertFalse(stage.isMaximized());
@@ -127,7 +130,7 @@ public class RestoreStagePositionTest {
         double y = stage.getY();
 
         Platform.runLater(() -> stage.setMaximized(true));
-        Thread.sleep(500);
+        Thread.sleep(200);
         Assertions.assertTrue(stage.isMaximized());
         CountDownLatch latch = new CountDownLatch(2);
 


### PR DESCRIPTION
On macOS the system animates the transition into and out of fullscreen and this animation runs asynchronously. JavaFX tries to make the setFullScreen call appear synchronous by running a nested event loop while the transition is going on. But this means that runLater runnables can fire during a call to setFullScreen.

This can also occur during a call to Window.hide() if the window is in fullscreen mode. During the setView call glass tries to take the window out of fullscreen mode which fires up a nested event loop and, again, runLater runnables (like pulses) start firing.

In this PR GlassRunnables that try to run during the fullscreen transition are instead placed in a deferral list. When the fullscreen event loop exits they are re-scheduled.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8176813](https://bugs.openjdk.org/browse/JDK-8176813): Mac: Failure to exit full-screen programmatically in some cases (**Bug** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1797/head:pull/1797` \
`$ git checkout pull/1797`

Update a local copy of the PR: \
`$ git checkout pull/1797` \
`$ git pull https://git.openjdk.org/jfx.git pull/1797/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1797`

View PR using the GUI difftool: \
`$ git pr show -t 1797`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1797.diff">https://git.openjdk.org/jfx/pull/1797.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1797#issuecomment-2836036234)
</details>
