### PR TITLE
8356688: [TestBug] SWT tests fail on some Linux distros

### DIFF
--- a/apps/toys/HelloFXCanvas/README.txt
+++ b/apps/toys/HelloFXCanvas/README.txt
@@ -6,6 +6,4 @@ HOW TO RUN
 2) Run "java @build/run.args --add-modules javafx.swt --enable-native-access=ALL-UNNAMED -cp apps/toys/HelloFXCanvas/dist/HelloFXCanvas.jar:build/libs/swt-debug.jar hellofxcanvas.HelloFXCanvas"
 3) In case of macOS we also need to pass -XstartOnFirstThread JVM argument to make SWT work with JavaFX
 4) In case of Windows path separator should be changed from ':' to ';'
-5) In case of Linux running on Wayland, we need to override X11 as backend for GDK, this can be done
-by using the command "export GDK_BACKEND=x11"
 =================================================================================================================


### PR DESCRIPTION
SWT unit tests were not enabled under [JDK-8169285](https://bugs.openjdk.org/browse/JDK-8169285) as it resulted in crash. We forced x11 as GDK backend under [JDK-8210411](https://bugs.openjdk.org/browse/JDK-8210411) but this is not sufficient in case where FXCanvas is embedded in an SWT window as captured at : https://github.com/openjdk/jfx/pull/1783#issuecomment-2844889943

Setting the environment variable in :swt:test gradle task fixes the issue. This is verified in Ubuntu 22.04 and 24.04 and swt tests run fine.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356688](https://bugs.openjdk.org/browse/JDK-8356688): [TestBug] SWT tests fail on some Linux distros (**Bug** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1890/head:pull/1890` \
`$ git checkout pull/1890`

Update a local copy of the PR: \
`$ git checkout pull/1890` \
`$ git pull https://git.openjdk.org/jfx.git pull/1890/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1890`

View PR using the GUI difftool: \
`$ git pr show -t 1890`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1890.diff">https://git.openjdk.org/jfx/pull/1890.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1890#issuecomment-3274230918)
</details>
