### PR TITLE
8359896: [TestBug][JUnit5] Possible configuration error

### DIFF
--- a/modules/javafx.graphics/src/test/java/test/javafx/concurrent/ServiceLifecycleTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/concurrent/ServiceLifecycleTest.java
@@ -1279,7 +1279,6 @@ public class ServiceLifecycleTest extends ServiceTestBase {
     }
 
     @RepeatedTest(50)
-    @Test
     public void cancelCalledFromOnSucceeded() {
         final AtomicInteger cancelNotificationCount = new AtomicInteger();
         service.addEventFilter(WorkerStateEvent.WORKER_STATE_SUCCEEDED, workerStateEvent -> {
@@ -1424,7 +1423,6 @@ public class ServiceLifecycleTest extends ServiceTestBase {
     }
 
     @RepeatedTest(50)
-    @Test
     public void cancelCalledFromOnFailed() {
         final AtomicInteger cancelNotificationCount = new AtomicInteger();
         service.addEventFilter(WorkerStateEvent.WORKER_STATE_FAILED, workerStateEvent -> {


### PR DESCRIPTION
A simple change to remove `@Test` annotation from two graphics unit tests.

The two tests have 2 test annotations `@Test` and `@RepeatedTest`, It results in warning message.

```
WARNING: Possible configuration error: method [public void test.javafx.concurrent.ServiceLifecycleTest.cancelCalledFromOnSucceeded()] resulted in multiple TestDescriptors
[org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor, org.junit.jupiter.engine.descriptor.TestTemplateTestDescriptor].
This is typically the result of annotating a method with multiple competing annotations such as @Test, @RepeatedTest, @ParameterizedTest, @TestFactory, etc.

WARNING: Possible configuration error: method [public void test.javafx.concurrent.ServiceLifecycleTest.cancelCalledFromOnFailed()] resulted in multiple TestDescriptors
[org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor, org.junit.jupiter.engine.descriptor.TestTemplateTestDescriptor].
This is typically the result of annotating a method with multiple competing annotations such as @Test, @RepeatedTest, @ParameterizedTest, @TestFactory, etc. 
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8359896](https://bugs.openjdk.org/browse/JDK-8359896): [TestBug][JUnit5] Possible configuration error (**Bug** - P4)


### Reviewers
 * [John Hendrikx](https://openjdk.org/census#jhendrikx) (@hjohn - **Reviewer**)
 * [Marius Hanl](https://openjdk.org/census#mhanl) (@Maran23 - Committer)
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - Committer)
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1833/head:pull/1833` \
`$ git checkout pull/1833`

Update a local copy of the PR: \
`$ git checkout pull/1833` \
`$ git pull https://git.openjdk.org/jfx.git pull/1833/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1833`

View PR using the GUI difftool: \
`$ git pr show -t 1833`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1833.diff">https://git.openjdk.org/jfx/pull/1833.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1833#issuecomment-2983340582)
</details>
