### PR TITLE
8359445: GHA: Update gradle wrapper-validation action to v4

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: gradle/actions/wrapper-validation@v3
+      - uses: gradle/actions/wrapper-validation@v4
 
 
   linux_x64_build:


### PR DESCRIPTION
As noted in JBS, our GitHub Actions workflow uses `gradle/actions/wrapper-validation@v3`. We should update to the latest version, which is v4.

In addition to it being a good idea to use the latest, we've seen a lot of intermittent failures in gradle validation, and I hope this might help.