### PR TITLE
8359601: Fix window button states of an extended stage

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/HeaderButtonOverlay.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/HeaderButtonOverlay.java
@@ -26,7 +26,6 @@
 package com.sun.glass.ui;
 
 import com.sun.glass.events.MouseEvent;
-import com.sun.javafx.binding.ObjectConstant;
 import com.sun.javafx.util.Utils;
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.ObjectProperty;
@@ -264,12 +263,15 @@ public class HeaderButtonOverlay extends Region {
     private final ButtonRegion maximizeButton = new ButtonRegion(HeaderButtonType.MAXIMIZE, "-FX-INTERNAL-maximize-button", 1);
     private final ButtonRegion closeButton = new ButtonRegion(HeaderButtonType.CLOSE, "-FX-INTERNAL-close-button", 2);
     private final Subscription subscriptions;
+    private final boolean modal;
     private final boolean utility;
     private final boolean rightToLeft;
 
     private Node buttonAtMouseDown;
 
-    public HeaderButtonOverlay(ObservableValue<String> stylesheet, boolean utility, boolean rightToLeft) {
+    public HeaderButtonOverlay(ObservableValue<String> stylesheet, boolean modal,
+                               boolean utility, boolean rightToLeft) {
+        this.modal = modal;
         this.utility = utility;
         this.rightToLeft = rightToLeft;
 
@@ -310,10 +312,7 @@ public class HeaderButtonOverlay extends Region {
         getStyleClass().setAll("-FX-INTERNAL-header-button-container");
 
         if (utility) {
-            iconifyButton.managedProperty().bind(ObjectConstant.valueOf(false));
-            maximizeButton.managedProperty().bind(ObjectConstant.valueOf(false));
             getChildren().add(closeButton);
-            getStyleClass().add(UTILITY_STYLE_CLASS);
         } else {
             getChildren().addAll(iconifyButton, maximizeButton, closeButton);
         }
@@ -450,6 +449,9 @@ public class HeaderButtonOverlay extends Region {
     }
 
     private void onResizableChanged(boolean resizable) {
+        boolean utilityStyle = utility || (modal && !resizable);
+        toggleStyleClass(this, UTILITY_STYLE_CLASS, utilityStyle);
+        iconifyButton.setDisable(utility || modal);
         maximizeButton.setDisable(!resizable);
     }
 

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Window.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Window.java
@@ -280,6 +280,7 @@ public abstract class Window {
         this.styleMask = styleMask;
         this.isDecorated = (this.styleMask & Window.TITLED) != 0;
         this.isPopup = (this.styleMask & Window.POPUP) != 0;
+        this.isModal = (this.styleMask & Window.MODAL) != 0;
 
         this.screen = screen != null ? screen : Screen.getMainScreen();
         if (PrismSettings.allowHiDPIScaling) {
@@ -1155,43 +1156,6 @@ public abstract class Window {
         Application.checkEventThread();
         checkNotClosed();
         _toBack(this.ptr);
-    }
-
-    // *****************************************************
-    // modality (prototype using native platform feature)
-    // *****************************************************
-    protected abstract void _enterModal(long ptr);
-    /**
-     * Enter modal state blocking everything except our window.
-     */
-    public void enterModal() {
-        checkNotClosed();
-        if (this.isModal == false) {
-            this.isModal = true;
-            _enterModal(this.ptr);
-        }
-    }
-
-    protected abstract void _enterModalWithWindow(long dialog, long window);
-    /**
-     * Enter modal state only blocking the given window.
-     * On Mac OS X this is done using a dialog sheet.
-     */
-    public void enterModal(final Window window) {
-        checkNotClosed();
-        if (this.isModal == false) {
-            this.isModal = true;
-            _enterModalWithWindow(this.ptr, window.getNativeHandle());
-        }
-    }
-
-    protected abstract void _exitModal(long ptr);
-    public void exitModal() {
-        checkNotClosed();
-        if (this.isModal == true) {
-            _exitModal(this.ptr);
-            this.isModal = false;
-        }
     }
 
     public boolean isModal() {

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/gtk/GtkWindow.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/gtk/GtkWindow.java
@@ -246,8 +246,7 @@ class GtkWindow extends Window {
     private HeaderButtonOverlay createHeaderButtonOverlay() {
         var overlay = new HeaderButtonOverlay(
             PlatformThemeObserver.getInstance().stylesheetProperty(),
-            isUtilityWindow(),
-            (getStyleMask() & RIGHT_TO_LEFT) != 0);
+            isModal(), isUtilityWindow(), (getStyleMask() & RIGHT_TO_LEFT) != 0);
 
         // Set the system-defined absolute minimum size to the size of the window buttons area,
         // regardless of whether the application has specified a smaller minimum size.

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/gtk/GtkWindow.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/gtk/GtkWindow.java
@@ -115,15 +115,6 @@ class GtkWindow extends Window {
     @Override
     protected native void _toBack(long ptr);
 
-    @Override
-    protected native void _enterModal(long ptr);
-
-    @Override
-    protected native void _enterModalWithWindow(long dialog, long window);
-
-    @Override
-    protected native void _exitModal(long ptr);
-
     protected native long _getNativeWindowImpl(long ptr);
 
     private native void _showSystemMenu(long ptr, int x, int y);

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/ios/IosWindow.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/ios/IosWindow.java
@@ -61,9 +61,6 @@ final class IosWindow extends Window {
     @Override native protected void _setIcon(long ptr, Pixels pixels);
     @Override native protected void _toFront(long ptr);
     @Override native protected void _toBack(long ptr);
-    @Override native protected void _enterModal(long ptr);
-    @Override native protected void _enterModalWithWindow(long dialog, long window);
-    @Override native protected void _exitModal(long ptr);
     @Override native protected boolean _grabFocus(long ptr);
     @Override native protected void _ungrabFocus(long ptr);
 

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacWindow.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacWindow.java
@@ -115,9 +115,6 @@ final class MacWindow extends Window {
 
     @Override native protected void _toFront(long ptr);
     @Override native protected void _toBack(long ptr);
-    @Override native protected void _enterModal(long ptr);
-    @Override native protected void _enterModalWithWindow(long dialog, long window);
-    @Override native protected void _exitModal(long ptr);
 
     @Override native protected boolean _grabFocus(long ptr);
     @Override native protected void _ungrabFocus(long ptr);

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/MonocleWindow.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/MonocleWindow.java
@@ -392,28 +392,6 @@ final class MonocleWindow extends Window {
         MonocleWindowManager.getInstance().ungrabFocus(this);
     }
 
-    /**
-     * The functions below are used when the platform support modality natively.
-     * Currently only GTK is using it. This functionality is disabled by
-     * default. In order to enable it this class need to override Window::
-     * supportsPlatformModality() to return true.
-     *
-     */
-    @Override
-    protected void _enterModal(long ptr) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    protected void _enterModalWithWindow(long dialog, long window) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    protected void _exitModal(long ptr) {
-        throw new UnsupportedOperationException();
-    }
-
     @Override
     protected void notifyClose() {
         super.notifyClose();

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinHeaderButtonOverlay.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinHeaderButtonOverlay.java
@@ -56,8 +56,8 @@ public class WinHeaderButtonOverlay extends HeaderButtonOverlay {
         { 2.5, 0.95 },
     };
 
-    public WinHeaderButtonOverlay(boolean utility, boolean rightToLeft) {
-        super(getStylesheet(), utility, rightToLeft);
+    public WinHeaderButtonOverlay(boolean modal, boolean utility, boolean rightToLeft) {
+        super(getStylesheet(), modal, utility, rightToLeft);
 
         var windowProperty = sceneProperty().flatMap(Scene::windowProperty);
 

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinWindow.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinWindow.java
@@ -289,9 +289,6 @@ class WinWindow extends Window {
     @Override native protected void _setIcon(long ptr, Pixels pixels);
     @Override native protected void _toFront(long ptr);
     @Override native protected void _toBack(long ptr);
-    @Override native protected void _enterModal(long ptr);
-    @Override native protected void _enterModalWithWindow(long dialog, long window);
-    @Override native protected void _exitModal(long ptr);
     @Override native protected boolean _grabFocus(long ptr);
     @Override native protected void _ungrabFocus(long ptr);
     @Override native protected void _setCursor(long ptr, Cursor cursor);

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinWindow.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinWindow.java
@@ -378,7 +378,7 @@ class WinWindow extends Window {
      */
     private HeaderButtonOverlay createHeaderButtonOverlay() {
         var overlay = new WinHeaderButtonOverlay(
-            isUtilityWindow(),
+            isModal(), isUtilityWindow(),
             (getStyleMask() & RIGHT_TO_LEFT) != 0);
 
         overlay.prefButtonHeightProperty().bind(prefHeaderButtonHeightProperty());

--- a/modules/javafx.graphics/src/main/native-glass/gtk/GlassWindow.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/GlassWindow.cpp
@@ -467,52 +467,6 @@ JNIEXPORT void JNICALL Java_com_sun_glass_ui_gtk_GtkWindow__1toBack
 }
 
 /*
- * Class:     com_sun_glass_ui_gtk_GtkWindow
- * Method:    _enterModal
- * Signature: (J)V
- */
-JNIEXPORT void JNICALL Java_com_sun_glass_ui_gtk_GtkWindow__1enterModal
-  (JNIEnv * env, jobject obj, jlong ptr)
-{
-    (void)env;
-    (void)obj;
-
-    WindowContext* ctx = JLONG_TO_WINDOW_CTX(ptr);
-    ctx->set_modal(true);
-}
-
-/*
- * Class:     com_sun_glass_ui_gtk_GtkWindow
- * Method:    _enterModalWithWindow
- * Signature: (JJ)V
- */
-JNIEXPORT void JNICALL Java_com_sun_glass_ui_gtk_GtkWindow__1enterModalWithWindow
-  (JNIEnv * env, jobject obj, jlong ptrDialog, jlong ptrWindow)
-{
-    (void)env;
-    (void)obj;
-
-    WindowContext* ctx = JLONG_TO_WINDOW_CTX(ptrDialog);
-    WindowContext* parent_ctx = JLONG_TO_WINDOW_CTX(ptrWindow);
-    ctx->set_modal(true, parent_ctx);
-}
-
-/*
- * Class:     com_sun_glass_ui_gtk_GtkWindow
- * Method:    _exitModal
- * Signature: (J)V
- */
-JNIEXPORT void JNICALL Java_com_sun_glass_ui_gtk_GtkWindow__1exitModal
-  (JNIEnv * env, jobject obj, jlong ptr)
-{
-    (void)env;
-    (void)obj;
-
-    WindowContext* ctx = JLONG_TO_WINDOW_CTX(ptr);
-    ctx->set_modal(false);
-}
-
-/*
  * Class:     com_sun_glass_ui_gtk_GtkCursor
  * Method:    _setCursorType
  * Signature: (JI)V

--- a/modules/javafx.graphics/src/main/native-glass/ios/GlassWindow.m
+++ b/modules/javafx.graphics/src/main/native-glass/ios/GlassWindow.m
@@ -1589,60 +1589,6 @@ JNIEXPORT void JNICALL Java_com_sun_glass_ui_ios_IosWindow__1toBack
 
 /*
  * Class:     com_sun_glass_ui_ios_IosWindow
- * Method:    _enterModal
- * Signature: (J)V
- */
-JNIEXPORT void JNICALL Java_com_sun_glass_ui_ios_IosWindow__1enterModal
-(JNIEnv *env, jobject jwindow, jlong windowPtr) {
-    GLASS_LOG("Java_com_sun_glass_ui_ios_IosWindow__1enterModal called.");
-    GLASS_ASSERT_MAIN_JAVA_THREAD(env);
-    GLASS_POOL_ENTER;
-    {
-        // implementation omes here
-    }
-    GLASS_POOL_EXIT;
-    GLASS_CHECK_EXCEPTION(env);
-}
-
-
-/*
- * Class:     com_sun_glass_ui_ios_IosWindow
- * Method:    _enterModalWithWindow
- * Signature: (JJ)V
- */
-JNIEXPORT void JNICALL Java_com_sun_glass_ui_ios_IosWindow__1enterModalWithWindow
-(JNIEnv *env, jobject jwindow, jlong windowPtr, jlong window) {
-    GLASS_LOG("Java_com_sun_glass_ui_ios_IosWindow__1enterModalWithWindow called.");
-    GLASS_ASSERT_MAIN_JAVA_THREAD(env);
-    GLASS_POOL_ENTER;
-    {
-        // implemenation comes here
-    }
-    GLASS_POOL_EXIT;
-    GLASS_CHECK_EXCEPTION(env);
-}
-
-
-/*
- * Class:     com_sun_glass_ui_ios_IosWindow
- * Method:    _exitModal
- * Signature: (J)V
- */
-JNIEXPORT void JNICALL Java_com_sun_glass_ui_ios_IosWindow__1exitModal
-(JNIEnv *env, jobject jwindow, jlong windowPtr) {
-    GLASS_LOG("Java_com_sun_glass_ui_ios_IosWindow__1exitModal called.");
-    GLASS_ASSERT_MAIN_JAVA_THREAD(env);
-    GLASS_POOL_ENTER;
-    {
-        // implementation comes here
-    }
-    GLASS_POOL_EXIT;
-    GLASS_CHECK_EXCEPTION(env);
-}
-
-
-/*
- * Class:     com_sun_glass_ui_ios_IosWindow
  * Method:    _setEnabled
  * Signature: (JZ)V
  */

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow.m
@@ -1404,69 +1404,6 @@ JNIEXPORT void JNICALL Java_com_sun_glass_ui_mac_MacWindow__1toBack
     GLASS_CHECK_EXCEPTION(env);
 }
 
-
-/*
- * Class:     com_sun_glass_ui_mac_MacWindow
- * Method:    _enterModal
- * Signature: (J)V
- */
-JNIEXPORT void JNICALL Java_com_sun_glass_ui_mac_MacWindow__1enterModal
-(JNIEnv *env, jobject jWindow, jlong jPtr)
-{
-    LOG("Java_com_sun_glass_ui_mac_MacWindow__1enterModal");
-    if (!jPtr) return;
-
-    GLASS_ASSERT_MAIN_JAVA_THREAD(env);
-    GLASS_POOL_ENTER;
-    {
-        GlassWindow *window = getGlassWindow(env, jPtr);
-        [NSApp runModalForWindow:window->nsWindow];
-    }
-    GLASS_POOL_EXIT;
-    GLASS_CHECK_EXCEPTION(env);
-}
-
-/*
- * Class:     com_sun_glass_ui_mac_MacWindow
- * Method:    _enterModalWithWindow
- * Signature: (JJ)V
- */
-JNIEXPORT void JNICALL Java_com_sun_glass_ui_mac_MacWindow__1enterModalWithWindow
-(JNIEnv *env, jobject jWindow, jlong jDialogPtr, jlong jWindowPtr)
-{
-    LOG("Java_com_sun_glass_ui_mac_MacWindow__1enterModalWithWindow");
-
-    GLASS_ASSERT_MAIN_JAVA_THREAD(env);
-    GLASS_POOL_ENTER;
-    {
-        //GlassWindow *window = getGlassWindow(env, jDialogPtr);
-        // TODO: implement _enterModalWithWindow
-    }
-    GLASS_POOL_EXIT;
-    GLASS_CHECK_EXCEPTION(env);
-}
-
-/*
- * Class:     com_sun_glass_ui_mac_MacWindow
- * Method:    _exitModal
- * Signature: (J)V
- */
-JNIEXPORT void JNICALL Java_com_sun_glass_ui_mac_MacWindow__1exitModal
-(JNIEnv *env, jobject jWindow, jlong jPtr)
-{
-    LOG("Java_com_sun_glass_ui_mac_MacWindow__1exitModal");
-    if (!jPtr) return;
-
-    GLASS_ASSERT_MAIN_JAVA_THREAD(env);
-    GLASS_POOL_ENTER;
-    {
-        GlassWindow *window = getGlassWindow(env, jPtr);
-        [NSApp stop:window->nsWindow];
-    }
-    GLASS_POOL_EXIT;
-    GLASS_CHECK_EXCEPTION(env);
-}
-
 /*
  * Class:     com_sun_glass_ui_mac_MacWindow
  * Method:    _performWindowDrag

--- a/modules/javafx.graphics/src/main/native-glass/win/GlassWindow.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/win/GlassWindow.cpp
@@ -924,7 +924,7 @@ BOOL GlassWindow::HandleNCHitTestEvent(SHORT x, SHORT y, LRESULT& result)
         int topBorderHeight = ::GetSystemMetrics(SM_CXPADDEDBORDER) + ::GetSystemMetrics(SM_CYSIZEFRAME);
         RECT windowRect;
 
-        if (::GetWindowRect(GetHWND(), &windowRect) && y < windowRect.top + topBorderHeight) {
+        if (m_isResizable && ::GetWindowRect(GetHWND(), &windowRect) && y < windowRect.top + topBorderHeight) {
             result = LRESULT(HTTOP);
             return TRUE;
         }

--- a/modules/javafx.graphics/src/main/resources/com/sun/glass/ui/gtk/WindowDecorationGnome.css
+++ b/modules/javafx.graphics/src/main/resources/com/sun/glass/ui/gtk/WindowDecorationGnome.css
@@ -101,12 +101,12 @@
     -fx-background-color: white;
 }
 
-.-FX-INTERNAL-maximize-button:disabled {
-    -fx-background-color: transparent;
-}
-
-.-FX-INTERNAL-maximize-button:disabled > .-FX-INTERNAL-glyph {
-    -fx-background-color: #777;
+.-FX-INTERNAL-iconify-button:disabled,
+.-FX-INTERNAL-maximize-button:disabled,
+.-FX-INTERNAL-header-button-container.utility > .-FX-INTERNAL-iconify-button,
+.-FX-INTERNAL-header-button-container.utility > .-FX-INTERNAL-maximize-button {
+    -fx-managed: false;
+    visibility: hidden;
 }
 
 .-FX-INTERNAL-iconify-button > .-FX-INTERNAL-glyph {

--- a/modules/javafx.graphics/src/main/resources/com/sun/glass/ui/gtk/WindowDecorationKDE.css
+++ b/modules/javafx.graphics/src/main/resources/com/sun/glass/ui/gtk/WindowDecorationKDE.css
@@ -89,7 +89,10 @@
     -fx-background-color: #6c7076 !important;
 }
 
-.-FX-INTERNAL-maximize-button:disabled {
+.-FX-INTERNAL-iconify-button:disabled,
+.-FX-INTERNAL-maximize-button:disabled,
+.-FX-INTERNAL-header-button-container.utility > .-FX-INTERNAL-iconify-button,
+.-FX-INTERNAL-header-button-container.utility > .-FX-INTERNAL-maximize-button {
     -fx-managed: false;
     visibility: hidden;
 }

--- a/modules/javafx.graphics/src/main/resources/com/sun/glass/ui/win/WindowDecoration.css
+++ b/modules/javafx.graphics/src/main/resources/com/sun/glass/ui/win/WindowDecoration.css
@@ -87,14 +87,23 @@
     -fx-background-color: white;
 }
 
+.-FX-INTERNAL-header-button-container.utility > .-FX-INTERNAL-iconify-button,
+.-FX-INTERNAL-header-button-container.utility > .-FX-INTERNAL-maximize-button {
+    -fx-managed: false;
+    visibility: hidden;
+}
+
+.-FX-INTERNAL-iconify-button:disabled,
 .-FX-INTERNAL-maximize-button:disabled {
     -fx-background-color: transparent !important;
 }
 
+.-FX-INTERNAL-iconify-button:disabled > .-FX-INTERNAL-glyph,
 .-FX-INTERNAL-maximize-button:disabled > .-FX-INTERNAL-glyph {
     -fx-background-color: #00000020 !important;
 }
 
+.-FX-INTERNAL-iconify-button.dark:disabled > .-FX-INTERNAL-glyph,
 .-FX-INTERNAL-maximize-button.dark:disabled > .-FX-INTERNAL-glyph {
     -fx-background-color: #ffffff20 !important;
 }

--- a/modules/javafx.graphics/src/test/java/test/com/sun/glass/ui/HeaderButtonOverlayTest.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/glass/ui/HeaderButtonOverlayTest.java
@@ -36,6 +36,8 @@ import javafx.scene.layout.HeaderButtonType;
 import javafx.scene.paint.Color;
 import javafx.stage.Stage;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import test.util.ReflectionUtils;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
@@ -57,7 +59,7 @@ public class HeaderButtonOverlayTest {
                                                        -fx-button-default-height: 20;
                                                        -fx-button-vertical-alignment: stretch; }
                 .-FX-INTERNAL-header-button { -fx-pref-width: 20; }
-            """), false, false);
+            """), false, false, false);
 
         var unused = new Scene(overlay);
         var children = overlay.getChildrenUnmodifiable();
@@ -83,7 +85,7 @@ public class HeaderButtonOverlayTest {
                                                         -fx-button-default-height: 20;
                                                         -fx-button-vertical-alignment: stretch; }
                 .-FX-INTERNAL-header-button { -fx-pref-width: 20; }
-            """), false, true);
+            """), false, false, true);
 
         var unused = new Scene(overlay);
         var children = overlay.getChildrenUnmodifiable();
@@ -111,7 +113,7 @@ public class HeaderButtonOverlayTest {
                                                         -fx-button-default-height: 20;
                                                         -fx-button-vertical-alignment: center; }
                 .-FX-INTERNAL-header-button { -fx-pref-width: 20; -fx-pref-height: 10; }
-            """), false, false);
+            """), false, false, false);
 
         var unused = new Scene(overlay);
         var children = overlay.getChildrenUnmodifiable();
@@ -138,7 +140,7 @@ public class HeaderButtonOverlayTest {
                                                         -fx-button-default-height: 20;
                                                         -fx-button-vertical-alignment: center; }
                 .-FX-INTERNAL-header-button { -fx-pref-width: 20; -fx-pref-height: 10; }
-            """), false, true);
+            """), false, false, true);
 
         var unused = new Scene(overlay);
         var children = overlay.getChildrenUnmodifiable();
@@ -165,7 +167,7 @@ public class HeaderButtonOverlayTest {
                                                         -fx-button-default-height: 20;
                                                         -fx-button-vertical-alignment: stretch; }
                 .-FX-INTERNAL-header-button { -fx-pref-width: 20; }
-            """), false, false);
+            """), false, false, false);
 
         var unused = new Scene(overlay);
         var children = overlay.getChildrenUnmodifiable();
@@ -191,7 +193,7 @@ public class HeaderButtonOverlayTest {
                                                         -fx-button-default-height: 20;
                                                         -fx-button-vertical-alignment: stretch; }
                 .-FX-INTERNAL-header-button { -fx-pref-width: 20; }
-            """), false, true);
+            """), false, false, true);
 
         var unused = new Scene(overlay);
         var children = overlay.getChildrenUnmodifiable();
@@ -219,7 +221,7 @@ public class HeaderButtonOverlayTest {
                                                         -fx-button-default-height: 20;
                                                         -fx-button-vertical-alignment: center; }
                 .-FX-INTERNAL-header-button { -fx-pref-width: 20; -fx-pref-height: 10; }
-            """), false, false);
+            """), false, false, false);
 
         var unused = new Scene(overlay);
         var children = overlay.getChildrenUnmodifiable();
@@ -246,7 +248,7 @@ public class HeaderButtonOverlayTest {
                                                         -fx-button-default-height: 20;
                                                         -fx-button-vertical-alignment: center; }
                 .-FX-INTERNAL-header-button { -fx-pref-width: 20; -fx-pref-height: 10; }
-            """), false, true);
+            """), false, false, true);
 
         var unused = new Scene(overlay);
         var children = overlay.getChildrenUnmodifiable();
@@ -274,7 +276,7 @@ public class HeaderButtonOverlayTest {
                 .-FX-INTERNAL-iconify-button { -fx-button-order: 5; }
                 .-FX-INTERNAL-maximize-button { -fx-button-order: 1; }
                 .-FX-INTERNAL-close-button { -fx-button-order: 3; }
-            """), false, false);
+            """), false, false, false);
 
         var unused = new Scene(overlay);
         var children = overlay.getChildrenUnmodifiable();
@@ -301,7 +303,7 @@ public class HeaderButtonOverlayTest {
                 .-FX-INTERNAL-iconify-button { -fx-button-order: 5; }
                 .-FX-INTERNAL-maximize-button { -fx-button-order: 1; }
                 .-FX-INTERNAL-close-button { -fx-button-order: 3; }
-            """), false, true);
+            """), false, false, true);
 
         var unused = new Scene(overlay);
         var children = overlay.getChildrenUnmodifiable();
@@ -322,11 +324,59 @@ public class HeaderButtonOverlayTest {
     void utilityDecorationIsOnlyCloseButton() {
         var overlay = new HeaderButtonOverlay(getStylesheet("""
                 .-FX-INTERNAL-header-button { -fx-pref-width: 20; -fx-pref-height: 10; }
-            """), true, false);
+            """), false, true, false);
 
         var children = overlay.getChildrenUnmodifiable();
         assertEquals(1, children.size());
         assertTrue(children.getFirst().getStyleClass().contains("-FX-INTERNAL-close-button"));
+    }
+
+    enum ButtonDisabledStateTest {
+        RESIZABLE(true, false, false, false),
+        UNRESIZABLE(false, false, false, true),
+        MODAL_RESIZABLE(true, true, true, false),
+        MODAL_UNRESIZABLE(false, true, true, true);
+
+        ButtonDisabledStateTest(boolean resizable, boolean modal, boolean iconifyDisabled, boolean maximizeDisabled) {
+            this.resizable = resizable;
+            this.modal = modal;
+            this.iconifyDisabled = iconifyDisabled;
+            this.maximizeDisabled = maximizeDisabled;
+        }
+
+        final boolean resizable;
+        final boolean modal;
+        final boolean iconifyDisabled;
+        final boolean maximizeDisabled;
+    }
+
+    /**
+     * Tests the disabled states of the iconify and maximize buttons for all combinations
+     * of resizable and modal window attributes.
+     */
+    @ParameterizedTest
+    @EnumSource(ButtonDisabledStateTest.class)
+    void buttonDisabledStateIsCorrect(ButtonDisabledStateTest test) {
+        var overlay = new HeaderButtonOverlay(getStylesheet("""
+                .-FX-INTERNAL-header-button { -fx-pref-width: 20; -fx-pref-height: 10; }
+            """), test.modal, false, false);
+
+        var scene = new Scene(overlay);
+        var stage = new Stage();
+        stage.setScene(scene);
+        stage.setResizable(test.resizable);
+
+        var children = overlay.getChildrenUnmodifiable();
+        assertEquals(3, children.size());
+
+        assertTrue(children.get(0).getStyleClass().contains("-FX-INTERNAL-iconify-button"));
+        assertEquals(test.iconifyDisabled, children.get(0).isDisabled());
+
+        assertTrue(children.get(1).getStyleClass().contains("-FX-INTERNAL-maximize-button"));
+        assertEquals(test.maximizeDisabled, children.get(1).isDisabled());
+
+        assertTrue(children.get(2).getStyleClass().contains("-FX-INTERNAL-close-button"));
+        assertFalse(children.get(2).isDisabled());
     }
 
     @Test
@@ -334,7 +384,7 @@ public class HeaderButtonOverlayTest {
         var overlay = new HeaderButtonOverlay(getStylesheet("""
                 .-FX-INTERNAL-header-button-container { -fx-button-placement: right; }
                 .-FX-INTERNAL-header-button { -fx-pref-width: 20; -fx-pref-height: 10; }
-            """), false, false);
+            """), false, false, false);
 
         var scene = new Scene(overlay);
         var stage = new Stage();
@@ -360,7 +410,7 @@ public class HeaderButtonOverlayTest {
         var overlay = new HeaderButtonOverlay(getStylesheet("""
                 .-FX-INTERNAL-header-button-container { -fx-button-placement: right; }
                 .-FX-INTERNAL-header-button { -fx-pref-width: 20; -fx-pref-height: 10; }
-            """), false, false);
+            """), false, false, false);
 
         var scene = new Scene(overlay);
         var stage = new Stage();
@@ -384,7 +434,7 @@ public class HeaderButtonOverlayTest {
         var overlay = new HeaderButtonOverlay(getStylesheet("""
                 .-FX-INTERNAL-header-button-container { -fx-button-placement: right; }
                 .-FX-INTERNAL-header-button { -fx-pref-width: 20; -fx-pref-height: 10; }
-            """), false, false);
+            """), false, false, false);
 
         var scene = new Scene(overlay);
         var stage = new Stage();
@@ -407,7 +457,7 @@ public class HeaderButtonOverlayTest {
         var overlay = new HeaderButtonOverlay(getStylesheet("""
                 .-FX-INTERNAL-header-button-container { -fx-button-placement: right; }
                 .-FX-INTERNAL-header-button { -fx-pref-width: 20; -fx-pref-height: 10; }
-            """), false, false);
+            """), false, false, false);
 
         var scene = new Scene(overlay);
 
@@ -426,7 +476,7 @@ public class HeaderButtonOverlayTest {
         var overlay = new HeaderButtonOverlay(getStylesheet("""
                 .-FX-INTERNAL-header-button-container { -fx-button-placement: right; -fx-button-vertical-alignment: stretch; }
                 .-FX-INTERNAL-header-button { -fx-pref-width: 20; -fx-pref-height: 10; }
-            """), false, false);
+            """), false, false, false);
 
         var unused = new Scene(overlay);
         overlay.resize(200, 100);

--- a/modules/javafx.graphics/src/test/java/test/com/sun/javafx/scene/layout/HeaderButtonBehaviorTest.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/javafx/scene/layout/HeaderButtonBehaviorTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.com.sun.javafx.scene.layout;
+
+import javafx.scene.Group;
+import javafx.scene.Node;
+import javafx.scene.Scene;
+import javafx.scene.layout.HeaderBar;
+import javafx.scene.layout.HeaderButtonType;
+import javafx.stage.Modality;
+import javafx.stage.Stage;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class HeaderButtonBehaviorTest {
+
+    enum ButtonDisabledStateTest {
+        RESIZABLE(true, false, false, false),
+        UNRESIZABLE(false, false, false, true),
+        MODAL_RESIZABLE(true, true, true, false),
+        MODAL_UNRESIZABLE(false, true, true, true);
+
+        ButtonDisabledStateTest(boolean resizable, boolean modal, boolean iconifyDisabled, boolean maximizeDisabled) {
+            this.resizable = resizable;
+            this.modal = modal;
+            this.iconifyDisabled = iconifyDisabled;
+            this.maximizeDisabled = maximizeDisabled;
+        }
+
+        final boolean resizable;
+        final boolean modal;
+        final boolean iconifyDisabled;
+        final boolean maximizeDisabled;
+    }
+
+    /**
+     * Tests the disabled states of the iconify and maximize buttons for all combinations
+     * of resizable and modal window attributes.
+     */
+    @ParameterizedTest
+    @EnumSource(ButtonDisabledStateTest.class)
+    void buttonDisabledStateIsCorrect(ButtonDisabledStateTest test) {
+        Node iconify = new Group(), maximize = new Group(), close = new Group();
+        HeaderBar.setButtonType(iconify, HeaderButtonType.ICONIFY);
+        HeaderBar.setButtonType(maximize, HeaderButtonType.MAXIMIZE);
+        HeaderBar.setButtonType(close, HeaderButtonType.CLOSE);
+
+        var stage = new Stage();
+        stage.initModality(test.modal ? Modality.WINDOW_MODAL : Modality.NONE);
+        stage.setResizable(test.resizable);
+        stage.setScene(new Scene(new Group(iconify, maximize, close)));
+        stage.show();
+
+        assertEquals(test.iconifyDisabled, iconify.isDisabled());
+        assertEquals(test.maximizeDisabled, maximize.isDisabled());
+        assertFalse(close.isDisabled());
+    }
+}


### PR DESCRIPTION
The window button states (disabled/hidden) of extended stages with a `HeaderButtonOverlay` or custom header buttons are inconsistent with what we would expect from the OS (Windows and Linux). To figure out what we would expect, I started with gathering some data. The following table shows the button states of system-decorated windows on various platforms:

#### Windows 11

| Window attributes | Iconify | Maximize | Close |
|---|---|---|---|
| resizable, not modal | visible | visible | visible |
| not resizable, not modal | visible | visible, disabled | visible |
| resizable, modal | visible, disabled | visible | visible |
| not resizable, modal | hidden | hidden | visible, utility-style |

#### Ubuntu 24 / Fedora 41 (GNOME)

| Window attributes | Iconify | Maximize | Close |
|---|---|---|---|
| resizable, not modal | visible | visible | visible |
| not resizable, not modal | visible | hidden | visible |
| resizable, modal | visible, _not working_ | visible, _not working_ | visible |
| not resizable, modal | visible, _not working_ | hidden | visible |

#### Kubuntu 24 (KDE)

| Window attributes | Iconify | Maximize | Close |
|---|---|---|---|
| resizable, not modal | visible | visible | visible |
| not resizable, not modal | visible | hidden | visible |
| resizable, modal | visible, _not working_ | visible | visible |
| not resizable, modal | visible, _not working_ | hidden | visible |

## Observations

1. On Windows, buttons are generally disabled when their operation is not possible with the given window attributes.
   * Exception: modal/non-resizable windows look like utility windows (iconify and maximize are hidden)
2. On GNOME and KDE, buttons are generally hidden when their operation is not possible.
   * Exception: iconify and maximize on modal windows is not hidden, but seems to simply not do anything (bug?)

## Permitted window button operations

Given the gathered observations and some simple logic, this is the table of operations that are permitted for all combinations of modal and resizable window attributes:

| Window attributes | Iconify | Maximize | Close |
|---|---|---|---|
| resizable, not modal | yes | yes | yes |
| not resizable, not modal | yes | no | yes |
| resizable, modal | no | yes | yes |
| not resizable, modal | no | no | yes |

## Fixes

This PR includes the following changes:
1. Unused code relating to window modality is removed.
2. The disabled states of `HeaderButtonOverlay` as well as `HeaderButtonBehavior` are changed to match the table above.
3. The stylesheets for GNOME and KDE are changed such that disabled buttons are hidden.
4. The stylesheet for Windows is changed such that a modal/non-resizable window looks like a utility window.