### PR TITLE
8361379: [macos] Refactor accessibility code to retrieve attribute by name

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/mac/a11y/AccessibleBase.h
+++ b/modules/javafx.graphics/src/main/native-glass/mac/a11y/AccessibleBase.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,6 +36,7 @@ id parent;
 }
 - (id)initWithEnv:(JNIEnv*)env accessible:(jobject)jAccessible;
 - (jobject)getJAccessible;
+- (id)requestNodeAttribute:(NSString *)attribute;
 - (NSRect)accessibilityFrame;
 - (id)accessibilityParent;
 - (BOOL)isAccessibilityElement;

--- a/modules/javafx.graphics/src/main/native-glass/mac/a11y/AccessibleBase.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/a11y/AccessibleBase.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,8 +47,7 @@ static NSMutableDictionary * rolesMap;
     [rolesMap setObject:@"JFXButtonAccessibility" forKey:@"INCREMENT_BUTTON"];
     [rolesMap setObject:@"JFXButtonAccessibility" forKey:@"SPLIT_MENU_BUTTON"];
     [rolesMap setObject:@"JFXRadiobuttonAccessibility" forKey:@"RADIO_BUTTON"];
-//  Requires TAB_GROUP to be implemented first
-//  [rolesMap setObject:@"JFXRadiobuttonAccessibility" forKey:@"TAB_ITEM"];
+    [rolesMap setObject:@"JFXRadiobuttonAccessibility" forKey:@"TAB_ITEM"];
     [rolesMap setObject:@"JFXRadiobuttonAccessibility" forKey:@"PAGE_ITEM"];
     [rolesMap setObject:@"JFXCheckboxAccessibility" forKey:@"CHECK_BOX"];
     [rolesMap setObject:@"JFXCheckboxAccessibility" forKey:@"TOGGLE_BUTTON"];
@@ -97,46 +96,44 @@ static NSMutableDictionary * rolesMap;
     [super dealloc];
 }
 
-- (jobject)getJAccessible
-{
+- (jobject)getJAccessible {
     return self->jAccessible;
+}
+
+/*
+ * Request accessibility attribute by name from JavaFX Node. Returns attribute value
+ * converted to the native format or NULL if attribute with that name does not exist.
+ * Code that uses this function needs to convert NULL to the default value of a certain type where required.
+ */
+- (id)requestNodeAttribute:(NSString *)attribute
+{
+    jobject jresult = NULL;
+    GET_MAIN_JENV;
+    if (env == NULL) return NULL;
+    jresult = (jobject)(*env)->CallLongMethod(env, [self getJAccessible],
+                                              jAccessibilityAttributeValue, (jlong)attribute);
+    GLASS_CHECK_EXCEPTION(env);
+    return variantToID(env, jresult);
 }
 
 - (id)accessibilityValue
 {
-    jobject jresult = NULL;
-    GET_MAIN_JENV;
-    if (env == NULL) return NULL;
-    jresult = (jobject)(*env)->CallLongMethod(env, self->jAccessible, jAccessibilityAttributeValue, (jlong)@"AXValue");
-    GLASS_CHECK_EXCEPTION(env);
-    return variantToID(env, jresult);
+    return [self requestNodeAttribute:@"AXValue"];
 }
 
 - (id)accessibilityMinValue
 {
-    jobject jresult = NULL;
-    GET_MAIN_JENV;
-    if (env == NULL) return NULL;
-    jresult = (jobject)(*env)->CallLongMethod(env, self->jAccessible,
-                                              jAccessibilityAttributeValue, (jlong)@"AXMinValue");
-    GLASS_CHECK_EXCEPTION(env);
-    return variantToID(env, jresult);
+    return [self requestNodeAttribute:@"AXMinValue"];
 }
 
 - (id)accessibilityMaxValue
 {
-    jobject jresult = NULL;
-    GET_MAIN_JENV;
-    if (env == NULL) return NULL;
-    jresult = (jobject)(*env)->CallLongMethod(env, self->jAccessible,
-                                              jAccessibilityAttributeValue, (jlong)@"AXMaxValue");
-    GLASS_CHECK_EXCEPTION(env);
-    return variantToID(env, jresult);
+    return [self requestNodeAttribute:@"AXMaxValue"];
 }
 
 - (NSString *)accessibilityLabel
 {
-    // Use the same value that is set for accessibilityTitle - some component
+    // Use the same value that is set for accessibilityTitle - some components
     // do not have titles and request it as a label
     return [self accessibilityTitle];
 }
@@ -144,59 +141,29 @@ static NSMutableDictionary * rolesMap;
 - (id)accessibilityParent
 {
     if (parent == nil) {
-        jobject jresult = NULL;
-        GET_MAIN_JENV;
-        if (env == NULL) return NULL;
-        jresult = (jobject)(*env)->CallLongMethod(env, self->jAccessible, jAccessibilityAttributeValue,
-                                                  (jlong) @"AXParent");
-        GLASS_CHECK_EXCEPTION(env);
-        parent = variantToID(env, jresult);
+        parent = [self requestNodeAttribute:@"AXParent"];
     }
     return parent;
 }
 
 - (id)accessibilityTitle
 {
-    jobject jresult = NULL;
-    GET_MAIN_JENV;
-    if (env == NULL) return NULL;
-    jresult = (jobject)(*env)->CallLongMethod(env, self->jAccessible,
-                                              jAccessibilityAttributeValue, (jlong)@"AXTitle");
-    GLASS_CHECK_EXCEPTION(env);
-    return variantToID(env, jresult);
+    return [self requestNodeAttribute:@"AXTitle"];
 }
 
 - (id)accessibilityTitleUIElement
 {
-    jobject jresult = NULL;
-    GET_MAIN_JENV;
-    if (env == NULL) return NULL;
-    jresult = (jobject)(*env)->CallLongMethod(env, self->jAccessible, jAccessibilityAttributeValue,
-                                              (jlong)@"AXTitleUIElement");
-    GLASS_CHECK_EXCEPTION(env);
-    return variantToID(env, jresult);
+    return [self requestNodeAttribute:@"AXTitleUIElement"];
 }
 
 - (NSArray *)accessibilityChildren
 {
-    jobject jresult = NULL;
-    GET_MAIN_JENV;
-    if (env == NULL) return NULL;
-    jresult = (jobject)(*env)->CallLongMethod(env, self->jAccessible,
-                                              jAccessibilityAttributeValue, (jlong)@"AXChildren");
-    GLASS_CHECK_EXCEPTION(env);
-    return variantToID(env, jresult);
+    return [self requestNodeAttribute:@"AXChildren"];
 }
 
 - (id)accessibilityRoleDescription
 {
-    jobject jresult = NULL;
-    GET_MAIN_JENV;
-    if (env == NULL) return NULL;
-    jresult = (jobject)(*env)->CallLongMethod(env, self->jAccessible, jAccessibilityAttributeValue,
-                                              (jlong)@"AXRoleDescription");
-    GLASS_CHECK_EXCEPTION(env);
-    return variantToID(env, jresult);
+    return [self requestNodeAttribute:@"AXRoleDescription"];
 }
 
 
@@ -219,15 +186,13 @@ static NSMutableDictionary * rolesMap;
 
 - (NSRect)accessibilityFrame
 {
-    jobject jresult = NULL;
-    GET_MAIN_JENV;
-    if (env == NULL) return NSZeroRect;
-    jresult = (jobject)(*env)->CallLongMethod(env, self->jAccessible, jAccessibilityAttributeValue, (jlong)@"AXPosition");
-    GLASS_CHECK_EXCEPTION(env);
-    NSPoint position = [variantToID(env, jresult) pointValue];
-    jresult = (jobject)(*env)->CallLongMethod(env, self->jAccessible, jAccessibilityAttributeValue, (jlong)@"AXSize");
-    GLASS_CHECK_EXCEPTION(env);
-    NSSize size = [variantToID(env, jresult) sizeValue];
+    id p = [self requestNodeAttribute:@"AXPosition"];
+    id s = [self requestNodeAttribute:@"AXSize"];
+    if (p == NULL || s == NULL) {
+        return NSZeroRect;
+    }
+    NSPoint position = [p pointValue];
+    NSSize size = [s sizeValue];
     return NSMakeRect(position.x, position.y, size.width, size.height);
 }
 
@@ -244,13 +209,12 @@ static NSMutableDictionary * rolesMap;
 
 - (BOOL)isAccessibilityFocused
 {
-    jobject jresult = NULL;
-    GET_MAIN_JENV;
-    if (env == NULL) return NO;
-    jresult = (jobject)(*env)->CallLongMethod(env, self->jAccessible, jAccessibilityAttributeValue, (jlong)@"AXFocused");
-    GLASS_CHECK_EXCEPTION(env);
-
-    return [variantToID(env, jresult) boolValue];
+    id retval = [self requestNodeAttribute:@"AXFocused"];
+    if (retval == NULL) {
+        return NO;
+    } else {
+        return [retval boolValue];
+    }
 }
 
 - (void)setAccessibilityFocused:(BOOL)value

--- a/modules/javafx.graphics/src/main/native-glass/mac/a11y/AccessibleBase.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/a11y/AccessibleBase.m
@@ -96,7 +96,8 @@ static NSMutableDictionary * rolesMap;
     [super dealloc];
 }
 
-- (jobject)getJAccessible {
+- (jobject)getJAccessible
+{
     return self->jAccessible;
 }
 

--- a/modules/javafx.graphics/src/main/native-glass/mac/a11y/AccessibleBase.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/a11y/AccessibleBase.m
@@ -108,10 +108,9 @@ static NSMutableDictionary * rolesMap;
  */
 - (id)requestNodeAttribute:(NSString *)attribute
 {
-    jobject jresult = NULL;
     GET_MAIN_JENV;
     if (env == NULL) return NULL;
-    jresult = (jobject)(*env)->CallLongMethod(env, [self getJAccessible],
+    jobject jresult = (jobject)(*env)->CallLongMethod(env, [self getJAccessible],
                                               jAccessibilityAttributeValue, (jlong)attribute);
     GLASS_CHECK_EXCEPTION(env);
     return variantToID(env, jresult);

--- a/modules/javafx.graphics/src/main/native-glass/mac/a11y/JFXTabGroupAccessibility.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/a11y/JFXTabGroupAccessibility.m
@@ -50,14 +50,7 @@
 
 - (NSArray *)accessibilityTabs
 {
-    jobject jresult = NULL;
-    GET_MAIN_JENV;
-    if (env == NULL) return NULL;
-    jresult = (jobject)(*env)->CallLongMethod(env, [self getJAccessible],
-                                              jAccessibilityAttributeValue,
-                                              (jlong)@"AXTabs");
-    GLASS_CHECK_EXCEPTION(env);
-    return variantToID(env, jresult);
+    return [self requestNodeAttribute:@"AXTabs"];
 }
 
 @end


### PR DESCRIPTION
- Copyright year update;
- Introduce new function requestNodeAttribute and refactor code to use it;
- Fix some typos;
- Enable new code to handle TabPages since TabGroup was implemented;

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8361379](https://bugs.openjdk.org/browse/JDK-8361379): [macos] Refactor accessibility code to retrieve attribute by name (**Enhancement** - P3)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1840/head:pull/1840` \
`$ git checkout pull/1840`

Update a local copy of the PR: \
`$ git checkout pull/1840` \
`$ git pull https://git.openjdk.org/jfx.git pull/1840/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1840`

View PR using the GUI difftool: \
`$ git pr show -t 1840`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1840.diff">https://git.openjdk.org/jfx/pull/1840.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1840#issuecomment-3033834288)
</details>
