### PR TITLE
8357714: AudioClip.play crash on macOS when loading resource from jar

### DIFF
--- a/modules/javafx.media/src/main/native/jfxmedia/platform/osx/OSXMediaPlayer.mm
+++ b/modules/javafx.media/src/main/native/jfxmedia/platform/osx/OSXMediaPlayer.mm
@@ -327,6 +327,7 @@ JNIEXPORT void JNICALL Java_com_sun_media_jfxmediaimpl_platform_osx_OSXMediaPlay
     if ([scheme caseInsensitiveCompare:@"jar"] == NSOrderedSame ||
         [scheme caseInsensitiveCompare:@"jrt"] == NSOrderedSame) {
         CJavaInputStreamCallbacks *callbacks = new (nothrow) CJavaInputStreamCallbacks();
+        jobject jConnectionHolder = CLocator::CreateConnectionHolder(env, jLocator);
         if (callbacks == NULL) {
             [mediaURL release];
             LOGGER_WARNMSG("OSXMediaPlayer: Unable to create CJavaInputStreamCallbacks\n");
@@ -335,7 +336,7 @@ JNIEXPORT void JNICALL Java_com_sun_media_jfxmediaimpl_platform_osx_OSXMediaPlay
             return;
         }
 
-        if (!callbacks->Init(env, jLocator)) {
+        if (!callbacks->Init(env, jConnectionHolder)) {
             [mediaURL release];
             delete callbacks;
             LOGGER_WARNMSG("OSXMediaPlayer: callbacks->Init() failed\n");

--- a/modules/javafx.media/src/main/native/jfxmedia/platform/osx/avf/AVFMediaPlayer.mm
+++ b/modules/javafx.media/src/main/native/jfxmedia/platform/osx/avf/AVFMediaPlayer.mm
@@ -803,8 +803,16 @@ static CVReturn displayLinkCallback(CVDisplayLinkRef displayLink,
         }
 
         NSMutableData* readData = nil;
+        bool isRandomAccess = locatorStream->GetCallbacks()->IsRandomAccess();
+        int64_t pos = 0;
+        int size = 65536;
         while (requestedLength > 0) {
-            unsigned int blockSize = locatorStream->GetCallbacks()->ReadNextBlock();
+            unsigned int blockSize = -1;
+            if (isRandomAccess) {
+                blockSize = locatorStream->GetCallbacks()->ReadBlock(pos, size);
+            } else {
+                blockSize = locatorStream->GetCallbacks()->ReadNextBlock();
+            }
             if (blockSize <= 0) {
                 break;
             }
@@ -818,6 +826,7 @@ static CVReturn displayLinkCallback(CVDisplayLinkRef displayLink,
             [loadingRequest.dataRequest respondWithData:readData];
 
             requestedLength -= readSize;
+            pos += readSize;
         }
 
         [loadingRequest finishLoading];


### PR DESCRIPTION
After JDK-8287822 (https://bugs.openjdk.org/browse/JDK-8287822), mpeg file content is no longer played via GSTPlatform but via OSXPlatform. 
We need to correctly handle data in case the source is a file inside a jar, in which case CJavaInputStreamCallbacks is used.

The 2 changes I made are:
1. Use ConnectionHolder instead of Locator for CJavaInputStreamCallbacks in case a jar resource is used.
2. In case of random access datasource, use readBlock instead of readNextBlock in AVMediaPlayer