### PR TITLE
8363813: Missing null check in GlassScreen

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/gtk/glass_screen.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/glass_screen.cpp
@@ -209,10 +209,12 @@ jobjectArray rebuild_screens(JNIEnv* env) {
     JNI_EXCEPTION_TO_CPP(env)
     LOG1("Available monitors: %d\n", n_monitors)
 
-    int i;
-    for (i=0; i < n_monitors; i++) {
-        env->SetObjectArrayElement(jscreens, i, createJavaScreen(env, default_gdk_screen, i));
-        JNI_EXCEPTION_TO_CPP(env)
+    if (jscreens != NULL) {
+        int i;
+        for (i=0; i < n_monitors; i++) {
+            env->SetObjectArrayElement(jscreens, i, createJavaScreen(env, default_gdk_screen, i));
+            JNI_EXCEPTION_TO_CPP(env)
+        }
     }
 
     return jscreens;

--- a/modules/javafx.graphics/src/main/native-glass/ios/GlassScreen.m
+++ b/modules/javafx.graphics/src/main/native-glass/ios/GlassScreen.m
@@ -87,9 +87,11 @@ jobjectArray createJavaScreens(JNIEnv* env) {
                                                       mat_jScreenClass,
                                                       NULL);
 
-    for (NSUInteger index = 0; index < [screens count]; index++) {
-        jobject javaScreen = createJavaScreen(env, [screens objectAtIndex:index]);
-        (*env)->SetObjectArrayElement(env, screenArray, index, javaScreen);
+    if (screenArray != NULL) {
+        for (NSUInteger index = 0; index < [screens count]; index++) {
+            jobject javaScreen = createJavaScreen(env, [screens objectAtIndex:index]);
+            (*env)->SetObjectArrayElement(env, screenArray, index, javaScreen);
+        }
     }
 
     return screenArray;

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassScreen.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassScreen.m
@@ -135,20 +135,22 @@ jobjectArray createJavaScreens(JNIEnv* env) {
                                                       jScreenClass,
                                                       NULL);
     GLASS_CHECK_EXCEPTION(env);
-    maxScreenDimensions = NSMakeSize(0.f,0.f);
-    for (NSUInteger index = 0; index < [screens count]; index++) {
-        NSRect screenRect = [[screens objectAtIndex:index] frame];
+    if (screenArray != NULL) {
+        maxScreenDimensions = NSMakeSize(0.f,0.f);
+        for (NSUInteger index = 0; index < [screens count]; index++) {
+            NSRect screenRect = [[screens objectAtIndex:index] frame];
 
-        if (screenRect.size.width > maxScreenDimensions.width) {
-            maxScreenDimensions.width = screenRect.size.width;
-        }
-        if (screenRect.size.height > maxScreenDimensions.height) {
-            maxScreenDimensions.height = screenRect.size.height;
-        }
+            if (screenRect.size.width > maxScreenDimensions.width) {
+                maxScreenDimensions.width = screenRect.size.width;
+            }
+            if (screenRect.size.height > maxScreenDimensions.height) {
+                maxScreenDimensions.height = screenRect.size.height;
+            }
 
-        jobject javaScreen = createJavaScreen(env, [screens objectAtIndex:index]);
-        (*env)->SetObjectArrayElement(env, screenArray, index, javaScreen);
-        GLASS_CHECK_EXCEPTION(env);
+            jobject javaScreen = createJavaScreen(env, [screens objectAtIndex:index]);
+            (*env)->SetObjectArrayElement(env, screenArray, index, javaScreen);
+            GLASS_CHECK_EXCEPTION(env);
+        }
     }
 
     return screenArray;

--- a/modules/javafx.graphics/src/main/native-glass/win/GlassScreen.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/win/GlassScreen.cpp
@@ -603,7 +603,7 @@ jobjectArray GlassScreen::CreateJavaScreens(JNIEnv *env)
     jclass screenCls = GetScreenCls(env);
 
     jobjectArray jScreens = env->NewObjectArray(numMonitors, screenCls, NULL);
-    if (CheckAndClearException(env)) {
+    if (CheckAndClearException(env) || jScreens == NULL) {
         free(g_MonitorInfos.pMonitorInfos);
         g_MonitorInfos.numInfos = g_MonitorInfos.maxInfos = 0;
         g_MonitorInfos.pMonitorInfos = NULL;


### PR DESCRIPTION
Clean backport of adding simple null checks in glass screen fix to the `jfx25` stabilization branch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8363813](https://bugs.openjdk.org/browse/JDK-8363813): Missing null check in GlassScreen (**Bug** - P3)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1854/head:pull/1854` \
`$ git checkout pull/1854`

Update a local copy of the PR: \
`$ git checkout pull/1854` \
`$ git pull https://git.openjdk.org/jfx.git pull/1854/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1854`

View PR using the GUI difftool: \
`$ git pr show -t 1854`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1854.diff">https://git.openjdk.org/jfx/pull/1854.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1854#issuecomment-3111487982)
</details>
