### PR TITLE
8361710: Mark QPathTest as unstable on all platforms

### DIFF
--- a/tests/system/src/test/java/test/com/sun/marlin/QPathTest.java
+++ b/tests/system/src/test/java/test/com/sun/marlin/QPathTest.java
@@ -29,7 +29,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
-import com.sun.javafx.PlatformUtil;
 import java.util.Locale;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -152,9 +151,7 @@ public class QPathTest {
     @Test
     @Timeout(value=15000, unit=TimeUnit.MILLISECONDS)
     public void TestBug() {
-        if (PlatformUtil.isLinux()) {
-            assumeTrue(Boolean.getBoolean("unstable.test")); // JDK-8328222
-        }
+        assumeTrue(Boolean.getBoolean("unstable.test")); // JDK-8328222
 
         Platform.runLater(() -> {
             SVGPath path = new SVGPath();


### PR DESCRIPTION
This PR marks QPathTest as "unstable" on all platforms. QPathTest is known to timeout intermittently. See [JDK-8328222](https://bugs.openjdk.org/browse/JDK-8328222). It is already skipped on Linux, since it was causing a lot of noise in our nightly and developer headful test runs. In the last few months, we've seen an increase of failures, especially when running tests with JDK 24 or 25. As a result, I will mark the test as unstable on all platforms by removing the `isLinux()` check.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361710](https://bugs.openjdk.org/browse/JDK-8361710): Mark QPathTest as unstable on all platforms (**Bug** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1841/head:pull/1841` \
`$ git checkout pull/1841`

Update a local copy of the PR: \
`$ git checkout pull/1841` \
`$ git pull https://git.openjdk.org/jfx.git pull/1841/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1841`

View PR using the GUI difftool: \
`$ git pr show -t 1841`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1841.diff">https://git.openjdk.org/jfx/pull/1841.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1841#issuecomment-3057784567)
</details>
