### PR TITLE
8353314: macOS: Inconsistent fullscreen behavior

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassViewDelegate.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassViewDelegate.m
@@ -1234,15 +1234,13 @@ static jstring convertNSStringToJString(id aString, int length)
 - (void)setResizableForFullscreen:(BOOL)resizable
 {
     NSWindow* window =  [self->nsView window];
-    if (!((GlassWindow*) window)->isResizable) {
-        NSUInteger mask = [window styleMask];
-        if (resizable) {
-            mask |= NSResizableWindowMask;
-        } else {
-            mask &= ~(NSUInteger)NSResizableWindowMask;
-        }
-        [window setStyleMask: mask];
+    NSUInteger mask = [window styleMask];
+    if (resizable) {
+        mask |= NSResizableWindowMask;
+    } else {
+        mask &= ~(NSUInteger)NSResizableWindowMask;
     }
+    [window setStyleMask: mask];
 }
 
 /*

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassViewDelegate.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassViewDelegate.m
@@ -1236,9 +1236,9 @@ static jstring convertNSStringToJString(id aString, int length)
     NSWindow* window =  [self->nsView window];
     NSUInteger mask = [window styleMask];
     if (resizable) {
-        mask |= NSResizableWindowMask;
+        mask |= NSWindowStyleMaskResizable;
     } else {
-        mask &= ~(NSUInteger)NSResizableWindowMask;
+        mask &= ~(NSUInteger)NSWindowStyleMaskResizable;
     }
     [window setStyleMask: mask];
 }


### PR DESCRIPTION
macOS will allow any window to enter fullscreen mode but won't expand the window's size if the resizable bit isn't set in the window's style mask. For undecorated stages the code has to set this bit before entering fullscreen and restore the old value after exiting fullscreen.

The old code was taking a pointer to an NSWindow and casting it to a pointer to an unrelated type (GlassWindow). It was also making an unnecessary check. windowWillEnterFullScreen stashes away the state of the resizable bit before setting it and windowDidExitFullScreen restores the old state. There's no need for setResizableForFullscreen to check anything, it just needs to do what it's told.

System tests for this case are underway as part of PR #1789.

You might have difficulty reproducing the bug in the master branch.  The old code was doing a bogus pointer cast and then dereferencing it to check a state flag so the code sometimes worked and sometimes didn't.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8353314](https://bugs.openjdk.org/browse/JDK-8353314): macOS: Inconsistent fullscreen behavior (**Bug** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1799/head:pull/1799` \
`$ git checkout pull/1799`

Update a local copy of the PR: \
`$ git checkout pull/1799` \
`$ git pull https://git.openjdk.org/jfx.git pull/1799/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1799`

View PR using the GUI difftool: \
`$ git pr show -t 1799`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1799.diff">https://git.openjdk.org/jfx/pull/1799.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1799#issuecomment-2842846925)
</details>
