### PR TITLE
8357067: Platform preference change can emit multiple notifications

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Application.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -84,7 +84,7 @@ public abstract class Application {
         // currently used only on Mac OS X
         public void handleQuitAction(Application app, long time) {
         }
-        public void handlePreferencesChanged(Map<String, Object> preferences) {
+        public void handlePreferencesChanged(Map<String, Object> preferences, int suggestedDelayMillis) {
         }
     }
 
@@ -255,10 +255,10 @@ public abstract class Application {
         }
     }
 
-    protected void notifyPreferencesChanged(Map<String, Object> preferences) {
+    protected void notifyPreferencesChanged(Map<String, Object> preferences, int suggestedDelayMillis) {
         EventHandler handler = getEventHandler();
         if (handler != null) {
-            handler.handlePreferencesChanged(preferences);
+            handler.handlePreferencesChanged(preferences, suggestedDelayMillis);
         }
     }
 

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/application/PlatformImpl.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/application/PlatformImpl.java
@@ -942,10 +942,7 @@ public class PlatformImpl {
         platformPreferences = new PlatformPreferences(platformKeys, platformKeyMappings);
         platformPreferences.addListener(PlatformImpl::checkHighContrastThemeChanged);
         platformPreferences.update(preferences);
-        platformPreferencesAggregator = new DelayedChangeAggregator(
-            platformPreferences::update,
-            Toolkit.getToolkit().getPrimaryTimer()::nanos,
-            PlatformImpl::runLater);
+        platformPreferencesAggregator = new DelayedChangeAggregator(platformPreferences::update);
     }
 
     /**

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/application/preferences/DelayedChangeAggregator.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/application/preferences/DelayedChangeAggregator.java
@@ -75,8 +75,12 @@ public class DelayedChangeAggregator extends AnimationTimer {
         if (now >= elapsedTimeNanos) {
             stop();
             running = false;
-            changeConsumer.accept(currentChangeSet);
-            currentChangeSet.clear();
+
+            try {
+                changeConsumer.accept(currentChangeSet);
+            } finally {
+                currentChangeSet.clear();
+            }
         }
     }
 

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/application/preferences/DelayedChangeAggregator.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/application/preferences/DelayedChangeAggregator.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.sun.javafx.application.preferences;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Executor;
+import java.util.function.Consumer;
+import java.util.function.LongSupplier;
+
+/**
+ * Aggregates multiple subsequent sets of changes into a single changeset, and notifies a consumer.
+ * Due to its delayed nature, the consumer may not be notified immediately when a changeset arrives.
+ * <p>
+ * This class is not thread-safe and can only safely be used on a single thread; this applies to the
+ * {@link #update(Map, int)}} method as well as the delayed executor.
+ */
+public final class DelayedChangeAggregator {
+
+    private final Executor delayedExecutor;
+    private final LongSupplier nanoTimeSupplier;
+    private final Consumer<Map<String, Object>> changeConsumer;
+    private final Map<String, Object> currentChangeSet;
+    private long elapsedTimeNanos;
+    private int serial;
+
+    public DelayedChangeAggregator(Consumer<Map<String, Object>> changeConsumer,
+                                   LongSupplier nanoTimeSupplier,
+                                   Executor delayedExecutor) {
+        this.changeConsumer = changeConsumer;
+        this.nanoTimeSupplier = nanoTimeSupplier;
+        this.delayedExecutor = delayedExecutor;
+        this.currentChangeSet = new HashMap<>();
+    }
+
+    /**
+     * Integrates the specified changeset into the current changeset, and applies the current changeset
+     * after the specified delay period. The delay is added to the current time, but will not elapse
+     * before any previous delays are scheduled to elapse.
+     *
+     * @param changeset the changeset
+     * @param delayMillis the delay period, in milliseconds
+     */
+    public void update(Map<String, Object> changeset, int delayMillis) {
+        if (delayMillis > 0 || !currentChangeSet.isEmpty()) {
+            int currentSerial = ++serial;
+            long newElapsedTimeNanos = nanoTimeSupplier.getAsLong() + (long)delayMillis * 1000000;
+            elapsedTimeNanos = Math.max(elapsedTimeNanos, newElapsedTimeNanos);
+            currentChangeSet.putAll(changeset);
+            delayedExecutor.execute(() -> update(currentSerial));
+        } else {
+            changeConsumer.accept(changeset);
+        }
+    }
+
+    private void update(int expectedSerial) {
+        if (expectedSerial == serial) {
+            if (nanoTimeSupplier.getAsLong() < elapsedTimeNanos) {
+                delayedExecutor.execute(() -> update(expectedSerial));
+            } else {
+                changeConsumer.accept(currentChangeSet);
+                currentChangeSet.clear();
+            }
+        }
+    }
+}

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/QuantumToolkit.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/QuantumToolkit.java
@@ -365,8 +365,8 @@ public final class QuantumToolkit extends Toolkit {
                 }
 
                 @Override
-                public void handlePreferencesChanged(Map<String, Object> preferences) {
-                    PlatformImpl.updatePreferences(preferences);
+                public void handlePreferencesChanged(Map<String, Object> preferences, int suggestedDelayMillis) {
+                    PlatformImpl.updatePreferences(preferences, suggestedDelayMillis);
                 }
             });
         }

--- a/modules/javafx.graphics/src/main/native-glass/gtk/PlatformSupport.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/PlatformSupport.cpp
@@ -189,7 +189,7 @@ void PlatformSupport::updatePreferences() const {
             jCollectionsCls, jCollectionsUnmodifiableMap, newPreferences);
 
         if (!EXCEPTION_OCCURED(env)) {
-            env->CallVoidMethod(application, jApplicationNotifyPreferencesChanged, unmodifiablePreferences);
+            env->CallVoidMethod(application, jApplicationNotifyPreferencesChanged, unmodifiablePreferences, 0);
             EXCEPTION_OCCURED(env);
 
             env->DeleteLocalRef(unmodifiablePreferences);

--- a/modules/javafx.graphics/src/main/native-glass/gtk/glass_general.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/glass_general.cpp
@@ -350,7 +350,7 @@ JNI_OnLoad(JavaVM *jvm, void *reserved)
     if (env->ExceptionCheck()) return JNI_ERR;
     jApplicationGetName = env->GetMethodID(jApplicationCls, "getName", "()Ljava/lang/String;");
     if (env->ExceptionCheck()) return JNI_ERR;
-    jApplicationNotifyPreferencesChanged = env->GetMethodID(jApplicationCls, "notifyPreferencesChanged", "(Ljava/util/Map;)V");
+    jApplicationNotifyPreferencesChanged = env->GetMethodID(jApplicationCls, "notifyPreferencesChanged", "(Ljava/util/Map;I)V");
     if (env->ExceptionCheck()) return JNI_ERR;
 
     clazz = env->FindClass("java/lang/Object");

--- a/modules/javafx.graphics/src/main/native-glass/gtk/glass_general.h
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/glass_general.h
@@ -227,7 +227,7 @@ private:
     extern jmethodID jApplicationReportException; // reportException(Ljava/lang/Throwable;)V
     extern jmethodID jApplicationGetApplication; // GetApplication()()Lcom/sun/glass/ui/Application;
     extern jmethodID jApplicationGetName; // getName()Ljava/lang/String;
-    extern jmethodID jApplicationNotifyPreferencesChanged; // notifyPreferencesChanged(Ljava/util/Map;)V
+    extern jmethodID jApplicationNotifyPreferencesChanged; // notifyPreferencesChanged(Ljava/util/Map;I)V
 
     extern jclass jObjectCls; // java.lang.Object
     extern jmethodID jObjectEquals; // java.lang.Object#equals(Ljava/lang/Object;)Z

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
@@ -967,7 +967,7 @@ JNIEXPORT void JNICALL Java_com_sun_glass_ui_mac_MacApplication__1initIDs
     if ((*env)->ExceptionCheck(env)) return;
 
     javaIDs.MacApplication.notifyPreferencesChanged = (*env)->GetMethodID(
-            env, jClass, "notifyPreferencesChanged", "(Ljava/util/Map;)V");
+            env, jClass, "notifyPreferencesChanged", "(Ljava/util/Map;I)V");
     if ((*env)->ExceptionCheck(env)) return;
 
     if (jRunnableRun == NULL)

--- a/modules/javafx.graphics/src/main/native-glass/mac/PlatformSupport.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/PlatformSupport.m
@@ -307,7 +307,7 @@
             (*env)->CallVoidMethod(
                 env, application,
                 javaIDs.MacApplication.notifyPreferencesChanged,
-                unmodifiablePreferences);
+                unmodifiablePreferences, 0);
             GLASS_CHECK_EXCEPTION(env);
 
             (*env)->DeleteLocalRef(env, unmodifiablePreferences);

--- a/modules/javafx.graphics/src/main/native-glass/win/GlassApplication.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/win/GlassApplication.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -182,9 +182,11 @@ LRESULT GlassApplication::WindowProc(UINT msg, WPARAM wParam, LPARAM lParam)
         case WM_THEMECHANGED:
         case WM_SYSCOLORCHANGE:
         case WM_DWMCOLORIZATIONCOLORCHANGED:
+            // Usually, the WM_THEMECHANGED and WM_SYSCOLORCHANGE messages are followed by other
+            // messages or WinRT callbacks that may change platform preferences.
             if (m_platformSupport.updatePreferences(
-                    PlatformSupport::PreferenceType(PlatformSupport::PT_SYSTEM_COLORS |
-                                                    PlatformSupport::PT_UI_SETTINGS))) {
+                    PlatformSupport::PreferenceType(PlatformSupport::PT_SYSTEM_COLORS | PlatformSupport::PT_SYSTEM_PARAMS),
+                    /* delayedChangesExpected: */ msg == WM_THEMECHANGED || msg == WM_SYSCOLORCHANGE)) {
                 return 0;
             }
             break;
@@ -332,7 +334,7 @@ JNIEXPORT void JNICALL Java_com_sun_glass_ui_win_WinApplication_initIDs
     if (CheckAndClearException(env)) return;
 
     javaIDs.Application.notifyPreferencesChangedMID =
-        env->GetMethodID(cls, "notifyPreferencesChanged", "(Ljava/util/Map;)V");
+        env->GetMethodID(cls, "notifyPreferencesChanged", "(Ljava/util/Map;I)V");
     ASSERT(javaIDs.Application.notifyPreferencesChangedMID);
     if (CheckAndClearException(env)) return;
 

--- a/modules/javafx.graphics/src/main/native-glass/win/PlatformSupport.h
+++ b/modules/javafx.graphics/src/main/native-glass/win/PlatformSupport.h
@@ -61,14 +61,19 @@ public:
      * Collect the specified platform preferences and notify the JavaFX application when a preference has changed.
      * The change notification includes all specified preferences, not only the changed preferences.
      */
-    bool updatePreferences(PreferenceType) const;
+    bool updatePreferences(PreferenceType, bool delayedChangesExpected) const;
 
     /**
      * Handles the WM_SETTINGCHANGE message.
-    */
+     */
     bool onSettingChanged(WPARAM, LPARAM) const;
 
 private:
+    /**
+     * Suggested aggregation delay for changes that come in over a period of time.
+     */
+    static constexpr int SUGGESTED_DELAY_MILLIS = 1000;
+
     JNIEnv* env;
     jobject application;
     bool initialized;
@@ -88,6 +93,7 @@ private:
     void querySystemColors(jobject properties) const;
     void querySystemParameters(jobject properties) const;
     void queryUISettings(jobject properties) const;
+    void queryUIColors(jobject properties) const;
     void queryNetworkInformation(jobject properties) const;
 
     void putString(jobject properties, const char* key, const char* value) const;

--- a/modules/javafx.graphics/src/test/java/test/com/sun/javafx/application/preferences/DelayedChangeAggregatorTest.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/javafx/application/preferences/DelayedChangeAggregatorTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.com.sun.javafx.application.preferences;
+
+import com.sun.javafx.application.preferences.DelayedChangeAggregator;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executor;
+import java.util.function.LongSupplier;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class DelayedChangeAggregatorTest {
+
+    static final int SHORT_DELAY = 100;
+    static final int LONG_DELAY = 1000;
+
+    @Test
+    void changeSetIsAppliedImmediately() {
+        var consumer = new HashMap<String, Object>();
+        var aggregator = new DelayedChangeAggregator(consumer::putAll, () -> 0, Runnable::run);
+        aggregator.update(Map.of("testKey", "testValue"), 0);
+        assertEquals(Map.of("testKey", "testValue"), consumer);
+    }
+
+    @Test
+    void subsequentChangeSetsAreAppliedImmediately() {
+        var consumer = new HashMap<String, Object>();
+        var aggregator = new DelayedChangeAggregator(consumer::putAll, () -> 0, Runnable::run);
+        aggregator.update(Map.of("testKey1", "testValue1"), 0);
+        assertEquals(Map.of("testKey1", "testValue1"), consumer);
+        aggregator.update(Map.of("testKey2", "testValue2"), 0);
+        assertEquals(Map.of("testKey1", "testValue1", "testKey2", "testValue2"), consumer);
+    }
+
+    @Test
+    void changeSetIsAppliedWithDelay() {
+        var executor = new ExecutorImpl();
+        var consumer = new HashMap<String, Object>();
+        var aggregator = new DelayedChangeAggregator(consumer::putAll, executor, executor);
+
+        aggregator.update(Map.of("testKey", "testValue"), SHORT_DELAY);
+        assertEquals(Map.of(), consumer);
+
+        // Advance the time half-way through the delay period.
+        executor.setTime(SHORT_DELAY / 2);
+        assertEquals(Map.of(), consumer);
+
+        // Advance the time to a millisecond before the end of the delay period.
+        executor.setTime(SHORT_DELAY - 1);
+        assertEquals(Map.of(), consumer);
+
+        // When the delay period has elapsed, the change is applied.
+        executor.setTime(SHORT_DELAY);
+        assertEquals(Map.of("testKey", "testValue"), consumer);
+    }
+
+    @Test
+    void subsequentChangeSetsAreAppliedWithDelay() {
+        var executor = new ExecutorImpl();
+        var consumer = new HashMap<String, Object>();
+        var aggregator = new DelayedChangeAggregator(consumer::putAll, executor, executor);
+
+        aggregator.update(Map.of("testKey1", "testValue1"), SHORT_DELAY);
+        assertEquals(Map.of(), consumer);
+
+        executor.setTime(SHORT_DELAY / 2);
+        aggregator.update(Map.of("testKey2", "testValue2"), SHORT_DELAY);
+        assertEquals(Map.of(), consumer);
+
+        executor.setTime((int)(SHORT_DELAY * 1.5));
+        assertEquals(Map.of("testKey1", "testValue1", "testKey2", "testValue2"), consumer);
+    }
+
+    @Test
+    void changeSetWithShortDelayWaitsForLastChangeSetWithLongDelay() {
+        var executor = new ExecutorImpl();
+        var consumer = new HashMap<String, Object>();
+        var aggregator = new DelayedChangeAggregator(consumer::putAll, executor, executor);
+
+        aggregator.update(Map.of("testKey1", "testValue1"), LONG_DELAY);
+        assertEquals(Map.of(), consumer);
+
+        // Advance the time half-way through the delay period.
+        executor.setTime(LONG_DELAY / 2);
+        assertEquals(Map.of(), consumer);
+
+        // The new changeset waits for the current changeset's delay period to elapse.
+        aggregator.update(Map.of("testKey2", "testValue2"), SHORT_DELAY);
+        assertEquals(Map.of(), consumer);
+
+        // Advance to the end of the first delay period. Both changesets are applied.
+        executor.setTime(LONG_DELAY);
+        assertEquals(Map.of("testKey1", "testValue1", "testKey2", "testValue2"), consumer);
+    }
+
+    private static class ExecutorImpl implements Executor, LongSupplier {
+        final List<Runnable> commands = new ArrayList<>();
+        long nanos;
+
+        @Override
+        public void execute(Runnable command) {
+            commands.add(command);
+        }
+
+        void run() {
+            var copy = List.copyOf(commands);
+            commands.clear();
+            copy.forEach(Runnable::run);
+        }
+
+        @Override
+        public long getAsLong() {
+            return nanos;
+        }
+
+        void setTime(int millis) {
+            nanos = (long)millis * 1000000;
+            run();
+        }
+    }
+}


### PR DESCRIPTION
Some platform preference changes can trigger the emission of multiple notifications. For example, when switching from a high-contrast theme on Windows to the regular theme, the following notifications are emitted (log can be viewed in `PlatformPreferencesChangedTest`):

```
changed:
	Windows.UIColor.Accent=0x0078d4ff
	Windows.SysColor.COLOR_HIGHLIGHTTEXT=0xffffffff
	Windows.SysColor.COLOR_WINDOW=0xffffffff
	Windows.UIColor.AccentLight1=0x0091f8ff
	Windows.SysColor.COLOR_3DFACE=0xf0f0f0ff
	Windows.SysColor.COLOR_HOTLIGHT=0x0066ccff
	Windows.SysColor.COLOR_WINDOWTEXT=0x000000ff
	Windows.SysColor.COLOR_BTNTEXT=0x000000ff
	Windows.UIColor.Foreground=0x000000ff
	Windows.UIColor.AccentDark1=0x0067c0ff
	Windows.UIColor.Background=0xffffffff
	Windows.UIColor.AccentLight3=0x99ebffff
	Windows.UIColor.AccentLight2=0x4cc2ffff
	Windows.SysColor.COLOR_GRAYTEXT=0x6d6d6dff
	Windows.SysColor.COLOR_HIGHLIGHT=0x0078d7ff
	Windows.UIColor.AccentDark2=0x003e92ff
	Windows.UIColor.AccentDark3=0x001a68ff

changed:
	-Windows.SPI.HighContrastColorScheme
	Windows.SPI.HighContrast=false

changed:
	Windows.UIColor.Foreground=0xffffffff
	Windows.UIColor.Background=0x000000ff
```

Notably, the values for Windows.UIColor.Foreground/Background are inconsistent between the notifications (although they are eventually correct). In general, only a single notification should be emitted that includes all of the changed preferences.

This artifact is only visible on Windows. The reason is that changing some system settings (like high-contrast theme) causes a number of different window messages to be sent to the application. We should wait for all window messages to come in, and then aggregate all of the changed preferences into a single notification.

In order to minimize the delay between changing a system setting and sending out the notification in JavaFX, the implementation only waits when instructed to do so by the native toolkit. This allows us to instantly send out notifications for most changes, but selectively wait a bit for changes where the native toolkit knows that more changes might be coming in.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8357067](https://bugs.openjdk.org/browse/JDK-8357067): Platform preference change can emit multiple notifications (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1810/head:pull/1810` \
`$ git checkout pull/1810`

Update a local copy of the PR: \
`$ git checkout pull/1810` \
`$ git pull https://git.openjdk.org/jfx.git pull/1810/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1810`

View PR using the GUI difftool: \
`$ git pr show -t 1810`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1810.diff">https://git.openjdk.org/jfx/pull/1810.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1810#issuecomment-2884633802)
</details>
