### PR TITLE
8358255: Factor out boilerplate code of EventHandler properties in Scene and Window

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
@@ -4410,23 +4410,8 @@ public class Scene implements EventTarget {
 
     public final ObjectProperty<EventHandler<? super ContextMenuEvent>> onContextMenuRequestedProperty() {
         if (onContextMenuRequested == null) {
-            onContextMenuRequested = new ObjectPropertyBase<>() {
-
-                @Override
-                protected void invalidated() {
-                    setEventHandler(ContextMenuEvent.CONTEXT_MENU_REQUESTED, get());
-                }
-
-                @Override
-                public Object getBean() {
-                    return Scene.this;
-                }
-
-                @Override
-                public String getName() {
-                    return "onContextMenuRequested";
-                }
-            };
+            onContextMenuRequested = new EventHandlerProperty<>(
+                "onContextMenuRequested", ContextMenuEvent.CONTEXT_MENU_REQUESTED);
         }
         return onContextMenuRequested;
     }
@@ -4453,23 +4438,7 @@ public class Scene implements EventTarget {
 
     public final ObjectProperty<EventHandler<? super MouseEvent>> onMouseClickedProperty() {
         if (onMouseClicked == null) {
-            onMouseClicked = new ObjectPropertyBase<>() {
-
-                @Override
-                protected void invalidated() {
-                    setEventHandler(MouseEvent.MOUSE_CLICKED, get());
-                }
-
-                @Override
-                public Object getBean() {
-                    return Scene.this;
-                }
-
-                @Override
-                public String getName() {
-                    return "onMouseClicked";
-                }
-            };
+            onMouseClicked = new EventHandlerProperty<>("onMouseClicked", MouseEvent.MOUSE_CLICKED);
         }
         return onMouseClicked;
     }
@@ -4490,23 +4459,7 @@ public class Scene implements EventTarget {
 
     public final ObjectProperty<EventHandler<? super MouseEvent>> onMouseDraggedProperty() {
         if (onMouseDragged == null) {
-            onMouseDragged = new ObjectPropertyBase<>() {
-
-                @Override
-                protected void invalidated() {
-                    setEventHandler(MouseEvent.MOUSE_DRAGGED, get());
-                }
-
-                @Override
-                public Object getBean() {
-                    return Scene.this;
-                }
-
-                @Override
-                public String getName() {
-                    return "onMouseDragged";
-                }
-            };
+            onMouseDragged = new EventHandlerProperty<>("onMouseDragged", MouseEvent.MOUSE_DRAGGED);
         }
         return onMouseDragged;
     }
@@ -4526,23 +4479,7 @@ public class Scene implements EventTarget {
 
     public final ObjectProperty<EventHandler<? super MouseEvent>> onMouseEnteredProperty() {
         if (onMouseEntered == null) {
-            onMouseEntered = new ObjectPropertyBase<>() {
-
-                @Override
-                protected void invalidated() {
-                    setEventHandler(MouseEvent.MOUSE_ENTERED, get());
-                }
-
-                @Override
-                public Object getBean() {
-                    return Scene.this;
-                }
-
-                @Override
-                public String getName() {
-                    return "onMouseEntered";
-                }
-            };
+            onMouseEntered = new EventHandlerProperty<>("onMouseEntered", MouseEvent.MOUSE_ENTERED);
         }
         return onMouseEntered;
     }
@@ -4562,23 +4499,7 @@ public class Scene implements EventTarget {
 
     public final ObjectProperty<EventHandler<? super MouseEvent>> onMouseExitedProperty() {
         if (onMouseExited == null) {
-            onMouseExited = new ObjectPropertyBase<>() {
-
-                @Override
-                protected void invalidated() {
-                    setEventHandler(MouseEvent.MOUSE_EXITED, get());
-                }
-
-                @Override
-                public Object getBean() {
-                    return Scene.this;
-                }
-
-                @Override
-                public String getName() {
-                    return "onMouseExited";
-                }
-            };
+            onMouseExited = new EventHandlerProperty<>("onMouseExited", MouseEvent.MOUSE_EXITED);
         }
         return onMouseExited;
     }
@@ -4599,23 +4520,7 @@ public class Scene implements EventTarget {
 
     public final ObjectProperty<EventHandler<? super MouseEvent>> onMouseMovedProperty() {
         if (onMouseMoved == null) {
-            onMouseMoved = new ObjectPropertyBase<>() {
-
-                @Override
-                protected void invalidated() {
-                    setEventHandler(MouseEvent.MOUSE_MOVED, get());
-                }
-
-                @Override
-                public Object getBean() {
-                    return Scene.this;
-                }
-
-                @Override
-                public String getName() {
-                    return "onMouseMoved";
-                }
-            };
+            onMouseMoved = new EventHandlerProperty<>("onMouseMoved", MouseEvent.MOUSE_MOVED);
         }
         return onMouseMoved;
     }
@@ -4636,23 +4541,7 @@ public class Scene implements EventTarget {
 
     public final ObjectProperty<EventHandler<? super MouseEvent>> onMousePressedProperty() {
         if (onMousePressed == null) {
-            onMousePressed = new ObjectPropertyBase<>() {
-
-                @Override
-                protected void invalidated() {
-                    setEventHandler(MouseEvent.MOUSE_PRESSED, get());
-                }
-
-                @Override
-                public Object getBean() {
-                    return Scene.this;
-                }
-
-                @Override
-                public String getName() {
-                    return "onMousePressed";
-                }
-            };
+            onMousePressed = new EventHandlerProperty<>("onMousePressed", MouseEvent.MOUSE_PRESSED);
         }
         return onMousePressed;
     }
@@ -4673,23 +4562,7 @@ public class Scene implements EventTarget {
 
     public final ObjectProperty<EventHandler<? super MouseEvent>> onMouseReleasedProperty() {
         if (onMouseReleased == null) {
-            onMouseReleased = new ObjectPropertyBase<>() {
-
-                @Override
-                protected void invalidated() {
-                    setEventHandler(MouseEvent.MOUSE_RELEASED, get());
-                }
-
-                @Override
-                public Object getBean() {
-                    return Scene.this;
-                }
-
-                @Override
-                public String getName() {
-                    return "onMouseReleased";
-                }
-            };
+            onMouseReleased = new EventHandlerProperty<>("onMouseReleased", MouseEvent.MOUSE_RELEASED);
         }
         return onMouseReleased;
     }
@@ -4710,23 +4583,7 @@ public class Scene implements EventTarget {
 
     public final ObjectProperty<EventHandler<? super MouseEvent>> onDragDetectedProperty() {
         if (onDragDetected == null) {
-            onDragDetected = new ObjectPropertyBase<>() {
-
-                @Override
-                protected void invalidated() {
-                    setEventHandler(MouseEvent.DRAG_DETECTED, get());
-                }
-
-                @Override
-                public Object getBean() {
-                    return Scene.this;
-                }
-
-                @Override
-                public String getName() {
-                    return "onDragDetected";
-                }
-            };
+            onDragDetected = new EventHandlerProperty<>("onDragDetected", MouseEvent.DRAG_DETECTED);
         }
         return onDragDetected;
     }
@@ -4748,23 +4605,7 @@ public class Scene implements EventTarget {
 
     public final ObjectProperty<EventHandler<? super MouseDragEvent>> onMouseDragOverProperty() {
         if (onMouseDragOver == null) {
-            onMouseDragOver = new ObjectPropertyBase<>() {
-
-                @Override
-                protected void invalidated() {
-                    setEventHandler(MouseDragEvent.MOUSE_DRAG_OVER, get());
-                }
-
-                @Override
-                public Object getBean() {
-                    return Scene.this;
-                }
-
-                @Override
-                public String getName() {
-                    return "onMouseDragOver";
-                }
-            };
+            onMouseDragOver = new EventHandlerProperty<>("onMouseDragOver", MouseDragEvent.MOUSE_DRAG_OVER);
         }
         return onMouseDragOver;
     }
@@ -4786,23 +4627,7 @@ public class Scene implements EventTarget {
 
     public final ObjectProperty<EventHandler<? super MouseDragEvent>> onMouseDragReleasedProperty() {
         if (onMouseDragReleased == null) {
-            onMouseDragReleased = new ObjectPropertyBase<>() {
-
-                @Override
-                protected void invalidated() {
-                    setEventHandler(MouseDragEvent.MOUSE_DRAG_RELEASED, get());
-                }
-
-                @Override
-                public Object getBean() {
-                    return Scene.this;
-                }
-
-                @Override
-                public String getName() {
-                    return "onMouseDragReleased";
-                }
-            };
+            onMouseDragReleased = new EventHandlerProperty<>("onMouseDragReleased", MouseDragEvent.MOUSE_DRAG_RELEASED);
         }
         return onMouseDragReleased;
     }
@@ -4824,23 +4649,7 @@ public class Scene implements EventTarget {
 
     public final ObjectProperty<EventHandler<? super MouseDragEvent>> onMouseDragEnteredProperty() {
         if (onMouseDragEntered == null) {
-            onMouseDragEntered = new ObjectPropertyBase<>() {
-
-                @Override
-                protected void invalidated() {
-                    setEventHandler(MouseDragEvent.MOUSE_DRAG_ENTERED, get());
-                }
-
-                @Override
-                public Object getBean() {
-                    return Scene.this;
-                }
-
-                @Override
-                public String getName() {
-                    return "onMouseDragEntered";
-                }
-            };
+            onMouseDragEntered = new EventHandlerProperty<>("onMouseDragEntered", MouseDragEvent.MOUSE_DRAG_ENTERED);
         }
         return onMouseDragEntered;
     }
@@ -4862,23 +4671,7 @@ public class Scene implements EventTarget {
 
     public final ObjectProperty<EventHandler<? super MouseDragEvent>> onMouseDragExitedProperty() {
         if (onMouseDragExited == null) {
-            onMouseDragExited = new ObjectPropertyBase<>() {
-
-                @Override
-                protected void invalidated() {
-                    setEventHandler(MouseDragEvent.MOUSE_DRAG_EXITED, get());
-                }
-
-                @Override
-                public Object getBean() {
-                    return Scene.this;
-                }
-
-                @Override
-                public String getName() {
-                    return "onMouseDragExited";
-                }
-            };
+            onMouseDragExited = new EventHandlerProperty<>("onMouseDragExited", MouseDragEvent.MOUSE_DRAG_EXITED);
         }
         return onMouseDragExited;
     }
@@ -4906,23 +4699,7 @@ public class Scene implements EventTarget {
 
     public final ObjectProperty<EventHandler<? super ScrollEvent>> onScrollStartedProperty() {
         if (onScrollStarted == null) {
-            onScrollStarted = new ObjectPropertyBase<>() {
-
-                @Override
-                protected void invalidated() {
-                    setEventHandler(ScrollEvent.SCROLL_STARTED, get());
-                }
-
-                @Override
-                public Object getBean() {
-                    return Scene.this;
-                }
-
-                @Override
-                public String getName() {
-                    return "onScrollStarted";
-                }
-            };
+            onScrollStarted = new EventHandlerProperty<>("onScrollStarted", ScrollEvent.SCROLL_STARTED);
         }
         return onScrollStarted;
     }
@@ -4942,23 +4719,7 @@ public class Scene implements EventTarget {
 
     public final ObjectProperty<EventHandler<? super ScrollEvent>> onScrollProperty() {
         if (onScroll == null) {
-            onScroll = new ObjectPropertyBase<>() {
-
-                @Override
-                protected void invalidated() {
-                    setEventHandler(ScrollEvent.SCROLL, get());
-                }
-
-                @Override
-                public Object getBean() {
-                    return Scene.this;
-                }
-
-                @Override
-                public String getName() {
-                    return "onScroll";
-                }
-            };
+            onScroll = new EventHandlerProperty<>("onScroll", ScrollEvent.SCROLL);
         }
         return onScroll;
     }
@@ -4979,23 +4740,7 @@ public class Scene implements EventTarget {
 
     public final ObjectProperty<EventHandler<? super ScrollEvent>> onScrollFinishedProperty() {
         if (onScrollFinished == null) {
-            onScrollFinished = new ObjectPropertyBase<>() {
-
-                @Override
-                protected void invalidated() {
-                    setEventHandler(ScrollEvent.SCROLL_FINISHED, get());
-                }
-
-                @Override
-                public Object getBean() {
-                    return Scene.this;
-                }
-
-                @Override
-                public String getName() {
-                    return "onScrollFinished";
-                }
-            };
+            onScrollFinished = new EventHandlerProperty<>("onScrollFinished", ScrollEvent.SCROLL_FINISHED);
         }
         return onScrollFinished;
     }
@@ -5016,23 +4761,7 @@ public class Scene implements EventTarget {
 
     public final ObjectProperty<EventHandler<? super RotateEvent>> onRotationStartedProperty() {
         if (onRotationStarted == null) {
-            onRotationStarted = new ObjectPropertyBase<>() {
-
-                @Override
-                protected void invalidated() {
-                    setEventHandler(RotateEvent.ROTATION_STARTED, get());
-                }
-
-                @Override
-                public Object getBean() {
-                    return Scene.this;
-                }
-
-                @Override
-                public String getName() {
-                    return "onRotationStarted";
-                }
-            };
+            onRotationStarted = new EventHandlerProperty<>("onRotationStarted", RotateEvent.ROTATION_STARTED);
         }
         return onRotationStarted;
     }
@@ -5053,23 +4782,7 @@ public class Scene implements EventTarget {
 
     public final ObjectProperty<EventHandler<? super RotateEvent>> onRotateProperty() {
         if (onRotate == null) {
-            onRotate = new ObjectPropertyBase<>() {
-
-                @Override
-                protected void invalidated() {
-                    setEventHandler(RotateEvent.ROTATE, get());
-                }
-
-                @Override
-                public Object getBean() {
-                    return Scene.this;
-                }
-
-                @Override
-                public String getName() {
-                    return "onRotate";
-                }
-            };
+            onRotate = new EventHandlerProperty<>("onRotate", RotateEvent.ROTATE);
         }
         return onRotate;
     }
@@ -5090,23 +4803,7 @@ public class Scene implements EventTarget {
 
     public final ObjectProperty<EventHandler<? super RotateEvent>> onRotationFinishedProperty() {
         if (onRotationFinished == null) {
-            onRotationFinished = new ObjectPropertyBase<>() {
-
-                @Override
-                protected void invalidated() {
-                    setEventHandler(RotateEvent.ROTATION_FINISHED, get());
-                }
-
-                @Override
-                public Object getBean() {
-                    return Scene.this;
-                }
-
-                @Override
-                public String getName() {
-                    return "onRotationFinished";
-                }
-            };
+            onRotationFinished = new EventHandlerProperty<>("onRotationFinished", RotateEvent.ROTATION_FINISHED);
         }
         return onRotationFinished;
     }
@@ -5127,23 +4824,7 @@ public class Scene implements EventTarget {
 
     public final ObjectProperty<EventHandler<? super ZoomEvent>> onZoomStartedProperty() {
         if (onZoomStarted == null) {
-            onZoomStarted = new ObjectPropertyBase<>() {
-
-                @Override
-                protected void invalidated() {
-                    setEventHandler(ZoomEvent.ZOOM_STARTED, get());
-                }
-
-                @Override
-                public Object getBean() {
-                    return Scene.this;
-                }
-
-                @Override
-                public String getName() {
-                    return "onZoomStarted";
-                }
-            };
+            onZoomStarted = new EventHandlerProperty<>("onZoomStarted", ZoomEvent.ZOOM_STARTED);
         }
         return onZoomStarted;
     }
@@ -5164,23 +4845,7 @@ public class Scene implements EventTarget {
 
     public final ObjectProperty<EventHandler<? super ZoomEvent>> onZoomProperty() {
         if (onZoom == null) {
-            onZoom = new ObjectPropertyBase<>() {
-
-                @Override
-                protected void invalidated() {
-                    setEventHandler(ZoomEvent.ZOOM, get());
-                }
-
-                @Override
-                public Object getBean() {
-                    return Scene.this;
-                }
-
-                @Override
-                public String getName() {
-                    return "onZoom";
-                }
-            };
+            onZoom = new EventHandlerProperty<>("onZoom", ZoomEvent.ZOOM);
         }
         return onZoom;
     }
@@ -5201,23 +4866,7 @@ public class Scene implements EventTarget {
 
     public final ObjectProperty<EventHandler<? super ZoomEvent>> onZoomFinishedProperty() {
         if (onZoomFinished == null) {
-            onZoomFinished = new ObjectPropertyBase<>() {
-
-                @Override
-                protected void invalidated() {
-                    setEventHandler(ZoomEvent.ZOOM_FINISHED, get());
-                }
-
-                @Override
-                public Object getBean() {
-                    return Scene.this;
-                }
-
-                @Override
-                public String getName() {
-                    return "onZoomFinished";
-                }
-            };
+            onZoomFinished = new EventHandlerProperty<>("onZoomFinished", ZoomEvent.ZOOM_FINISHED);
         }
         return onZoomFinished;
     }
@@ -5239,23 +4888,7 @@ public class Scene implements EventTarget {
 
     public final ObjectProperty<EventHandler<? super SwipeEvent>> onSwipeUpProperty() {
         if (onSwipeUp == null) {
-            onSwipeUp = new ObjectPropertyBase<>() {
-
-                @Override
-                protected void invalidated() {
-                    setEventHandler(SwipeEvent.SWIPE_UP, get());
-                }
-
-                @Override
-                public Object getBean() {
-                    return Scene.this;
-                }
-
-                @Override
-                public String getName() {
-                    return "onSwipeUp";
-                }
-            };
+            onSwipeUp = new EventHandlerProperty<>("onSwipeUp", SwipeEvent.SWIPE_UP);
         }
         return onSwipeUp;
     }
@@ -5277,23 +4910,7 @@ public class Scene implements EventTarget {
 
     public final ObjectProperty<EventHandler<? super SwipeEvent>> onSwipeDownProperty() {
         if (onSwipeDown == null) {
-            onSwipeDown = new ObjectPropertyBase<>() {
-
-                @Override
-                protected void invalidated() {
-                    setEventHandler(SwipeEvent.SWIPE_DOWN, get());
-                }
-
-                @Override
-                public Object getBean() {
-                    return Scene.this;
-                }
-
-                @Override
-                public String getName() {
-                    return "onSwipeDown";
-                }
-            };
+            onSwipeDown = new EventHandlerProperty<>("onSwipeDown", SwipeEvent.SWIPE_DOWN);
         }
         return onSwipeDown;
     }
@@ -5315,23 +4932,7 @@ public class Scene implements EventTarget {
 
     public final ObjectProperty<EventHandler<? super SwipeEvent>> onSwipeLeftProperty() {
         if (onSwipeLeft == null) {
-            onSwipeLeft = new ObjectPropertyBase<>() {
-
-                @Override
-                protected void invalidated() {
-                    setEventHandler(SwipeEvent.SWIPE_LEFT, get());
-                }
-
-                @Override
-                public Object getBean() {
-                    return Scene.this;
-                }
-
-                @Override
-                public String getName() {
-                    return "onSwipeLeft";
-                }
-            };
+            onSwipeLeft = new EventHandlerProperty<>("onSwipeLeft", SwipeEvent.SWIPE_LEFT);
         }
         return onSwipeLeft;
     }
@@ -5353,23 +4954,7 @@ public class Scene implements EventTarget {
 
     public final ObjectProperty<EventHandler<? super SwipeEvent>> onSwipeRightProperty() {
         if (onSwipeRight == null) {
-            onSwipeRight = new ObjectPropertyBase<>() {
-
-                @Override
-                protected void invalidated() {
-                    setEventHandler(SwipeEvent.SWIPE_RIGHT, get());
-                }
-
-                @Override
-                public Object getBean() {
-                    return Scene.this;
-                }
-
-                @Override
-                public String getName() {
-                    return "onSwipeRight";
-                }
-            };
+            onSwipeRight = new EventHandlerProperty<>("onSwipeRight", SwipeEvent.SWIPE_RIGHT);
         }
         return onSwipeRight;
     }
@@ -5396,23 +4981,7 @@ public class Scene implements EventTarget {
 
     public final ObjectProperty<EventHandler<? super TouchEvent>> onTouchPressedProperty() {
         if (onTouchPressed == null) {
-            onTouchPressed = new ObjectPropertyBase<>() {
-
-                @Override
-                protected void invalidated() {
-                    setEventHandler(TouchEvent.TOUCH_PRESSED, get());
-                }
-
-                @Override
-                public Object getBean() {
-                    return Scene.this;
-                }
-
-                @Override
-                public String getName() {
-                    return "onTouchPressed";
-                }
-            };
+            onTouchPressed = new EventHandlerProperty<>("onTouchPressed", TouchEvent.TOUCH_PRESSED);
         }
         return onTouchPressed;
     }
@@ -5433,23 +5002,7 @@ public class Scene implements EventTarget {
 
     public final ObjectProperty<EventHandler<? super TouchEvent>> onTouchMovedProperty() {
         if (onTouchMoved == null) {
-            onTouchMoved = new ObjectPropertyBase<>() {
-
-                @Override
-                protected void invalidated() {
-                    setEventHandler(TouchEvent.TOUCH_MOVED, get());
-                }
-
-                @Override
-                public Object getBean() {
-                    return Scene.this;
-                }
-
-                @Override
-                public String getName() {
-                    return "onTouchMoved";
-                }
-            };
+            onTouchMoved = new EventHandlerProperty<>("onTouchMoved", TouchEvent.TOUCH_MOVED);
         }
         return onTouchMoved;
     }
@@ -5470,23 +5023,7 @@ public class Scene implements EventTarget {
 
     public final ObjectProperty<EventHandler<? super TouchEvent>> onTouchReleasedProperty() {
         if (onTouchReleased == null) {
-            onTouchReleased = new ObjectPropertyBase<>() {
-
-                @Override
-                protected void invalidated() {
-                    setEventHandler(TouchEvent.TOUCH_RELEASED, get());
-                }
-
-                @Override
-                public Object getBean() {
-                    return Scene.this;
-                }
-
-                @Override
-                public String getName() {
-                    return "onTouchReleased";
-                }
-            };
+            onTouchReleased = new EventHandlerProperty<>("onTouchReleased", TouchEvent.TOUCH_RELEASED);
         }
         return onTouchReleased;
     }
@@ -5508,23 +5045,7 @@ public class Scene implements EventTarget {
 
     public final ObjectProperty<EventHandler<? super TouchEvent>> onTouchStationaryProperty() {
         if (onTouchStationary == null) {
-            onTouchStationary = new ObjectPropertyBase<>() {
-
-                @Override
-                protected void invalidated() {
-                    setEventHandler(TouchEvent.TOUCH_STATIONARY, get());
-                }
-
-                @Override
-                public Object getBean() {
-                    return Scene.this;
-                }
-
-                @Override
-                public String getName() {
-                    return "onTouchStationary";
-                }
-            };
+            onTouchStationary = new EventHandlerProperty<>("onTouchStationary", TouchEvent.TOUCH_STATIONARY);
         }
         return onTouchStationary;
     }
@@ -5635,23 +5156,7 @@ public class Scene implements EventTarget {
      */
     public final ObjectProperty<EventHandler<? super DragEvent>> onDragEnteredProperty() {
         if (onDragEntered == null) {
-            onDragEntered = new ObjectPropertyBase<>() {
-
-                @Override
-                protected void invalidated() {
-                    setEventHandler(DragEvent.DRAG_ENTERED, get());
-                }
-
-                @Override
-                public Object getBean() {
-                    return Scene.this;
-                }
-
-                @Override
-                public String getName() {
-                    return "onDragEntered";
-                }
-            };
+            onDragEntered = new EventHandlerProperty<>("onDragEntered", DragEvent.DRAG_ENTERED);
         }
         return onDragEntered;
     }
@@ -5673,23 +5178,7 @@ public class Scene implements EventTarget {
      */
     public final ObjectProperty<EventHandler<? super DragEvent>> onDragExitedProperty() {
         if (onDragExited == null) {
-            onDragExited = new ObjectPropertyBase<>() {
-
-                @Override
-                protected void invalidated() {
-                    setEventHandler(DragEvent.DRAG_EXITED, get());
-                }
-
-                @Override
-                public Object getBean() {
-                    return Scene.this;
-                }
-
-                @Override
-                public String getName() {
-                    return "onDragExited";
-                }
-            };
+            onDragExited = new EventHandlerProperty<>("onDragExited", DragEvent.DRAG_EXITED);
         }
         return onDragExited;
     }
@@ -5712,23 +5201,7 @@ public class Scene implements EventTarget {
      */
     public final ObjectProperty<EventHandler<? super DragEvent>> onDragOverProperty() {
         if (onDragOver == null) {
-            onDragOver = new ObjectPropertyBase<>() {
-
-                @Override
-                protected void invalidated() {
-                    setEventHandler(DragEvent.DRAG_OVER, get());
-                }
-
-                @Override
-                public Object getBean() {
-                    return Scene.this;
-                }
-
-                @Override
-                public String getName() {
-                    return "onDragOver";
-                }
-            };
+            onDragOver = new EventHandlerProperty<>("onDragOver", DragEvent.DRAG_OVER);
         }
         return onDragOver;
     }
@@ -5784,23 +5257,7 @@ public class Scene implements EventTarget {
      */
     public final ObjectProperty<EventHandler<? super DragEvent>> onDragDroppedProperty() {
         if (onDragDropped == null) {
-            onDragDropped = new ObjectPropertyBase<>() {
-
-                @Override
-                protected void invalidated() {
-                    setEventHandler(DragEvent.DRAG_DROPPED, get());
-                }
-
-                @Override
-                public Object getBean() {
-                    return Scene.this;
-                }
-
-                @Override
-                public String getName() {
-                    return "onDragDropped";
-                }
-            };
+            onDragDropped = new EventHandlerProperty<>("onDragDropped", DragEvent.DRAG_DROPPED);
         }
         return onDragDropped;
     }
@@ -5833,23 +5290,7 @@ public class Scene implements EventTarget {
      */
     public final ObjectProperty<EventHandler<? super DragEvent>> onDragDoneProperty() {
         if (onDragDone == null) {
-            onDragDone = new ObjectPropertyBase<>() {
-
-                @Override
-                protected void invalidated() {
-                    setEventHandler(DragEvent.DRAG_DONE, get());
-                }
-
-                @Override
-                public Object getBean() {
-                    return Scene.this;
-                }
-
-                @Override
-                public String getName() {
-                    return "onDragDone";
-                }
-            };
+            onDragDone = new EventHandlerProperty<>("onDragDone", DragEvent.DRAG_DONE);
         }
         return onDragDone;
     }
@@ -5949,23 +5390,7 @@ public class Scene implements EventTarget {
 
     public final ObjectProperty<EventHandler<? super KeyEvent>> onKeyPressedProperty() {
         if (onKeyPressed == null) {
-            onKeyPressed = new ObjectPropertyBase<>() {
-
-                @Override
-                protected void invalidated() {
-                    setEventHandler(KeyEvent.KEY_PRESSED, get());
-                }
-
-                @Override
-                public Object getBean() {
-                    return Scene.this;
-                }
-
-                @Override
-                public String getName() {
-                    return "onKeyPressed";
-                }
-            };
+            onKeyPressed = new EventHandlerProperty<>("onKeyPressed", KeyEvent.KEY_PRESSED);
         }
         return onKeyPressed;
     }
@@ -5988,23 +5413,7 @@ public class Scene implements EventTarget {
 
     public final ObjectProperty<EventHandler<? super KeyEvent>> onKeyReleasedProperty() {
         if (onKeyReleased == null) {
-            onKeyReleased = new ObjectPropertyBase<>() {
-
-                @Override
-                protected void invalidated() {
-                    setEventHandler(KeyEvent.KEY_RELEASED, get());
-                }
-
-                @Override
-                public Object getBean() {
-                    return Scene.this;
-                }
-
-                @Override
-                public String getName() {
-                    return "onKeyReleased";
-                }
-            };
+            onKeyReleased = new EventHandlerProperty<>("onKeyReleased", KeyEvent.KEY_RELEASED);
         }
         return onKeyReleased;
     }
@@ -6028,26 +5437,9 @@ public class Scene implements EventTarget {
         return onKeyTyped == null ? null : onKeyTyped.get();
     }
 
-    public final ObjectProperty<EventHandler<? super KeyEvent>> onKeyTypedProperty(
-    ) {
+    public final ObjectProperty<EventHandler<? super KeyEvent>> onKeyTypedProperty() {
         if (onKeyTyped == null) {
-            onKeyTyped = new ObjectPropertyBase<>() {
-
-                @Override
-                protected void invalidated() {
-                    setEventHandler(KeyEvent.KEY_TYPED, get());
-                }
-
-                @Override
-                public Object getBean() {
-                    return Scene.this;
-                }
-
-                @Override
-                public String getName() {
-                    return "onKeyTyped";
-                }
-            };
+            onKeyTyped = new EventHandlerProperty<>("onKeyTyped", KeyEvent.KEY_TYPED);
         }
         return onKeyTyped;
     }
@@ -6081,23 +5473,8 @@ public class Scene implements EventTarget {
 
     public final ObjectProperty<EventHandler<? super InputMethodEvent>> onInputMethodTextChangedProperty() {
         if (onInputMethodTextChanged == null) {
-            onInputMethodTextChanged = new ObjectPropertyBase<>() {
-
-                @Override
-                protected void invalidated() {
-                    setEventHandler(InputMethodEvent.INPUT_METHOD_TEXT_CHANGED, get());
-                }
-
-                @Override
-                public Object getBean() {
-                    return Scene.this;
-                }
-
-                @Override
-                public String getName() {
-                    return "onInputMethodTextChanged";
-                }
-            };
+            onInputMethodTextChanged = new EventHandlerProperty<>(
+                "onInputMethodTextChanged", InputMethodEvent.INPUT_METHOD_TEXT_CHANGED);
         }
         return onInputMethodTextChanged;
     }
@@ -6182,6 +5559,31 @@ public class Scene implements EventTarget {
         private void set(Node n, Scene s) {
             node = n;
             scene = s;
+        }
+    }
+
+    private final class EventHandlerProperty<T extends Event> extends ObjectPropertyBase<EventHandler<? super T>> {
+        private final String name;
+        private final EventType<T> eventType;
+
+        EventHandlerProperty(String name, EventType<T> eventType) {
+            this.name = name;
+            this.eventType = eventType;
+        }
+
+        @Override
+        public Object getBean() {
+            return Scene.this;
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        protected void invalidated() {
+            setEventHandler(eventType, get());
         }
     }
 

--- a/modules/javafx.graphics/src/main/java/javafx/stage/Window.java
+++ b/modules/javafx.graphics/src/main/java/javafx/stage/Window.java
@@ -945,24 +945,9 @@ public class Window implements EventTarget {
     public final EventHandler<WindowEvent> getOnCloseRequest() {
         return (onCloseRequest != null) ? onCloseRequest.get() : null;
     }
-    public final ObjectProperty<EventHandler<WindowEvent>>
-            onCloseRequestProperty() {
+    public final ObjectProperty<EventHandler<WindowEvent>> onCloseRequestProperty() {
         if (onCloseRequest == null) {
-            onCloseRequest = new ObjectPropertyBase<>() {
-                @Override protected void invalidated() {
-                    setEventHandler(WindowEvent.WINDOW_CLOSE_REQUEST, get());
-                }
-
-                @Override
-                public Object getBean() {
-                    return Window.this;
-                }
-
-                @Override
-                public String getName() {
-                    return "onCloseRequest";
-                }
-            };
+            onCloseRequest = new EventHandlerProperty<>("onCloseRequest", WindowEvent.WINDOW_CLOSE_REQUEST);
         }
         return onCloseRequest;
     }
@@ -977,21 +962,7 @@ public class Window implements EventTarget {
     }
     public final ObjectProperty<EventHandler<WindowEvent>> onShowingProperty() {
         if (onShowing == null) {
-            onShowing = new ObjectPropertyBase<>() {
-                @Override protected void invalidated() {
-                    setEventHandler(WindowEvent.WINDOW_SHOWING, get());
-                }
-
-                @Override
-                public Object getBean() {
-                    return Window.this;
-                }
-
-                @Override
-                public String getName() {
-                    return "onShowing";
-                }
-            };
+            onShowing = new EventHandlerProperty<>("onShowing", WindowEvent.WINDOW_SHOWING);
         }
         return onShowing;
     }
@@ -1006,21 +977,7 @@ public class Window implements EventTarget {
     }
     public final ObjectProperty<EventHandler<WindowEvent>> onShownProperty() {
         if (onShown == null) {
-            onShown = new ObjectPropertyBase<>() {
-                @Override protected void invalidated() {
-                    setEventHandler(WindowEvent.WINDOW_SHOWN, get());
-                }
-
-                @Override
-                public Object getBean() {
-                    return Window.this;
-                }
-
-                @Override
-                public String getName() {
-                    return "onShown";
-                }
-            };
+            onShown = new EventHandlerProperty<>("onShown", WindowEvent.WINDOW_SHOWN);
         }
         return onShown;
     }
@@ -1035,21 +992,7 @@ public class Window implements EventTarget {
     }
     public final ObjectProperty<EventHandler<WindowEvent>> onHidingProperty() {
         if (onHiding == null) {
-            onHiding = new ObjectPropertyBase<>() {
-                @Override protected void invalidated() {
-                    setEventHandler(WindowEvent.WINDOW_HIDING, get());
-                }
-
-                @Override
-                public Object getBean() {
-                    return Window.this;
-                }
-
-                @Override
-                public String getName() {
-                    return "onHiding";
-                }
-            };
+            onHiding = new EventHandlerProperty<>("onHiding", WindowEvent.WINDOW_HIDING);
         }
         return onHiding;
     }
@@ -1067,21 +1010,7 @@ public class Window implements EventTarget {
     }
     public final ObjectProperty<EventHandler<WindowEvent>> onHiddenProperty() {
         if (onHidden == null) {
-            onHidden = new ObjectPropertyBase<>() {
-                @Override protected void invalidated() {
-                    setEventHandler(WindowEvent.WINDOW_HIDDEN, get());
-                }
-
-                @Override
-                public Object getBean() {
-                    return Window.this;
-                }
-
-                @Override
-                public String getName() {
-                    return "onHidden";
-                }
-            };
+            onHidden = new EventHandlerProperty<>("onHidden", WindowEvent.WINDOW_HIDDEN);
         }
         return onHidden;
     }
@@ -1594,6 +1523,31 @@ public class Window implements EventTarget {
                 Toolkit.getToolkit().requestNextPulse();
                 dirty = true;
             }
+        }
+    }
+
+    private final class EventHandlerProperty<T extends Event> extends ObjectPropertyBase<EventHandler<T>> {
+        private final String name;
+        private final EventType<T> eventType;
+
+        EventHandlerProperty(String name, EventType<T> eventType) {
+            this.name = name;
+            this.eventType = eventType;
+        }
+
+        @Override
+        public Object getBean() {
+            return Window.this;
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        protected void invalidated() {
+            setEventHandler(eventType, get());
         }
     }
 }


### PR DESCRIPTION
`EventHandler` property implementations in `Scene` and `Window` use anonymous classes derived from `ObjectPropertyBase`. We can remove about 650 lines of boilerplate code by using a common property class instead.

/reviewers 2

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8358255](https://bugs.openjdk.org/browse/JDK-8358255): Factor out boilerplate code of EventHandler properties in Scene and Window (**Enhancement** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [John Hendrikx](https://openjdk.org/census#jhendrikx) (@hjohn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1819/head:pull/1819` \
`$ git checkout pull/1819`

Update a local copy of the PR: \
`$ git checkout pull/1819` \
`$ git pull https://git.openjdk.org/jfx.git pull/1819/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1819`

View PR using the GUI difftool: \
`$ git pr show -t 1819`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1819.diff">https://git.openjdk.org/jfx/pull/1819.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1819#issuecomment-2927949769)
</details>
