### PR TITLE
8342530: Specifying "@Nx" scaling level in ImageStorage should only load that specific level

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/iio/ImageStorage.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/iio/ImageStorage.java
@@ -443,13 +443,22 @@ public class ImageStorage {
                     }
                 } else {
                     // Use Mac Retina conventions for >= 1.5f (rounded to the next integer scale)
-                    for (int imageScale = Math.round(devPixelScale); imageScale >= 2; --imageScale) {
-                        try {
-                            String scaledName = ImageTools.getScaledImageName(input, imageScale);
-                            theStream = ImageTools.createInputStream(scaledName);
-                            imgPixelScale = imageScale;
-                            break;
-                        } catch (IOException ignored) {
+                    // first, check if the scale is not already requested in the input
+                    if (ImageTools.hasScaledName(input)) {
+                        // scaled name exists, assume user explicitly wants it and attempt loading
+                        // if we can't find the resource this should throw and cancel the load
+                        theStream = ImageTools.createInputStream(input);
+                    }
+
+                    if (theStream == null) {
+                        for (int imageScale = Math.round(devPixelScale); imageScale >= 2; --imageScale) {
+                            try {
+                                String scaledName = ImageTools.getScaledImageName(input, imageScale);
+                                theStream = ImageTools.createInputStream(scaledName);
+                                imgPixelScale = imageScale;
+                                break;
+                            } catch (IOException ignored) {
+                            }
                         }
                     }
 

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/iio/ImageStorage.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/iio/ImageStorage.java
@@ -451,6 +451,7 @@ public class ImageStorage {
                     }
 
                     if (theStream == null) {
+                        // not the case, find the highest available scale
                         for (int imageScale = Math.round(devPixelScale); imageScale >= 2; --imageScale) {
                             try {
                                 String scaledName = ImageTools.getScaledImageName(input, imageScale);

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/iio/common/ImageTools.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/iio/common/ImageTools.java
@@ -52,7 +52,7 @@ public class ImageTools {
     /**
      * Regex pattern for hasScaledName
      */
-    private static final Pattern SCALED_FILE_PATTERN = Pattern.compile(".*@[1-9][0-9]?x(\\.[^\\.]+)?");
+    private static final Pattern SCALED_FILE_PATTERN = Pattern.compile(".*@[1-9][0-9]?x(?:\\.[^\\.]+)?");
 
     /**
      * See the general contract of the <code>readFully</code>

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/iio/common/ImageTools.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/iio/common/ImageTools.java
@@ -146,6 +146,24 @@ public class ImageTools {
         return result.toString();
     }
 
+    public static boolean hasScaledName(String path) {
+        int slash = path.lastIndexOf('/');
+        String name = (slash < 0) ? path : path.substring(slash + 1);
+        int at = name.lastIndexOf('@');
+        if (at < 0) return false;
+
+        int dot = name.lastIndexOf('.');
+        String scale = (dot < 0) ? name.substring(at + 1) : name.substring(at + 1, dot);
+        if (!scale.endsWith("x")) return false;
+
+        try {
+            Integer.valueOf(scale.substring(0, scale.length() - 1));
+        } catch (NumberFormatException ignored) {
+            return false;
+        }
+        return true;
+    }
+
     public static InputStream createInputStream(String input) throws IOException {
         InputStream stream = null;
 

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/iio/common/ImageTools.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/iio/common/ImageTools.java
@@ -35,6 +35,8 @@ import java.io.InputStream;
 import java.net.URL;
 import java.nio.ByteBuffer;
 import java.util.Locale;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
 
 /**
  * A set of format-independent convenience methods useful in image loading
@@ -46,6 +48,11 @@ public class ImageTools {
      * The percentage increment between progress report updates.
      */
     public static final int PROGRESS_INTERVAL = 5;
+
+    /**
+     * Regex pattern for hasScaledName
+     */
+    private static final Pattern SCALED_FILE_PATTERN = Pattern.compile(".*@[1-9][0-9]?x(\\.[^\\.]+)?");
 
     /**
      * See the general contract of the <code>readFully</code>
@@ -147,21 +154,7 @@ public class ImageTools {
     }
 
     public static boolean hasScaledName(String path) {
-        int slash = path.lastIndexOf('/');
-        String name = (slash < 0) ? path : path.substring(slash + 1);
-        int at = name.lastIndexOf('@');
-        if (at < 0) return false;
-
-        int dot = name.lastIndexOf('.');
-        String scale = (dot < 0) ? name.substring(at + 1) : name.substring(at + 1, dot);
-        if (!scale.endsWith("x")) return false;
-
-        try {
-            Integer.valueOf(scale.substring(0, scale.length() - 1));
-        } catch (NumberFormatException ignored) {
-            return false;
-        }
-        return true;
+        return SCALED_FILE_PATTERN.matcher(path).matches();
     }
 
     public static InputStream createInputStream(String input) throws IOException {

--- a/modules/javafx.graphics/src/test/java/test/com/sun/javafx/iio/ImageStorageTest.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/javafx/iio/ImageStorageTest.java
@@ -91,6 +91,14 @@ public class ImageStorageTest {
         assertEquals(50, frames1x[0].getHeight());
     }
 
+    @Test
+    public void testImageLoadRequestedScaleDoesNotExist() throws ImageStorageException {
+        final String path2x = getResourcePath("lightblue@1x.png").replace("lightblue@1x.png", "lightblue@2x.png");
+        assertThrows(ImageStorageException.class,
+            () -> { new ImageStorage().loadAll(path2x, null, 0, 0, true, 1.0f, true); },
+            "Expected loadAll() to throw with requested scale resource not existing");
+    }
+
     @ParameterizedTest
     @ValueSource(ints = {1, 2, 3, 4})
     public void testImageNames(int scale) {

--- a/modules/javafx.graphics/src/test/java/test/com/sun/javafx/iio/common/ImageToolsTest.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/javafx/iio/common/ImageToolsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -126,5 +126,29 @@ public class ImageToolsTest {
         assertThrows(IllegalArgumentException.class, () -> ImageTools.validateMaxDimensions(Integer.MAX_VALUE - 1, Integer.MAX_VALUE - 1, 1));
         assertThrows(IllegalArgumentException.class, () -> ImageTools.validateMaxDimensions(Integer.MAX_VALUE, Integer.MAX_VALUE, 1));
         assertThrows(IllegalArgumentException.class, () -> ImageTools.validateMaxDimensions(Integer.MAX_VALUE, Integer.MAX_VALUE, 3));
+    }
+
+    @Test
+    public void testGetScaledImageName() {
+        String nameWithoutPath = "image.png";
+        String nameWithPath = "/home/path/test/for/testing/image.png";
+        String expectedWithoutPath = "image@3x.png";
+        String expectedWithPath = "/home/path/test/for/testing/image@4x.png";
+
+        assertEquals(expectedWithoutPath, ImageTools.getScaledImageName(nameWithoutPath, 3));
+        assertEquals(expectedWithPath, ImageTools.getScaledImageName(nameWithPath, 4));
+    }
+
+    @Test
+    public void testHasScaledName() {
+        assertTrue(ImageTools.hasScaledName("image@3x.png"));
+        assertTrue(ImageTools.hasScaledName("/home/path/test/for/testing/image@2x.png"));
+        assertTrue(ImageTools.hasScaledName("image@5x"));
+        assertFalse(ImageTools.hasScaledName("image.png"));
+        assertFalse(ImageTools.hasScaledName("/home/path/test/for/testing/image.png"));
+        assertFalse(ImageTools.hasScaledName("image"));
+        assertFalse(ImageTools.hasScaledName("image@somewhere"));
+        assertFalse(ImageTools.hasScaledName("image@3ish"));
+        assertFalse(ImageTools.hasScaledName("image@4ix"));
     }
 }

--- a/modules/javafx.graphics/src/test/java/test/com/sun/javafx/iio/common/ImageToolsTest.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/javafx/iio/common/ImageToolsTest.java
@@ -150,5 +150,7 @@ public class ImageToolsTest {
         assertFalse(ImageTools.hasScaledName("image@somewhere"));
         assertFalse(ImageTools.hasScaledName("image@3ish"));
         assertFalse(ImageTools.hasScaledName("image@4ix"));
+        assertFalse(ImageTools.hasScaledName("image@0x"));
+        assertFalse(ImageTools.hasScaledName("image@-1x"));
     }
 }


### PR DESCRIPTION
This follow-up change finishes the earlier changes to `ImageStorage.loadAll()` and adds support for loading specific scale requested in the input.

`loadAll()` will now first check if the input path ends with a scaling level specified, and if that is the case it will attempt creating a Stream. If requested resource does not exist it will throw an Exception, skipping the rest of the load process. If the resource does _not_ have a scaled name in its path, it will continue loading as normal - looking for all scale levels, trying to load the main resource and falling back to trying to load "@1x" variant.

Added tests to check the new `ImageTools.hasScaledName()` method + new behavior.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8342530](https://bugs.openjdk.org/browse/JDK-8342530): Specifying "@<!---->Nx" scaling level in ImageStorage should only load that specific level (**Bug** - P4)


### Reviewers
 * [Michael Strauß](https://openjdk.org/census#mstrauss) (@mstr2 - **Reviewer**)
 * [John Hendrikx](https://openjdk.org/census#jhendrikx) (@hjohn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1809/head:pull/1809` \
`$ git checkout pull/1809`

Update a local copy of the PR: \
`$ git checkout pull/1809` \
`$ git pull https://git.openjdk.org/jfx.git pull/1809/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1809`

View PR using the GUI difftool: \
`$ git pr show -t 1809`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1809.diff">https://git.openjdk.org/jfx/pull/1809.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1809#issuecomment-2883497884)
</details>
