### PR TITLE
8359108: Mac - When Swing starts First, native application menu doesn't work for JavaFX

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacApplication.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacApplication.java
@@ -402,7 +402,9 @@ final class MacApplication extends Application implements InvokeLaterDispatcher.
         return true;
     }
 
-    @Override native protected boolean _supportsSystemMenu();
+    @Override protected boolean _supportsSystemMenu() {
+        return true;
+    }
 
     // NOTE: this will not return a valid result until the native _runloop
     // method has been executed and called the Runnable passed to that method.

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.h
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.h
@@ -74,4 +74,6 @@
 
 + (BOOL)syncRenderingDisabled;
 
++ (BOOL)isEmbedded;
+
 @end

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
@@ -912,6 +912,10 @@ static void inputDidChangeCallback(CFNotificationCenterRef center, void *observe
     return disableSyncRendering;
 }
 
++ (BOOL)isEmbedded {
+    return isEmbedded;
+}
+
 @end
 
 #pragma mark --- JNI
@@ -1219,18 +1223,6 @@ JNIEXPORT jobjectArray JNICALL Java_com_sun_glass_ui_mac_MacApplication_staticSc
     GLASS_CHECK_EXCEPTION(env);
 
     return screenArray;
-}
-
-
-/*
- * Class:     com_sun_glass_ui_mac_MacApplication
- * Method:    _supportsSystemMenu
- * Signature: ()Z;
- */
-JNIEXPORT jboolean JNICALL Java_com_sun_glass_ui_mac_MacApplication__1supportsSystemMenu
-(JNIEnv *env, jobject japplication)
-{
-    return !isEmbedded;
 }
 
 /*

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow+Overrides.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow+Overrides.m
@@ -61,6 +61,10 @@
 
 - (void)windowDidBecomeKey:(NSNotification *)notification
 {
+    // store host menu if running embedded, otherwise we 
+    // just store a default menu
+    self->hostMenu = [NSApp mainMenu];
+
     GET_MAIN_JENV;
     if (!self->isEnabled)
     {
@@ -80,6 +84,11 @@
 
 - (void)windowDidResignKey:(NSNotification *)notification
 {
+    // restore menu of host application if running embedded,
+    // otherwise we just restore a default menu
+    [NSApp setMainMenu:self->hostMenu];
+    [[NSApp mainMenu] update];
+
     [self _ungrabFocus];
 
     GET_MAIN_JENV_NOWARN;

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow+Overrides.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow+Overrides.m
@@ -61,7 +61,7 @@
 
 - (void)windowDidBecomeKey:(NSNotification *)notification
 {
-    // store host menu if running embedded, otherwise we 
+    // store host menu if running embedded, otherwise we
     // just store a default menu
     self->hostMenu = [NSApp mainMenu];
 

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow.h
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow.h
@@ -64,6 +64,11 @@
     BOOL                isSizeAssigned;
     BOOL                isLocationAssigned;
 
+    // Stores the menu of the host application when running embedded.
+    // This is used to allow JFX to install its own system menu
+    // without interfering with the hosting application.
+    NSMenu* hostMenu;
+
 @private
     BOOL                isWindowResizable;
 }

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow.m
@@ -889,8 +889,14 @@ JNIEXPORT jboolean JNICALL Java_com_sun_glass_ui_mac_MacWindow__1setMenubar
     {
         GlassWindow *window = getGlassWindow(env, jPtr);
         window->menubar = (GlassMenubar*)jlong_to_ptr(jMenubarPtr);
-        [NSApp setMainMenu:window->menubar->menu];
-        [[NSApp mainMenu] update];
+
+        BOOL isEmbedded = [GlassApplication isEmbedded];
+        BOOL isKeyWindow = [window->nsWindow isKeyWindow];
+
+        if (!isEmbedded || isKeyWindow) {
+            [NSApp setMainMenu:window->menubar->menu];
+            [[NSApp mainMenu] update];
+        }
     }
     GLASS_POOL_EXIT;
     GLASS_CHECK_EXCEPTION(env);

--- a/tests/system/src/test/java/test/javafx/stage/MacOSSystemMenuMultiWindowTest.java
+++ b/tests/system/src/test/java/test/javafx/stage/MacOSSystemMenuMultiWindowTest.java
@@ -58,11 +58,10 @@ import javax.swing.JMenuItem;
 import javax.swing.SwingUtilities;
 import test.util.Util;
 
-
 public class MacOSSystemMenuMultiWindowTest extends MacOSSystemMenuTestBase {
 
     @Test
-    public void testMultiWindow() throws InterruptedException, IOException {             
+    public void testMultiWindow() throws InterruptedException, IOException {
         initSwing(List.of(TEST_MENUS_0, TEST_MENUS_2));
         initJavaFX(List.of(TEST_MENUS_1, TEST_MENUS_3));
 

--- a/tests/system/src/test/java/test/javafx/stage/MacOSSystemMenuMultiWindowTest.java
+++ b/tests/system/src/test/java/test/javafx/stage/MacOSSystemMenuMultiWindowTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package test.javafx.stage;
+
+import com.sun.javafx.tk.Toolkit;
+import javafx.application.Platform;
+import javafx.scene.Scene;
+import javafx.scene.control.Menu;
+import javafx.scene.control.MenuBar;
+import javafx.scene.control.MenuItem;
+import javafx.scene.layout.BorderPane;
+import javafx.stage.Stage;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Stack;
+import java.util.concurrent.CountDownLatch;
+import java.util.stream.Collectors;
+
+import javax.swing.JFrame;
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+import javax.swing.JMenuItem;
+import javax.swing.SwingUtilities;
+import test.util.Util;
+
+
+public class MacOSSystemMenuMultiWindowTest extends MacOSSystemMenuTestBase {
+
+    @Test
+    public void testMultiWindow() throws InterruptedException, IOException {             
+        initSwing(List.of(TEST_MENUS_0, TEST_MENUS_2));
+        initJavaFX(List.of(TEST_MENUS_1, TEST_MENUS_3));
+
+        focusJavaFX(0);
+        List<Element> jfxElements = getMenusOfFocusedWindow();
+        compareMenus(jfxElements, TEST_MENUS_1);
+
+        focusJavaFX(1);
+        jfxElements = getMenusOfFocusedWindow();
+        compareMenus(jfxElements, TEST_MENUS_3);
+
+        focusSwing(0);
+        List<Element> swingElements = getMenusOfFocusedWindow();
+        compareMenus(swingElements, TEST_MENUS_0);
+
+        focusJavaFX(1);
+        jfxElements = getMenusOfFocusedWindow();
+        compareMenus(jfxElements, TEST_MENUS_3);
+
+        focusSwing(1);
+        swingElements = getMenusOfFocusedWindow();
+        compareMenus(swingElements, TEST_MENUS_2);
+    }
+}

--- a/tests/system/src/test/java/test/javafx/stage/MacOSSystemMenuSetTest.java
+++ b/tests/system/src/test/java/test/javafx/stage/MacOSSystemMenuSetTest.java
@@ -64,7 +64,7 @@ public class MacOSSystemMenuSetTest extends MacOSSystemMenuTestBase {
     private CountDownLatch latch;
 
     @Test
-    public void testSet() throws InterruptedException, IOException {             
+    public void testSet() throws InterruptedException, IOException {
         initSwing(List.of(TEST_MENUS_0));
         initJavaFX(List.of(TEST_MENUS_1));
 

--- a/tests/system/src/test/java/test/javafx/stage/MacOSSystemMenuSetTest.java
+++ b/tests/system/src/test/java/test/javafx/stage/MacOSSystemMenuSetTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package test.javafx.stage;
+
+import com.sun.javafx.tk.Toolkit;
+import javafx.application.Platform;
+import javafx.scene.Scene;
+import javafx.scene.control.Menu;
+import javafx.scene.control.MenuBar;
+import javafx.scene.control.MenuItem;
+import javafx.scene.layout.BorderPane;
+import javafx.stage.Stage;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Stack;
+import java.util.concurrent.CountDownLatch;
+import java.util.stream.Collectors;
+
+import javax.swing.JFrame;
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+import javax.swing.JMenuItem;
+import javax.swing.SwingUtilities;
+import test.util.Util;
+
+
+public class MacOSSystemMenuSetTest extends MacOSSystemMenuTestBase {
+
+    private CountDownLatch latch;
+
+    @Test
+    public void testSet() throws InterruptedException, IOException {             
+        initSwing(List.of(TEST_MENUS_0));
+        initJavaFX(List.of(TEST_MENUS_1));
+
+        focusJavaFX(0);
+        runOnFXThread(() -> javaFXMenuBars.get(0).setUseSystemMenuBar(false));
+
+        List<Element> elements = getMenusOfFocusedWindow();
+        compareMenus(elements, List.of());
+
+        runOnFXThread(() -> javaFXMenuBars.get(0).setUseSystemMenuBar(true));
+        elements = getMenusOfFocusedWindow();
+        compareMenus(elements, TEST_MENUS_1);
+
+        focusSwing(0);
+        runOnFXThread(() -> javaFXMenuBars.get(0).setUseSystemMenuBar(false));
+        elements = getMenusOfFocusedWindow();
+        compareMenus(elements, TEST_MENUS_0);
+
+        focusJavaFX(0);
+        elements = getMenusOfFocusedWindow();
+        compareMenus(elements, List.of());
+
+        focusSwing(0);
+        runOnFXThread(() -> javaFXMenuBars.get(0).setUseSystemMenuBar(true));
+        elements = getMenusOfFocusedWindow();
+        compareMenus(elements, TEST_MENUS_0);
+
+        focusJavaFX(0);
+        elements = getMenusOfFocusedWindow();
+        compareMenus(elements, TEST_MENUS_1);
+    }
+
+    private void runOnFXThread(Runnable runnable) throws InterruptedException {
+        latch = new CountDownLatch(1);
+
+        Platform.runLater(() -> {
+            runnable.run();
+            latch.countDown();
+        });
+
+        latch.await();
+    }
+}

--- a/tests/system/src/test/java/test/javafx/stage/MacOSSystemMenuSingleWindowTest.java
+++ b/tests/system/src/test/java/test/javafx/stage/MacOSSystemMenuSingleWindowTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package test.javafx.stage;
+
+import com.sun.javafx.tk.Toolkit;
+import javafx.application.Platform;
+import javafx.scene.Scene;
+import javafx.scene.control.Menu;
+import javafx.scene.control.MenuBar;
+import javafx.scene.control.MenuItem;
+import javafx.scene.layout.BorderPane;
+import javafx.stage.Stage;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Stack;
+import java.util.concurrent.CountDownLatch;
+import java.util.stream.Collectors;
+
+import javax.swing.JFrame;
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+import javax.swing.JMenuItem;
+import javax.swing.SwingUtilities;
+import test.util.Util;
+
+
+public class MacOSSystemMenuSingleWindowTest extends MacOSSystemMenuTestBase {
+
+    @Test
+    public void testSingleWindow() throws InterruptedException, IOException {             
+        initSwing(List.of(TEST_MENUS_0));
+        initJavaFX(List.of(TEST_MENUS_1));
+
+        focusJavaFX(0);
+        List<Element> jfxElements = getMenusOfFocusedWindow();
+
+        focusSwing(0);
+        List<Element> swingElements = getMenusOfFocusedWindow();
+
+        compareMenus(swingElements, TEST_MENUS_0);
+        compareMenus(jfxElements, TEST_MENUS_1);
+    }
+}

--- a/tests/system/src/test/java/test/javafx/stage/MacOSSystemMenuSingleWindowTest.java
+++ b/tests/system/src/test/java/test/javafx/stage/MacOSSystemMenuSingleWindowTest.java
@@ -62,7 +62,7 @@ import test.util.Util;
 public class MacOSSystemMenuSingleWindowTest extends MacOSSystemMenuTestBase {
 
     @Test
-    public void testSingleWindow() throws InterruptedException, IOException {             
+    public void testSingleWindow() throws InterruptedException, IOException {
         initSwing(List.of(TEST_MENUS_0));
         initJavaFX(List.of(TEST_MENUS_1));
 

--- a/tests/system/src/test/java/test/javafx/stage/MacOSSystemMenuTestBase.java
+++ b/tests/system/src/test/java/test/javafx/stage/MacOSSystemMenuTestBase.java
@@ -40,7 +40,7 @@ public class MacOSSystemMenuTestBase {
      * A utility record to represent a menu and its possible children (items)
      */
     protected static record Element(String name, List<Element> items) {
-        
+
         public Element(String name) {
             this(name, List.of());
         }
@@ -140,9 +140,9 @@ public class MacOSSystemMenuTestBase {
     private CountDownLatch latch = null;
 
     /////////////////////////////////////////////////////////
-    /// 
+    ///
     /// Helpers for creation and focusing of windows
-    /// 
+    ///
     /////////////////////////////////////////////////////////
     
     protected void initJavaFX(List<List<Element>> menus) {
@@ -194,13 +194,13 @@ public class MacOSSystemMenuTestBase {
         initLock();
 
         SwingUtilities.invokeLater(() -> {
-            swingWindows.get(id).setAlwaysOnTop(true); 
+            swingWindows.get(id).setAlwaysOnTop(true);
             swingWindows.get(id).toFront();
             swingWindows.get(id).requestFocus();
-            swingWindows.get(id).setAlwaysOnTop(false); 
+            swingWindows.get(id).setAlwaysOnTop(false);
 
             releaseLock();
-        }); 
+        });
 
         awaitLock();
     }
@@ -280,9 +280,9 @@ public class MacOSSystemMenuTestBase {
     }
 
     /////////////////////////////////////////////////////////
-    /// 
+    ///
     /// Helpers for system menu comparison
-    /// 
+    ///
     /////////////////////////////////////////////////////////
 
     /**
@@ -300,7 +300,7 @@ public class MacOSSystemMenuTestBase {
     }
 
     /**
-     * Compares two menus where the first one is with an app menu and 
+     * Compares two menus where the first one is with an app menu and
      * the last one is without an app menu. This is used for comparing
      * the hardcoded menus inside this file to the actual menus used
      * when launching the application on MacOS.
@@ -401,9 +401,9 @@ public class MacOSSystemMenuTestBase {
     }
 
     /////////////////////////////////////////////////////////
-    /// 
+    ///
     /// Helpers for synchronization
-    /// 
+    ///
     /////////////////////////////////////////////////////////
 
     private void initLock() {

--- a/tests/system/src/test/java/test/javafx/stage/MacOSSystemMenuTestBase.java
+++ b/tests/system/src/test/java/test/javafx/stage/MacOSSystemMenuTestBase.java
@@ -1,0 +1,428 @@
+package test.javafx.stage;
+
+import com.sun.javafx.tk.Toolkit;
+import javafx.application.Platform;
+import javafx.scene.Scene;
+import javafx.scene.control.Menu;
+import javafx.scene.control.MenuBar;
+import javafx.scene.control.MenuItem;
+import javafx.scene.layout.BorderPane;
+import javafx.stage.Stage;
+
+import java.awt.GraphicsDevice;
+import java.awt.GraphicsEnvironment;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Stack;
+import java.util.concurrent.CountDownLatch;
+import java.util.stream.Collectors;
+
+import javax.swing.JFrame;
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+import javax.swing.JMenuItem;
+import javax.swing.SwingUtilities;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+public class MacOSSystemMenuTestBase {
+
+    /**
+     * A utility record to represent a menu and its possible children (items)
+     */
+    protected static record Element(String name, List<Element> items) {
+        
+        public Element(String name) {
+            this(name, List.of());
+        }
+    }
+
+    /**
+     * Test menu bar contents 0
+     */
+    protected static final List<Element> TEST_MENUS_0 = List.of(
+            new Element("MyFile", List.of(
+                    new Element("New", List.of(
+                            new Element("Project"),
+                            new Element("Module"),
+                            new Element("File")
+                    )),
+                    new Element("Open"),
+                    new Element("Save")
+            )),
+            new Element("MyEdit", List.of(
+                    new Element("Undo"),
+                    new Element("Redo")
+            ))
+    );
+
+    /**
+     * Test menu bar contents 1
+     */
+    protected static final List<Element> TEST_MENUS_1 = List.of(
+            new Element("MyView", List.of(
+                    new Element("Windows", List.of(
+                            new Element("Editor"),
+                            new Element("Project"),
+                            new Element("Debugger")
+                    )),
+                    new Element("Appearance")
+            )),
+            new Element("MyNavigate", List.of(
+                    new Element("Class..."),
+                    new Element("Files..."),
+                    new Element("Symbol..."),
+                    new Element("Text..."),
+                    new Element("File", List.of(
+                            new Element("Next Method"),
+                            new Element("Next Field")
+                    ))
+            ))
+    );
+
+    /**
+     * Test menu bar contents 2
+     */
+    protected static final List<Element> TEST_MENUS_2 = List.of(
+            new Element("MyTasks", List.of(
+                    new Element("Create", List.of(
+                            new Element("New")
+                    )),
+                    new Element("Read"),
+                    new Element("Update"),
+                    new Element("Delete")
+            )),
+            new Element("MyCalender", List.of(
+                    new Element("Dates", List.of(
+                            new Element("Year"),
+                            new Element("Month"),
+                            new Element("Day")
+                    )),
+                    new Element("Time")
+            )),
+            new Element("Opt 1"),
+            new Element("Opt 2"),
+            new Element("Opt 3")
+    );
+
+    /**
+     * Test menu bar contents 3
+     */
+    protected static final List<Element> TEST_MENUS_3 = List.of(
+            new Element("MyImages", List.of(
+                    new Element("Scale", List.of(
+                            new Element("Small"),
+                            new Element("Medium"),
+                            new Element("Large")
+                    )),
+                    new Element("Color"),
+                    new Element("Pixels"),
+                    new Element("Shadow"),
+                    new Element("Shapes")
+            ))
+    );
+
+    protected final List<MenuBar> javaFXMenuBars = new ArrayList<>();
+
+    protected final List<Stage> javaFXWindows = new ArrayList<>();
+
+    protected final List<JFrame> swingWindows = new ArrayList<>();
+
+    private CountDownLatch latch = null;
+
+    /////////////////////////////////////////////////////////
+    /// 
+    /// Helpers for creation and focusing of windows
+    /// 
+    /////////////////////////////////////////////////////////
+    
+    protected void initJavaFX(List<List<Element>> menus) {
+        initJavaFX(false, menus);
+    }
+
+    protected void initJavaFX(boolean fullscreen, List<List<Element>> menus) {
+        assert menus.size() > 0;
+        initLock();
+
+        Platform.startup(() -> {
+            for (int i = 0; i < menus.size(); i++) {
+                initJavaFXWindow(fullscreen, i, menus.get(i));
+            }
+
+            releaseLock();
+        });
+
+        awaitLock();
+    }
+
+    protected void initSwing(List<List<Element>> menus) {
+        initSwing(false, menus);
+    }
+
+    protected void initSwing(boolean fullscreen, List<List<Element>> menus) {
+        assert menus.size() > 0;
+        System.setProperty("apple.laf.useScreenMenuBar", "true");
+
+        for (int i = 0; i < menus.size(); i++) {
+            initSwingWindow(fullscreen, i, menus.get(i));
+        }
+    }
+
+    protected void focusJavaFX(int id) {
+        initLock();
+
+        Platform.runLater(() -> {
+            javaFXWindows.get(id).toFront();
+            javaFXWindows.get(id).requestFocus();
+
+            releaseLock();
+        });
+
+        awaitLock();
+    }
+
+    protected void focusSwing(int id) {
+        initLock();
+
+        SwingUtilities.invokeLater(() -> {
+            swingWindows.get(id).setAlwaysOnTop(true); 
+            swingWindows.get(id).toFront();
+            swingWindows.get(id).requestFocus();
+            swingWindows.get(id).setAlwaysOnTop(false); 
+
+            releaseLock();
+        }); 
+
+        awaitLock();
+    }
+
+    protected void initJavaFXWindow(boolean fullscreen, int id, List<Element> menus) {
+        MenuBar menuBar = new MenuBar();
+        BorderPane root = new BorderPane();
+        Scene scene = new Scene(root);
+        Stage window = new Stage();
+
+        for (Element menu : menus) {
+            menuBar.getMenus().add(createJavaFXMenu(menu));
+        }
+
+        menuBar.setUseSystemMenuBar(true);
+        root.setTop(menuBar);
+        window.setScene(scene);
+        window.setTitle("JavaFX Window [" + id + "]");
+        window.setFullScreen(fullscreen);
+        window.show();
+
+        javaFXMenuBars.add(menuBar);
+        javaFXWindows.add(window);
+    }
+
+    protected Menu createJavaFXMenu(Element element) {
+        Menu menu = new Menu(element.name);
+
+        for (Element item : element.items) {
+            if (item.items.isEmpty()) {
+                menu.getItems().add(new MenuItem(item.name));
+            } else {
+                menu.getItems().add(createJavaFXMenu(item));
+            }
+        }
+
+        return menu;
+    }
+
+    protected void initSwingWindow(boolean fullscreen, int id, List<Element> menus) {
+        JMenuBar menuBar = new JMenuBar();
+        JFrame window = new JFrame();
+
+        for (Element menu : menus) {
+            menuBar.add(createSwingMenu(menu));
+        }
+
+        if (fullscreen) {
+            GraphicsEnvironment ge = GraphicsEnvironment.getLocalGraphicsEnvironment();
+            GraphicsDevice gd = ge.getDefaultScreenDevice();
+
+            window.setUndecorated(true);
+            window.setResizable(false);
+            gd.setFullScreenWindow(window);
+        }
+
+        window.setJMenuBar(menuBar);
+        window.setTitle("Swing Window [" + id + "]");
+        window.setSize(400, 200);
+        window.setVisible(true);
+
+        swingWindows.add(window);
+    }
+
+    protected JMenu createSwingMenu(Element element) {
+        JMenu menu = new JMenu(element.name);
+
+        for (Element item : element.items) {
+            if (item.items.isEmpty()) {
+                menu.add(new JMenuItem(item.name));
+            } else {
+                menu.add(createSwingMenu(item));
+            }
+        }
+
+        return menu;
+    }
+
+    /////////////////////////////////////////////////////////
+    /// 
+    /// Helpers for system menu comparison
+    /// 
+    /////////////////////////////////////////////////////////
+
+    /**
+     * Compares the app menus of the provided menu bars. The app menu
+     * is the menu after the apple menu.
+     */
+    protected void compareAppMenus(List<Element> first, List<Element> second) {
+        assertFalse(first.isEmpty(), "No app menu present");
+        assertFalse(second.isEmpty(), "No app menu present");
+
+        Element firstElement = first.get(0);
+        Element secondElement = second.get(0);
+
+        assertEquals(firstElement, secondElement, "App menus are not identical");
+    }
+
+    /**
+     * Compares two menus where the first one is with an app menu and 
+     * the last one is without an app menu. This is used for comparing
+     * the hardcoded menus inside this file to the actual menus used
+     * when launching the application on MacOS.
+     */
+    protected void compareMenus(List<Element> withAppMenu, List<Element> withoutAppMenu) {
+        withAppMenu = new ArrayList<>(withAppMenu);
+
+        assertFalse(withAppMenu.isEmpty(), "No app menu present");
+        withAppMenu.remove(0);
+
+        assertTrue(withAppMenu.size() == withoutAppMenu.size(), "Menu size is different: " + withAppMenu.size() + " != " + withoutAppMenu.size());
+
+        for (int i = 0; i < withAppMenu.size(); i++) {
+            assertEquals(withAppMenu.get(i), withoutAppMenu.get(i), "Menus are different");
+        }
+    }
+
+    /**
+     * Returns the menu bar and its menu items for the currently
+     * active window. The result does not contain the apple menu.
+     */
+    protected List<Element> getMenusOfFocusedWindow() throws IOException {
+        List<Element> result = getMenusOfFocusedWindow(new Stack<>());
+        // remove apple menu
+        result.remove(0);
+
+        return result;
+    }
+
+    private List<Element> getMenusOfFocusedWindow(Stack<Integer> indices) throws IOException {
+        Process process = getMenuReaderProcess(indices);
+
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getErrorStream()))) {
+            String lines = getMenuReaderProcess(process.getInputStream());
+            String error = getMenuReaderProcess(process.getErrorStream());
+
+            assertTrue(error.isEmpty(), error);
+
+            List<Element> result = new ArrayList<>();
+            List<String> parts = Arrays.stream(lines.split(", "))
+                    .filter(part -> !part.equals("missing value"))
+                    .collect(Collectors.toList());
+
+            if (lines.isEmpty()) {
+                return result;
+            }
+
+            for (int i = 0; i < parts.size(); i++) {
+                indices.push(i + 1);
+                List<Element> elements = getMenusOfFocusedWindow(indices);
+                indices.pop();
+
+                result.add(new Element(parts.get(i), elements));
+            }
+
+            return result;
+        }
+    }
+
+    /**
+     * Returns the process used for retreiving the menu items
+     * of the currently active window. For this 'osascript' is
+     * used as a java process.
+     */
+    private static Process getMenuReaderProcess(Stack<Integer> indices) throws IOException {
+        StringBuilder arg = new StringBuilder(indices.isEmpty()
+                ? "menus"
+                : "menu items");
+
+        for (int i = indices.size() - 1; i >= 0; i--) {
+            if (i == 0) {
+                arg.append(" of menu " + indices.get(i) + " ");
+            } else {
+                arg.append(" of menu of menu item " + indices.get(i) + " ");
+            }
+        }
+
+        String[] command = { "osascript", "-e", "tell application \"System Events\" to tell (first process whose frontmost is true) to get name of " + arg + " of menu bar 1"};
+        return new ProcessBuilder(command).start();
+    }
+
+    /**
+     * Safely gets the output of a process. For this the input stream
+     * of the process is supplied. This input stream can either be the
+     * normal input stream or the error input stream.
+     */
+    private static String getMenuReaderProcess(InputStream in) throws IOException {
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(in))) {
+            StringBuilder result = new StringBuilder();
+            String line;
+
+            while ((line = reader.readLine()) != null) {
+                result.append(line);
+            }
+
+            return result.toString();
+        }
+    }
+
+    /////////////////////////////////////////////////////////
+    /// 
+    /// Helpers for synchronization
+    /// 
+    /////////////////////////////////////////////////////////
+
+    private void initLock() {
+        latch = new CountDownLatch(1);
+    }
+
+    private void awaitLock() {
+        try {
+            latch.await();
+        } catch (InterruptedException e) {}
+    }
+
+    private void releaseLock() {
+        latch.countDown();
+    }
+
+    protected void sleep(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (Exception e) {}
+    }
+}

--- a/tests/system/src/test/java/test/javafx/stage/MacOSSystemMenuTestBase.java
+++ b/tests/system/src/test/java/test/javafx/stage/MacOSSystemMenuTestBase.java
@@ -144,7 +144,7 @@ public class MacOSSystemMenuTestBase {
     /// Helpers for creation and focusing of windows
     ///
     /////////////////////////////////////////////////////////
-    
+
     protected void initJavaFX(List<List<Element>> menus) {
         initJavaFX(false, menus);
     }


### PR DESCRIPTION
This pull request fixes the system menu bar on Mac when combining windows of Swing and JavaFX.

The first issue was to get the native menu bar working simultaneously on Swing and JavaFX, which was done by just returning always true inside the supportsSystemMenu method.

The second issue was to remove all system menu items installed by a swing window. This was fixed by checking the system menu bar every time an item is inserted or removed and removing all menu items that are not owned by JavaFX. This check is done on every insert and remove as JavaFX does not have a clear method inside the MenuBarDelegate class that could be called every time the window gets the focus.

I tested the fix with two Swing and two JavaFX windows that are run inside the same application and it worked without any errors, but on further testing I noticed some issues with the menu bar. I am currently writing the test and fixes for it.

Co-Author: @FlorianKirmaier

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8359108](https://bugs.openjdk.org/browse/JDK-8359108): Mac - When Swing starts First, native application menu doesn't work for JavaFX (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1835/head:pull/1835` \
`$ git checkout pull/1835`

Update a local copy of the PR: \
`$ git checkout pull/1835` \
`$ git pull https://git.openjdk.org/jfx.git pull/1835/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1835`

View PR using the GUI difftool: \
`$ git pr show -t 1835`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1835.diff">https://git.openjdk.org/jfx/pull/1835.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1835#issuecomment-2985695103)
</details>
