### PR TITLE
8357004: Windows platform color changes are not picked up in some cases

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/win/GlassApplication.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/win/GlassApplication.cpp
@@ -182,7 +182,9 @@ LRESULT GlassApplication::WindowProc(UINT msg, WPARAM wParam, LPARAM lParam)
         case WM_THEMECHANGED:
         case WM_SYSCOLORCHANGE:
         case WM_DWMCOLORIZATIONCOLORCHANGED:
-            if (m_platformSupport.updatePreferences(PlatformSupport::PT_SYSTEM_COLORS)) {
+            if (m_platformSupport.updatePreferences(
+                    PlatformSupport::PreferenceType(PlatformSupport::PT_SYSTEM_COLORS |
+                                                    PlatformSupport::PT_UI_SETTINGS))) {
                 return 0;
             }
             break;

--- a/modules/javafx.graphics/src/main/native-glass/win/PlatformSupport.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/win/PlatformSupport.cpp
@@ -202,6 +202,8 @@ bool PlatformSupport::onSettingChanged(WPARAM wParam, LPARAM lParam) const
 {
     switch ((UINT)wParam) {
         case SPI_SETHIGHCONTRAST:
+            return updatePreferences(PreferenceType(PT_SYSTEM_PARAMS | PT_UI_SETTINGS));
+
         case SPI_SETCLIENTAREAANIMATION:
             return updatePreferences(PT_SYSTEM_PARAMS);
     }


### PR DESCRIPTION
The platform preferences API does not pick up the correct `UIColor` values when changing from a high-contrast Windows theme to another high-contrast theme.

The reason is that the implementation incorrectly assumes that changing the high-contrast theme does not affect the `UIColor` values. The fix is simple: when we query the `SysColor` values, we also need to query the `UIColor` values.

To reproduce: open platform preferences monitor in MonkeyTester (Tools -> Platform Preferences Monitor). Then switch between different high-contrast themes in Windows Settings and observe the `Windows.UIColor.*` values.

This fix can only be tested manually, since it requires interacting with the Windows OS in non-automatable ways.

/reviewers 2

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8357004](https://bugs.openjdk.org/browse/JDK-8357004): Windows platform color changes are not picked up in some cases (**Bug** - P4)


### Reviewers
 * [Lukasz Kostyra](https://openjdk.org/census#lkostyra) (@lukostyra - **Reviewer**)
 * [Markus Mack](https://openjdk.org/census#mmack) (@drmarmac - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1806/head:pull/1806` \
`$ git checkout pull/1806`

Update a local copy of the PR: \
`$ git checkout pull/1806` \
`$ git pull https://git.openjdk.org/jfx.git pull/1806/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1806`

View PR using the GUI difftool: \
`$ git pr show -t 1806`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1806.diff">https://git.openjdk.org/jfx/pull/1806.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1806#issuecomment-2881788529)
</details>
