### PR TITLE
8356687: [TestBug] SWT tests do not run on macOS

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -497,8 +497,8 @@ defineProperty("AWT_TEST", "true")
 ext.IS_AWT_TEST = Boolean.parseBoolean(AWT_TEST);
 
 // Specifies whether to run system tests that depend on SWT (only used when FULL_TEST is also enabled)
-// JDK-8356687 and JDK-8356688 track the disablement of the SWT tests on both platforms.
-defineProperty("SWT_TEST", (IS_MAC || IS_LINUX) ? "false" : "true")
+// JDK-8356688 tracks the disablement of the SWT tests on Linux platform.
+defineProperty("SWT_TEST", (IS_LINUX) ? "false" : "true")
 ext.IS_SWT_TEST = Boolean.parseBoolean(SWT_TEST);
 
 // Specifies whether to run unstable tests (true) - tests that don't run well with Hudson builds
@@ -3213,6 +3213,9 @@ project(":swt") {
         enabled = IS_FULL_TEST && IS_SWT_TEST
 
         jvmArgs enableNativeGraphics
+        if (IS_MAC) {
+            jvmArgs "-XstartOnFirstThread"
+        }
 
     }
 


### PR DESCRIPTION
We have enabled swt tests under [JDK-8169285](https://bugs.openjdk.org/browse/JDK-8169285) but they were disabled on macOS as they throw below exception :

```
FXCanvasScaledTest STANDARD_OUT
    ***WARNING: Display must be created on main thread due to Cocoa restrictions. Use vmarg -XstartOnFirstThread

FXCanvasScaledTest > initializationError FAILED
    org.eclipse.swt.SWTException: Invalid thread access
```

Using `-XstartOnFirstThread` flag in gradle was not reliable and the issue was tracked under https://issues.gradle.org/browse/GRADLE-3290 and later under https://github.com/gradle/gradle/issues/864. This gradle issue is resolved and we can use `-XstartOnFirstThread` and enable SWT tests on macOS.

With `-XstartOnFirstThread`, SWT tests run fine on macOS.