### PR TITLE
8364088: ToolBarSkin: NPE in select()

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ToolBarSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ToolBarSkin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -192,6 +192,9 @@ public class ToolBarSkin extends SkinBase<ToolBar> {
                     // The current focus owner is a child of some Toolbar's item
                     Parent item = owner.getParent();
                     while (!boxChildren.contains(item)) {
+                        if (item == null) {
+                            return null;
+                        }
                         item = item.getParent();
                     }
                     Node selected = context.selectInSubtree(item, owner, dir);


### PR DESCRIPTION
Fixed an NPE in the ToolBar.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8364088](https://bugs.openjdk.org/browse/JDK-8364088): ToolBarSkin: NPE in select() (**Bug** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1861/head:pull/1861` \
`$ git checkout pull/1861`

Update a local copy of the PR: \
`$ git checkout pull/1861` \
`$ git pull https://git.openjdk.org/jfx.git pull/1861/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1861`

View PR using the GUI difftool: \
`$ git pr show -t 1861`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1861.diff">https://git.openjdk.org/jfx/pull/1861.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1861#issuecomment-3134033581)
</details>
