### PR TITLE
8361713: JavaFX API docs overview is missing an intro section

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4571,7 +4571,15 @@ task createMSPfile() {
     }
 }
 
-task javadoc(type: Javadoc, dependsOn: createMSPfile) {
+task createOverviewFile(type: Copy) {
+    from "${rootProject.projectDir}/overview.html"
+    into rootProject.buildDir
+    filter { line ->
+        line.replaceAll("@JAVADOC_VERSION@", jfxReleaseMajorVersion)
+    }
+}
+
+task javadoc(type: Javadoc, dependsOn: [createMSPfile, createOverviewFile]) {
     group = "Basic"
     description = "Generates the JavaDoc for all the public API"
     executable = JAVADOC
@@ -4618,6 +4626,9 @@ task javadoc(type: Javadoc, dependsOn: createMSPfile) {
     options.addStringOption("-since-label").setValue("New API since JavaFX 9")
     options.addStringOption("Xmaxwarns").setValue("1000")
     options.addStringOption("Xmaxerrs").setValue("1000")
+
+    String overviewFile = "$buildDir/overview.html"
+    options.addStringOption("overview").setValue(overviewFile)
 
     String draftMsg = IS_MILESTONE_FCS ? "" : "<br><b>DRAFT ${RELEASE_VERSION_LONG}</b>"
     String javadocTitleImpl = javadocTitle

--- a/overview.html
+++ b/overview.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <h1 id="javafx-overview" class="title">JavaFX Software Development Kit<br>
+    Version @JAVADOC_VERSION@ API Specification</h1>
+
+    The JavaFX API is composed of the following groups of modules:
+
+    <ul>
+      <li>Core JavaFX Modules: These APIs are in modules whose names start with <code>javafx</code>. They are part of the core JavaFX platform.</li>
+      <li>JavaScript Object: These APIs are in the <code>jdk.jsobject</code> module.
+      <li>Incubator Modules: These APIs are in modules whose names start with <code>jfx.incubator</code>. They are experimental APIs subject to modification or removal in subsequent versions of JavaFX.</li>
+    </ul>
+  </body>
+</html>


### PR DESCRIPTION
This PR adds an introductory section to the JavaFX 24 API docs similar to that of the JDK docs.