### PR TITLE
8359396: [Linux] Require Gtk3 >= 3.20 for glass-gtk

### DIFF
--- a/buildSrc/linux.gradle
+++ b/buildSrc/linux.gradle
@@ -25,6 +25,11 @@
 
 ext.LINUX = [:]
 
+def gtk3MinMinorVersion = "20"
+def gtk3MinMicroVersion = "0"
+
+def gtk3MinVersion = "3.%s.%s".formatted(gtk3MinMinorVersion, gtk3MinMicroVersion)
+
 // Declare whether this particular target file applies to the current system
 LINUX.canBuild = IS_LINUX;
 if (!LINUX.canBuild) return;
@@ -82,11 +87,23 @@ if (hasProperty('toolchainDir')) {
     toolchainDir = ""
 }
 
-def gtk3CCFlags = [ "-Wno-deprecated-declarations" ];
+def gtk3CCFlags = [ "-Wno-deprecated-declarations",
+                    "-DGTK_3_MIN_MINOR_VERSION="+gtk3MinMinorVersion,
+                    "-DGTK_3_MIN_MICRO_VERSION="+gtk3MinMicroVersion];
 def gtk3LinkFlags = [ ];
 
 setupTools("linux_gtk3",
     { propFile ->
+        def checkGTK3Version = exec {
+            commandLine "${toolchainDir}pkg-config", "--exists", "gtk+-3.0 >= " + gtk3MinVersion
+            ignoreExitValue = true
+        }
+
+        if (checkGTK3Version.exitValue != 0) {
+            throw new IllegalStateException("GTK3 " + gtk3MinVersion + "+ development packages not found."
+                    + " If GTK3 packages are installed, please remove the build directory and try again.")
+        }
+
         ByteArrayOutputStream results2 = new ByteArrayOutputStream();
         exec {
             commandLine("${toolchainDir}pkg-config", "--cflags", "gtk+-3.0", "gthread-2.0", "xtst", "gio-unix-2.0")
@@ -109,8 +126,6 @@ setupTools("linux_gtk3",
         if (cflagsGTK3 && libsGTK3) {
             gtk3CCFlags.addAll(cflagsGTK3.split(" "))
             gtk3LinkFlags.addAll(libsGTK3.split(" "))
-        } else {
-            throw new IllegalStateException("GTK3 development packages not found. If GTK3 packages are installed, please remove the build directory and try again.")
         }
     }
 )

--- a/buildSrc/linux.gradle
+++ b/buildSrc/linux.gradle
@@ -26,6 +26,7 @@
 ext.LINUX = [:]
 
 // Glass Gtk is built with GTK+ 3. It is not compatible with other major GTK versions (e.g., GTK 2 or GTK 4).
+// Requires GTK+ 3.20.0 or newer
 def gtk3MinMinorVersion = "20"
 def gtk3MinMicroVersion = "0"
 def gtk3MinVersion = "3.%s.%s".formatted(gtk3MinMinorVersion, gtk3MinMicroVersion)

--- a/buildSrc/linux.gradle
+++ b/buildSrc/linux.gradle
@@ -25,9 +25,9 @@
 
 ext.LINUX = [:]
 
+// Glass Gtk is built with GTK+ 3. It is not compatible with other major GTK versions (e.g., GTK 2 or GTK 4).
 def gtk3MinMinorVersion = "20"
 def gtk3MinMicroVersion = "0"
-
 def gtk3MinVersion = "3.%s.%s".formatted(gtk3MinMinorVersion, gtk3MinMicroVersion)
 
 // Declare whether this particular target file applies to the current system

--- a/modules/javafx.graphics/src/main/native-glass/gtk/GlassApplication.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/GlassApplication.cpp
@@ -68,8 +68,6 @@ void checkGtkVersion(JNIEnv* env, jint reqMajor) {
         if (uoe != nullptr) {
             env->ThrowNew(uoe, oss.str().c_str());
         }
-
-        return;
     }
 }
 

--- a/modules/javafx.graphics/src/main/native-glass/gtk/GlassApplication.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/GlassApplication.cpp
@@ -28,6 +28,7 @@
 #include <gdk/gdkx.h>
 #include <gtk/gtk.h>
 #include <glib.h>
+#include <sstream>
 
 #include <cstdlib>
 #include <com_sun_glass_ui_gtk_GtkApplication.h>
@@ -51,6 +52,26 @@ JNIEnv* mainEnv; // Use only with main loop thread!!!
 PlatformSupport* platformSupport = NULL;
 
 extern gboolean disableGrab;
+
+void checkGtkVersion(JNIEnv* env, jint reqMajor) {
+    // Major version is checked before loading
+    // GTK_3_MIN_MINOR_VERSION and GTK_3_MIN_MICRO_VERSION comes from the build system
+    if (reqMajor == 3
+        && gtk_check_version(reqMajor, GTK_3_MIN_MINOR_VERSION, GTK_3_MIN_MICRO_VERSION)) {
+
+        std::ostringstream oss;
+        oss << "Minimum GTK version required is " << reqMajor << "." << GTK_3_MIN_MINOR_VERSION
+            << "." << GTK_3_MIN_MICRO_VERSION << ". System has " << gtk_major_version << "."
+            << gtk_minor_version << "." << gtk_micro_version << ".";
+
+        jclass uoe = env->FindClass("java/lang/UnsupportedOperationException");
+        if (uoe != nullptr) {
+            env->ThrowNew(uoe, oss.str().c_str());
+        }
+
+        return;
+    }
+}
 
 static gboolean call_runnable (gpointer data)
 {
@@ -114,20 +135,7 @@ JNIEXPORT void JNICALL Java_com_sun_glass_ui_gtk_GtkApplication__1initGTK
     gdk_threads_enter();
     gtk_init(NULL, NULL);
 
-    // Major version is checked before loading
-    if (version == 3
-        && gtk_check_version(version, GTK_3_MIN_MINOR_VERSION, GTK_3_MIN_MICRO_VERSION)) {
-        char message[100];
-        snprintf(message, sizeof(message),
-                 "Minimum GTK version required is %d.%d.%d. System has %d.%d.%d.",
-                 version, GTK_3_MIN_MINOR_VERSION, GTK_3_MIN_MICRO_VERSION,
-                 gtk_major_version, gtk_minor_version, gtk_micro_version);
-
-        jclass uoe = env->FindClass("java/lang/UnsupportedOperationException");
-        env->ThrowNew(uoe, message);
-
-        return;
-    }
+    checkGtkVersion(env, version);
 }
 
 /*

--- a/modules/javafx.graphics/src/main/native-glass/gtk/glass_general.h
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/glass_general.h
@@ -35,15 +35,7 @@
 
 #include "wrapped.h"
 
-#if GTK_CHECK_VERSION(3, 0, 0)
-#if ! GTK_CHECK_VERSION(3, 8, 0)
-#error GTK development version is not the minimum 3.8
-#endif
 #define GLASS_GTK3
-#endif
-
-#define GTK_3_MIN_MINOR_VERSION 8
-#define GTK_3_MIN_MICRO_VERSION 0
 
 #ifndef GDK_TOUCH_MASK
 #define GDK_TOUCH_MASK (1 << 22)


### PR DESCRIPTION
Upgrade the minimum required GTK version for JavaFX to GTK 3.20 to enable modern features and better Linux desktop integration.

JavaFX currently depends on GTK 3.8, [released](https://mail.gnome.org/archives/gtk-devel-list/2013-March/msg00108.html) in March 2013. This version is outdated and predates many useful GTK API improvements.

GTK 3.20 was [released](https://mail.gnome.org/archives/gtk-list/2016-March/msg00026.html) on March 21, 2016.

Updating the GTK minimum requirement to 3.20 would enable JavaFX to support new features, including the improvements proposed in  #1605 

Major Linux distributions already provide GTK 3.20 or newer:
- Ubuntu LTS 18.04+ (ships GTK 3.22+)
- Debian 9+ (ships GTK 3.22+)
- Fedora 24+ (ships GTK 3.20+)
- Oracle Linux and Red Hat Enterprise Linux 8+ (ships GTK 3.22+)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8359396](https://bugs.openjdk.org/browse/JDK-8359396): [Linux] Require Gtk3 &gt;= 3.20 for glass-gtk (**Enhancement** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Johan Vos](https://openjdk.org/census#jvos) (@johanvos - **Reviewer**) Review applies to [ab611660](https://git.openjdk.org/jfx/pull/1825/files/ab611660a3aea26b6dbf4fcb7a3646eb7379bc2e)
 * [Lukasz Kostyra](https://openjdk.org/census#lkostyra) (@lukostyra - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1825/head:pull/1825` \
`$ git checkout pull/1825`

Update a local copy of the PR: \
`$ git checkout pull/1825` \
`$ git pull https://git.openjdk.org/jfx.git pull/1825/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1825`

View PR using the GUI difftool: \
`$ git pr show -t 1825`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1825.diff">https://git.openjdk.org/jfx/pull/1825.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1825#issuecomment-2968677634)
</details>
