### PR TITLE
8358770: incubator.richtext pom missing dependency on incubator.input

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2904,7 +2904,7 @@ project(":incubator.input") {
     modulePath += File.pathSeparator + "${rootProject.projectDir}/modules/javafx.graphics/build/classes/java/main"
     modulePath += File.pathSeparator + "${rootProject.projectDir}/modules/javafx.base/build/classes/java/main"
 
-    addMavenPublication(project, [ 'graphics' , 'controls'])
+    addMavenPublication(project, [ 'controls' ])
 
     addValidateSourceSets(project, sourceSets)
 }
@@ -2963,7 +2963,7 @@ project(":incubator.richtext") {
     modulePath += File.pathSeparator + "${rootProject.projectDir}/modules/javafx.graphics/build/classes/java/main"
     modulePath += File.pathSeparator + "${rootProject.projectDir}/modules/javafx.base/build/classes/java/main"
 
-    addMavenPublication(project, [ 'graphics' , 'controls'])
+    addMavenPublication(project, [ 'controls', 'incubator.input' ])
 
     addValidateSourceSets(project, sourceSets)
 }


### PR DESCRIPTION
This PR adds a missing maven dependency for `jfx.incubator.richtext` on the `jfx.incubator.input` module. The dependency is correctly present in the `module-info.java` of `jfx.incubator.richtext` as well as the gradle dependency for the project. It's only the maven dependency that is missing. While fixing this, I noticed that there is an unnecessary maven dependency in the `incubator.richtext` and `incubator.input` projects on the `graphics` project. Both projects already list `controls`, so do not need to list `graphics` or `base` (see the `fxml` and `web` projects for comparison).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8358770](https://bugs.openjdk.org/browse/JDK-8358770): incubator.richtext pom missing dependency on incubator.input (**Bug** - P3)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Joeri Sykora](https://openjdk.org/census#sykora) (@tiainen - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1821/head:pull/1821` \
`$ git checkout pull/1821`

Update a local copy of the PR: \
`$ git checkout pull/1821` \
`$ git pull https://git.openjdk.org/jfx.git pull/1821/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1821`

View PR using the GUI difftool: \
`$ git pr show -t 1821`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1821.diff">https://git.openjdk.org/jfx/pull/1821.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1821#issuecomment-2949629991)
</details>
