### PR TITLE
8364687 : Headless allow lowercase for -Dglass.platform

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Platform.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Platform.java
@@ -32,6 +32,7 @@ final class Platform {
     public static final String WINDOWS = "Win";
     public static final String GTK = "Gtk";
     public static final String IOS = "Ios";
+    public static final String HEADLESS = "Headless";
     public static final String UNKNOWN = "unknown";
 
     static private String type = null;
@@ -53,6 +54,8 @@ final class Platform {
                    type = GTK;
                 else if (userPlatform.equals("ios"))
                    type = IOS;
+                else if (userPlatform.equals("headless"))
+                    type = HEADLESS;
                 else
                    type = userPlatform;
                 return type;


### PR DESCRIPTION
Basically allow -Dglass.platform=headless to enable headless, not only -Dglass.platform=Headless.
This makes it consistent with other processings (macosx, windows, linux, gtk and ios) as well was less error-prone for enabling it.