### PR TITLE
8350479: SW pipeline should use default pipeline in Glass

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/prism/impl/PrismSettings.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/impl/PrismSettings.java
@@ -50,7 +50,7 @@ public final class PrismSettings {
     public static final boolean cacheComplexShapes;
     public static final boolean useNewImageLoader;
     public static final List<String> tryOrder;
-    public static final String macDefaultPipeline;
+    public static final String defaultPipeline;
     public static final int prismStatFrequency;
     public static final RasterizerType rasterizerSpec;
     public static final String refType;
@@ -201,28 +201,26 @@ public final class PrismSettings {
         /* Force GPU, if GPU is PS 3 capable, disable GPU qualification check. */
         forceGPU = getBoolean(systemProperties, "prism.forceGPU", false);
 
-        String order = systemProperties.getProperty("prism.order");
         String[] tryOrderArr;
-        String[] macDefaultOrderArr = new String[] { "es2", "mtl", "sw" };
-        // macDefaultPipeline flag will be used to determine whether to
-        // use es2/mtl pipeline in glass, when sw pipeline is used in prism
-        macDefaultPipeline = macDefaultOrderArr[0];
+        if (PlatformUtil.isWindows()) {
+            tryOrderArr = new String[] { "d3d", "sw" };
+        } else if (PlatformUtil.isMac()) {
+            tryOrderArr = new String[] { "es2", "mtl", "sw" };
+        } else if (PlatformUtil.isIOS()) {
+            tryOrderArr = new String[] { "es2" };
+        } else if (PlatformUtil.isAndroid()) {
+                tryOrderArr = new String[] { "es2" };
+        } else if (PlatformUtil.isLinux()) {
+            tryOrderArr = new String[] { "es2", "sw" };
+        } else {
+            tryOrderArr = new String[] { "sw" };
+        }
+
+        defaultPipeline = tryOrderArr[0];
+
+        String order = systemProperties.getProperty("prism.order");
         if (order != null) {
             tryOrderArr = split(order, ",");
-        } else {
-            if (PlatformUtil.isWindows()) {
-                tryOrderArr = new String[] { "d3d", "sw" };
-            } else if (PlatformUtil.isMac()) {
-                tryOrderArr = macDefaultOrderArr;
-            } else if (PlatformUtil.isIOS()) {
-                tryOrderArr = new String[] { "es2" };
-            } else if (PlatformUtil.isAndroid()) {
-                    tryOrderArr = new String[] { "es2" };
-            } else if (PlatformUtil.isLinux()) {
-                tryOrderArr = new String[] { "es2", "sw" };
-            } else {
-                tryOrderArr = new String[] { "sw" };
-            }
         }
 
         tryOrder = List.of(tryOrderArr);

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/impl/PrismSettings.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/impl/PrismSettings.java
@@ -50,6 +50,7 @@ public final class PrismSettings {
     public static final boolean cacheComplexShapes;
     public static final boolean useNewImageLoader;
     public static final List<String> tryOrder;
+    public static final String macDefaultPipeline;
     public static final int prismStatFrequency;
     public static final RasterizerType rasterizerSpec;
     public static final String refType;
@@ -202,13 +203,17 @@ public final class PrismSettings {
 
         String order = systemProperties.getProperty("prism.order");
         String[] tryOrderArr;
+        String[] macDefaultOrderArr = new String[] { "es2", "mtl", "sw" };
+        // macDefaultPipeline flag will be used to determine whether to
+        // use es2/mtl pipeline in glass, when sw pipeline is used in prism
+        macDefaultPipeline = macDefaultOrderArr[0];
         if (order != null) {
             tryOrderArr = split(order, ",");
         } else {
             if (PlatformUtil.isWindows()) {
                 tryOrderArr = new String[] { "d3d", "sw" };
             } else if (PlatformUtil.isMac()) {
-                tryOrderArr = new String[] { "es2", "mtl", "sw" };
+                tryOrderArr = macDefaultOrderArr;
             } else if (PlatformUtil.isIOS()) {
                 tryOrderArr = new String[] { "es2" };
             } else if (PlatformUtil.isAndroid()) {

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/sw/SWPipeline.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/sw/SWPipeline.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@ import com.sun.glass.ui.Screen;
 import com.sun.glass.utils.NativeLibLoader;
 import com.sun.prism.GraphicsPipeline;
 import com.sun.prism.ResourceFactory;
+import com.sun.javafx.PlatformUtil;
 
 import java.util.List;
 import java.util.HashMap;
@@ -40,6 +41,8 @@ public final class SWPipeline extends GraphicsPipeline {
     }
 
     @Override public boolean init() {
+        HashMap devDetails = new HashMap();
+        setDeviceDetails(devDetails);
         return true;
     }
 
@@ -69,6 +72,14 @@ public final class SWPipeline extends GraphicsPipeline {
         if (factory == null) {
             factory = new SWResourceFactory(screen);
             factories.put(index, factory);
+            if (PlatformUtil.isMac()) {
+                HashMap devDetails =
+                    (HashMap)SWPipeline.getInstance().getDeviceDetails();
+                // When Metal becomes default hardware pipeline, we need
+                // enable this flag
+                devDetails.put("useMTLInGlass",
+                                false);
+            }
         }
         return factory;
     }

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/sw/SWPipeline.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/sw/SWPipeline.java
@@ -32,8 +32,9 @@ import com.sun.prism.ResourceFactory;
 import com.sun.prism.impl.PrismSettings;
 import com.sun.javafx.PlatformUtil;
 
-import java.util.List;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public final class SWPipeline extends GraphicsPipeline {
 
@@ -42,7 +43,7 @@ public final class SWPipeline extends GraphicsPipeline {
     }
 
     @Override public boolean init() {
-        HashMap devDetails = new HashMap();
+        Map<String, Boolean> devDetails = new HashMap<>();
         setDeviceDetails(devDetails);
         return true;
     }
@@ -74,7 +75,7 @@ public final class SWPipeline extends GraphicsPipeline {
             factory = new SWResourceFactory(screen);
             factories.put(index, factory);
             if (PlatformUtil.isMac()) {
-                HashMap devDetails = (HashMap)getDeviceDetails();
+                Map<String, Boolean> devDetails = getDeviceDetails();
                 if (PrismSettings.defaultPipeline.equals("es2")) {
                     devDetails.put("useMTLInGlassForSW", false);
                 } else {

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/sw/SWPipeline.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/sw/SWPipeline.java
@@ -29,6 +29,7 @@ import com.sun.glass.ui.Screen;
 import com.sun.glass.utils.NativeLibLoader;
 import com.sun.prism.GraphicsPipeline;
 import com.sun.prism.ResourceFactory;
+import com.sun.prism.impl.PrismSettings;
 import com.sun.javafx.PlatformUtil;
 
 import java.util.List;
@@ -75,10 +76,11 @@ public final class SWPipeline extends GraphicsPipeline {
             if (PlatformUtil.isMac()) {
                 HashMap devDetails =
                     (HashMap)SWPipeline.getInstance().getDeviceDetails();
-                // When Metal becomes default hardware pipeline, we need
-                // enable this flag
-                devDetails.put("useMTLInGlass",
-                                false);
+                if (PrismSettings.macDefaultPipeline.equals("es2")) {
+                    devDetails.put("useMTLInGlass", false);
+                } else {
+                    devDetails.put("useMTLInGlass", true);
+                }
             }
         }
         return factory;

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/sw/SWPipeline.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/sw/SWPipeline.java
@@ -74,12 +74,11 @@ public final class SWPipeline extends GraphicsPipeline {
             factory = new SWResourceFactory(screen);
             factories.put(index, factory);
             if (PlatformUtil.isMac()) {
-                HashMap devDetails =
-                    (HashMap)SWPipeline.getInstance().getDeviceDetails();
+                HashMap devDetails = (HashMap)getDeviceDetails();
                 if (PrismSettings.macDefaultPipeline.equals("es2")) {
-                    devDetails.put("useMTLInGlass", false);
+                    devDetails.put("useMTLInGlassForSW", false);
                 } else {
-                    devDetails.put("useMTLInGlass", true);
+                    devDetails.put("useMTLInGlassForSW", true);
                 }
             }
         }

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/sw/SWPipeline.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/sw/SWPipeline.java
@@ -75,7 +75,7 @@ public final class SWPipeline extends GraphicsPipeline {
             factories.put(index, factory);
             if (PlatformUtil.isMac()) {
                 HashMap devDetails = (HashMap)getDeviceDetails();
-                if (PrismSettings.macDefaultPipeline.equals("es2")) {
+                if (PrismSettings.defaultPipeline.equals("es2")) {
                     devDetails.put("useMTLInGlassForSW", false);
                 } else {
                     devDetails.put("useMTLInGlassForSW", true);

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassLayer.h
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassLayer.h
@@ -36,7 +36,8 @@
     andClientContext:(NSObject*)clCtx
          mtlQueuePtr:(long)mtlCommandQueuePtr
       withHiDPIAware:(BOOL)HiDPIAware
-        withIsSwPipe:(BOOL)isSwPipe;
+        withIsSwPipe:(BOOL)isSwPipe
+       useMTLForBlit:(BOOL)useMTLInGlass;
 
 - (GlassOffscreen*)getPainterOffscreen;
 - (void)bindForWidth:(unsigned int)width

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassLayer.h
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassLayer.h
@@ -37,7 +37,7 @@
          mtlQueuePtr:(long)mtlCommandQueuePtr
       withHiDPIAware:(BOOL)HiDPIAware
         withIsSwPipe:(BOOL)isSwPipe
-       useMTLForBlit:(BOOL)useMTLInGlass;
+         useMTLForSW:(BOOL)mtlForSW;
 
 - (GlassOffscreen*)getPainterOffscreen;
 - (void)bindForWidth:(unsigned int)width

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassLayer.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassLayer.m
@@ -45,18 +45,22 @@ static NSArray *allModes = nil;
          mtlQueuePtr:(long)mtlCommandQueuePtr
       withHiDPIAware:(BOOL)HiDPIAware
         withIsSwPipe:(BOOL)isSwPipe
+       useMTLForBlit:(BOOL)useMTLInGlass
 {
     LOG("GlassLayer initGlassLayer]");
     self = [super init];
     if (self != nil)
     {
-        if (mtlCommandQueuePtr != 0l) { // MTL
+        if (mtlCommandQueuePtr != 0l ||
+            useMTLInGlass) { // MTL
+            LOG("GlassLayer initGlassLayer using MTLLayer");
             GlassLayerMTL* mtlLayer = [[GlassLayerMTL alloc] init:mtlCommandQueuePtr
                                                      withIsSwPipe:isSwPipe];
             self->painterOffScreen = [mtlLayer getPainterOffscreen];
             self->glassOffScreen = nil;
             [self addSublayer:mtlLayer];
         } else {
+            LOG("GlassLayer initGlassLayer using CGLLayer");
             GlassLayerCGL* cglLayer = [[GlassLayerCGL alloc] initWithSharedContext:(CGLContextObj)ctx
                                                                   andClientContext:(CGLContextObj)clCtx
                                                                     withHiDPIAware:HiDPIAware

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassLayer.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassLayer.m
@@ -45,14 +45,13 @@ static NSArray *allModes = nil;
          mtlQueuePtr:(long)mtlCommandQueuePtr
       withHiDPIAware:(BOOL)HiDPIAware
         withIsSwPipe:(BOOL)isSwPipe
-       useMTLForBlit:(BOOL)useMTLInGlass
+         useMTLForSW:(BOOL)mtlForSW
 {
     LOG("GlassLayer initGlassLayer]");
     self = [super init];
     if (self != nil)
     {
-        if (mtlCommandQueuePtr != 0l ||
-            useMTLInGlass) { // MTL
+        if (mtlCommandQueuePtr != 0l || mtlForSW) { // MTL
             LOG("GlassLayer initGlassLayer using MTLLayer");
             GlassLayerMTL* mtlLayer = [[GlassLayerMTL alloc] init:mtlCommandQueuePtr
                                                      withIsSwPipe:isSwPipe];

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassView3D.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassView3D.m
@@ -110,7 +110,7 @@
     // TODO : We again fetch isHiDPIAware in GlassViewCGL
     // Try to merge it
     self->isHiDPIAware = NO;
-    BOOL useMTLInGlass = NO;
+    BOOL mtlForSW = NO;
     if (jproperties != NULL)
     {
         jobject kHiDPIAwareKey = (*env)->NewObject(env, jIntegerClass, jIntegerInitMethod, com_sun_glass_ui_View_Capability_kHiDPIAwareKeyValue);
@@ -122,12 +122,12 @@
             self->isHiDPIAware = (*env)->CallBooleanMethod(env, kHiDPIAwareValue, jBooleanValueMethod) ? YES : NO;
             GLASS_CHECK_EXCEPTION(env);
         }
-        jobject useMTLInGlassKey = (*env)->NewStringUTF(env, "useMTLInGlass");
-        jobject useMTLInGlassValue = (*env)->CallObjectMethod(env, jproperties, jMapGetMethod, useMTLInGlassKey);
+        jobject mtlForSWKey = (*env)->NewStringUTF(env, "useMTLInGlassForSW");
+        jobject mtlForSWValue = (*env)->CallObjectMethod(env, jproperties, jMapGetMethod, mtlForSWKey);
         GLASS_CHECK_EXCEPTION(env);
-        if (useMTLInGlassValue != NULL)
+        if (mtlForSWValue != NULL)
         {
-            useMTLInGlass = (*env)->CallBooleanMethod(env, useMTLInGlassValue, jBooleanValueMethod) ? YES : NO;
+            mtlForSW = (*env)->CallBooleanMethod(env, mtlForSWValue, jBooleanValueMethod) ? YES : NO;
             GLASS_CHECK_EXCEPTION(env);
         }
     }
@@ -135,16 +135,16 @@
     self = [super initWithFrame:frame];
     if (self != nil) {
         if (mtlCommandQueuePtr != 0l ||
-            useMTLInGlass) {
+            mtlForSW) {
             LOG("GlassView3D initWithFrame using MTLView");
             GlassViewMTL* mtlSubView;
-            subView = mtlSubView = [[GlassViewMTL alloc] initWithFrame:frame withJview:jView withJproperties:jproperties useMTLForBlit:useMTLInGlass];
+            subView = mtlSubView = [[GlassViewMTL alloc] initWithFrame:frame withJview:jView withJproperties:jproperties useMTLForSW:mtlForSW];
             self->layer = [mtlSubView getLayer];
             self->isHiDPIAware = YES;
         } else {
             LOG("GlassView3D initWithFrame using CGLView");
             GlassViewCGL* cglSubView;
-            subView = cglSubView = [[GlassViewCGL alloc] initWithFrame:frame withJview:jView withJproperties:jproperties useMTLForBlit:useMTLInGlass];
+            subView = cglSubView = [[GlassViewCGL alloc] initWithFrame:frame withJview:jView withJproperties:jproperties useMTLForSW:mtlForSW];
             self->layer = [cglSubView getLayer];
         }
         [subView setAutoresizingMask:(NSViewWidthSizable|NSViewHeightSizable)];

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassView3D.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassView3D.m
@@ -134,8 +134,7 @@
 
     self = [super initWithFrame:frame];
     if (self != nil) {
-        if (mtlCommandQueuePtr != 0l ||
-            mtlForSW) {
+        if (mtlCommandQueuePtr != 0l || mtlForSW) {
             LOG("GlassView3D initWithFrame using MTLView");
             GlassViewMTL* mtlSubView;
             subView = mtlSubView = [[GlassViewMTL alloc] initWithFrame:frame withJview:jView withJproperties:jproperties useMTLForSW:mtlForSW];

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassViewCGL.h
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassViewCGL.h
@@ -46,6 +46,7 @@
 
 - (id)initWithFrame:(NSRect)frame
           withJview:(jobject)jView
-    withJproperties:(jobject)jproperties;
+    withJproperties:(jobject)jproperties
+      useMTLForBlit:(BOOL)useMTLInGlass;
 
 @end

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassViewCGL.h
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassViewCGL.h
@@ -47,6 +47,6 @@
 - (id)initWithFrame:(NSRect)frame
           withJview:(jobject)jView
     withJproperties:(jobject)jproperties
-      useMTLForBlit:(BOOL)useMTLInGlass;
+        useMTLForSW:(BOOL)mtlForSW;
 
 @end

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassViewCGL.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassViewCGL.m
@@ -88,6 +88,7 @@
 }
 
 - (void)_initialize3dWithJproperties:(jobject)jproperties
+                       useMTLForBlit:(BOOL)useMTLInGlass
 {
     GET_MAIN_JENV;
 
@@ -173,7 +174,8 @@
                                     andClientContext:(NSObject*)clientCGL
                                          mtlQueuePtr:0l
                                       withHiDPIAware:isHiDPIAware
-                                        withIsSwPipe:isSwPipe];
+                                        withIsSwPipe:isSwPipe
+                                       useMTLForBlit:useMTLInGlass];
     // https://developer.apple.com/library/mac/documentation/Cocoa/Reference/ApplicationKit/Classes/nsview_Class/Reference/NSView.html#//apple_ref/occ/instm/NSView/setWantsLayer:
     // the order of the following 2 calls is important: here we indicate we want a layer-hosting view
     [self setLayer:self->layer];
@@ -183,6 +185,7 @@
 - (id)initWithFrame:(NSRect)frame
           withJview:(jobject)jView
     withJproperties:(jobject)jproperties
+      useMTLForBlit:(BOOL)useMTLInGlass;
 {
     LOG("GlassViewCGL initWithFrame:withJview:withJproperties");
 
@@ -200,7 +203,8 @@
     self = [super initWithFrame:frame pixelFormat:pFormat];
     if (self != nil)
     {
-        [self _initialize3dWithJproperties:jproperties];
+        [self _initialize3dWithJproperties:jproperties
+            useMTLForBlit:(BOOL)useMTLInGlass];
     }
     return self;
 }

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassViewCGL.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassViewCGL.m
@@ -88,7 +88,7 @@
 }
 
 - (void)_initialize3dWithJproperties:(jobject)jproperties
-                       useMTLForBlit:(BOOL)useMTLInGlass
+                         useMTLForSW:(BOOL)mtlForSW
 {
     GET_MAIN_JENV;
 
@@ -175,7 +175,7 @@
                                          mtlQueuePtr:0l
                                       withHiDPIAware:isHiDPIAware
                                         withIsSwPipe:isSwPipe
-                                       useMTLForBlit:useMTLInGlass];
+                                         useMTLForSW:mtlForSW];
     // https://developer.apple.com/library/mac/documentation/Cocoa/Reference/ApplicationKit/Classes/nsview_Class/Reference/NSView.html#//apple_ref/occ/instm/NSView/setWantsLayer:
     // the order of the following 2 calls is important: here we indicate we want a layer-hosting view
     [self setLayer:self->layer];
@@ -185,7 +185,7 @@
 - (id)initWithFrame:(NSRect)frame
           withJview:(jobject)jView
     withJproperties:(jobject)jproperties
-      useMTLForBlit:(BOOL)useMTLInGlass;
+        useMTLForSW:(BOOL)mtlForSW;
 {
     LOG("GlassViewCGL initWithFrame:withJview:withJproperties");
 
@@ -204,7 +204,7 @@
     if (self != nil)
     {
         [self _initialize3dWithJproperties:jproperties
-            useMTLForBlit:(BOOL)useMTLInGlass];
+                               useMTLForSW:(BOOL)mtlForSW];
     }
     return self;
 }

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassViewMTL.h
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassViewMTL.h
@@ -35,6 +35,7 @@
 - (GlassLayer*)getLayer;
 - (id)initWithFrame:(NSRect)frame
           withJview:(jobject)jView
-    withJproperties:(jobject)jproperties;
+    withJproperties:(jobject)jproperties
+      useMTLForBlit:(BOOL)useMTLInGlass;
 
 @end

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassViewMTL.h
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassViewMTL.h
@@ -36,6 +36,6 @@
 - (id)initWithFrame:(NSRect)frame
           withJview:(jobject)jView
     withJproperties:(jobject)jproperties
-      useMTLForBlit:(BOOL)useMTLInGlass;
+        useMTLForSW:(BOOL)mtlForSW;
 
 @end

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassViewMTL.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassViewMTL.m
@@ -37,6 +37,7 @@
 @implementation GlassViewMTL
 
 - (void)_initialize3dWithJproperties:(jobject)jproperties
+                       useMTLForBlit:(BOOL)useMTLInGlass
 {
     GET_MAIN_JENV;
     long mtlCommandQueuePtr = 0l;
@@ -86,7 +87,8 @@
 
     self->layer = [[GlassLayer alloc] initGlassLayer:nil
         andClientContext:nil mtlQueuePtr:mtlCommandQueuePtr
-        withHiDPIAware:YES withIsSwPipe:isSwPipe];
+        withHiDPIAware:YES withIsSwPipe:isSwPipe
+        useMTLForBlit:useMTLInGlass];
 
     // https://developer.apple.com/library/mac/documentation/Cocoa/Reference/ApplicationKit/Classes/nsview_Class/Reference/NSView.html#//apple_ref/occ/instm/NSView/setWantsLayer:
     // the order of the following 2 calls is important: here we indicate we want a layer-hosting view
@@ -102,14 +104,15 @@
     return TRUE;
 }
 
-- (id)initWithFrame:(NSRect)frame withJview:(jobject)jView withJproperties:(jobject)jproperties
+- (id)initWithFrame:(NSRect)frame withJview:(jobject)jView withJproperties:(jobject)jproperties useMTLForBlit:(BOOL)useMTLInGlass
 {
     LOG("GlassViewMTL initWithFrame:withJview:withJproperties");
 
     self = [super initWithFrame: frame];
     if (self != nil)
     {
-        [self _initialize3dWithJproperties:jproperties];
+        [self _initialize3dWithJproperties:jproperties
+                useMTLForBlit:(BOOL)useMTLInGlass];
     }
     return self;
 }

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassViewMTL.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassViewMTL.m
@@ -37,7 +37,7 @@
 @implementation GlassViewMTL
 
 - (void)_initialize3dWithJproperties:(jobject)jproperties
-                       useMTLForBlit:(BOOL)useMTLInGlass
+                         useMTLForSW:(BOOL)mtlForSW
 {
     GET_MAIN_JENV;
     long mtlCommandQueuePtr = 0l;
@@ -86,9 +86,11 @@
     }
 
     self->layer = [[GlassLayer alloc] initGlassLayer:nil
-        andClientContext:nil mtlQueuePtr:mtlCommandQueuePtr
-        withHiDPIAware:YES withIsSwPipe:isSwPipe
-        useMTLForBlit:useMTLInGlass];
+                                    andClientContext:nil
+                                         mtlQueuePtr:mtlCommandQueuePtr
+                                      withHiDPIAware:YES
+                                        withIsSwPipe:isSwPipe
+                                         useMTLForSW:mtlForSW];
 
     // https://developer.apple.com/library/mac/documentation/Cocoa/Reference/ApplicationKit/Classes/nsview_Class/Reference/NSView.html#//apple_ref/occ/instm/NSView/setWantsLayer:
     // the order of the following 2 calls is important: here we indicate we want a layer-hosting view
@@ -104,7 +106,7 @@
     return TRUE;
 }
 
-- (id)initWithFrame:(NSRect)frame withJview:(jobject)jView withJproperties:(jobject)jproperties useMTLForBlit:(BOOL)useMTLInGlass
+- (id)initWithFrame:(NSRect)frame withJview:(jobject)jView withJproperties:(jobject)jproperties useMTLForSW:(BOOL)mtlForSW
 {
     LOG("GlassViewMTL initWithFrame:withJview:withJproperties");
 
@@ -112,7 +114,7 @@
     if (self != nil)
     {
         [self _initialize3dWithJproperties:jproperties
-                useMTLForBlit:(BOOL)useMTLInGlass];
+                               useMTLForSW:(BOOL)mtlForSW];
     }
     return self;
 }


### PR DESCRIPTION
We have Metal pipeline also now in macOS apart from OpenGL pipeline for accelerated hardware pipelines.

Currently when Software pipeline is used we continue to use OpenGL(ES2) pipeline on glass side, which is the default hardware pipeline in macOS. If we want to switch to Metal pipeline as default hardware pipeline in prism, we should be able to use Metal pipeline in glass also when software pipeline is used. For this to happen we need to set some information when SWPipeline is getting initialized and pass that information to glass.

This PR adds new flag `useMTLInGlass` in device details when SWPipeline is getting initialized and then passes it to glass code. When SWPipeline is used, based on this flag we will use appropriate hardware pipeline in glass.

Patch is tested when useMTLInGlass is set to true/false and then using -Dprism.order=es2/mtl/sw and it picks proper GlassView/Layer.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8350479](https://bugs.openjdk.org/browse/JDK-8350479): SW pipeline should use default pipeline in Glass (**Bug** - P3)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1868/head:pull/1868` \
`$ git checkout pull/1868`

Update a local copy of the PR: \
`$ git checkout pull/1868` \
`$ git pull https://git.openjdk.org/jfx.git pull/1868/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1868`

View PR using the GUI difftool: \
`$ git pr show -t 1868`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1868.diff">https://git.openjdk.org/jfx/pull/1868.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1868#issuecomment-3183884499)
</details>
