### PR TITLE
8364825: Skip failing MenuDoubleShortcutTest

### DIFF
--- a/tests/system/src/test/java/test/robot/javafx/scene/MenuDoubleShortcutTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/MenuDoubleShortcutTest.java
@@ -105,7 +105,7 @@ public class MenuDoubleShortcutTest {
 
     // On platforms other than Mac the menu bar should process the event
     // and the scene should not.
-    @Disabled("JDK-8364825")
+    @Disabled("JDK-8364405")
     @Test
     void nonMacMenuBarComesBeforeScene() {
         Assumptions.assumeFalse(PlatformUtil.isMac());

--- a/tests/system/src/test/java/test/robot/javafx/scene/MenuDoubleShortcutTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/MenuDoubleShortcutTest.java
@@ -45,6 +45,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import com.sun.javafx.PlatformUtil;
@@ -104,6 +105,7 @@ public class MenuDoubleShortcutTest {
 
     // On platforms other than Mac the menu bar should process the event
     // and the scene should not.
+    @Disabled("JDK-8364825")
     @Test
     void nonMacMenuBarComesBeforeScene() {
         Assumptions.assumeFalse(PlatformUtil.isMac());


### PR DESCRIPTION
Skipping failing `MenuDoubleShortcutTest#nonMacMenuBarComesBeforeScene()`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8364825](https://bugs.openjdk.org/browse/JDK-8364825): Skip failing MenuDoubleShortcutTest (**Bug** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1867/head:pull/1867` \
`$ git checkout pull/1867`

Update a local copy of the PR: \
`$ git checkout pull/1867` \
`$ git pull https://git.openjdk.org/jfx.git pull/1867/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1867`

View PR using the GUI difftool: \
`$ git pr show -t 1867`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1867.diff">https://git.openjdk.org/jfx/pull/1867.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1867#issuecomment-3164883845)
</details>
