### PR TITLE
8366842: Update the classpath file of the graphics module

### DIFF
--- a/modules/javafx.graphics/.classpath
+++ b/modules/javafx.graphics/.classpath
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src/main/java"/>
-	<classpathentry kind="src" path="build/gensrc/jsl-prism"/>
-	<classpathentry kind="src" path="build/gensrc/jsl-decora"/>
-	<classpathentry kind="src" path="build/hlsl/Decora"/>
-	<classpathentry kind="src" path="build/hlsl/Prism"/>
-	<classpathentry kind="src" path="build/msl/"/>
+	<classpathentry kind="src" path="src/main/resources">
+		<attributes>
+			<attribute name="optional" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="src" output="testbin" path="src/shims/java">
 		<attributes>
 			<attribute name="test" value="true"/>
@@ -14,11 +14,6 @@
 	<classpathentry kind="src" output="testbin" path="src/test/java">
 		<attributes>
 			<attribute name="test" value="true"/>
-			<attribute name="optional" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="src" path="src/main/resources">
-		<attributes>
 			<attribute name="optional" value="true"/>
 		</attributes>
 	</classpathentry>

--- a/modules/javafx.graphics/.classpath
+++ b/modules/javafx.graphics/.classpath
@@ -1,6 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src/main/java"/>
+	<classpathentry kind="src" path="build/gensrc/jsl-prism"/>
+	<classpathentry kind="src" path="build/gensrc/jsl-decora"/>
+	<classpathentry kind="src" path="build/msl">
+		<attributes>
+			<attribute name="ignore_optional_problems" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" path="build/hlsl/Decora">
+		<attributes>
+			<attribute name="ignore_optional_problems" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" path="build/hlsl/Prism">
+		<attributes>
+			<attribute name="ignore_optional_problems" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="src" path="src/main/resources">
 		<attributes>
 			<attribute name="optional" value="true"/>


### PR DESCRIPTION
Removed the the directories under "build" from the sources list in Eclipse since they can be platform-specific or just irrelevant for almost all cases. Contributors can add them manually as needed.

Another option is to mark them as optional.

/reviewers 2

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8366842](https://bugs.openjdk.org/browse/JDK-8366842): Update the classpath file of the graphics module (**Task** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [John Hendrikx](https://openjdk.org/census#jhendrikx) (@hjohn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1884/head:pull/1884` \
`$ git checkout pull/1884`

Update a local copy of the PR: \
`$ git checkout pull/1884` \
`$ git pull https://git.openjdk.org/jfx.git pull/1884/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1884`

View PR using the GUI difftool: \
`$ git pr show -t 1884`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1884.diff">https://git.openjdk.org/jfx/pull/1884.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1884#issuecomment-3250993019)
</details>
