### PR TITLE
8364203: Ignore native mac tests on headless

### DIFF
--- a/modules/javafx.base/src/main/java/com/sun/javafx/PlatformUtil.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/PlatformUtil.java
@@ -70,6 +70,7 @@ public class PlatformUtil {
     private static final boolean SOLARIS = os.startsWith("SunOS");
     private static final boolean IOS = os.startsWith("iOS");
     private static final boolean STATIC_BUILD = "Substrate VM".equals(System.getProperty("java.vm.name"));
+    private static final boolean HEADLESS = "headless".equals(embeddedType);
 
     /**
      * Utility method used to determine whether the version number as
@@ -165,6 +166,13 @@ public class PlatformUtil {
      */
     public static String getEmbeddedType() {
         return embeddedType;
+    }
+
+    /**
+     * Returns true if the Headless glass platform is selected
+     */
+    public static boolean isHeadless(){
+        return HEADLESS;
     }
 
     /**

--- a/tests/system/src/test/java/test/com/sun/glass/ui/mac/MacPasteboardTest.java
+++ b/tests/system/src/test/java/test/com/sun/glass/ui/mac/MacPasteboardTest.java
@@ -50,7 +50,7 @@ public class MacPasteboardTest {
 
     @BeforeAll
     public static void setup() throws Exception {
-        if (PlatformUtil.isMac()) {
+        if (PlatformUtil.isMac() && !PlatformUtil.isHeadless()) {
             Platform.startup(() -> {
                 macPasteboardShim = new MacPasteboardShim();
                 startupLatch.countDown();
@@ -60,7 +60,7 @@ public class MacPasteboardTest {
 
     @AfterAll
     public static void teardown() {
-        if (PlatformUtil.isMac()) {
+        if (PlatformUtil.isMac() && !PlatformUtil.isHeadless()) {
             Platform.exit();
         }
     }

--- a/tests/system/src/test/java/test/com/sun/glass/ui/mac/MacPasteboardTest.java
+++ b/tests/system/src/test/java/test/com/sun/glass/ui/mac/MacPasteboardTest.java
@@ -67,7 +67,7 @@ public class MacPasteboardTest {
 
     @Test
     public void testValidLocalImageURLMacPasteboard() throws Exception {
-        assumeTrue(PlatformUtil.isMac());
+        assumeTrue(PlatformUtil.isMac() && !PlatformUtil.isHeadless());
         final String localImage = getClass().getResource("blue.png").toURI().toURL().toString();
         runAndWait(() -> {
             macPasteboardShim.pushMacPasteboard(new HashMap<>(Map.of(Clipboard.URI_TYPE, localImage)));
@@ -82,7 +82,7 @@ public class MacPasteboardTest {
 
     @Test
     public void testDataBase64ImageMacPasteboard() {
-        assumeTrue(PlatformUtil.isMac());
+        assumeTrue(PlatformUtil.isMac() && !PlatformUtil.isHeadless());
         final String encodedImage = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAKCAIAAAA7N+mxAAAAAXNSR0IArs4c6QAAAAR"
                 + "nQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAcSURBVChTY/jPwADBZACyNMHAqGYSwZDU/P8/ABieT81GAGKoAAAAAElFTkSuQmCC";
         runAndWait(() -> {
@@ -94,7 +94,7 @@ public class MacPasteboardTest {
 
     @Test
     public void testNotAnImageURLMacPasteboard() {
-        assumeTrue(PlatformUtil.isMac());
+        assumeTrue(PlatformUtil.isMac() && !PlatformUtil.isHeadless());
         final String invalidImage = "not.an.image.url";
         runAndWait(() -> {
             macPasteboardShim.pushMacPasteboard(new HashMap<>(Map.of(Clipboard.URI_TYPE, invalidImage)));


### PR DESCRIPTION
Add PlatformUtil.isHeadless() method.
Use that in tests to conditionally skip tests.

Fix JDK-8364203

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8364203](https://bugs.openjdk.org/browse/JDK-8364203): Ignore native mac tests on headless (**Bug** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1859/head:pull/1859` \
`$ git checkout pull/1859`

Update a local copy of the PR: \
`$ git checkout pull/1859` \
`$ git pull https://git.openjdk.org/jfx.git pull/1859/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1859`

View PR using the GUI difftool: \
`$ git pr show -t 1859`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1859.diff">https://git.openjdk.org/jfx/pull/1859.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1859#issuecomment-3129790068)
</details>
