### PR TITLE
8365576: Temporarily make Metal the default JavaFX rendering pipeline for macOS

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/prism/impl/PrismSettings.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/impl/PrismSettings.java
@@ -205,7 +205,7 @@ public final class PrismSettings {
         if (PlatformUtil.isWindows()) {
             tryOrderArr = new String[] { "d3d", "sw" };
         } else if (PlatformUtil.isMac()) {
-            tryOrderArr = new String[] { "es2", "mtl", "sw" };
+            tryOrderArr = new String[] { "mtl", "es2", "sw" };
         } else if (PlatformUtil.isIOS()) {
             tryOrderArr = new String[] { "es2" };
         } else if (PlatformUtil.isAndroid()) {

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/impl/PrismSettings.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/impl/PrismSettings.java
@@ -205,6 +205,8 @@ public final class PrismSettings {
         if (PlatformUtil.isWindows()) {
             tryOrderArr = new String[] { "d3d", "sw" };
         } else if (PlatformUtil.isMac()) {
+            // Temporarily set the default rendering pipeline to Metal, to get more testing
+            // of Metal pipeline. It will be reverted with JDK-8365577.
             tryOrderArr = new String[] { "mtl", "es2", "sw" };
         } else if (PlatformUtil.isIOS()) {
             tryOrderArr = new String[] { "es2" };

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/impl/PrismSettings.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/impl/PrismSettings.java
@@ -206,7 +206,7 @@ public final class PrismSettings {
             tryOrderArr = new String[] { "d3d", "sw" };
         } else if (PlatformUtil.isMac()) {
             // Temporarily set the default rendering pipeline to Metal, to get more testing
-            // of Metal pipeline. It will be reverted with JDK-8365577.
+            // of Metal pipeline. This change will be reverted as part of JDK-8365577.
             tryOrderArr = new String[] { "mtl", "es2", "sw" };
         } else if (PlatformUtil.isIOS()) {
             tryOrderArr = new String[] { "es2" };


### PR DESCRIPTION
On macOS, temporarily set the default rendering pipeline to Metal, for the next ~7 weeks (until Oct 2).
This is done to get more testing of the Metal pipeline.
If you need to use the ES2 pipeline, add **-Dprism.order=es2** option to the Java command.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8365576](https://bugs.openjdk.org/browse/JDK-8365576): Temporarily make Metal the default JavaFX rendering pipeline for macOS (**Enhancement** - P3)


### Reviewers
 * [Jayathirth D V](https://openjdk.org/census#jdv) (@jayathirthrao - Committer)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1876/head:pull/1876` \
`$ git checkout pull/1876`

Update a local copy of the PR: \
`$ git checkout pull/1876` \
`$ git pull https://git.openjdk.org/jfx.git pull/1876/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1876`

View PR using the GUI difftool: \
`$ git pr show -t 1876`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1876.diff">https://git.openjdk.org/jfx/pull/1876.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1876#issuecomment-3199477904)
</details>
