### PR TITLE
8354940: Fail to sign in to Microsoft sites with WebView

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -620,6 +620,7 @@ defineProperty("HUDSON_JOB_NAME", "not_hudson")
 defineProperty("HUDSON_BUILD_NUMBER","0000")
 defineProperty("PROMOTED_BUILD_NUMBER", "0")
 defineProperty("MILESTONE_FCS", "false")
+defineProperty("WEBVIEW_VERSION", "18.4")
 ext.IS_MILESTONE_FCS = Boolean.parseBoolean(MILESTONE_FCS)
 
 // The following properties define the product name for Oracle JDK and OpenJDK
@@ -4019,6 +4020,7 @@ project(":web") {
                     } else {
                         targetCpuBitDepthSwitch = "--32-bit"
                     }
+                    cmakeArgs += " -DWEBVIEW_RELEASE_VERSION=${WEBVIEW_VERSION}"
                     cmakeArgs += " -DJAVAFX_RELEASE_VERSION=${jfxReleaseMajorVersion}"
                     commandLine("perl", "$projectDir/src/main/native/Tools/Scripts/build-webkit",
                         "--java", "--icu-unicode", targetCpuBitDepthSwitch,

--- a/modules/javafx.web/src/main/native/Source/WebKitLegacy/java/WebCoreSupport/WebPage.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebKitLegacy/java/WebCoreSupport/WebPage.cpp
@@ -729,6 +729,7 @@ static String defaultUserAgent()
         String wkVersion = makeString(
                               WTF::String::number(WEBKIT_MAJOR_VERSION), WTF::String::fromLatin1("."), WTF::String::number(WEBKIT_MINOR_VERSION),
                               WTF::String::fromLatin1(" (KHTML, like Gecko) JavaFX/"), WTF::String::fromLatin1(JAVAFX_RELEASE_VERSION),
+                              WTF::String::fromLatin1(" Version/"), WTF::String::fromLatin1(WEBVIEW_RELEASE_VERSION),
                               WTF::String::fromLatin1(" Safari/"), WTF::String::number(WEBKIT_MAJOR_VERSION), WTF::String::fromLatin1("."),  WTF::String::number(WEBKIT_MINOR_VERSION));
         return makeString(WTF::String::fromLatin1("Mozilla/5.0 ("), agentOS(), WTF::String::fromLatin1(") AppleWebKit/"), wkVersion);
     }();

--- a/modules/javafx.web/src/main/native/Source/WebKitLegacy/java/WebCoreSupport/WebPageConfig.h.in
+++ b/modules/javafx.web/src/main/native/Source/WebKitLegacy/java/WebCoreSupport/WebPageConfig.h.in
@@ -25,6 +25,13 @@
 
 #pragma once
 
+#cmakedefine WEBVIEW_RELEASE_VERSION "@WEBVIEW_RELEASE_VERSION@"
+
+#if !defined(WEBVIEW_RELEASE_VERSION)
+#error "WebView release version not defined"
+#endif
+
+
 #cmakedefine JAVAFX_RELEASE_VERSION "@JAVAFX_RELEASE_VERSION@"
 
 #if !defined(JAVAFX_RELEASE_VERSION)


### PR DESCRIPTION
URL "https://m365.cloud.microsoft/" does a browser version check before making the web content to the user. During the process, the micorosoft web server checks the User Agent of the Browser version (like safari version) for its approval process. At present the browser version is not part of the user agent string we are using.

Solution:
Added a version string in the user agent similar to safari.

Verification:
The test program attached to the JBS passes with this change.