### PR TITLE
8367306: HeaderButtonOverlayTest fails to compile with TEST_SDK_PATH

### DIFF
--- a/modules/javafx.graphics/src/test/addExports
+++ b/modules/javafx.graphics/src/test/addExports
@@ -5,6 +5,7 @@
 --add-exports javafx.base/com.sun.javafx.event=ALL-UNNAMED
 --add-exports javafx.base/com.sun.javafx.logging=ALL-UNNAMED
 #
+--add-exports javafx.graphics/com.sun.glass.events=ALL-UNNAMED
 --add-exports javafx.graphics/com.sun.glass.ui=ALL-UNNAMED
 --add-exports javafx.graphics/com.sun.javafx.animation=ALL-UNNAMED
 --add-exports javafx.graphics/com.sun.javafx.application=ALL-UNNAMED


### PR DESCRIPTION
When using `-PTEST_SDK_PATH=<path>` and `-PTEST_ONLY=true`, the test `HeaderButtonOverlayTest` fails to compile with error: _package com.sun.glass.events is not visible_

The test compiles and executes fine with normal command: `gradle :graphics:test`.
In this case the JavaFX is built locally and the `com.sun.glass.events.MouseEvent` class file becomes reachable through classpath. A bug is filed to investigate this separately : [JDK-8367327](https://bugs.openjdk.org/browse/JDK-8367327)

Fix is quick, to update the `modules/javafx.graphics/src/test/addExports`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367306](https://bugs.openjdk.org/browse/JDK-8367306): HeaderButtonOverlayTest fails to compile with TEST_SDK_PATH (**Bug** - P3)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1891/head:pull/1891` \
`$ git checkout pull/1891`

Update a local copy of the PR: \
`$ git checkout pull/1891` \
`$ git pull https://git.openjdk.org/jfx.git pull/1891/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1891`

View PR using the GUI difftool: \
`$ git pr show -t 1891`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1891.diff">https://git.openjdk.org/jfx/pull/1891.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1891#issuecomment-3274548703)
</details>
