### PR TITLE
8351357: Resolve system test focus issues

### DIFF
--- a/tests/system/src/test/java/test/robot/javafx/stage/StageFocusTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/stage/StageFocusTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.robot.javafx.stage;
+
+import java.util.concurrent.CountDownLatch;
+
+import javafx.application.Application;
+import javafx.application.Platform;
+import javafx.scene.Group;
+import javafx.scene.Scene;
+import javafx.scene.input.KeyCode;
+import javafx.scene.paint.Color;
+import javafx.scene.robot.Robot;
+import javafx.stage.Stage;
+import javafx.stage.WindowEvent;
+import test.util.Util;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class StageFocusTest {
+
+    static CountDownLatch startupLatch;
+
+    static final double STAGE_SIZE = 200;
+
+    static final double STAGE_X = 100;
+    static final double STAGE_Y = 100;
+
+    static boolean receivedEvent = false;
+
+    Robot robot;
+
+    public static class TestApp extends Application {
+        @Override
+        public void start(Stage stage) {
+            Platform.setImplicitExit(false);
+
+            Group root = new Group();
+            Scene scene = new Scene(root, STAGE_SIZE, STAGE_SIZE);
+            scene.setFill(Color.LIGHTGREEN);
+            scene.setOnKeyPressed(e -> {
+                if (e.getCode() == KeyCode.A)
+                    receivedEvent = true;
+            });
+
+            stage.setScene(scene);
+            stage.addEventHandler(WindowEvent.WINDOW_SHOWN, e -> {
+                Platform.runLater(() -> {
+                    stage.setX(STAGE_X);
+                    stage.setY(STAGE_Y);
+                    startupLatch.countDown();
+                });
+            });
+            stage.show();
+        }
+    }
+
+    @BeforeAll
+    public static void setupOnce() throws Exception {
+        startupLatch = new CountDownLatch(1);
+        Util.launch(startupLatch, TestApp.class);
+    }
+
+    @AfterAll
+    public static void teardown() {
+        Util.shutdown();
+    }
+
+    @BeforeEach
+    public void setup() {
+        Util.runAndWait(() -> robot = new Robot());
+    }
+
+    /**
+     * Checks whether Stage is actually shown when calling show()
+     *
+     * Meant as a "canary" test of sorts to ensure other tests relying on
+     * Stage being actually shown and on foreground work fine.
+     */
+    @Test
+    public void testStageHasFocusAfterShow() {
+        Util.sleep(250);
+        Util.runAndWait(() -> {
+            robot.keyPress(KeyCode.A);
+        });
+        assertTrue(receivedEvent, "Expected key press has NOT been received! Stage did not have focus after showing. Some tests might fail because of this." +
+                                  "If that is the case, try re-running the tests with '--no-daemon' flag in Gradle.");
+    }
+}


### PR DESCRIPTION
Originally this issue was supposed to resolve problems with some system tests (`MenuDoubleShortcutTest`, `TextAreaBehaviorTest` and others) failing on my machine. In the process of figuring this out I found out the problem is Windows `::SetForegroundWindow()` API refusing to give focus to JFX Stage upon calling `Stage.show()`.

The problem happened only when running system tests via Gradle, and with more investigation it turned out the culprit is actually running tests via a Gradle Daemon, which is the default behavior. According to [SetForegroundWindow API remarks](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setforegroundwindow) there is a list of conditions a process must meet to be granted a privilege of receiving focus, which is supposed to prevent focus stealing. While we do meet the required conditions, we don't meet "one of" additional conditions listed in the reference:
- Gradle daemon is a background process, so tests started by it do not meet `The calling process is the foreground process.` and `The calling process was started by the foreground process.` conditions
- We most probably run the tests from the terminal, so `There is currently no foreground window, and thus no foreground process.` condition fails - the foreground window is the Terminal itself.
- Each test has fresh-started JFX stage so `The calling process received the last input event.` condition cannot be met and would require either Robot workarounds or manual interaction before each test case.
- There is no debugger involved in the process (at least most of the time) so `Either the foreground process or the calling process is being debugged.` is also not met.

As such, Windows refuses to grant JFX Stage focus, which fails some system tests relying on it.

While we cannot remedy these conditions in-code (outside of hacky solutions I found with `AttachThreadInput` API which I am not a fan of) the only solution seems to be running the tests on Windows via either `gradle --no-daemon` or by setting `org.gradle.daemon=false` property somewhere in `gradle.properties`.

In the process of debugging this problem I wrote a canary test to detect whether a Stage receives focus right after calling `show()`. I ran this test on all (accessible to me) platforms (Windows, Linux, macOS) - on both Linux and macOS the test passes regardless of whether the Gradle deamon is used or not. On my Windows machine (Win 11 24H2) it fails when testing through Gradle Daemon (among tests mentioned in the first paragraph) and succeeds when `--no-daemon` flag is used.

I figured the test could be added to the repository and serve as a helper if someone else encounters similar problems.