### PR TITLE
8356652: Input field ignores custom input source characters

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassView3D.h
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassView3D.h
@@ -53,7 +53,7 @@
     BOOL handlingKeyEvent;
     BOOL didCommitText;
     BOOL isHiDPIAware;
-
+    unichar insertTextChar;
     NSEvent *lastKeyEvent;
 }
 

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassViewDelegate.h
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassViewDelegate.h
@@ -83,7 +83,7 @@ typedef enum GestureMaskType {
 - (void)sendJavaMouseEvent:(NSEvent *)theEvent;
 - (void)resetMouseTracking;
 - (void)sendJavaMenuEvent:(NSEvent *)theEvent;
-- (BOOL)sendJavaKeyEvent:(NSEvent *)event isDown:(BOOL)isDown;
+- (BOOL)sendJavaKeyEvent:(NSEvent *)event isDown:(BOOL)isDown character:(unichar)textChar;
 - (void)sendJavaModifierKeyEvent:(NSEvent *)theEvent;
 - (void)sendJavaGestureEvent:(NSEvent *)theEvent type:(int)type;
 - (void)sendJavaGestureBeginEvent:(NSEvent *)theEvent;

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassViewDelegate.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassViewDelegate.m
@@ -676,13 +676,23 @@ static jint getSwipeDirFromEvent(NSEvent *theEvent)
             jKeyChars, jModifiers); \
     GLASS_CHECK_EXCEPTION(env);
 
-- (BOOL)sendJavaKeyEvent:(NSEvent *)theEvent isDown:(BOOL)isDown
+- (BOOL)sendJavaKeyEvent:(NSEvent *)theEvent isDown:(BOOL)isDown character:(unichar)textChar
 {
     GET_MAIN_JENV;
 
     jint jKeyCode = GetJavaKeyCode(theEvent);
-    jcharArray jKeyChars = GetJavaKeyChars(env, theEvent);
     jint jModifiers = GetJavaModifiers(theEvent);
+    jcharArray jKeyChars;
+    if (textChar != 0) {
+        jchar jc[1] = { textChar };
+        jKeyChars = (*env)->NewCharArray(env, 1);
+        if (jKeyChars == NULL) {
+            return YES;
+        }
+        (*env)->SetCharArrayRegion(env, jKeyChars, 0, 1, jc);
+    } else {
+        jKeyChars = GetJavaKeyChars(env, theEvent);
+    }
 
     // This routine returns YES if the PRESS event was consumed. This is
     // used to ensure that performKeyEquivalent doesn't allow an event


### PR DESCRIPTION
Under the hood the Keyman input method appears as a US English keyboard layout. The characters attached to an NSEvent are always US English Roman even if the selected Keyman layout is, say, Hebrew or Dvorak. Keyman sends the correct Hebrew or Dvorak character to insertText:replacementRange: instead.

This PR special-cases the Keyman layout, detecting it using the same method that AWT does. When Keyman is active Glass records the insertText: character and uses that when sending out KeyEvents.