### PR TITLE
8365632: Remove unused local variable in GlassWindow

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/win/GlassWindow.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/win/GlassWindow.cpp
@@ -831,10 +831,9 @@ void GlassWindow::HandleFocusDisabledEvent()
 
 LRESULT GlassWindow::HandleNCCalcSizeEvent(UINT msg, WPARAM wParam, LPARAM lParam)
 {
-    // Capture the top and size before DefWindowProc applies the default frame.
+    // Capture the top before DefWindowProc applies the default frame.
     NCCALCSIZE_PARAMS *p = (NCCALCSIZE_PARAMS*)lParam;
     LONG originalTop = p->rgrc[0].top;
-    RECT originalSize = p->rgrc[0];
 
     // Apply the default window frame.
     LRESULT res = DefWindowProc(GetHWND(), msg, wParam, lParam);


### PR DESCRIPTION
`originalSize` in GlassWindow::HandleNCCalcSizeEvent is not used and can be removed.