### PR TITLE
JDK-8365637 Unmanaged nodes are not added to the Scene's dirty layout list

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
@@ -8651,6 +8651,12 @@ public abstract sealed class Node
     }
 
     void markDirtyLayoutBranch() {
+        if (this instanceof Parent p && p.layoutRoot) {  // is this node a layout root?
+            markAsDirtyLayoutRoot(p);
+
+            return;  // No need to propagate flags any further up the hierarchy
+        }
+
         Parent p = getParent();
         while (p != null && p.layoutFlag == LayoutFlags.CLEAN) {
             p.setLayoutFlag(LayoutFlags.DIRTY_BRANCH);
@@ -8660,9 +8666,23 @@ public abstract sealed class Node
                     getSubScene().setDirtyLayout(p);
                 }
             }
+            else if (p.layoutRoot) {
+                markAsDirtyLayoutRoot(p);
+
+                return;  // No need to propagate flags any further up the hierarchy
+            }
+
             p = p.getParent();
         }
+    }
 
+    private void markAsDirtyLayoutRoot(Parent p) {
+        Toolkit.getToolkit().requestNextPulse();
+        Scene s = getScene();
+
+        if (s != null) {
+            s.addToDirtyLayoutList(p);
+        }
     }
 
     private boolean isWindowShowing() {

--- a/modules/javafx.graphics/src/main/java/javafx/scene/Parent.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Parent.java
@@ -1021,7 +1021,7 @@ public abstract non-sealed class Parent extends Node {
      * rendered. This is batched up asynchronously to happen once per
      * "pulse", or frame of animation.
      * <p>
-     * If this parent is either a layout root or unmanaged, then it will be
+     * If this parent is either a scene root or unmanaged, then it will be
      * added directly to the scene's dirty layout list, otherwise requestParentLayout
      * will be invoked.
      * @since JavaFX 8.0

--- a/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
@@ -645,6 +645,21 @@ public class Scene implements EventTarget {
         clearInitialCssStateNodes.remove(node);
     }
 
+    /**
+     * A set of nodes that are layout roots and are in need of layout. Any unmanaged
+     * {@link Parent} is considered a layout root. If a child of such a node
+     * requests layout, the layout root will be added to this set, to be laid
+     * out on the next layout pass.
+     *
+     * @see Node#managedProperty()
+     * @see Parent#requestLayout()
+     */
+    private final Set<Parent> dirtyLayoutRoots = new HashSet<>();
+
+    void addToDirtyLayoutList(Parent layoutRoot) {
+        dirtyLayoutRoots.add(layoutRoot);
+    }
+
     void doLayoutPass() {
         if (peer != null) {
             peer.layoutOverlay();
@@ -653,6 +668,14 @@ public class Scene implements EventTarget {
         final Parent r = getRoot();
         if (r != null) {
             r.layout();
+        }
+
+        Set<Parent> copy = new HashSet<>(dirtyLayoutRoots);
+
+        dirtyLayoutRoots.clear();
+
+        for (Parent parent : copy) {
+            parent.layout();
         }
     }
 


### PR DESCRIPTION
This PR adds the necessary logic to automatically relayout unmanaged nodes when they're dirty as specified by the documentation. Relevant sections (emphasis mine):

### Parent::requestLayout

> If this parent is either a layout root or unmanaged, then it will be added directly to the **scene's dirty layout list**, otherwise requestParentLayout will be invoked.

### Node::managedProperty

> If a managed node's layoutBounds changes, it will **automatically trigger relayout** up the scene-graph to the **nearest layout root**

And:

> If an **unmanaged node** is of type `Parent`, it will act as a **"layout root"**

From this I conclude that:
- A layout root is any node that is unmanaged (and of type `Parent`), or a Scene's root node
- Changes requiring layout in managed children that have an unmanaged parent somewhere in their ancestry should cause layout to be triggered for the affected areas
- Automatic relayout is triggered either by scheduling a pulse (for scene roots) or by adding a layout root to the Scene's dirty layout list

Note that Scene currently does not have a dirty layout list.

Note also that the documentation for `requestLayout` probably meant to say "**scene** root or unmanaged" instead of "**layout** root or unmanaged."
