### PR TITLE
8359599: Calling refresh() for all virtualized controls recreates all cells instead of refreshing the cells

### DIFF
--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/Properties.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/Properties.java
@@ -82,12 +82,12 @@ public class Properties {
 
     /***************************************************************************
      *
-     * ListView, TableView
+     * Virtualized controls
      *
      **************************************************************************/
 
-    public static final String REFRESH = "refreshKey";
     public static final String RECREATE = "recreateKey";
+    public static final String REBUILD = "rebuildKey";
 
 
 

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ListView.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ListView.java
@@ -1032,8 +1032,8 @@ public class ListView<T> extends Control {
     }
 
     /**
-     * Calling {@code refresh()} forces the ListView control to recreate and
-     * repopulate the cells necessary to populate the visual bounds of the control.
+     * Calling {@code refresh()} forces the ListView control to repopulate the
+     * cells necessary to populate the visual bounds of the control.
      * In other words, this forces the ListView to update what it is showing to
      * the user. This is useful in cases where the underlying data source has
      * changed in a way that is not observed by the ListView itself.
@@ -1041,7 +1041,7 @@ public class ListView<T> extends Control {
      * @since JavaFX 8u60
      */
     public void refresh() {
-        getProperties().put(Properties.RECREATE, Boolean.TRUE);
+        getProperties().put(Properties.REBUILD, Boolean.TRUE);
     }
 
 

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TableView.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TableView.java
@@ -1763,8 +1763,8 @@ public class TableView<S> extends Control {
     }
 
     /**
-     * Calling {@code refresh()} forces the TableView control to recreate and
-     * repopulate the cells necessary to populate the visual bounds of the control.
+     * Calling {@code refresh()} forces the TableView control to repopulate the
+     * cells necessary to populate the visual bounds of the control.
      * In other words, this forces the TableView to update what it is showing to
      * the user. This is useful in cases where the underlying data source has
      * changed in a way that is not observed by the TableView itself.
@@ -1772,7 +1772,7 @@ public class TableView<S> extends Control {
      * @since JavaFX 8u60
      */
     public void refresh() {
-        getProperties().put(Properties.RECREATE, Boolean.TRUE);
+        getProperties().put(Properties.REBUILD, Boolean.TRUE);
     }
 
 

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableView.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableView.java
@@ -2079,8 +2079,8 @@ public class TreeTableView<S> extends Control {
     }
 
     /**
-     * Calling {@code refresh()} forces the TreeTableView control to recreate and
-     * repopulate the cells necessary to populate the visual bounds of the control.
+     * Calling {@code refresh()} forces the TreeTableView control to repopulate the
+     * cells necessary to populate the visual bounds of the control.
      * In other words, this forces the TreeTableView to update what it is showing to
      * the user. This is useful in cases where the underlying data source has
      * changed in a way that is not observed by the TreeTableView itself.
@@ -2088,7 +2088,7 @@ public class TreeTableView<S> extends Control {
      * @since JavaFX 8u60
      */
     public void refresh() {
-        getProperties().put(Properties.RECREATE, Boolean.TRUE);
+        getProperties().put(Properties.REBUILD, Boolean.TRUE);
     }
 
 

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeView.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeView.java
@@ -1109,8 +1109,8 @@ public class TreeView<T> extends Control {
     }
 
     /**
-     * Calling {@code refresh()} forces the TreeView control to recreate and
-     * repopulate the cells necessary to populate the visual bounds of the control.
+     * Calling {@code refresh()} forces the TreeView control to repopulate the
+     * cells necessary to populate the visual bounds of the control.
      * In other words, this forces the TreeView to update what it is showing to
      * the user. This is useful in cases where the underlying data source has
      * changed in a way that is not observed by the TreeView itself.
@@ -1118,7 +1118,7 @@ public class TreeView<T> extends Control {
      * @since JavaFX 8u60
      */
     public void refresh() {
-        getProperties().put(Properties.RECREATE, Boolean.TRUE);
+        getProperties().put(Properties.REBUILD, Boolean.TRUE);
     }
 
 

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ListViewSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ListViewSkin.java
@@ -101,7 +101,6 @@ public class ListViewSkin<T> extends VirtualContainerBase<ListView<T>, ListCell<
 
     private ObservableList<T> listViewItems;
 
-    private boolean needCellsRebuilt = true;
     private boolean needCellsReconfigured = false;
 
     private int itemCount = -1;
@@ -117,10 +116,9 @@ public class ListViewSkin<T> extends VirtualContainerBase<ListView<T>, ListCell<
 
     private MapChangeListener<Object, Object> propertiesMapListener = c -> {
         if (! c.wasAdded()) return;
-        if (Properties.RECREATE.equals(c.getKey())) {
-            needCellsRebuilt = true;
-            getSkinnable().requestLayout();
-            getSkinnable().getProperties().remove(Properties.RECREATE);
+        if (Properties.REBUILD.equals(c.getKey())) {
+            requestRebuildCells();
+            getSkinnable().getProperties().remove(Properties.REBUILD);
         }
     };
 
@@ -230,7 +228,7 @@ public class ListViewSkin<T> extends VirtualContainerBase<ListView<T>, ListCell<
         control.itemsProperty().addListener(weakItemsChangeListener);
 
         final ObservableMap<Object, Object> properties = control.getProperties();
-        properties.remove(Properties.RECREATE);
+        properties.remove(Properties.REBUILD);
         properties.addListener(weakPropertiesMapListener);
 
         // Register listeners
@@ -281,13 +279,10 @@ public class ListViewSkin<T> extends VirtualContainerBase<ListView<T>, ListCell<
                                             final double w, final double h) {
         super.layoutChildren(x, y, w, h);
 
-        if (needCellsRebuilt) {
-            flow.rebuildCells();
-        } else if (needCellsReconfigured) {
+        if (needCellsReconfigured) {
             flow.reconfigureCells();
         }
 
-        needCellsRebuilt = false;
         needCellsReconfigured = false;
 
         if (getItemCount() == 0) {

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableViewSkinBase.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableViewSkinBase.java
@@ -152,7 +152,6 @@ public abstract class TableViewSkinBase<M, S, C extends Control, I extends Index
 
     private int visibleColCount;
 
-    boolean needCellsRecreated = true;
     boolean needCellsReconfigured = false;
 
     private int itemCount = -1;
@@ -297,19 +296,18 @@ public abstract class TableViewSkinBase<M, S, C extends Control, I extends Index
         });
 
         final ObservableMap<Object, Object> properties = control.getProperties();
-        properties.remove(Properties.REFRESH);
         properties.remove(Properties.RECREATE);
+        properties.remove(Properties.REBUILD);
         lh.addMapChangeListener(properties, (c) -> {
             if (!c.wasAdded()) {
                 return;
             }
-            if (Properties.REFRESH.equals(c.getKey())) {
-                refreshView();
-                getSkinnable().getProperties().remove(Properties.REFRESH);
-            } else if (Properties.RECREATE.equals(c.getKey())) {
-                needCellsRecreated = true;
-                refreshView();
+            if (Properties.RECREATE.equals(c.getKey())) {
+                requestRecreateCells();
                 getSkinnable().getProperties().remove(Properties.RECREATE);
+            } else if (Properties.REBUILD.equals(c.getKey())) {
+                requestRebuildCells();
+                getSkinnable().getProperties().remove(Properties.REBUILD);
             }
         });
 
@@ -425,13 +423,10 @@ public abstract class TableViewSkinBase<M, S, C extends Control, I extends Index
 
         super.layoutChildren(x, y, w, h);
 
-        if (needCellsRecreated) {
-            flow.recreateCells();
-        } else if (needCellsReconfigured) {
+        if (needCellsReconfigured) {
             flow.reconfigureCells();
         }
 
-        needCellsRecreated = false;
         needCellsReconfigured = false;
 
         final double baselineOffset = table.getLayoutBounds().getHeight() / 2;

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TreeViewSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TreeViewSkin.java
@@ -102,9 +102,9 @@ public class TreeViewSkin<T> extends VirtualContainerBase<TreeView<T>, TreeCell<
 
     private MapChangeListener<Object, Object> propertiesMapListener = c -> {
         if (! c.wasAdded()) return;
-        if (Properties.RECREATE.equals(c.getKey())) {
+        if (Properties.REBUILD.equals(c.getKey())) {
             requestRebuildCells();
-            getSkinnable().getProperties().remove(Properties.RECREATE);
+            getSkinnable().getProperties().remove(Properties.REBUILD);
         }
     };
 
@@ -184,7 +184,7 @@ public class TreeViewSkin<T> extends VirtualContainerBase<TreeView<T>, TreeCell<
         flow.getHbar().addEventFilter(MouseEvent.MOUSE_PRESSED, ml);
 
         final ObservableMap<Object, Object> properties = control.getProperties();
-        properties.remove(Properties.RECREATE);
+        properties.remove(Properties.REBUILD);
         properties.addListener(propertiesMapListener);
 
         // init the behavior 'closures'

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualContainerBase.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualContainerBase.java
@@ -191,4 +191,8 @@ public abstract class VirtualContainerBase<C extends Control, I extends IndexedC
         flow.rebuildCells();
     }
 
+    void requestRecreateCells() {
+        flow.recreateCells();
+    }
+
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/TreeTableRowSkinTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/TreeTableRowSkinTest.java
@@ -352,20 +352,6 @@ public class TreeTableRowSkinTest {
         assertEquals(5, row.getChildrenUnmodifiable().stream().filter(TreeTableCell.class::isInstance).count());
     }
 
-    /** TreeTableView.refresh() must release all discarded cells JDK-8307538 */
-    @Test
-    public void cellsMustBeCollectableAfterRefresh() {
-        IndexedCell<?> row = VirtualFlowTestUtils.getCell(treeTableView, 0);
-        assertNotNull(row);
-        WeakReference<Object> ref = new WeakReference<>(row);
-        row = null;
-
-        treeTableView.refresh();
-        Toolkit.getToolkit().firePulse();
-
-        JMemoryBuddy.assertCollectable(ref);
-    }
-
     /** TreeTableView.setRowFactory() must release all discarded cells JDK-8307538 */
     @Test
     public void cellsMustBeCollectableAfterRowFactoryChange() {


### PR DESCRIPTION
When calling `refresh()` on virtualized Controls (`ListView`, `TreeView`, `TableView`, `TreeTableView`), all cells will be recreated completely, instead of just refreshing them.

This is because `recreateCells()` of the `VirtualFlow` is called when `refresh()` was called. This is not needed, since refreshing the cells can be done much cheaper with `rebuildCells()`.

This will reset all cells (`index = -1`), add them to the pile and fill them back in the viewport with an index again. This ensures `updateItem()` is called.

The contract of `refresh()` is also a big vague, stating:
```
Calling {@code refresh()} forces the XXX control to recreate and repopulate the cells 
necessary to populate the visual bounds of the control.
In other words, this forces the XXX to update what it is showing to the user. 
This is useful in cases where the underlying data source has changed in a way that is not observed by the XXX itself.
```

As written above, recreating is not needed in order to fulfull the contract of updating what is shown to the user in case the underlying data source changed without JavaFX noticing (e.g. calling a normal Setter without any Property and therefore listener involved).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 2 [Reviewers](https://openjdk.org/bylaws#reviewer))
- [ ] Change requires a CSR request matching fixVersion jfx26 to be approved (needs to be created)

### Issue
 * [JDK-8359599](https://bugs.openjdk.org/browse/JDK-8359599): Calling refresh() for all virtualized controls recreates all cells instead of refreshing the cells (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1830/head:pull/1830` \
`$ git checkout pull/1830`

Update a local copy of the PR: \
`$ git checkout pull/1830` \
`$ git pull https://git.openjdk.org/jfx.git pull/1830/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1830`

View PR using the GUI difftool: \
`$ git pr show -t 1830`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1830.diff">https://git.openjdk.org/jfx/pull/1830.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1830#issuecomment-2973953731)
</details>
