### PR TITLE
8362095: HeaderButtonMetrics should not be used across toolkit boundary

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/stage/HeaderButtonMetrics.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/stage/HeaderButtonMetrics.java
@@ -23,9 +23,10 @@
  * questions.
  */
 
-package com.sun.glass.ui;
+package com.sun.javafx.stage;
 
 import javafx.geometry.Dimension2D;
+import javafx.scene.layout.HeaderBar;
 import javafx.stage.StageStyle;
 import java.util.Objects;
 
@@ -35,11 +36,9 @@ import java.util.Objects;
  * @param leftInset the size of the left inset
  * @param rightInset the size of the right inset
  * @param minHeight the minimum height of the window buttons
- * @see HeaderButtonOverlay
+ * @see HeaderBar
  */
 public record HeaderButtonMetrics(Dimension2D leftInset, Dimension2D rightInset, double minHeight) {
-
-    public static HeaderButtonMetrics EMPTY = new HeaderButtonMetrics(new Dimension2D(0, 0), new Dimension2D(0, 0), 0);
 
     public HeaderButtonMetrics {
         Objects.requireNonNull(leftInset);
@@ -48,13 +47,5 @@ public record HeaderButtonMetrics(Dimension2D leftInset, Dimension2D rightInset,
         if (minHeight < 0) {
             throw new IllegalArgumentException("minHeight cannot be negative");
         }
-    }
-
-    public double totalInsetWidth() {
-        return leftInset.getWidth() + rightInset.getWidth();
-    }
-
-    public double maxInsetHeight() {
-        return Math.max(leftInset.getHeight(), rightInset.getHeight());
     }
 }

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/stage/StageHelper.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/stage/StageHelper.java
@@ -25,7 +25,6 @@
 
 package com.sun.javafx.stage;
 
-import com.sun.glass.ui.HeaderButtonMetrics;
 import com.sun.javafx.util.Utils;
 import javafx.beans.value.ObservableValue;
 import javafx.stage.Stage;

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/stage/StagePeerListener.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/stage/StagePeerListener.java
@@ -25,9 +25,7 @@
 
 package com.sun.javafx.stage;
 
-import com.sun.glass.ui.HeaderButtonMetrics;
 import javafx.stage.Stage;
-
 
 public class StagePeerListener extends WindowPeerListener {
     private final Stage stage;

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/WindowStage.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/WindowStage.java
@@ -42,6 +42,7 @@ import com.sun.glass.ui.Window.Level;
 import com.sun.javafx.PlatformUtil;
 import com.sun.javafx.iio.common.PushbroomScaler;
 import com.sun.javafx.iio.common.ScalerFactory;
+import com.sun.javafx.stage.HeaderButtonMetrics;
 import com.sun.javafx.stage.StagePeerListener;
 import com.sun.javafx.tk.FocusCause;
 import com.sun.javafx.tk.TKScene;
@@ -227,7 +228,9 @@ public class WindowStage extends GlassStage {
 
     private void notifyHeaderButtonMetricsChanged() {
         if (stageListener instanceof StagePeerListener listener && platformWindow != null) {
-            listener.changedHeaderButtonMetrics(platformWindow.headerButtonMetricsProperty().get());
+            var metrics = platformWindow.headerButtonMetricsProperty().get();
+            listener.changedHeaderButtonMetrics(
+                new HeaderButtonMetrics(metrics.leftInset(), metrics.rightInset(), metrics.minHeight()));
         }
     }
 

--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/HeaderBar.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/HeaderBar.java
@@ -25,10 +25,10 @@
 
 package javafx.scene.layout;
 
-import com.sun.glass.ui.HeaderButtonMetrics;
 import com.sun.javafx.PreviewFeature;
 import com.sun.javafx.geom.Vec2d;
 import com.sun.javafx.scene.layout.HeaderButtonBehavior;
+import com.sun.javafx.stage.HeaderButtonMetrics;
 import com.sun.javafx.stage.StageHelper;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.BooleanPropertyBase;

--- a/modules/javafx.graphics/src/main/java/javafx/stage/Stage.java
+++ b/modules/javafx.graphics/src/main/java/javafx/stage/Stage.java
@@ -41,11 +41,11 @@ import javafx.scene.image.Image;
 import javafx.scene.input.KeyCombination;
 import javafx.scene.layout.HeaderBar;
 
-import com.sun.glass.ui.HeaderButtonMetrics;
 import com.sun.javafx.PreviewFeature;
 import com.sun.javafx.collections.VetoableListDecorator;
 import com.sun.javafx.collections.TrackableObservableList;
 import com.sun.javafx.scene.SceneHelper;
+import com.sun.javafx.stage.HeaderButtonMetrics;
 import com.sun.javafx.stage.StageHelper;
 import com.sun.javafx.stage.StagePeerListener;
 import com.sun.javafx.tk.TKStage;


### PR DESCRIPTION
The record `com.sun.glass.ui.HeaderButtonMetrics` is used by Glass, but also in the FX layer (in `Stage` and `HeaderBar`). This is architectually unsound, as the FX layer should not directly reference the Glass implementation.

The solution here is to introduce another record that is used in the FX layer, and translate between the Glass/FX types in quantum toolkit.