### PR TITLE
8362873: Regression in BorderPane after JDK-8350149

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/BorderPane.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/BorderPane.java
@@ -626,8 +626,8 @@ public class BorderPane extends Pane {
     private double getAreaHeight(Node child, double width, boolean minimum) {
         if (child != null && child.isManaged()) {
             Insets margin = getNodeMargin(child);
-            return minimum ? computeChildMinAreaHeight(child, -1, margin, width, false):
-                                   computeChildPrefAreaHeight(child, -1, margin, width, false);
+            return minimum ? computeChildMinAreaHeight(child, -1, margin, width, true):
+                                   computeChildPrefAreaHeight(child, -1, margin, width, true);
         }
         return 0;
     }


### PR DESCRIPTION
This pull request contains a backport of commit [7b59ebce](https://github.com/openjdk/jfx/commit/7b59ebcec74cf3e0da25e35b22a9722b9d93ebdb) from the [openjdk/jfx](https://git.openjdk.org/jfx) repository.

The commit being backported was authored by John Hendrikx on 23 Jul 2025 and was reviewed by Andy Goryachev, Michael Strauß and Kevin Rushforth.
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8362873](https://bugs.openjdk.org/browse/JDK-8362873): Regression in BorderPane after JDK-8350149 (**Bug** - P3)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1852/head:pull/1852` \
`$ git checkout pull/1852`

Update a local copy of the PR: \
`$ git checkout pull/1852` \
`$ git pull https://git.openjdk.org/jfx.git pull/1852/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1852`

View PR using the GUI difftool: \
`$ git pr show -t 1852`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1852.diff">https://git.openjdk.org/jfx/pull/1852.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1852#issuecomment-3109209411)
</details>
