### PR TITLE
8357157: Exception thrown from AnimationTimer freezes application

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/scenario/animation/AbstractPrimaryTimer.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/scenario/animation/AbstractPrimaryTimer.java
@@ -63,10 +63,9 @@ public abstract class AbstractPrimaryTimer {
     private final int PULSE_DURATION_NS = getPulseDuration(1000000000);
     private final int PULSE_DURATION_TICKS = getPulseDuration((int)TickCalculation.fromMillis(1000));
 
-    // This property is used to control the number of exceptions that can be thrown by a timer callback
-    // before we stop logging them to prevent spamming the log.
-    private static final String FAILING_TIMER_THRESHOLD_PROP = "com.sun.scenario.animation.failingTimerThreshold";
-    public static final int FAILING_TIMER_THRESHOLD = Settings.getInt(FAILING_TIMER_THRESHOLD_PROP, 100);
+    // The number of exceptions that can be thrown by a timer callback before we stop sending
+    // them to the uncaught exception handler to prevent spamming the log.
+    public static final int FAILING_TIMER_THRESHOLD = 100;
 
     // This PropertyChangeListener is added to Settings to listen for changes
     // to the nogap and fullspeed properties.
@@ -386,9 +385,7 @@ public abstract class AbstractPrimaryTimer {
 
                 if (Logging.getJavaFXLogger().isLoggable(System.Logger.Level.WARNING)) {
                     Logging.getJavaFXLogger().warning(
-                        "Too many exceptions thrown by " + type().getSimpleName() + ", ignoring further exceptions." +
-                        " The cut-off number can be set with the system property " + FAILING_TIMER_THRESHOLD_PROP +
-                        " (current = " + FAILING_TIMER_THRESHOLD + ").");
+                        "Too many exceptions thrown by " + type().getSimpleName() + ", ignoring further exceptions.");
                 }
             }
         }

--- a/modules/javafx.graphics/src/main/java/com/sun/scenario/animation/AbstractPrimaryTimer.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/scenario/animation/AbstractPrimaryTimer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,8 +26,10 @@
 package com.sun.scenario.animation;
 
 import java.util.Arrays;
+import javafx.animation.AnimationTimer;
 import javafx.util.Callback;
 import com.sun.javafx.animation.TickCalculation;
+import com.sun.javafx.util.Logging;
 import com.sun.scenario.DelayedRunnable;
 import com.sun.scenario.Settings;
 import com.sun.scenario.animation.shared.PulseReceiver;
@@ -61,6 +63,9 @@ public abstract class AbstractPrimaryTimer {
     private final int PULSE_DURATION_NS = getPulseDuration(1000000000);
     private final int PULSE_DURATION_TICKS = getPulseDuration((int)TickCalculation.fromMillis(1000));
 
+    private static final String FAILING_TIMER_THRESHOLD_PROP = "com.sun.scenario.animation.failingTimerThreshold";
+    public static final int FAILING_TIMER_THRESHOLD = Settings.getInt(FAILING_TIMER_THRESHOLD_PROP, 100);
+
     // This PropertyChangeListener is added to Settings to listen for changes
     // to the nogap and fullspeed properties.
     private static Callback<String, Void> pcl = key -> {
@@ -79,13 +84,15 @@ public abstract class AbstractPrimaryTimer {
         return null;
     };
 
-    private PulseReceiver receivers[] = new PulseReceiver[2];
+    @SuppressWarnings("unchecked")
+    private ReceiverRecord<PulseReceiver>[] receivers = new ReceiverRecord[2];
     private int receiversLength;
     private boolean receiversLocked;
 
     // synchronize to update frameJobList and frameJobs
-    private TimerReceiver animationTimers[] = new TimerReceiver[2]; // frameJobList
-                                                                     // snapshot
+    @SuppressWarnings("unchecked")
+    private ReceiverRecord<TimerReceiver>[] animationTimers = new ReceiverRecord[2]; // frameJobList
+                                                                                     // snapshot
     private int animationTimersLength;
     private boolean animationTimersLocked;
 
@@ -146,7 +153,7 @@ public abstract class AbstractPrimaryTimer {
             receivers = Arrays.copyOf(receivers, needMoreSize ? receivers.length * 3 / 2 + 1 : receivers.length);
             receiversLocked = false;
         }
-        receivers[receiversLength++] = target;
+        receivers[receiversLength++] = ReceiverRecord.ofPulseReceiver(target);
         if (receiversLength == 1) {
             theMainLoop.updateAnimationRunnable();
         }
@@ -158,7 +165,7 @@ public abstract class AbstractPrimaryTimer {
             receiversLocked = false;
         }
         for (int i = 0; i < receiversLength; ++i) {
-            if (target == receivers[i]) {
+            if (target == receivers[i].receiver()) {
                 if (i == receiversLength - 1) {
                     receivers[i] = null;
                 } else {
@@ -180,7 +187,7 @@ public abstract class AbstractPrimaryTimer {
             animationTimers = Arrays.copyOf(animationTimers, needMoreSize ? animationTimers.length * 3 / 2 + 1 : animationTimers.length);
             animationTimersLocked = false;
         }
-        animationTimers[animationTimersLength++] = timer;
+        animationTimers[animationTimersLength++] = ReceiverRecord.ofAnimationTimer(timer);
         if (animationTimersLength == 1) {
             theMainLoop.updateAnimationRunnable();
         }
@@ -192,7 +199,7 @@ public abstract class AbstractPrimaryTimer {
             animationTimersLocked = false;
         }
         for (int i = 0; i < animationTimersLength; ++i) {
-            if (timer == animationTimers[i]) {
+            if (timer == animationTimers[i].receiver()) {
                 if (i == animationTimersLength - 1) {
                     animationTimers[i] = null;
                 } else {
@@ -308,29 +315,74 @@ public abstract class AbstractPrimaryTimer {
             debugNanos += fixedPulseLength;
             now = debugNanos;
         }
-        final PulseReceiver receiversSnapshot[] = receivers;
+
+        final ReceiverRecord<PulseReceiver>[] receiversSnapshot = receivers;
         final int rLength = receiversLength;
-        try {
-            receiversLocked = true;
-            for (int i = 0; i < rLength; i++) {
-                receiversSnapshot[i].timePulse(TickCalculation.fromNano(now));
+        receiversLocked = true;
+
+        for (int i = 0; i < rLength; i++) {
+            try {
+                receiversSnapshot[i].receiver().timePulse(TickCalculation.fromNano(now));
+            } catch (Throwable e) {
+                receiversSnapshot[i].handleException(e);
             }
-        } finally {
-            receiversLocked = false;
         }
+
+        receiversLocked = false;
         recordAnimationEnd();
 
-        final TimerReceiver animationTimersSnapshot[] = animationTimers;
+        final ReceiverRecord<TimerReceiver>[] animationTimersSnapshot = animationTimers;
         final int aTLength = animationTimersLength;
-        try {
-            animationTimersLocked = true;
-            // After every frame, call any frame jobs
-            for (int i = 0; i < aTLength; i++) {
-                animationTimersSnapshot[i].handle(now);
+        animationTimersLocked = true;
+
+        // After every frame, call any frame jobs
+        for (int i = 0; i < aTLength; i++) {
+            try {
+                animationTimersSnapshot[i].receiver().handle(now);
+            } catch (Throwable e) {
+                animationTimersSnapshot[i].handleException(e);
             }
-        } finally {
-            animationTimersLocked = false;
         }
+
+        animationTimersLocked = false;
     }
 
+    private static abstract class ReceiverRecord<T> {
+
+        static ReceiverRecord<TimerReceiver> ofAnimationTimer(TimerReceiver receiver) {
+            return new ReceiverRecord<>() {
+                @Override TimerReceiver receiver() { return receiver; }
+                @Override Class<?> type() { return AnimationTimer.class; }
+            };
+        }
+
+        static ReceiverRecord<PulseReceiver> ofPulseReceiver(PulseReceiver receiver) {
+            return new ReceiverRecord<>() {
+                @Override PulseReceiver receiver() { return receiver; }
+                @Override Class<?> type() { return PulseReceiver.class; }
+            };
+        }
+
+        abstract T receiver();
+        abstract Class<?> type();
+
+        int exceptionsThrown;
+
+        void handleException(Throwable e) {
+            if (exceptionsThrown < FAILING_TIMER_THRESHOLD) {
+                exceptionsThrown++;
+                Thread thread = Thread.currentThread();
+                thread.getUncaughtExceptionHandler().uncaughtException(thread, e);
+            } else if (exceptionsThrown == FAILING_TIMER_THRESHOLD) {
+                exceptionsThrown++;
+
+                if (Logging.getJavaFXLogger().isLoggable(System.Logger.Level.WARNING)) {
+                    Logging.getJavaFXLogger().warning(
+                        "Too many exceptions thrown by " + type().getSimpleName() + ", ignoring further exceptions." +
+                        " The cut-off number can be set with the system property " + FAILING_TIMER_THRESHOLD_PROP +
+                        " (current = " + FAILING_TIMER_THRESHOLD + ").");
+                }
+            }
+        }
+    }
 }

--- a/modules/javafx.graphics/src/test/java/test/com/sun/scenario/animation/AbstractPrimaryTimerTest.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/scenario/animation/AbstractPrimaryTimerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,8 @@
 
 package test.com.sun.scenario.animation;
 
+import java.util.ArrayList;
+import java.util.List;
 import javafx.animation.AnimationTimer;
 import com.sun.scenario.DelayedRunnable;
 import com.sun.scenario.animation.AbstractPrimaryTimer;
@@ -88,6 +90,148 @@ public class AbstractPrimaryTimerTest {
         timer.removeAnimationTimer(timerReceiver);
         timer.simulatePulse();
         assertFalse(flag.isFlagged());
+    }
+
+    @Test
+    public void testExceptionInAnimationTimerIsHandledInPrimaryTimer() {
+        Thread currentThread = Thread.currentThread();
+        String currentMethodName = currentThread.getStackTrace()[0].getMethodName();
+        Throwable[] uncaughtException = new Exception[1];
+        Thread.UncaughtExceptionHandler exceptionHandler = currentThread.getUncaughtExceptionHandler();
+        currentThread.setUncaughtExceptionHandler((_, e) -> uncaughtException[0] = e);
+
+        try {
+            var timer1 = new AnimationTimer() {
+                @Override
+                public void handle(long now) {
+                    throw new RuntimeException(currentMethodName);
+                }
+            };
+
+            var flag = new Flag();
+            var timer2 = new AnimationTimer() {
+                @Override
+                public void handle(long now) {
+                    flag.flag();
+                }
+            };
+
+            timer.addAnimationTimer(timer1::handle);
+            timer.addAnimationTimer(timer2::handle);
+            assertFalse(flag.isFlagged());
+
+            timer.simulatePulse();
+            assertTrue(flag.isFlagged());
+            assertEquals(currentMethodName, uncaughtException[0].getMessage());
+        } finally {
+            currentThread.setUncaughtExceptionHandler(exceptionHandler);
+        }
+    }
+
+    @Test
+    public void testExceptionInPulseReceiverIsHandledInPrimaryTimer() {
+        Thread currentThread = Thread.currentThread();
+        String currentMethodName = currentThread.getStackTrace()[0].getMethodName();
+        Throwable[] uncaughtException = new Exception[1];
+        Thread.UncaughtExceptionHandler exceptionHandler = currentThread.getUncaughtExceptionHandler();
+        currentThread.setUncaughtExceptionHandler((_, e) -> uncaughtException[0] = e);
+
+        try {
+            var receiver1 = new PulseReceiver() {
+                @Override
+                public void timePulse(long now) {
+                    throw new RuntimeException(currentMethodName);
+                }
+            };
+
+            var flag = new Flag();
+            var receiver2 = new PulseReceiver() {
+                @Override
+                public void timePulse(long now) {
+                    flag.flag();
+                }
+            };
+
+            timer.addPulseReceiver(receiver1);
+            timer.addPulseReceiver(receiver2);
+            assertFalse(flag.isFlagged());
+
+            timer.simulatePulse();
+            assertTrue(flag.isFlagged());
+            assertEquals(currentMethodName, uncaughtException[0].getMessage());
+        } finally {
+            currentThread.setUncaughtExceptionHandler(exceptionHandler);
+        }
+    }
+
+    @Test
+    public void testExceptionsInNoisyFailingAnimationTimerAreNotReported() {
+        Thread currentThread = Thread.currentThread();
+        String currentMethodName = currentThread.getStackTrace()[0].getMethodName();
+        List<Throwable> uncaughtExceptions = new ArrayList<>();
+        Thread.UncaughtExceptionHandler exceptionHandler = currentThread.getUncaughtExceptionHandler();
+        currentThread.setUncaughtExceptionHandler((_, e) -> uncaughtExceptions.add(e));
+
+        try {
+            var animTimer = new AnimationTimer() {
+                @Override
+                public void handle(long now) {
+                    throw new RuntimeException(currentMethodName);
+                }
+            };
+
+            timer.addAnimationTimer(animTimer::handle);
+
+            for (int i = 0; i < AbstractPrimaryTimer.FAILING_TIMER_THRESHOLD; ++i) {
+                timer.simulatePulse();
+            }
+
+            assertEquals(AbstractPrimaryTimer.FAILING_TIMER_THRESHOLD, uncaughtExceptions.size());
+            assertTrue(uncaughtExceptions.stream().allMatch(e -> e.getMessage().equals(currentMethodName)));
+
+            // The following exceptions are not reported
+            for (int i = 0; i < 3; ++i) {
+                timer.simulatePulse();
+                assertEquals(AbstractPrimaryTimer.FAILING_TIMER_THRESHOLD, uncaughtExceptions.size());
+            }
+        } finally {
+            currentThread.setUncaughtExceptionHandler(exceptionHandler);
+        }
+    }
+
+    @Test
+    public void testExceptionsInNoisyFailingPulseReceiverAreNotReported() {
+        Thread currentThread = Thread.currentThread();
+        String currentMethodName = currentThread.getStackTrace()[0].getMethodName();
+        List<Throwable> uncaughtExceptions = new ArrayList<>();
+        Thread.UncaughtExceptionHandler exceptionHandler = currentThread.getUncaughtExceptionHandler();
+        currentThread.setUncaughtExceptionHandler((_, e) -> uncaughtExceptions.add(e));
+
+        try {
+            var receiver = new PulseReceiver() {
+                @Override
+                public void timePulse(long now) {
+                    throw new RuntimeException(currentMethodName);
+                }
+            };
+
+            timer.addPulseReceiver(receiver);
+
+            for (int i = 0; i < AbstractPrimaryTimer.FAILING_TIMER_THRESHOLD; ++i) {
+                timer.simulatePulse();
+            }
+
+            assertEquals(AbstractPrimaryTimer.FAILING_TIMER_THRESHOLD, uncaughtExceptions.size());
+            assertTrue(uncaughtExceptions.stream().allMatch(e -> e.getMessage().equals(currentMethodName)));
+
+            // The following exceptions are not reported
+            for (int i = 0; i < 3; ++i) {
+                timer.simulatePulse();
+                assertEquals(AbstractPrimaryTimer.FAILING_TIMER_THRESHOLD, uncaughtExceptions.size());
+            }
+        } finally {
+            currentThread.setUncaughtExceptionHandler(exceptionHandler);
+        }
     }
 
     private static class Flag {


### PR DESCRIPTION
When an exception is thrown from `AnimationTimer::handle`, the JavaFX application freezes. The reason is that the user exception will bubble up into framework code, preventing the normal operation of JavaFX.

The following program demonstrates the defect:

```java
public class FailingAnimationTimer extends Application {
    @Override
    public void start(Stage stage) throws Exception {
        var button = new Button("start timer");
        button.setOnAction(_ -> {
            var timer = new AnimationTimer() {
                @Override
                public void handle(long l) {
                    throw new RuntimeException("foo");
                }
            };

            timer.start();
        });

        var root = new HBox();
        root.getChildren().add(new TextField("test"));
        root.getChildren().add(button);
        stage.setScene(new Scene(root));
        stage.show();
    }
}
```

The solution is to not allow user exceptions to bubble up into animation framework code. If an exception occurs, it is instead sent to the current thread's uncaught exception handler. This is the same thing that we already do for exceptions thrown by invalidation listeners and change listeners.

In addition to that, a failing animation timer has the potential to spam logs, which is why I introduced a cut-off value at 100 exceptions for each individual timer, after which no further exceptions from this particular timer are sent to the uncaught exception handler. After reaching the cut-off value, the following warning is logged:

`WARNING: Too many exceptions thrown by AnimationTimer, ignoring further exceptions. The cut-off number can be set with the system property com.sun.scenario.animation.failingTimerThreshold (current = 100).`

/reviewers 2

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8357157](https://bugs.openjdk.org/browse/JDK-8357157): Exception thrown from AnimationTimer freezes application (**Bug** - P3)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1811/head:pull/1811` \
`$ git checkout pull/1811`

Update a local copy of the PR: \
`$ git checkout pull/1811` \
`$ git pull https://git.openjdk.org/jfx.git pull/1811/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1811`

View PR using the GUI difftool: \
`$ git pr show -t 1811`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1811.diff">https://git.openjdk.org/jfx/pull/1811.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1811#issuecomment-2886926623)
</details>
