### PR TITLE
8358092: Create accessibility protocol implementation that covers various type of menu items

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/mac/a11y/AccessibleBase.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/a11y/AccessibleBase.m
@@ -40,7 +40,7 @@ static NSMutableDictionary * rolesMap;
      * All JavaFX roles and corresponding available properties are defined in
      * enum javafx.scene.AccessibleRole
      */
-    rolesMap = [[NSMutableDictionary alloc] initWithCapacity:16];
+    rolesMap = [[NSMutableDictionary alloc] initWithCapacity:21];
 
     [rolesMap setObject:@"JFXButtonAccessibility" forKey:@"BUTTON"];
     [rolesMap setObject:@"JFXButtonAccessibility" forKey:@"DECREMENT_BUTTON"];
@@ -59,6 +59,10 @@ static NSMutableDictionary * rolesMap;
     [rolesMap setObject:@"JFXImageAccessibility" forKey:@"IMAGE_VIEW"];
     [rolesMap setObject:@"JFXTabGroupAccessibility" forKey:@"TAB_PANE"];
     [rolesMap setObject:@"JFXTabGroupAccessibility" forKey:@"PAGINATION"];
+    [rolesMap setObject:@"JFXMenuItemAccessibility" forKey:@"MENU"];
+    [rolesMap setObject:@"JFXMenuItemAccessibility" forKey:@"MENU_ITEM"];
+    [rolesMap setObject:@"JFXMenuItemAccessibility" forKey:@"RADIO_MENU_ITEM"];
+    [rolesMap setObject:@"JFXMenuItemAccessibility" forKey:@"CHECK_MENU_ITEM"];
 
 }
 

--- a/modules/javafx.graphics/src/main/native-glass/mac/a11y/JFXMenuItemAccessibility.h
+++ b/modules/javafx.graphics/src/main/native-glass/mac/a11y/JFXMenuItemAccessibility.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+
+#import "JFXButtonAccessibility.h"
+#import <AppKit/NSAccessibility.h>
+
+@interface JFXMenuItemAccessibility : AccessibleBase {
+};
+
+- (NSAccessibilityRole)accessibilityRole;
+- (id)accessibilityValue;
+- (NSRect)accessibilityFrame;
+- (id)accessibilityTitleUIElement;
+@end
+

--- a/modules/javafx.graphics/src/main/native-glass/mac/a11y/JFXMenuItemAccessibility.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/a11y/JFXMenuItemAccessibility.m
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#import "JFXMenuItemAccessibility.h"
+
+@implementation JFXMenuItemAccessibility
+
+- (NSAccessibilityRole)accessibilityRole
+{
+    return NSAccessibilityMenuItemRole;
+}
+
+- (NSString * _Nullable)accessibilityLabel {
+    return [super accessibilityTitle];
+}
+
+- (NSString * _Nullable)accessibilityTitle {
+    return [self requestNodeAttribute:@"AXMenuItemMarkChar"];
+}
+
+- (id)accessibilityTitleUIElement
+{
+    return [super accessibilityTitleUIElement];
+}
+
+- (id)accessibilityValue
+{
+    return [super accessibilityValue];
+}
+
+- (NSRect)accessibilityFrame
+{
+    return [super accessibilityFrame];
+}
+
+- (id)accessibilityParent
+{
+    return [super accessibilityParent];
+}
+@end
+


### PR DESCRIPTION
Initial implementation. Note that second level menu navigation with the non-system menus does not work but it was not working with the current implementation so i am raising a new bug for tracking that but that can not be a showstopper for this PR.

The bug raised to track menu deficiencies JDK-8364133

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8358092](https://bugs.openjdk.org/browse/JDK-8358092): Create accessibility protocol implementation that covers various type of menu items (**Enhancement** - P3)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1858/head:pull/1858` \
`$ git checkout pull/1858`

Update a local copy of the PR: \
`$ git checkout pull/1858` \
`$ git pull https://git.openjdk.org/jfx.git pull/1858/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1858`

View PR using the GUI difftool: \
`$ git pr show -t 1858`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1858.diff">https://git.openjdk.org/jfx/pull/1858.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1858#issuecomment-3120682845)
</details>
