### PR TITLE
8359598: [TestBug] VirtualFlowTestUtils should not create a temporary Stage

### DIFF
--- a/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/infrastructure/VirtualFlowTestUtils.java
+++ b/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/infrastructure/VirtualFlowTestUtils.java
@@ -24,11 +24,8 @@
  */
 package test.com.sun.javafx.scene.control.infrastructure;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import java.util.List;
+import com.sun.javafx.scene.control.LabeledText;
+import com.sun.javafx.scene.control.VirtualScrollBar;
 import javafx.geometry.Orientation;
 import javafx.scene.Node;
 import javafx.scene.control.Cell;
@@ -46,8 +43,13 @@ import javafx.scene.control.skin.TableHeaderRow;
 import javafx.scene.control.skin.TableViewSkinBase;
 import javafx.scene.control.skin.VirtualFlow;
 import javafx.util.Callback;
-import com.sun.javafx.scene.control.LabeledText;
-import com.sun.javafx.scene.control.VirtualScrollBar;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class VirtualFlowTestUtils {
 
@@ -332,11 +334,6 @@ public class VirtualFlowTestUtils {
     }
 
     public static VirtualFlow<?> getVirtualFlow(Control control) {
-        StageLoader sl = null;
-        if (control.getScene() == null) {
-            sl = new StageLoader(control);
-        }
-
         VirtualFlow<?> flow;
         if (control instanceof ComboBox) {
             final ComboBox cb = (ComboBox) control;
@@ -345,10 +342,6 @@ public class VirtualFlowTestUtils {
         }
 
         flow = (VirtualFlow<?>)control.lookup("#virtual-flow");
-
-        if (sl != null) {
-            sl.dispose();
-        }
 
         return flow;
     }

--- a/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/infrastructure/VirtualFlowTestUtils.java
+++ b/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/infrastructure/VirtualFlowTestUtils.java
@@ -343,6 +343,11 @@ public class VirtualFlowTestUtils {
 
         flow = (VirtualFlow<?>)control.lookup("#virtual-flow");
 
+        if (flow == null) {
+            throw new IllegalArgumentException("VirtualFlow could not be found for: " + control + ". "
+                    + "Make sure that the Control is inside a Scene.");
+        }
+
         return flow;
     }
 

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListViewMouseInputTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListViewMouseInputTest.java
@@ -68,6 +68,8 @@ public class ListViewMouseInputTest {
 
         listView.getItems().setAll("1", "2", "3", "4", "5", "6", "7", "8", "9", "10");
         sm.clearAndSelect(0);
+
+        stageLoader = new StageLoader(listView);
     }
 
     @AfterEach
@@ -132,6 +134,8 @@ public class ListViewMouseInputTest {
 
         sm.clearAndSelect(9);
 
+        stageLoader = new StageLoader(listView);
+
         // select all from 9 - 7
         VirtualFlowTestUtils.clickOnRow(listView, 7, KeyModifier.SHIFT);
         assertTrue(isSelected(7,8,9), debug());
@@ -145,6 +149,8 @@ public class ListViewMouseInputTest {
         sm.setSelectionMode(SelectionMode.MULTIPLE);
 
         sm.clearAndSelect(5);
+
+        stageLoader = new StageLoader(listView);
 
         // select all from 5 - 7
         VirtualFlowTestUtils.clickOnRow(listView, 7, KeyModifier.SHIFT);
@@ -172,6 +178,8 @@ public class ListViewMouseInputTest {
         assertEquals(0,rt30394_count);
         assertFalse(fm.isFocused(0));
 
+        stageLoader = new StageLoader(listView);
+
         // select the first row with the shift key held down. The focus event
         // should only fire once - for focus on 0 (never -1 as this bug shows).
         VirtualFlowTestUtils.clickOnRow(listView, 0, KeyModifier.SHIFT);
@@ -182,6 +190,8 @@ public class ListViewMouseInputTest {
     @Test public void test_rt32119() {
         sm.setSelectionMode(SelectionMode.MULTIPLE);
         sm.clearSelection();
+
+        stageLoader = new StageLoader(listView);
 
         // select rows 2, 3, and 4
         VirtualFlowTestUtils.clickOnRow(listView, 2);
@@ -253,6 +263,8 @@ public class ListViewMouseInputTest {
             listView.getItems().add("Row " + i);
         }
 
+        stageLoader = new StageLoader(listView);
+
         final MultipleSelectionModel sm = listView.getSelectionModel();
         sm.setSelectionMode(SelectionMode.MULTIPLE);
         sm.clearAndSelect(0);
@@ -279,6 +291,8 @@ public class ListViewMouseInputTest {
             listView.getItems().add("Row " + i);
         }
 
+        stageLoader = new StageLoader(listView);
+
         final MultipleSelectionModel sm = listView.getSelectionModel();
         sm.setSelectionMode(SelectionMode.MULTIPLE);
         sm.clearAndSelect(0);
@@ -304,6 +318,8 @@ public class ListViewMouseInputTest {
             listView.getItems().add("Row " + i);
         }
 
+        stageLoader = new StageLoader(listView);
+
         final MultipleSelectionModel sm = listView.getSelectionModel();
         final FocusModel fm = listView.getFocusModel();
         sm.setSelectionMode(SelectionMode.SINGLE);
@@ -321,7 +337,7 @@ public class ListViewMouseInputTest {
 
     @Test public void test_rt_37069() {
         final int items = 8;
-        listView.getItems().clear();
+        listView = new ListView<>();
         for (int i = 0; i < items; i++) {
             listView.getItems().add("Row " + i);
         }
@@ -364,6 +380,8 @@ public class ListViewMouseInputTest {
             assertFalse(copy.contains(null));
         });
 
+        stageLoader = new StageLoader(listView);
+
         // select all
         VirtualFlowTestUtils.clickOnRow(listView, 0, KeyModifier.getShortcutKey());
         assertEquals(1, hitCount.get());
@@ -391,8 +409,6 @@ public class ListViewMouseInputTest {
 
     @Test public void testClickWithNullSelectionModelDoesNotThrowNPE() {
         listView.setSelectionModel(null);
-
-        stageLoader = new StageLoader(listView);
 
         assertDoesNotThrow(()  -> VirtualFlowTestUtils.clickOnRow(listView, 2));
     }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListViewTest.java
@@ -672,7 +672,7 @@ public class ListViewTest {
         ObservableList<String> mod = FXCollections.observableArrayList();
         String value = System.currentTimeMillis()+"";
         mod.add(value);
-        
+
         listView.setItems(mod);
         Toolkit.getToolkit().firePulse();
 

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListViewTest.java
@@ -567,6 +567,8 @@ public class ListViewTest {
                 new Person("Emma", "Jones", "emma.jones@example.com"),
                 new Person("Michael", "Brown", "michael.brown@example.com")));
 
+        stageLoader = new StageLoader(list);
+
         VirtualFlowTestUtils.assertRowsNotEmpty(list, 0, 5); // rows 0 - 5 should be filled
         VirtualFlowTestUtils.assertRowsEmpty(list, 5, -1); // rows 5+ should be empty
 
@@ -575,6 +577,7 @@ public class ListViewTest {
         list.setItems(FXCollections.observableArrayList(
                 new Person("*_*Emma", "Jones", "emma.jones@example.com"),
                 new Person("_Michael", "Brown", "michael.brown@example.com")));
+        Toolkit.getToolkit().firePulse();
 
         VirtualFlowTestUtils.assertRowsNotEmpty(list, 0, 2); // rows 0 - 2 should be filled
         VirtualFlowTestUtils.assertRowsEmpty(list, 2, -1); // rows 2+ should be empty
@@ -662,12 +665,17 @@ public class ListViewTest {
 
         final ListView<String> listView = new ListView<>();
         listView.setItems(emptyModel);
+        stageLoader = new StageLoader(listView);
+
         VirtualFlowTestUtils.assertRowsEmpty(listView, 0, 5);
 
         ObservableList<String> mod = FXCollections.observableArrayList();
         String value = System.currentTimeMillis()+"";
         mod.add(value);
+        
         listView.setItems(mod);
+        Toolkit.getToolkit().firePulse();
+
         VirtualFlowTestUtils.assertCellCount(listView, 1);
         VirtualFlowTestUtils.assertCellTextEquals(listView, 0, value);
     }
@@ -677,12 +685,17 @@ public class ListViewTest {
 
         final ListView<String> listView = new ListView<>();
         listView.setItems(emptyModel);
+        stageLoader = new StageLoader(listView);
+
         VirtualFlowTestUtils.assertRowsEmpty(listView, 0, 5);
 
         ObservableList<String> mod1 = FXCollections.observableArrayList();
         String value1 = System.currentTimeMillis()+"";
         mod1.add(value1);
+
         listView.getItems().setAll(mod1);
+        Toolkit.getToolkit().firePulse();
+
         VirtualFlowTestUtils.assertCellCount(listView, 1);
         VirtualFlowTestUtils.assertCellTextEquals(listView, 0, value1);
     }
@@ -698,6 +711,8 @@ public class ListViewTest {
         final ListView<String> listView = new ListView<>(items);
         listView.setMaxHeight(50);
         listView.setPrefHeight(50);
+
+        stageLoader = new StageLoader(listView);
 
         // we want the vertical scrollbar
         VirtualScrollBar scrollBar = VirtualFlowTestUtils.getVirtualFlowVerticalScrollbar(listView);
@@ -722,6 +737,8 @@ public class ListViewTest {
         listView.setMinHeight(100);
         listView.setPrefHeight(100);
         listView.setCellFactory(CheckBoxListCell.forListView(param -> new ReadOnlyBooleanWrapper(true)));
+
+        stageLoader = new StageLoader(listView);
 
         // because only the first row has data, all other rows should be
         // empty (and not contain check boxes - we just check the first four here)
@@ -771,6 +788,8 @@ public class ListViewTest {
         listView.setEditable(true);
         listView.setCellFactory(ComboBoxListCell.forListView(names));
 
+        stageLoader = new StageLoader(listView);
+
         IndexedCell cell = VirtualFlowTestUtils.getCell(listView, 1);
         assertEquals("1", cell.getText());
         assertFalse(cell.isEditing());
@@ -790,6 +809,8 @@ public class ListViewTest {
     @Test public void test_rt31471() {
         final ObservableList names = FXCollections.observableArrayList("Adam", "Alex", "Alfred", "Albert");
         final ListView listView = new ListView(names);
+
+        stageLoader = new StageLoader(listView);
 
         IndexedCell cell = VirtualFlowTestUtils.getCell(listView, 0);
         assertEquals("Adam", cell.getItem());
@@ -870,6 +891,8 @@ public class ListViewTest {
         // First two rows have content, so the graphic should show.
         // All other rows have no content, so graphic should not show.
         listView.getItems().setAll("one", "two");
+
+        stageLoader = new StageLoader(listView);
 
         VirtualFlowTestUtils.assertGraphicIsVisible(listView, 0);
         VirtualFlowTestUtils.assertGraphicIsVisible(listView, 1);
@@ -1016,6 +1039,8 @@ public class ListViewTest {
             rt_35889_cancel_count++;
             //System.out.println("On Edit Cancel: " + t);
         });
+
+        stageLoader = new StageLoader(textFieldListView);
 
         ListCell cell0 = (ListCell) VirtualFlowTestUtils.getCell(textFieldListView, 0);
         assertNull(cell0.getGraphic());
@@ -1577,6 +1602,8 @@ public class ListViewTest {
         sm.setSelectionMode(SelectionMode.MULTIPLE);
 
         FocusModel<String> fm = stringListView.getFocusModel();
+
+        stageLoader = new StageLoader(stringListView);
 
         // click on row 0
         VirtualFlowTestUtils.clickOnRow(stringListView, 0);

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/MultipleSelectionModelImplTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/MultipleSelectionModelImplTest.java
@@ -67,7 +67,6 @@ import javafx.scene.control.TreeTableView.TreeTableViewSelectionModel;
 import javafx.scene.control.TreeTableViewShim;
 import javafx.scene.control.TreeView;
 import javafx.scene.control.TreeViewShim;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -114,6 +113,8 @@ public class MultipleSelectionModelImplTest {
     // TableView
     private TableView tableView;
 
+    private StageLoader stageLoader;
+
     private static Collection<Class<? extends MultipleSelectionModel>> parameters() {
         return List.of(
             ListViewShim.get_ListViewBitSetSelectionModel_class(),
@@ -123,8 +124,12 @@ public class MultipleSelectionModelImplTest {
         );
     }
 
-    @AfterAll
-    public static void tearDownClass() throws Exception {    }
+    @AfterEach
+    public void cleanup() {
+        if (stageLoader != null) {
+            stageLoader.dispose();
+        }
+    }
 
     // @BeforeEach
     // junit5 does not support parameterized class-level tests yet
@@ -1111,6 +1116,7 @@ public class MultipleSelectionModelImplTest {
         setUp(c);
         msModel().setSelectionMode(SelectionMode.MULTIPLE);
 
+        stageLoader = new StageLoader(currentControl);
         IndexedCell cell_3 = VirtualFlowTestUtils.getCell(currentControl, 3);
         assertNotNull(cell_3);
         assertFalse(cell_3.isSelected());

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/SelectionModelImplTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/SelectionModelImplTest.java
@@ -65,6 +65,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import test.com.sun.javafx.scene.control.infrastructure.StageLoader;
 import test.com.sun.javafx.scene.control.infrastructure.VirtualFlowTestUtils;
 
 /**
@@ -111,6 +112,8 @@ public class SelectionModelImplTest {
     // ComboBox
     private ComboBox comboBox;
 
+    private StageLoader stageLoader;
+
     // --- ListView model data
 
     private static Collection<Class<? extends SelectionModel>> parameters() {
@@ -124,8 +127,12 @@ public class SelectionModelImplTest {
         );
     }
 
-    @AfterAll
-    public static void tearDownClass() throws Exception {    }
+    @AfterEach
+    public void cleanup() {
+        if (stageLoader != null) {
+            stageLoader.dispose();
+        }
+    }
 
     // @BeforeEach
     // junit5 does not support parameterized class-level tests yet
@@ -451,6 +458,8 @@ public class SelectionModelImplTest {
             assertFalse(model.isSelected(3));
             assertNull(choiceBox.getValue());
         } else {
+            stageLoader = new StageLoader(currentControl);
+
             IndexedCell cell_3 = VirtualFlowTestUtils.getCell(currentControl, 3);
             assertNotNull(cell_3);
             assertFalse(cell_3.isSelected());
@@ -508,6 +517,7 @@ public class SelectionModelImplTest {
         // model and the visuals disagree in this case).
         // TODO remove the ComboBox conditional and test for that too
         if (! (currentControl instanceof ChoiceBox || currentControl instanceof ComboBox)) {
+            stageLoader = new StageLoader(currentControl);
             IndexedCell cell = VirtualFlowTestUtils.getCell(currentControl, 0);
             assertTrue(cell.isSelected());
         }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewMouseInputTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewMouseInputTest.java
@@ -75,6 +75,8 @@ public class TableViewMouseInputTest {
     private final TableColumn<String, String> col3 = new TableColumn<>("col3");
     private final TableColumn<String, String> col4 = new TableColumn<>("col4");
 
+    private StageLoader stageLoader;
+
     @BeforeEach
     public void setup() {
         tableView = new TableView<>();
@@ -88,10 +90,15 @@ public class TableViewMouseInputTest {
         tableView.getColumns().setAll(col0, col1, col2, col3, col4);
 
         sm.clearAndSelect(0);
+
+        stageLoader = new StageLoader(tableView);
     }
 
     @AfterEach
     public void tearDown() {
+        if (stageLoader != null) {
+            stageLoader.dispose();
+        }
         if (tableView.getSkin() != null) {
             tableView.getSkin().dispose();
         }
@@ -159,6 +166,8 @@ public class TableViewMouseInputTest {
 
         sm.clearAndSelect(9);
 
+        stageLoader = new StageLoader(tableView);
+
         // select all from 9 - 7
         VirtualFlowTestUtils.clickOnRow(tableView, 7, KeyModifier.SHIFT);
         assertTrue(isSelected(7,8,9), debug());
@@ -173,6 +182,8 @@ public class TableViewMouseInputTest {
         sm.setSelectionMode(SelectionMode.MULTIPLE);
 
         sm.clearAndSelect(5);
+
+        stageLoader = new StageLoader(tableView);
 
         // select all from 5 - 7
         VirtualFlowTestUtils.clickOnRow(tableView, 7, KeyModifier.SHIFT);
@@ -201,6 +212,8 @@ public class TableViewMouseInputTest {
         assertEquals(0,rt30394_count);
         assertFalse(fm.isFocused(0));
 
+        stageLoader = new StageLoader(tableView);
+
         // select the first row with the shift key held down. The focus event
         // should only fire once - for focus on 0 (never -1 as this bug shows).
         VirtualFlowTestUtils.clickOnRow(tableView, 0, KeyModifier.SHIFT);
@@ -211,6 +224,8 @@ public class TableViewMouseInputTest {
     @Test public void test_rt32119() {
         sm.setSelectionMode(SelectionMode.MULTIPLE);
         sm.clearSelection();
+
+        stageLoader = new StageLoader(tableView);
 
         // select rows 2, 3, and 4
         VirtualFlowTestUtils.clickOnRow(tableView, 2);
@@ -243,6 +258,8 @@ public class TableViewMouseInputTest {
         col0.setMaxWidth(10);
         tableView.getColumns().add(col0);
 
+        stageLoader = new StageLoader(tableView);
+
         // select rows 1, 2, 3, 4, and 5
         VirtualFlowTestUtils.clickOnRow(tableView, 1, true);
         VirtualFlowTestUtils.clickOnRow(tableView, 5, true, KeyModifier.SHIFT);
@@ -259,6 +276,8 @@ public class TableViewMouseInputTest {
         for (int i = 0; i < items; i++) {
             tableView.getItems().add("Row " + i);
         }
+
+        stageLoader = new StageLoader(tableView);
 
         final int selectRow = 3;
 
@@ -282,6 +301,8 @@ public class TableViewMouseInputTest {
             tableView.getItems().add("Row " + i);
         }
 
+        stageLoader = new StageLoader(tableView);
+
         final int selectRow = 3;
 
         final MultipleSelectionModel sm = tableView.getSelectionModel();
@@ -303,6 +324,8 @@ public class TableViewMouseInputTest {
         for (int i = 0; i < items; i++) {
             tableView.getItems().add("Row " + i);
         }
+
+        stageLoader = new StageLoader(tableView);
 
         final int selectRow = 3;
 
@@ -326,6 +349,8 @@ public class TableViewMouseInputTest {
             tableView.getItems().add("Row " + i);
         }
 
+        stageLoader = new StageLoader(tableView);
+
         final int selectRow = 3;
 
         final MultipleSelectionModel sm = tableView.getSelectionModel();
@@ -347,6 +372,8 @@ public class TableViewMouseInputTest {
         for (int i = 0; i < items; i++) {
             tableView.getItems().add("Row " + i);
         }
+
+        stageLoader = new StageLoader(tableView);
 
         final MultipleSelectionModel sm = tableView.getSelectionModel();
         sm.setSelectionMode(SelectionMode.MULTIPLE);
@@ -373,7 +400,7 @@ public class TableViewMouseInputTest {
             tableView.getItems().add("Row " + i);
         }
 
-        StageLoader sl = new StageLoader(tableView);
+        stageLoader = new StageLoader(tableView);
 
         final MultipleSelectionModel sm = tableView.getSelectionModel();
         sm.setSelectionMode(SelectionMode.MULTIPLE);
@@ -391,8 +418,6 @@ public class TableViewMouseInputTest {
         assertEquals(0, sm.getSelectedIndex());
         assertEquals(0, fm.getFocusedIndex());
         assertEquals(1, sm.getSelectedItems().size());
-
-        sl.dispose();
     }
 
     private int rt_30626_count = 0;
@@ -402,6 +427,8 @@ public class TableViewMouseInputTest {
         for (int i = 0; i < items; i++) {
             tableView.getItems().add("Row " + i);
         }
+
+        stageLoader = new StageLoader(tableView);
 
         final TableSelectionModel sm = tableView.getSelectionModel();
         sm.setSelectionMode(SelectionMode.MULTIPLE);
@@ -436,6 +463,8 @@ public class TableViewMouseInputTest {
         sm.setSelectionMode(SelectionMode.MULTIPLE);
         sm.setCellSelectionEnabled(false);
 
+        stageLoader = new StageLoader(tableView);
+
         VirtualFlowTestUtils.clickOnRow(tableView, 1);
         assertEquals(1, sm.getSelectedCells().size());
 
@@ -455,6 +484,8 @@ public class TableViewMouseInputTest {
         sm.setSelectionMode(SelectionMode.MULTIPLE);
         sm.setCellSelectionEnabled(true);
 
+        stageLoader = new StageLoader(tableView);
+
         VirtualFlowTestUtils.clickOnRow(tableView, 1);
         assertEquals(1, sm.getSelectedCells().size());
 
@@ -469,6 +500,8 @@ public class TableViewMouseInputTest {
         for (int i = 0; i < items; i++) {
             tableView.getItems().add("Row " + i);
         }
+
+        stageLoader = new StageLoader(tableView);
 
         final MultipleSelectionModel sm = tableView.getSelectionModel();
         final FocusModel fm = tableView.getFocusModel();
@@ -493,6 +526,8 @@ public class TableViewMouseInputTest {
         tableView.setMinWidth(1000);
         tableView.setMinWidth(1000);
 
+        stageLoader = new StageLoader(tableView);
+
         TableRow row = (TableRow) VirtualFlowTestUtils.getCell(tableView, 4);
         assertNotNull(row);
         assertNull(row.getItem());
@@ -505,7 +540,7 @@ public class TableViewMouseInputTest {
 
     @Test public void test_rt_37069() {
         final int items = 8;
-        tableView.getItems().clear();
+        tableView = new TableView<>();
         for (int i = 0; i < items; i++) {
             tableView.getItems().add("Row " + i);
         }
@@ -514,11 +549,10 @@ public class TableViewMouseInputTest {
         Button btn = new Button("Button");
         VBox vbox = new VBox(btn, tableView);
 
-        StageLoader sl = new StageLoader(vbox);
-        sl.getStage().requestFocus();
+        stageLoader = new StageLoader(vbox);
+        stageLoader.getStage().requestFocus();
         btn.requestFocus();
         Toolkit.getToolkit().firePulse();
-        Scene scene = sl.getStage().getScene();
 
         assertTrue(btn.isFocused());
         assertFalse(tableView.isFocused());
@@ -529,8 +563,6 @@ public class TableViewMouseInputTest {
 
         assertTrue(btn.isFocused());
         assertFalse(tableView.isFocused());
-
-        sl.dispose();
     }
 
     @Test public void test_rt_38306_selectFirstRow() {
@@ -567,6 +599,8 @@ public class TableViewMouseInputTest {
         emailCol.setCellValueFactory(new PropertyValueFactory<Person, String>("email"));
 
         table.getColumns().addAll(firstNameCol, lastNameCol, emailCol);
+
+        stageLoader = new StageLoader(table);
 
         sm.select(0, firstNameCol);
 
@@ -636,6 +670,8 @@ public class TableViewMouseInputTest {
 
         table.getColumns().addAll(firstNameCol, lastNameCol, emailCol);
 
+        stageLoader = new StageLoader(table);
+
         sm.clearSelection();
         sm.select(0, lastNameCol);
 
@@ -698,6 +734,8 @@ public class TableViewMouseInputTest {
         emailCol.setCellValueFactory(new PropertyValueFactory<Person, String>("email"));
 
         table.getColumns().addAll(firstNameCol, lastNameCol, emailCol);
+
+        stageLoader = new StageLoader(table);
 
         sm.clearSelection();
         sm.select(0, emailCol);
@@ -777,9 +815,10 @@ public class TableViewMouseInputTest {
 
         table.getColumns().addAll(firstNameCol, lastNameCol, emailCol);
 
+        stageLoader = new StageLoader(table);
+
         TableCell cell_0_0 = (TableCell) VirtualFlowTestUtils.getCell(table, 0, 0);
         TableCell cell_0_1 = (TableCell) VirtualFlowTestUtils.getCell(table, 0, 1);
-        TableCell cell_0_2 = (TableCell) VirtualFlowTestUtils.getCell(table, 0, 2);
 
         sm.clearSelection();
 
@@ -864,6 +903,8 @@ public class TableViewMouseInputTest {
             List<?> copy = new ArrayList<>(sm.getSelectedItems());
             assertFalse(copy.contains(null));
         });
+
+        stageLoader = new StageLoader(table);
 
         // select all
         VirtualFlowTestUtils.clickOnRow(table, 0, true, KeyModifier.getShortcutKey());

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
@@ -1071,6 +1071,8 @@ public class TableViewTest {
 
         table.getColumns().addAll(firstNameCol, lastNameCol, emailCol);
 
+        stageLoader = new StageLoader(table);
+
         VirtualFlowTestUtils.assertRowsNotEmpty(table, 0, 5); // rows 0 - 5 should be filled
         VirtualFlowTestUtils.assertRowsEmpty(table, 5, -1); // rows 5+ should be empty
 
@@ -1079,6 +1081,7 @@ public class TableViewTest {
         table.setItems(FXCollections.observableArrayList(
             new Person("*_*Emma", "Jones", "emma.jones@example.com"),
             new Person("_Michael", "Brown", "michael.brown@example.com")));
+        Toolkit.getToolkit().firePulse();
 
         VirtualFlowTestUtils.assertRowsNotEmpty(table, 0, 2); // rows 0 - 2 should be filled
         VirtualFlowTestUtils.assertRowsEmpty(table, 2, -1); // rows 2+ should be empty
@@ -1418,6 +1421,8 @@ public class TableViewTest {
 
         table.getColumns().addAll(firstNameCol, lastNameCol, emailCol);
 
+        stageLoader = new StageLoader(table);
+
         // test the state before we hide and re-add a column
         VirtualFlowTestUtils.assertCellTextEquals(table, 0, "Jacob", "Smith", "jacob.smith@example.com");
         VirtualFlowTestUtils.assertCellTextEquals(table, 1, "Isabella", "Johnson", "isabella.johnson@example.com");
@@ -1427,6 +1432,7 @@ public class TableViewTest {
 
         // hide the last name column, and test cells again
         table.getColumns().remove(lastNameCol);
+        Toolkit.getToolkit().firePulse();
         VirtualFlowTestUtils.assertCellTextEquals(table, 0, "Jacob", "jacob.smith@example.com");
         VirtualFlowTestUtils.assertCellTextEquals(table, 1, "Isabella", "isabella.johnson@example.com");
         VirtualFlowTestUtils.assertCellTextEquals(table, 2, "Ethan", "ethan.williams@example.com");
@@ -1439,6 +1445,7 @@ public class TableViewTest {
         // some of the last name values will not be where we expect them to be.
         // This is clearly not ideal!
         table.getColumns().add(1, lastNameCol);
+        Toolkit.getToolkit().firePulse();
         VirtualFlowTestUtils.assertCellTextEquals(table, 0, "Jacob", "Smith", "jacob.smith@example.com");
         VirtualFlowTestUtils.assertCellTextEquals(table, 1, "Isabella", "Johnson", "isabella.johnson@example.com");
         VirtualFlowTestUtils.assertCellTextEquals(table, 2, "Ethan", "Williams", "ethan.williams@example.com");
@@ -1474,6 +1481,8 @@ public class TableViewTest {
 
         tableView.getColumns().add(firstNameCol);
 
+        stageLoader = new StageLoader(tableView);
+
         // we want the vertical scrollbar
         VirtualScrollBar scrollBar = VirtualFlowTestUtils.getVirtualFlowVerticalScrollbar(tableView);
 
@@ -1501,6 +1510,8 @@ public class TableViewTest {
         firstNameCol.setCellFactory(CheckBoxTableCell.forTableColumn(param -> new ReadOnlyBooleanWrapper(true)));
         tableView.getColumns().add(firstNameCol);
 
+        stageLoader = new StageLoader(tableView);
+
         // because only the first row has data, all other rows should be
         // empty (and not contain check boxes - we just check the first four here)
         VirtualFlowTestUtils.assertRowsNotEmpty(tableView, 0, 1);
@@ -1526,6 +1537,8 @@ public class TableViewTest {
         firstNameCol.setEditable(true);
 
         tableView.getColumns().add(firstNameCol);
+
+        stageLoader = new StageLoader(tableView);
 
         IndexedCell cell = VirtualFlowTestUtils.getCell(tableView, 1, 0);
         assertEquals("Jim", cell.getText());
@@ -1558,6 +1571,8 @@ public class TableViewTest {
         TableColumn firstNameCol = new TableColumn("First Name");
         firstNameCol.setCellValueFactory(new PropertyValueFactory<>("firstName"));
         tableView.getColumns().add(firstNameCol);
+
+        stageLoader = new StageLoader(tableView);
 
         IndexedCell cell = VirtualFlowTestUtils.getCell(tableView, 0);
         assertEquals(jacobSmith, cell.getItem());
@@ -1720,6 +1735,8 @@ public class TableViewTest {
                 ccc = new Person("CCC", "Giles", "jim.bob@example.com")
         ));
 
+        stageLoader = new StageLoader(table);
+
         final TableView.TableViewSelectionModel sm = table.getSelectionModel();
 
         // test pre-conditions
@@ -1813,6 +1830,8 @@ public class TableViewTest {
             }
         });
 
+        stageLoader = new StageLoader(table);
+
         // First two rows have content, so the graphic should show.
         // All other rows have no content, so graphic should not show.
 
@@ -1854,6 +1873,8 @@ public class TableViewTest {
                 };
             }
         });
+
+        stageLoader = new StageLoader(table);
 
         // First two rows have content, so the graphic should show.
         // All other rows have no content, so graphic should not show.
@@ -1959,6 +1980,8 @@ public class TableViewTest {
         table.setItems(FXCollections.observableArrayList(
                 new Person("John", "Smith", "jacob.smith@example.com")
         ));
+
+        stageLoader = new StageLoader(table);
 
         TableRow<Person> rowCell = (TableRow<Person>)VirtualFlowTestUtils.getCell(table, 0);
         final double initialWidth = ControlShim.computePrefWidth(rowCell, -1);
@@ -4826,7 +4849,7 @@ public class TableViewTest {
 
         TableView.TableViewFocusModel fm = stringTableView.getFocusModel();
 
-        StageLoader sl = new StageLoader(stringTableView);
+        stageLoader = new StageLoader(stringTableView);
 
         // click on row 0
         sm.select(0, column);
@@ -4865,8 +4888,6 @@ public class TableViewTest {
         assertTrue(TableCellBehavior.hasNonDefaultAnchor(stringTableView));
         assertEquals(1, anchor.getRow());
         assertEquals(column, anchor.getTableColumn());
-
-        sl.dispose();
     }
 
     private final ObservableList<String> rt_39256_list = FXCollections.observableArrayList();
@@ -5518,6 +5539,8 @@ public class TableViewTest {
         c2.setCellValueFactory(new PropertyValueFactory<>("lastName"));
         t.getColumns().addAll(c1, c2);
 
+        stageLoader = new StageLoader(t);
+
         final int startIndex = toRight ? 0 : 2;
         final int endIndex = toRight ? 2 : 0;
         final TableColumn<Person,String> startColumn = toBottom ? c1 : c2;
@@ -5821,7 +5844,7 @@ public class TableViewTest {
         sm.setCellSelectionEnabled(true);
         sm.setSelectionMode(SelectionMode.MULTIPLE);
 
-        StageLoader sl = new StageLoader(table);
+        stageLoader = new StageLoader(table);
         KeyEventFirer keyboard = new KeyEventFirer(table);
 
         assertEquals(0, sm.getSelectedItems().size());
@@ -5849,8 +5872,6 @@ public class TableViewTest {
         sm.clearAndSelect(0, firstNameCol);
         assertEquals(1, sm.getSelectedCells().size());
         assertEquals(1, sm.getSelectedItems().size());
-
-        sl.dispose();
     }
 
     @Test
@@ -5916,6 +5937,8 @@ public class TableViewTest {
         sm.setCellSelectionEnabled(true);
         sm.setSelectionMode(SelectionMode.MULTIPLE);
 
+        stageLoader = new StageLoader(table);
+
         // Call change::toString
         table.getSelectionModel().getSelectedItems().addListener((ListChangeListener<Person>) Object::toString);
 
@@ -5949,6 +5972,8 @@ public class TableViewTest {
 
         TableSelectionModel<String> sm = stringTableView.getSelectionModel();
         sm.setSelectionMode(SelectionMode.MULTIPLE);
+
+        stageLoader = new StageLoader(stringTableView);
 
         // click on row 1
         Cell startCell = VirtualFlowTestUtils.getCell(stringTableView, 1, 0);

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeAndTableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeAndTableViewTest.java
@@ -42,17 +42,28 @@ import javafx.scene.control.TreeTableView;
 import javafx.scene.control.TreeTableView.TreeTableViewSelectionModel;
 import javafx.scene.control.skin.TableColumnHeader;
 import javafx.scene.input.MouseEvent;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import com.sun.javafx.tk.Toolkit;
 import test.com.sun.javafx.scene.control.infrastructure.KeyModifier;
 import test.com.sun.javafx.scene.control.infrastructure.MouseEventFirer;
-import test.com.sun.javafx.scene.control.infrastructure.VirtualFlowTestUtils;
+import test.com.sun.javafx.scene.control.infrastructure.StageLoader;
 
 /**
  * Tests for:
  * - NPE with null selection model JDK-8187145
  */
 public class TreeAndTableViewTest {
+
+    private StageLoader stageLoader;
+
+    @AfterEach
+    public void cleanup() {
+        if (stageLoader != null) {
+            stageLoader.dispose();
+        }
+    }
+
     /** Sorting TableView with a null selection model should not generate an NPE */
     @Test
     public void test_TableView_jdk_8187145() {
@@ -69,8 +80,7 @@ public class TreeAndTableViewTest {
             ""
             );
 
-        // important: actually creates cells
-        VirtualFlowTestUtils.getCell(table, 0);
+        stageLoader = new StageLoader(table);
 
         // row selection mode
         TableViewSelectionModel<String> oldSelectionModel = table.getSelectionModel();
@@ -143,8 +153,7 @@ public class TreeAndTableViewTest {
             createTreeTableColumn("C2")
             );
 
-        // important: actually creates cells
-        VirtualFlowTestUtils.getCell(tree, 0);
+        stageLoader = new StageLoader(tree);
 
         // row selection mode
         TreeTableViewSelectionModel<String> oldSelectionModel = tree.getSelectionModel();
@@ -215,14 +224,6 @@ public class TreeAndTableViewTest {
         TableColumn c = new TableColumn(name);
         c.setCellValueFactory((f) -> new SimpleStringProperty("..."));
         return c;
-    }
-
-    protected static <T extends Node> List<T> collectNodes(Node root, String selector, Class<T> type) {
-        return (List<T>)root.
-            lookupAll(selector).
-            stream().
-            filter((n) -> (n.getClass().isAssignableFrom(type))).
-            collect(Collectors.toList());
     }
 
     protected static boolean containsPseudoclass(Node n, String pseudoclass) {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewMouseInputTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewMouseInputTest.java
@@ -92,6 +92,8 @@ public class TreeTableViewMouseInputTest {
     private TreeItem<String> child9;            // 12
     private TreeItem<String> child10;           // 13
 
+    private StageLoader stageLoader;
+
     @BeforeEach
     public void setup() {
         root = new TreeItem<>("Root");             // 0
@@ -148,6 +150,9 @@ public class TreeTableViewMouseInputTest {
 
     @AfterEach
     public void tearDown() {
+        if (stageLoader != null) {
+            stageLoader.dispose();
+        }
         if (tableView.getSkin() != null) {
             tableView.getSkin().dispose();
         }
@@ -224,6 +229,8 @@ public class TreeTableViewMouseInputTest {
 
         sm.clearAndSelect(9);
 
+        stageLoader = new StageLoader(tableView);
+
         // select all from 9 - 7
         VirtualFlowTestUtils.clickOnRow(tableView, 7, KeyModifier.SHIFT);
         assertTrue(isSelected(7,8,9), debug());
@@ -238,6 +245,8 @@ public class TreeTableViewMouseInputTest {
         sm.setSelectionMode(SelectionMode.MULTIPLE);
 
         sm.clearAndSelect(5);
+
+        stageLoader = new StageLoader(tableView);
 
         // select all from 5 - 7
         VirtualFlowTestUtils.clickOnRow(tableView, 7, KeyModifier.SHIFT);
@@ -267,6 +276,8 @@ public class TreeTableViewMouseInputTest {
         assertEquals(0,rt30394_count);
         assertFalse(fm.isFocused(0));
 
+        stageLoader = new StageLoader(tableView);
+
         // select the first row with the shift key held down. The focus event
         // should only fire once - for focus on 0 (never -1 as this bug shows).
         VirtualFlowTestUtils.clickOnRow(tableView, 0, KeyModifier.SHIFT);
@@ -278,6 +289,8 @@ public class TreeTableViewMouseInputTest {
     @Test public void test_rt32119() {
         sm.setSelectionMode(SelectionMode.MULTIPLE);
         sm.clearSelection();
+
+        stageLoader = new StageLoader(tableView);
 
         // select rows 2, 3, and 4
         VirtualFlowTestUtils.clickOnRow(tableView, 2);
@@ -310,6 +323,8 @@ public class TreeTableViewMouseInputTest {
         col0.setMaxWidth(10);
         tableView.getColumns().add(col0);
 
+        stageLoader = new StageLoader(tableView);
+
         // select rows 1, 2, 3, 4, and 5
         VirtualFlowTestUtils.clickOnRow(tableView, 1, true);
         VirtualFlowTestUtils.clickOnRow(tableView, 5, true, KeyModifier.SHIFT);
@@ -326,6 +341,8 @@ public class TreeTableViewMouseInputTest {
         for (int i = 0; i < items; i++) {
             root.getChildren().add(new TreeItem<>("Row " + i));
         }
+
+        stageLoader = new StageLoader(tableView);
 
         final int selectRow = 3;
 
@@ -350,6 +367,8 @@ public class TreeTableViewMouseInputTest {
             root.getChildren().add(new TreeItem<>("Row " + i));
         }
 
+        stageLoader = new StageLoader(tableView);
+
         final int selectRow = 3;
 
         tableView.setShowRoot(false);
@@ -370,6 +389,8 @@ public class TreeTableViewMouseInputTest {
         for (int i = 0; i < items; i++) {
             root.getChildren().add(new TreeItem<>("Row " + i));
         }
+
+        stageLoader = new StageLoader(tableView);
 
         final int selectRow = 3;
 
@@ -394,6 +415,8 @@ public class TreeTableViewMouseInputTest {
             root.getChildren().add(new TreeItem<>("Row " + i));
         }
 
+        stageLoader = new StageLoader(tableView);
+
         final int selectRow = 3;
 
         tableView.setShowRoot(false);
@@ -414,6 +437,8 @@ public class TreeTableViewMouseInputTest {
         for (int i = 0; i < items; i++) {
             root.getChildren().add(new TreeItem<>("Row " + i));
         }
+
+        stageLoader = new StageLoader(tableView);
 
         final MultipleSelectionModel sm = tableView.getSelectionModel();
         sm.setSelectionMode(SelectionMode.MULTIPLE);
@@ -440,10 +465,10 @@ public class TreeTableViewMouseInputTest {
         for (int i = 0; i < items; i++) {
             root.getChildren().add(new TreeItem<>("Row " + i));
         }
-
-//        StageLoader sl = new StageLoader(tableView);
-
         tableView.setShowRoot(true);
+
+        stageLoader = new StageLoader(tableView);
+
         final MultipleSelectionModel sm = tableView.getSelectionModel();
         sm.setSelectionMode(SelectionMode.MULTIPLE);
         sm.clearAndSelect(0);
@@ -473,8 +498,10 @@ public class TreeTableViewMouseInputTest {
             root.getChildren().add(new TreeItem<>("Row " + i));
         }
         tableView.setRoot(root);
-
         tableView.setShowRoot(true);
+
+        stageLoader = new StageLoader(tableView);
+
         final MultipleSelectionModel sm = tableView.getSelectionModel();
         sm.setSelectionMode(SelectionMode.MULTIPLE);
         sm.clearAndSelect(0);
@@ -544,8 +571,10 @@ public class TreeTableViewMouseInputTest {
             root.getChildren().add(new TreeItem<>("Row " + i));
         }
         tableView.setRoot(root);
-
         tableView.setShowRoot(true);
+
+        stageLoader = new StageLoader(tableView);
+
         final MultipleSelectionModel sm = tableView.getSelectionModel();
         sm.setSelectionMode(SelectionMode.MULTIPLE);
         sm.clearAndSelect(0);
@@ -580,6 +609,8 @@ public class TreeTableViewMouseInputTest {
         sm.setSelectionMode(SelectionMode.MULTIPLE);
         sm.setCellSelectionEnabled(false);
 
+        stageLoader = new StageLoader(tableView);
+
         VirtualFlowTestUtils.clickOnRow(tableView, 1);
         assertEquals(1, sm.getSelectedCells().size());
 
@@ -601,6 +632,8 @@ public class TreeTableViewMouseInputTest {
         sm.setSelectionMode(SelectionMode.MULTIPLE);
         sm.setCellSelectionEnabled(true);
 
+        stageLoader = new StageLoader(tableView);
+
         VirtualFlowTestUtils.clickOnRow(tableView, 1);
         assertEquals(1, sm.getSelectedCells().size());
 
@@ -617,6 +650,8 @@ public class TreeTableViewMouseInputTest {
             root.getChildren().add(new TreeItem<>("Row " + i));
         }
         tableView.setRoot(root);
+
+        stageLoader = new StageLoader(tableView);
 
         final MultipleSelectionModel sm = tableView.getSelectionModel();
         final FocusModel fm = tableView.getFocusModel();
@@ -642,6 +677,8 @@ public class TreeTableViewMouseInputTest {
         tableView.setMinWidth(1000);
         tableView.setMinWidth(1000);
 
+        stageLoader = new StageLoader(tableView);
+
         TreeTableRow row = (TreeTableRow) VirtualFlowTestUtils.getCell(tableView, 4);
         assertNotNull(row);
         assertNull(row.getItem());
@@ -660,6 +697,8 @@ public class TreeTableViewMouseInputTest {
             root.getChildren().add(new TreeItem<>("Row " + i));
         }
         tableView.setRoot(root);
+
+        stageLoader = new StageLoader(tableView);
 
         // expand
         assertFalse(root.isExpanded());
@@ -745,6 +784,8 @@ public class TreeTableViewMouseInputTest {
 
         table.getColumns().addAll(firstNameCol, lastNameCol, emailCol);
 
+        stageLoader = new StageLoader(table);
+
         sm.select(0, firstNameCol);
 
         assertTrue(sm.isSelected(0, firstNameCol));
@@ -813,6 +854,8 @@ public class TreeTableViewMouseInputTest {
 
         table.getColumns().addAll(firstNameCol, lastNameCol, emailCol);
 
+        stageLoader = new StageLoader(table);
+
         sm = table.getSelectionModel();
         sm.setCellSelectionEnabled(false);
         sm.setSelectionMode(SelectionMode.MULTIPLE);
@@ -879,6 +922,8 @@ public class TreeTableViewMouseInputTest {
         emailCol.setCellValueFactory(new TreeItemPropertyValueFactory<Person, String>("email"));
 
         table.getColumns().addAll(firstNameCol, lastNameCol, emailCol);
+
+        stageLoader = new StageLoader(table);
 
         sm = table.getSelectionModel();
         sm.setCellSelectionEnabled(true);
@@ -961,6 +1006,8 @@ public class TreeTableViewMouseInputTest {
         emailCol.setCellValueFactory(new TreeItemPropertyValueFactory<Person, String>("email"));
 
         table.getColumns().addAll(firstNameCol, lastNameCol, emailCol);
+
+        stageLoader = new StageLoader(table);
 
         TreeTableView.TreeTableViewSelectionModel<Person> sm = table.getSelectionModel();
         sm.setCellSelectionEnabled(cellSelection);
@@ -1057,6 +1104,8 @@ public class TreeTableViewMouseInputTest {
             List<?> copy = new ArrayList<>(sm.getSelectedItems());
             assertFalse(copy.contains(null));
         });
+
+        stageLoader = new StageLoader(table);
 
         // select all
         VirtualFlowTestUtils.clickOnRow(table, 0, true, KeyModifier.getShortcutKey());

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
@@ -1728,6 +1728,8 @@ public class TreeTableViewTest {
 
         table.getColumns().addAll(firstNameCol, lastNameCol, emailCol);
 
+        stageLoader = new StageLoader(table);
+
         VirtualFlowTestUtils.assertRowsNotEmpty(table, 0, 6); // rows 0 - 6 should be filled
         VirtualFlowTestUtils.assertRowsEmpty(table, 6, -1); // rows 6+ should be empty
 
@@ -1736,6 +1738,7 @@ public class TreeTableViewTest {
         root.getChildren().setAll(
                 new TreeItem(new Person("*_*Emma", "Jones", "emma.jones@example.com")),
                 new TreeItem(new Person("_Michael", "Brown", "michael.brown@example.com")));
+        Toolkit.getToolkit().firePulse();
 
         VirtualFlowTestUtils.assertRowsNotEmpty(table, 0, 3); // rows 0 - 3 should be filled
         VirtualFlowTestUtils.assertRowsEmpty(table, 3, -1); // rows 3+ should be empty
@@ -2164,6 +2167,8 @@ public class TreeTableViewTest {
 
         table.getColumns().addAll(firstNameCol, lastNameCol, emailCol);
 
+        stageLoader = new StageLoader(table);
+
         // test the state before we hide and re-add a column
         VirtualFlowTestUtils.assertCellTextEquals(table, 0, "Jacob", "Smith", "jacob.smith@example.com");
         VirtualFlowTestUtils.assertCellTextEquals(table, 1, "Isabella", "Johnson", "isabella.johnson@example.com");
@@ -2173,6 +2178,7 @@ public class TreeTableViewTest {
 
         // hide the last name column, and test cells again
         table.getColumns().remove(lastNameCol);
+        Toolkit.getToolkit().firePulse();
         VirtualFlowTestUtils.assertCellTextEquals(table, 0, "Jacob", "jacob.smith@example.com");
         VirtualFlowTestUtils.assertCellTextEquals(table, 1, "Isabella", "isabella.johnson@example.com");
         VirtualFlowTestUtils.assertCellTextEquals(table, 2, "Ethan", "ethan.williams@example.com");
@@ -2185,6 +2191,7 @@ public class TreeTableViewTest {
         // some of the last name values will not be where we expect them to be.
         // This is clearly not ideal!
         table.getColumns().add(1, lastNameCol);
+        Toolkit.getToolkit().firePulse();
         VirtualFlowTestUtils.assertCellTextEquals(table, 0, "Jacob", "Smith", "jacob.smith@example.com");
         VirtualFlowTestUtils.assertCellTextEquals(table, 1, "Isabella", "Johnson", "isabella.johnson@example.com");
         VirtualFlowTestUtils.assertCellTextEquals(table, 2, "Ethan", "Williams", "ethan.williams@example.com");
@@ -2227,6 +2234,7 @@ public class TreeTableViewTest {
 
         table.getColumns().add(firstNameCol);
 
+        stageLoader = new StageLoader(table);
         Toolkit.getToolkit().firePulse();
 
         // we want the vertical scrollbar
@@ -2443,6 +2451,8 @@ public class TreeTableViewTest {
         firstNameCol.setCellFactory(CheckBoxTreeTableCell.forTreeTableColumn(param -> new ReadOnlyBooleanWrapper(true)));
         tableView.getColumns().add(firstNameCol);
 
+        stageLoader = new StageLoader(tableView);
+
         // because only the first row has data, all other rows should be
         // empty (and not contain check boxes - we just check the first four here)
         VirtualFlowTestUtils.assertRowsNotEmpty(tableView, 0, 1);
@@ -2463,6 +2473,8 @@ public class TreeTableViewTest {
         firstNameCol.setEditable(true);
 
         treeTableView.getColumns().add(firstNameCol);
+
+        stageLoader = new StageLoader(treeTableView);
 
         IndexedCell cell = VirtualFlowTestUtils.getCell(treeTableView, 1, 0);
         assertEquals("TEST", cell.getText());
@@ -2488,6 +2500,8 @@ public class TreeTableViewTest {
 
         treeTableView.getColumns().add(firstNameCol);
 
+        stageLoader = new StageLoader(treeTableView);
+
         IndexedCell cell = VirtualFlowTestUtils.getCell(treeTableView, 0, 0);
         assertEquals("Root", cell.getText());
 
@@ -2502,6 +2516,8 @@ public class TreeTableViewTest {
         firstNameCol.setCellValueFactory(param -> new ReadOnlyStringWrapper(param.getValue().getValue()));
 
         treeTableView.getColumns().add(firstNameCol);
+
+        stageLoader = new StageLoader(treeTableView);
 
         IndexedCell cell = VirtualFlowTestUtils.getCell(treeTableView, 0);
         assertEquals("Root", cell.getItem());
@@ -2526,11 +2542,15 @@ public class TreeTableViewTest {
 
         treeTableView.getColumns().add(firstNameCol);
 
+        stageLoader = new StageLoader(treeTableView);
+
         TreeTableRow cell = (TreeTableRow) VirtualFlowTestUtils.getCell(treeTableView, 0);
         assertEquals("Root", cell.getItem());
 
         // set the first graphic - which we expect to see as a child of the cell
         root.setGraphic(graphic1);
+        Toolkit.getToolkit().firePulse();
+
         cell = (TreeTableRow) VirtualFlowTestUtils.getCell(treeTableView, 0);
         boolean matchGraphic1 = false;
         boolean matchGraphic2 = false;
@@ -2547,6 +2567,8 @@ public class TreeTableViewTest {
 
         // set the second graphic - which we also expect to see - but of course graphic1 should not be a child any longer
         root.setGraphic(graphic2);
+        Toolkit.getToolkit().firePulse();
+
         cell = (TreeTableRow) VirtualFlowTestUtils.getCell(treeTableView, 0);
         matchGraphic1 = false;
         matchGraphic2 = false;
@@ -2703,6 +2725,8 @@ public class TreeTableViewTest {
         col.setCellValueFactory(param -> new ReadOnlyObjectWrapper<>(param.getValue().getValue()));
         treeTableView.getColumns().add(col);
 
+        stageLoader = new StageLoader(treeTableView);
+
         // test pre-conditions
         assertEquals(0, sm.getSelectedCells().size());
         assertEquals(0, sm.getSelectedItems().size());
@@ -2791,6 +2815,8 @@ public class TreeTableViewTest {
             }
         });
 
+        stageLoader = new StageLoader(treeTableView);
+
         // First four rows have content, so the graphic should show.
         // All other rows have no content, so graphic should not show.
 
@@ -2829,6 +2855,8 @@ public class TreeTableViewTest {
                 };
             }
         });
+
+        stageLoader = new StageLoader(treeTableView);
 
         // First two rows have content, so the graphic should show.
         // All other rows have no content, so graphic should not show.
@@ -4363,6 +4391,8 @@ public class TreeTableViewTest {
         assertEquals(one, sm.getSelectedItem());
         assertTrue(sm.isSelected(4), debug());
 
+        stageLoader = new StageLoader(treeTableView);
+
         // this line would create a NPE
         VirtualFlowTestUtils.clickOnRow(treeTableView, 4, true);
 
@@ -5289,7 +5319,7 @@ public class TreeTableViewTest {
 
         TreeTableViewFocusModel<String> fm = stringTreeView.getFocusModel();
 
-        StageLoader sl = new StageLoader(stringTreeView);
+        stageLoader = new StageLoader(stringTreeView);
 
         // test pre-conditions
         assertTrue(sm.isEmpty());
@@ -5335,8 +5365,6 @@ public class TreeTableViewTest {
         assertTrue(TreeTableCellBehavior.hasNonDefaultAnchor(stringTreeView));
         assertEquals(1, anchor.getRow());
         assertEquals(column, anchor.getTableColumn());
-
-        sl.dispose();
     }
 
     private final ObservableList<TreeItem<String>> rt_39256_list = FXCollections.observableArrayList();
@@ -6336,6 +6364,8 @@ public class TreeTableViewTest {
         c2.setCellValueFactory(cdf -> new ReadOnlyStringWrapper(cdf.getValue().getValue()));
         t.getColumns().addAll(c1, c2);
 
+        stageLoader = new StageLoader(t);
+
         final int startIndex = toRight ? 0 : 2;
         final int endIndex = toRight ? 2 : 0;
         final TreeTableColumn<String,String> startColumn = toBottom ? c1 : c2;
@@ -6890,6 +6920,8 @@ public class TreeTableViewTest {
         sm.setSelectionMode(SelectionMode.MULTIPLE);
         sm.setCellSelectionEnabled(true);
 
+        stageLoader = new StageLoader(table);
+
         assertEquals(0, sm.getSelectedItems().size());
 
         sm.select(1, firstNameCol);
@@ -7009,6 +7041,8 @@ public class TreeTableViewTest {
         sm.setSelectionMode(SelectionMode.MULTIPLE);
         sm.setCellSelectionEnabled(true);
 
+        stageLoader = new StageLoader(table);
+
         // Call change::toString
         table.getSelectionModel().getSelectedItems().addListener((ListChangeListener<TreeItem<Person>>) Object::toString);
 
@@ -7053,6 +7087,8 @@ public class TreeTableViewTest {
 
         TreeTableView.TreeTableViewSelectionModel<String> sm = stringTreeView.getSelectionModel();
         sm.setSelectionMode(SelectionMode.MULTIPLE);
+
+        stageLoader = new StageLoader(stringTreeView);
 
         // test pre-conditions
         assertTrue(sm.isEmpty());

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeViewMouseInputTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeViewMouseInputTest.java
@@ -72,6 +72,8 @@ public class TreeViewMouseInputTest {
         private TreeItem<String> child9;            // 12
         private TreeItem<String> child10;           // 13
 
+    private StageLoader stageLoader;
+
     @BeforeEach
     public void setup() {
         root = new TreeItem<>("Root");             // 0
@@ -121,10 +123,15 @@ public class TreeViewMouseInputTest {
         sm = treeView.getSelectionModel();
         sm.setSelectionMode(SelectionMode.MULTIPLE);
         fm = treeView.getFocusModel();
+
+        stageLoader = new StageLoader(treeView);
     }
 
     @AfterEach
     public void tearDown() {
+        if (stageLoader != null) {
+            stageLoader.dispose();
+        }
         treeView.getSkin().dispose();
     }
 
@@ -185,6 +192,8 @@ public class TreeViewMouseInputTest {
 
         sm.clearAndSelect(9);
 
+        stageLoader = new StageLoader(treeView);
+
         // select all from 9 - 7
         VirtualFlowTestUtils.clickOnRow(treeView, 7, KeyModifier.SHIFT);
         assertTrue(isSelected(7,8,9), debug());
@@ -198,6 +207,8 @@ public class TreeViewMouseInputTest {
         sm.setSelectionMode(SelectionMode.MULTIPLE);
 
         sm.clearAndSelect(5);
+
+        stageLoader = new StageLoader(treeView);
 
         // select all from 5 - 7
         VirtualFlowTestUtils.clickOnRow(treeView, 7, KeyModifier.SHIFT);
@@ -225,6 +236,8 @@ public class TreeViewMouseInputTest {
         assertEquals(0,rt30394_count);
         assertFalse(fm.isFocused(0));
 
+        stageLoader = new StageLoader(treeView);
+
         // select the first row with the shift key held down. The focus event
         // should only fire once - for focus on 0 (never -1 as this bug shows).
         VirtualFlowTestUtils.clickOnRow(treeView, 0, KeyModifier.SHIFT);
@@ -235,6 +248,8 @@ public class TreeViewMouseInputTest {
     @Test public void test_rt32119() {
         sm.setSelectionMode(SelectionMode.MULTIPLE);
         sm.clearSelection();
+
+        stageLoader = new StageLoader(treeView);
 
         // select rows 2, 3, and 4
         VirtualFlowTestUtils.clickOnRow(treeView, 2);
@@ -335,8 +350,10 @@ public class TreeViewMouseInputTest {
             root.getChildren().add(new TreeItem<>("Row " + i));
         }
         treeView.setRoot(root);
-
         treeView.setShowRoot(true);
+
+        stageLoader = new StageLoader(treeView);
+
         final MultipleSelectionModel sm = treeView.getSelectionModel();
         sm.setSelectionMode(SelectionMode.MULTIPLE);
         sm.clearAndSelect(0);
@@ -365,8 +382,10 @@ public class TreeViewMouseInputTest {
             root.getChildren().add(new TreeItem<>("Row " + i));
         }
         treeView.setRoot(root);
-
         treeView.setShowRoot(true);
+
+        stageLoader = new StageLoader(treeView);
+
         final MultipleSelectionModel sm = treeView.getSelectionModel();
         sm.setSelectionMode(SelectionMode.MULTIPLE);
         sm.clearAndSelect(0);
@@ -394,6 +413,8 @@ public class TreeViewMouseInputTest {
         }
         treeView.setRoot(root);
 
+        stageLoader = new StageLoader(treeView);
+
         final MultipleSelectionModel sm = treeView.getSelectionModel();
         final FocusModel fm = treeView.getFocusModel();
         sm.setSelectionMode(SelectionMode.SINGLE);
@@ -418,6 +439,8 @@ public class TreeViewMouseInputTest {
         }
         treeView.setRoot(root);
 
+        stageLoader = new StageLoader(treeView);
+
         // expand
         assertFalse(root.isExpanded());
         VirtualFlowTestUtils.clickOnRow(treeView, 0, 2);
@@ -434,7 +457,8 @@ public class TreeViewMouseInputTest {
 
     @Test public void test_rt_37069() {
         final int items = 8;
-        root.getChildren().clear();
+        treeView = new TreeView<>(new TreeItem<>());
+        root = treeView.getRoot();
         root.setExpanded(false);
         for (int i = 0; i < items; i++) {
             root.getChildren().add(new TreeItem<>("Row " + i));
@@ -445,11 +469,10 @@ public class TreeViewMouseInputTest {
         Button btn = new Button("Button");
         VBox vbox = new VBox(btn, treeView);
 
-        StageLoader sl = new StageLoader(vbox);
-        sl.getStage().requestFocus();
+        stageLoader= new StageLoader(vbox);
+        stageLoader.getStage().requestFocus();
         btn.requestFocus();
         Toolkit.getToolkit().firePulse();
-        Scene scene = sl.getStage().getScene();
 
         assertTrue(btn.isFocused());
         assertFalse(treeView.isFocused());
@@ -460,8 +483,6 @@ public class TreeViewMouseInputTest {
 
         assertTrue(btn.isFocused());
         assertFalse(treeView.isFocused());
-
-        sl.dispose();
     }
 
     @Test public void test_jdk_8147823() {
@@ -485,6 +506,8 @@ public class TreeViewMouseInputTest {
             List<TreeItem<String>> copy = new ArrayList<>(sm.getSelectedItems());
             assertFalse(copy.contains(null));
         });
+
+        stageLoader = new StageLoader(treeView);
 
         // select all
         VirtualFlowTestUtils.clickOnRow(treeView, 0, KeyModifier.getShortcutKey());

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeViewTest.java
@@ -752,6 +752,8 @@ public class TreeViewTest {
 
         TreeView<Person> tree = new TreeView<>(root);
 
+        stageLoader = new StageLoader(tree);
+
         VirtualFlowTestUtils.assertRowsNotEmpty(tree, 0, 6); // rows 0 - 6 should be filled
         VirtualFlowTestUtils.assertRowsEmpty(tree, 6, -1); // rows 6+ should be empty
 
@@ -760,6 +762,7 @@ public class TreeViewTest {
         root.getChildren().setAll(
                 new TreeItem(new Person("*_*Emma", "Jones", "emma.jones@example.com")),
                 new TreeItem(new Person("_Michael", "Brown", "michael.brown@example.com")));
+        Toolkit.getToolkit().firePulse();
 
         VirtualFlowTestUtils.assertRowsNotEmpty(tree, 0, 3); // rows 0 - 3 should be filled
         VirtualFlowTestUtils.assertRowsEmpty(tree, 3, -1); // rows 3+ should be empty
@@ -789,6 +792,8 @@ public class TreeViewTest {
         rootNode.getChildren().setAll(nodeList);
 
         TreeView<String> treeView = new TreeView<>(rootNode);
+
+        stageLoader = new StageLoader(treeView);
 
         final double indent = PlatformImpl.isCaspian() ? 31 :
                         PlatformImpl.isModena()  ? 35 :
@@ -990,6 +995,7 @@ public class TreeViewTest {
         treeView.setShowRoot(false);
         root.getChildren().setAll(persons);
 
+        stageLoader = new StageLoader(treeView);
         Toolkit.getToolkit().firePulse();
 
         // we want the vertical scrollbar
@@ -1126,6 +1132,8 @@ public class TreeViewTest {
                 CheckBoxTreeCell.forTreeView(
                         param -> new ReadOnlyBooleanWrapper(true)));
 
+        stageLoader = new StageLoader(treeView);
+
         // because only the first row has data, all other rows should be
         // empty (and not contain check boxes - we just check the first four here)
         VirtualFlowTestUtils.assertRowsNotEmpty(treeView, 0, 1);
@@ -1139,6 +1147,8 @@ public class TreeViewTest {
         installChildren();
         treeView.setEditable(true);
         treeView.setCellFactory(TextFieldTreeCell.forTreeView());
+
+        stageLoader = new StageLoader(treeView);
 
         IndexedCell cell = VirtualFlowTestUtils.getCell(treeView, 1);
         assertEquals(child1.getValue(), cell.getText());
@@ -1159,6 +1169,8 @@ public class TreeViewTest {
     @Test public void test_rt31404() {
         installChildren();
 
+        stageLoader = new StageLoader(treeView);
+
         IndexedCell cell = VirtualFlowTestUtils.getCell(treeView, 0);
         assertEquals("Root", cell.getText());
 
@@ -1169,6 +1181,8 @@ public class TreeViewTest {
 
     @Test public void test_rt31471() {
         installChildren();
+
+        stageLoader = new StageLoader(treeView);
 
         IndexedCell cell = VirtualFlowTestUtils.getCell(treeView, 0);
         assertEquals("Root", cell.getItem());
@@ -1244,6 +1258,8 @@ public class TreeViewTest {
                 };
             }
         });
+
+        stageLoader = new StageLoader(treeView);
 
         // First two four have content, so the graphic should show.
         // All other rows have no content, so graphic should not show.
@@ -1846,6 +1862,8 @@ public class TreeViewTest {
         textFieldTreeView.setOnEditCancel(t -> {
             rt_35889_cancel_count++;
         });
+
+        stageLoader = new StageLoader(textFieldTreeView);
 
         TreeCell cell0 = (TreeCell) VirtualFlowTestUtils.getCell(textFieldTreeView, 0);
         assertNull(cell0.getGraphic());
@@ -2786,7 +2804,7 @@ public class TreeViewTest {
 
         FocusModel<TreeItem<String>> fm = stringTreeView.getFocusModel();
 
-        StageLoader sl = new StageLoader(stringTreeView);
+        stageLoader = new StageLoader(stringTreeView);
 
         // test pre-conditions
         assertTrue(sm.isEmpty());
@@ -2826,8 +2844,6 @@ public class TreeViewTest {
         assertNotNull(anchor);
         assertTrue(TreeCellBehavior.hasNonDefaultAnchor(stringTreeView));
         assertEquals(1, (int)anchor);
-
-        sl.dispose();
     }
 
     private final ObservableList<TreeItem<String>> rt_39256_list = FXCollections.observableArrayList();
@@ -4142,7 +4158,9 @@ public class TreeViewTest {
         rootNode.getChildren().addAll(generateChildren(1));
         TreeView<String> treeView = new TreeView<>(rootNode);
         treeView.scrollTo(100);
-        IndexedCell expandedCell = VirtualFlowTestUtils.getCell(treeView, 100);
+
+        stageLoader = new StageLoader(treeView);
+
         Toolkit.getToolkit().firePulse();
         rootNode.getChildren().get(1).setExpanded(false);
         Toolkit.getToolkit().firePulse();


### PR DESCRIPTION
Currently, the VirtualFlowTestUtils used ONLY for tests has many utility methods to get and do something with the VirtualFlow of Virtualized Controls.

It has one flaw: It may creates a temporary Stage with the StageLoader, when the Control was never inside a Scene (and Stage) yet. This is done to get the VirtualFlow, which is not possible otherwise.

Take the following test code:
```
VirtualFlowTestUtils.clickOnRow(tableView, 2);
VirtualFlowTestUtils.clickOnRow(tableView, 4);
```

What it does it to create a Stage for the first method and dispose it after. And create another Stage for the second method and dispose it after.

This does not test a realistic scenario and the chance is quite high that developers used that methods without even knowing that it contains such logic.

So the idea is to remove the StageLoader code from VirtualFlowTestUtils and rather use it in the Test code before calling the Util methods.

For the example above, this would result in:
```
stageLoader = new StageLoader(tableView);
VirtualFlowTestUtils.clickOnRow(tableView, 2);
VirtualFlowTestUtils.clickOnRow(tableView, 4);
```

The stageLoader should be disposed in an @AfterEach.

Note: Nearly all touched tests are indeed much older test code. New tests are not affected and already use it correcty.
Sometimes a call to `Toolkit.getToolkit().firePulse();` was needed. Previously, creating a new Stage for every call to the util methods did that implicitly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8359598](https://bugs.openjdk.org/browse/JDK-8359598): [TestBug] VirtualFlowTestUtils should not create a temporary Stage (**Enhancement** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1829/head:pull/1829` \
`$ git checkout pull/1829`

Update a local copy of the PR: \
`$ git checkout pull/1829` \
`$ git pull https://git.openjdk.org/jfx.git pull/1829/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1829`

View PR using the GUI difftool: \
`$ git pr show -t 1829`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1829.diff">https://git.openjdk.org/jfx/pull/1829.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1829#issuecomment-2974611407)
</details>
