### PR TITLE
8321625: ContextMenuNPETest fails intermittently on Linux

### DIFF
--- a/tests/system/src/test/java/test/robot/javafx/scene/ContextMenuNPETest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/ContextMenuNPETest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
The test seems to be working in Linux currently, so I enabled it for Linux systems.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321625](https://bugs.openjdk.org/browse/JDK-8321625): ContextMenuNPETest fails intermittently on Linux (**Bug** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1893/head:pull/1893` \
`$ git checkout pull/1893`

Update a local copy of the PR: \
`$ git checkout pull/1893` \
`$ git pull https://git.openjdk.org/jfx.git pull/1893/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1893`

View PR using the GUI difftool: \
`$ git pr show -t 1893`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1893.diff">https://git.openjdk.org/jfx/pull/1893.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1893#issuecomment-3276556690)
</details>
