### PR TITLE
8365402: Bump minimum JDK version for JavaFX to JDK 24

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -234,7 +234,7 @@ New code should be formatted consistently in accordance with the above guideline
 
 ### Building and testing
 
-JDK 23 (at a minimum) is required to build OpenJFX. You must have the JDK
+JDK 24 (at a minimum) is required to build OpenJFX. You must have the JDK
 installed on your system
 with the environment variable `JAVA_HOME` referencing the path to Java home for
 your JDK installation. By default, tests use the same runtime as `JAVA_HOME`.

--- a/build.properties
+++ b/build.properties
@@ -90,9 +90,9 @@ javadoc.top=<div style="padding: 6px; text-align: center; font-size: 80%;">This 
 jdk.docs.version=24
 jfx.build.jdk.version=24.0.1
 jfx.build.jdk.buildnum=9
-jfx.build.jdk.version.min=23
-jfx.build.jdk.buildnum.min=37
-jfx.jdk.target.version=23
+jfx.build.jdk.version.min=24
+jfx.build.jdk.buildnum.min=36
+jfx.jdk.target.version=24
 
 # The jfx.gradle.version property defines the version of gradle that is
 # used in the build. It must match the version number in
@@ -100,7 +100,7 @@ jfx.jdk.target.version=23
 # The jfx.gradle.version.min property defines the minimum version of gradle
 # that is supported. It must be <= jfx.gradle.version.
 jfx.gradle.version=8.14.2
-jfx.gradle.version.min=8.10.2
+jfx.gradle.version.min=8.14.2
 
 # Toolchains
 jfx.build.linux.gcc.version=gcc14.2.0-OL6.4+1.0


### PR DESCRIPTION
This PR bumps the minimum version of the JDK needed to run JavaFX to JDK 24.

In order for JavaFX to be able to use more recent JDK features, we should increase the minimum version of the JDK that can run the latest JavaFX. Additionally, there is an ongoing cost to keeping JavaFX buildable and runnable on older versions of Java, and little reason to continue to do so.

This continues our current practice of setting the minimum JDK for JavaFX N to JDK N-2. JavaFX N is primarily intended for use with JDK N and we also build and test it against JDK N-1 (which is typically what we use as the boot JDK). Anything older than that, including the proposed minimum JDK N-2 (24 in this specific case), is untested.

This PR targeted to JavaFX 26, and must not be backported to any earlier version. This needs a CSR and a release note.

/reviewers 2
/csr
