### PR TITLE
8362873: Regression in BorderPane after JDK-8350149

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/BorderPane.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/BorderPane.java
@@ -626,8 +626,8 @@ public class BorderPane extends Pane {
     private double getAreaHeight(Node child, double width, boolean minimum) {
         if (child != null && child.isManaged()) {
             Insets margin = getNodeMargin(child);
-            return minimum ? computeChildMinAreaHeight(child, -1, margin, width, false):
-                                   computeChildPrefAreaHeight(child, -1, margin, width, false);
+            return minimum ? computeChildMinAreaHeight(child, -1, margin, width, true):
+                                   computeChildPrefAreaHeight(child, -1, margin, width, true);
         }
         return 0;
     }


### PR DESCRIPTION
This PR fixes a regression introduced in #1723

It reverts the changes made in the BorderPaneTest with new comments explaining why the values are what they are.  It only fixes the regression that was introduced, but it can be said that the calculation is probably also incorrect when a vertical biased control is encountered (the `getAreaWidth` and `getAreaHeight` in `BorderPane` were, and are still not using the same way to calculate their respective sizes).  See the ticket for more details and screenshots.

Let me know if I should only address the regression introduced, or also include the fix for the bias calculation for vertical bias controls.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8362873](https://bugs.openjdk.org/browse/JDK-8362873): Regression in BorderPane after JDK-8350149 (**Bug** - P3)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Michael Strauß](https://openjdk.org/census#mstrauss) (@mstr2 - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1850/head:pull/1850` \
`$ git checkout pull/1850`

Update a local copy of the PR: \
`$ git checkout pull/1850` \
`$ git pull https://git.openjdk.org/jfx.git pull/1850/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1850`

View PR using the GUI difftool: \
`$ git pr show -t 1850`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1850.diff">https://git.openjdk.org/jfx/pull/1850.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1850#issuecomment-3100034731)
</details>
