### PR TITLE
8357620: Expression binding error with forward reference

### DIFF
--- a/modules/javafx.fxml/src/test/java/test/javafx/fxml/FXMLLoader_ExpressionTest.java
+++ b/modules/javafx.fxml/src/test/java/test/javafx/fxml/FXMLLoader_ExpressionTest.java
@@ -309,6 +309,25 @@ public class FXMLLoader_ExpressionTest {
     }
 
     @Test
+    public void testInternalBinding() throws IOException {
+        /*
+            Test binding of a property to another property in the same FXML file.
+         */
+        FXMLLoader fxmlLoader = new FXMLLoader(getClass().getResource("expression_binding_internal.fxml"));
+        fxmlLoader.load();
+
+        Widget childWidget1 = (Widget)fxmlLoader.getNamespace().get("childWidget1");
+        Widget childWidget2 = (Widget)fxmlLoader.getNamespace().get("childWidget2");
+        Widget childWidget3 = (Widget)fxmlLoader.getNamespace().get("childWidget3");
+        assertEquals("0", childWidget2.getName());
+        assertEquals(10, childWidget3.getNumber());
+
+        childWidget1.setNumber(5);
+        assertEquals("10", childWidget2.getName());
+        assertEquals(5, childWidget3.getNumber());
+    }
+
+    @Test
     public void testEscapeSequences() throws IOException {
         System.err.println("Below warning about - deprecated escape sequence - is expected from this test.");
 

--- a/modules/javafx.fxml/src/test/resources/test/javafx/fxml/expression_binding_internal.fxml
+++ b/modules/javafx.fxml/src/test/resources/test/javafx/fxml/expression_binding_internal.fxml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2010, 2015, Oracle and/or its affiliates. All rights reserved.
+DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+
+This code is free software; you can redistribute it and/or modify it
+under the terms of the GNU General Public License version 2 only, as
+published by the Free Software Foundation.  Oracle designates this
+particular file as subject to the "Classpath" exception as provided
+by Oracle in the LICENSE file that accompanied this code.
+
+This code is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+version 2 for more details (a copy is included in the LICENSE file that
+accompanied this code).
+
+You should have received a copy of the GNU General Public License version
+2 along with this work; if not, write to the Free Software Foundation,
+Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+or visit www.oracle.com if you need additional information or have any
+questions.
+-->
+
+<?import test.javafx.fxml.Widget?>
+
+<Widget fx:controller="test.javafx.fxml.ExpressionBindingController"
+    xmlns:fx="http://javafx.com/fxml">
+    <Widget fx:id="childWidget3" number="${10-childWidget1.number}" />
+    <Widget fx:id="childWidget2" name="${childWidget1.number*2}" number="${childWidget1.number}"/>
+    <Widget fx:id="childWidget1" name="Child Widget 1" number="0" />
+</Widget>
+
+


### PR DESCRIPTION
The FXML loader will throw a null pointer exception if a binding expression refers to an element which occurs later in the XML ( see [JDK-8357620](https://bugs.java.com/bugdatabase/view_bug?bug_id=JDK-8357620)).
This PR stores each binding, as a runnable, in a list and then resolves them, in order, once all the XML has been read.
A test is included which fails without the patch and passes with it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Issue
 * [JDK-8357620](https://bugs.openjdk.org/browse/JDK-8357620): Expression binding error with forward reference (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1815/head:pull/1815` \
`$ git checkout pull/1815`

Update a local copy of the PR: \
`$ git checkout pull/1815` \
`$ git pull https://git.openjdk.org/jfx.git pull/1815/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1815`

View PR using the GUI difftool: \
`$ git pr show -t 1815`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1815.diff">https://git.openjdk.org/jfx/pull/1815.diff</a>

</details>
