### PR TITLE
8362091: Window title bar should reflect scene color scheme

### DIFF
--- a/buildSrc/win.gradle
+++ b/buildSrc/win.gradle
@@ -326,9 +326,9 @@ WIN.glass.rcFlags = [
 WIN.glass.ccFlags = [ccFlags].flatten()
 WIN.glass.linker = linker
 WIN.glass.linkFlags = (IS_STATIC_BUILD ? [linkFlags] : [linkFlags, "delayimp.lib", "gdi32.lib", "urlmon.lib", "Comdlg32.lib",
-        "winmm.lib", "imm32.lib", "shell32.lib", "Uiautomationcore.lib", "dwmapi.lib",
+        "winmm.lib", "imm32.lib", "shell32.lib", "Uiautomationcore.lib", "dwmapi.lib", "version.lib",
         "/DELAYLOAD:user32.dll", "/DELAYLOAD:urlmon.dll", "/DELAYLOAD:winmm.dll", "/DELAYLOAD:shell32.dll",
-        "/DELAYLOAD:Uiautomationcore.dll", "/DELAYLOAD:dwmapi.dll"]).flatten()
+        "/DELAYLOAD:Uiautomationcore.dll", "/DELAYLOAD:dwmapi.dll", "/DELAYLOAD:version.dll"]).flatten()
 WIN.glass.lib = "glass"
 
 WIN.decora = [:]

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Window.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Window.java
@@ -173,6 +173,11 @@ public abstract class Window {
      */
     @Native public static final int MODAL = 1 << 10;
 
+    /**
+     * Indicates that the window should use a dark window frame.
+     */
+    @Native public static final int DARK_FRAME = 1 << 11;
+
     final static public class State {
         @Native public static final int NORMAL = 1;
         @Native public static final int MINIMIZED = 2;
@@ -986,6 +991,8 @@ public abstract class Window {
         checkNotClosed();
         return _setBackground(this.ptr, r, g, b);
     }
+
+    public void setDarkFrame(boolean value) {}
 
     public boolean isEnabled() {
         Application.checkEventThread();

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacWindow.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacWindow.java
@@ -113,6 +113,13 @@ final class MacWindow extends Window {
 
     private native void _setIcon(long ptr, Object iconBuffer, int width, int height);
 
+    @Override
+    public void setDarkFrame(boolean value) {
+        _setDarkFrame(getRawHandle(), value);
+    }
+
+    private native void _setDarkFrame(long ptr, boolean value);
+
     @Override native protected void _toFront(long ptr);
     @Override native protected void _toBack(long ptr);
     @Override native protected void _enterModal(long ptr);

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinWindow.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinWindow.java
@@ -265,6 +265,13 @@ class WinWindow extends Window {
         return true;
     }
 
+    private native void _setDarkFrame(long ptr, boolean value);
+
+    @Override
+    public void setDarkFrame(boolean value) {
+        _setDarkFrame(getRawHandle(), value);
+    }
+
     native private long _getInsets(long ptr);
     native private long _getAnchor(long ptr);
     native private void _showSystemMenu(long ptr, int x, int y);

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/DummyToolkit.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/DummyToolkit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -101,7 +101,8 @@ final public class DummyToolkit extends Toolkit {
     }
 
     @Override
-    public TKStage createTKStage(Window peerWindow, StageStyle stageStyle, boolean primary, Modality modality, TKStage owner, boolean rtl) {
+    public TKStage createTKStage(Window peerWindow, StageStyle stageStyle, boolean primary,
+                                 Modality modality, TKStage owner, boolean rtl, boolean darkFrame) {
         throw new UnsupportedOperationException("Not supported yet.");
     }
 

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/TKStage.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/TKStage.java
@@ -124,6 +124,8 @@ public interface TKStage {
 
     public void setPrefHeaderButtonHeight(double height);
 
+    public void setDarkFrame(boolean value);
+
     // =================================================================================================================
     // Functions
 

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/Toolkit.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/Toolkit.java
@@ -360,7 +360,8 @@ public abstract class Toolkit {
 
     public abstract boolean isNestedLoopRunning();
 
-    public abstract TKStage createTKStage(Window peerWindow, StageStyle stageStyle, boolean primary, Modality modality, TKStage owner, boolean rtl);
+    public abstract TKStage createTKStage(Window peerWindow, StageStyle stageStyle, boolean primary,
+                                          Modality modality, TKStage owner, boolean rtl, boolean darkFrame);
 
     public abstract TKStage createTKPopupStage(Window peerWindow, StageStyle popupStyle, TKStage owner);
     public abstract TKStage createTKEmbeddedStage(HostInterface host);

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassStage.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassStage.java
@@ -77,6 +77,9 @@ abstract class GlassStage implements TKStage {
     @Override
     public void setPrefHeaderButtonHeight(double height) {}
 
+    @Override
+    public void setDarkFrame(boolean value) {}
+
     protected final GlassScene getScene() {
         return scene;
     }

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/QuantumToolkit.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/QuantumToolkit.java
@@ -608,9 +608,10 @@ public final class QuantumToolkit extends Toolkit {
         }
     }
 
-    @Override public TKStage createTKStage(Window peerWindow, StageStyle stageStyle, boolean primary, Modality modality, TKStage owner, boolean rtl) {
+    @Override public TKStage createTKStage(Window peerWindow, StageStyle stageStyle, boolean primary,
+                                           Modality modality, TKStage owner, boolean rtl, boolean darkFrame) {
         assertToolkitRunning();
-        WindowStage stage = new WindowStage(peerWindow, stageStyle, modality, owner);
+        WindowStage stage = new WindowStage(peerWindow, stageStyle, modality, owner, darkFrame);
         if (primary) {
             stage.setIsPrimary();
         }
@@ -693,7 +694,7 @@ public final class QuantumToolkit extends Toolkit {
 
     @Override public TKStage createTKPopupStage(Window peerWindow, StageStyle popupStyle, TKStage owner) {
         assertToolkitRunning();
-        WindowStage stage = new WindowStage(peerWindow, popupStyle, null, owner);
+        WindowStage stage = new WindowStage(peerWindow, popupStyle, null, owner, false);
         stage.setIsPopup();
         stage.init(systemMenu);
         return stage;

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/WindowStage.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/WindowStage.java
@@ -65,6 +65,7 @@ public class WindowStage extends GlassStage {
     private OverlayWarning warning = null;
     private boolean rtl = false;
     private boolean transparent = false;
+    private boolean darkFrame = false;
     private boolean isPrimaryStage = false;
     private boolean isPopupStage = false;
     private boolean isInFullScreen = false;
@@ -84,11 +85,12 @@ public class WindowStage extends GlassStage {
         ResourceBundle.getBundle(WindowStage.class.getPackage().getName() +
                                  ".QuantumMessagesBundle", LOCALE);
 
-
-    public WindowStage(javafx.stage.Window peerWindow, final StageStyle stageStyle, Modality modality, TKStage owner) {
+    public WindowStage(javafx.stage.Window peerWindow, final StageStyle stageStyle, Modality modality,
+                       TKStage owner, boolean darkFrame) {
         this.style = stageStyle;
         this.owner = (GlassStage)owner;
         this.modality = modality;
+        this.darkFrame = darkFrame;
 
         if (peerWindow instanceof javafx.stage.Stage) {
             fxStage = (Stage)peerWindow;
@@ -174,6 +176,10 @@ public class WindowStage extends GlassStage {
 
             if (modality != Modality.NONE) {
                 windowMask |= Window.MODAL;
+            }
+
+            if (darkFrame) {
+                windowMask |= Window.DARK_FRAME;
             }
 
             platformWindow = app.createWindow(ownerWindow, Screen.getMainScreen(), windowMask);
@@ -899,6 +905,15 @@ public class WindowStage extends GlassStage {
     public void setPrefHeaderButtonHeight(double height) {
         if (platformWindow != null) {
             platformWindow.setPrefHeaderButtonHeight(height);
+        }
+    }
+
+    @Override
+    public void setDarkFrame(boolean value) {
+        darkFrame = value;
+
+        if (platformWindow != null) {
+            platformWindow.setDarkFrame(value);
         }
     }
 }

--- a/modules/javafx.graphics/src/main/java/javafx/stage/Stage.java
+++ b/modules/javafx.graphics/src/main/java/javafx/stage/Stage.java
@@ -28,6 +28,7 @@ package javafx.stage;
 import java.util.ArrayList;
 import java.util.List;
 
+import javafx.application.ColorScheme;
 import javafx.application.Platform;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.SimpleBooleanProperty;
@@ -43,6 +44,7 @@ import javafx.scene.layout.HeaderBar;
 
 import com.sun.glass.ui.HeaderButtonMetrics;
 import com.sun.javafx.PreviewFeature;
+import com.sun.javafx.application.PlatformImpl;
 import com.sun.javafx.collections.VetoableListDecorator;
 import com.sun.javafx.collections.TrackableObservableList;
 import com.sun.javafx.scene.SceneHelper;
@@ -1111,10 +1113,13 @@ public class Stage extends Window {
             TKStage tkStage = (window == null ? null : window.getPeer());
             Scene scene = getScene();
             boolean rtl = scene != null && scene.getEffectiveNodeOrientation() == NodeOrientation.RIGHT_TO_LEFT;
+            ColorScheme colorScheme = scene != null
+                ? scene.getPreferences().getColorScheme()
+                : PlatformImpl.getPlatformPreferences().getColorScheme();
 
             StageStyle stageStyle = getStyle();
             setPeer(toolkit.createTKStage(this, stageStyle, isPrimary(),
-                    getModality(), tkStage, rtl));
+                    getModality(), tkStage, rtl, colorScheme == ColorScheme.DARK));
             getPeer().setMinimumSize((int) Math.ceil(getMinWidth()),
                     (int) Math.ceil(getMinHeight()));
             getPeer().setMaximumSize((int) Math.floor(getMaxWidth()),

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow.m
@@ -382,6 +382,7 @@ static jlong _createWindowCommonDo(JNIEnv *env, jobject jWindow, jlong jOwnerPtr
         bool isPopup = (jStyleMask & com_sun_glass_ui_Window_POPUP) != 0;
         bool isUnified = (jStyleMask & com_sun_glass_ui_Window_UNIFIED) != 0;
         bool isExtended = (jStyleMask & com_sun_glass_ui_Window_EXTENDED) != 0;
+        bool isDarkFrame = (jStyleMask & com_sun_glass_ui_Window_DARK_FRAME) != 0;
 
         NSUInteger styleMask = NSWindowStyleMaskBorderless;
         // only titled windows get title
@@ -506,6 +507,9 @@ static jlong _createWindowCommonDo(JNIEnv *env, jobject jWindow, jlong jOwnerPtr
         window->isSizeAssigned = NO;
         window->isLocationAssigned = NO;
 
+        [window->nsWindow setAppearance:isDarkFrame
+            ? [NSAppearance appearanceNamed:NSAppearanceNameDarkAqua]
+            : [NSAppearance appearanceNamed:NSAppearanceNameAqua]];
     }
     [pool drain];
 
@@ -1357,6 +1361,29 @@ JNIEXPORT void JNICALL Java_com_sun_glass_ui_mac_MacWindow__1setIcon
         } else {
             [[window->nsWindow standardWindowButton:NSWindowDocumentIconButton] setImage:nil];
         }
+    }
+    GLASS_POOL_EXIT;
+    GLASS_CHECK_EXCEPTION(env);
+}
+
+/*
+ * Class:     com_sun_glass_ui_mac_MacWindow
+ * Method:    _setDarkFrame
+ * Signature: (JZ)V
+ */
+JNIEXPORT void JNICALL Java_com_sun_glass_ui_mac_MacWindow__1setDarkFrame
+(JNIEnv *env, jobject jWindow, jlong jPtr, jboolean dark)
+{
+    LOG("Java_com_sun_glass_ui_mac_MacWindow__1setDarkFrame");
+    if (!jPtr) return;
+
+    GLASS_ASSERT_MAIN_JAVA_THREAD(env);
+    GLASS_POOL_ENTER;
+    {
+        GlassWindow *window = getGlassWindow(env, jPtr);
+        [window->nsWindow setAppearance:dark
+            ? [NSAppearance appearanceNamed:NSAppearanceNameDarkAqua]
+            : [NSAppearance appearanceNamed:NSAppearanceNameAqua]];
     }
     GLASS_POOL_EXIT;
     GLASS_CHECK_EXCEPTION(env);

--- a/modules/javafx.graphics/src/main/native-glass/win/GlassWindow.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/win/GlassWindow.cpp
@@ -1258,6 +1258,55 @@ void GlassWindow::SetIcon(HICON hIcon)
     m_hIcon = hIcon;
 }
 
+void GlassWindow::SetDarkFrame(bool dark)
+{
+    // The value of the DWMWA_USE_IMMERSIVE_DARK_MODE constant may be different depending on the OS version.
+    // We are going to query the file version of dwmapi.dll to make sure we use the right constant, or the
+    // value 0 to indicate that we don't support this feature.
+    // See: https://github.com/MicrosoftDocs/sdk-api/commit/c19f1c8a148b930444dce998d3c717c8fb7751e1
+    static const DWORD DWMWA_USE_IMMERSIVE_DARK_MODE = []() {
+        DWORD ignored;
+        DWORD infoSize = GetFileVersionInfoSizeEx(FILE_VER_GET_NEUTRAL, L"dwmapi.dll", &ignored);
+        if (infoSize <= 0) {
+            return 0;
+        }
+
+        std::vector<char> buffer(infoSize);
+        if (!GetFileVersionInfoEx(FILE_VER_GET_NEUTRAL, L"dwmapi.dll", ignored,
+                                  static_cast<DWORD>(buffer.size()), &buffer[0])) {
+            return 0;
+        }
+
+        UINT size = 0;
+        VS_FIXEDFILEINFO* fileInfo = nullptr;
+        if (!VerQueryValue(buffer.data(), L"\\", reinterpret_cast<LPVOID*>(&fileInfo), &size)) {
+            return 0;
+        }
+
+        WORD major = HIWORD(fileInfo->dwFileVersionMS);
+        WORD minor = LOWORD(fileInfo->dwFileVersionMS);
+        WORD build = HIWORD(fileInfo->dwFileVersionLS);
+
+        // Windows 10 before build 10.0.17763: not supported
+        if (major < 10 || (major == 10 && minor == 0 && build < 17763)) {
+            return 0;
+        }
+
+        // Windows 10 build 10.0.17763 until 10.0.18985
+        if (major == 10 && minor == 0 && build >= 17763 && build < 18985) {
+            return 19;
+        }
+
+        // Windows 10 build 10.0.18985 or later
+        return 20;
+    }();
+
+    if (DWMWA_USE_IMMERSIVE_DARK_MODE) {
+        BOOL darkMode = dark;
+        DwmSetWindowAttribute(GetHWND(), DWMWA_USE_IMMERSIVE_DARK_MODE, &darkMode, sizeof(darkMode));
+    }
+}
+
 void GlassWindow::ShowSystemMenu(int x, int y)
 {
     WINDOWPLACEMENT placement;
@@ -1453,6 +1502,10 @@ JNIEXPORT jlong JNICALL Java_com_sun_glass_ui_win_WinWindow__1createWindow
                     ::EnableMenuItem(hSysMenu, SC_CLOSE,
                             MF_BYCOMMAND | MF_DISABLED | MF_GRAYED);
                 }
+            }
+
+            if (mask & com_sun_glass_ui_Window_DARK_FRAME) {
+                pWindow->SetDarkFrame(true);
             }
         }
 
@@ -1692,6 +1745,28 @@ JNIEXPORT jboolean JNICALL Java_com_sun_glass_ui_win_WinWindow__1setBackground2
     PERFORM();
 
     return JNI_TRUE;
+}
+
+/*
+ * Class:     com_sun_glass_ui_win_WinWindow
+ * Method:    _setDarkFrame
+ * Signature: (JZ)V
+ */
+JNIEXPORT void JNICALL Java_com_sun_glass_ui_win_WinWindow__1setDarkFrame
+    (JNIEnv *env, jobject jThis, jlong ptr, jboolean dark)
+{
+    ENTER_MAIN_THREAD()
+    {
+        GlassWindow *pWindow = GlassWindow::FromHandle(hWnd);
+        if (pWindow) {
+            pWindow->SetDarkFrame(dark);
+        }
+    }
+    jboolean dark;
+    LEAVE_MAIN_THREAD_WITH_hWnd;
+
+    ARG(dark) = dark;
+    PERFORM();
 }
 
 /*

--- a/modules/javafx.graphics/src/main/native-glass/win/GlassWindow.h
+++ b/modules/javafx.graphics/src/main/native-glass/win/GlassWindow.h
@@ -102,6 +102,7 @@ public:
     virtual void ExitFullScreenMode(BOOL animate);
 
     void SetIcon(HICON hIcon);
+    void SetDarkFrame(bool);
     void HandleWindowPosChangedEvent();
     void ShowSystemMenu(int x, int y);
 

--- a/modules/javafx.graphics/src/test/java/test/com/sun/javafx/pgstub/StubStage.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/javafx/pgstub/StubStage.java
@@ -224,6 +224,10 @@ public class StubStage implements TKStage {
     }
 
     @Override
+    public void setDarkFrame(boolean value) {
+    }
+
+    @Override
     public void requestFocus() {
         notificationSender.changedFocused(true, FocusCause.ACTIVATED);
     }

--- a/modules/javafx.graphics/src/test/java/test/com/sun/javafx/pgstub/StubToolkit.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/javafx/pgstub/StubToolkit.java
@@ -145,7 +145,8 @@ public class StubToolkit extends Toolkit {
     }
 
     @Override
-    public TKStage createTKStage(Window peerWindow, StageStyle stageStyle, boolean primary, Modality modality, TKStage owner, boolean rtl) {
+    public TKStage createTKStage(Window peerWindow, StageStyle stageStyle, boolean primary,
+                                 Modality modality, TKStage owner, boolean rtl, boolean darkFrame) {
 
         return new StubStage();
     }


### PR DESCRIPTION
Currently, the color scheme of a system-decorated stage is as follows:
* On Windows, the title bar is always light (even if the OS color scheme is dark).
* On macOS and Linux, the title bar is light or dark depending on the OS color scheme.

The expected behavior is that the title bar matches the color scheme of the `Scene`.
If an application doesn't specify a color scheme, the title bar color should match the OS color scheme.

This PR fixes the behavior for Windows and macOS, but not for Linux (there's no good way to do that).
Depending on how you look at it, this is either a bug fix or an enhancement.

/reviewers 2