### PR TITLE
8367370: Accent color platform preference not updating in macOS 26 (Tahoe)

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/mac/PlatformSupport.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/PlatformSupport.m
@@ -103,16 +103,15 @@
     self->currentPathConstrained = false;
     self->currentPathExpensive = false;
 
+    [NSApp addObserver:self
+           forKeyPath:@"effectiveAppearance"
+           options:0
+           context:nil];
+
     [[NSNotificationCenter defaultCenter]
         addObserver:self
         selector:@selector(updatePreferences)
         name:NSPreferredScrollerStyleDidChangeNotification
-        object:nil];
-
-    [[NSDistributedNotificationCenter defaultCenter]
-        addObserver:self
-        selector:@selector(updatePreferences)
-        name:@"AppleInterfaceThemeChangedNotification"
         object:nil];
 
     [[NSNotificationCenter defaultCenter]
@@ -141,10 +140,14 @@
 }
 
 - (void)stopEventProcessing {
+    [NSApp removeObserver:self forKeyPath:@"effectiveAppearance"];
     [[NSNotificationCenter defaultCenter] removeObserver:self];
-    [[NSDistributedNotificationCenter defaultCenter] removeObserver:self];
     [[[NSWorkspace sharedWorkspace] notificationCenter] removeObserver:self];
     nw_path_monitor_cancel(pathMonitor);
+}
+
+- (void)observeValueForKeyPath:(NSString*)keyPath ofObject:(id)object change:(NSDictionary*)change context:(void*)c {
+    [self updatePreferences];
 }
 
 - (jobject)collectPreferences {

--- a/modules/javafx.graphics/src/main/native-glass/mac/PlatformSupport.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/PlatformSupport.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -105,25 +105,25 @@
 
     [[NSNotificationCenter defaultCenter]
         addObserver:self
-        selector:@selector(platformPreferencesDidChange)
+        selector:@selector(updatePreferences)
         name:NSPreferredScrollerStyleDidChangeNotification
         object:nil];
 
     [[NSDistributedNotificationCenter defaultCenter]
         addObserver:self
-        selector:@selector(platformPreferencesDidChange)
+        selector:@selector(updatePreferences)
         name:@"AppleInterfaceThemeChangedNotification"
         object:nil];
 
-    [[NSDistributedNotificationCenter defaultCenter]
+    [[NSNotificationCenter defaultCenter]
         addObserver:self
-        selector:@selector(platformPreferencesDidChange)
-        name:@"AppleColorPreferencesChangedNotification"
+        selector:@selector(updatePreferences)
+        name:NSSystemColorsDidChangeNotification
         object:nil];
 
     [[[NSWorkspace sharedWorkspace] notificationCenter]
         addObserver:self
-        selector:@selector(platformPreferencesDidChange)
+        selector:@selector(updatePreferences)
         name:NSWorkspaceAccessibilityDisplayOptionsDidChangeNotification
         object:nil];
 
@@ -145,21 +145,6 @@
     [[NSDistributedNotificationCenter defaultCenter] removeObserver:self];
     [[[NSWorkspace sharedWorkspace] notificationCenter] removeObserver:self];
     nw_path_monitor_cancel(pathMonitor);
-}
-
-- (void)platformPreferencesDidChange {
-    // Some dynamic colors like NSColor.controlAccentColor don't seem to be reliably updated
-    // at the exact moment AppleColorPreferencesChangedNotification is received.
-    // As a workaround, we wait for a short period of time (one second seems sufficient) before
-    // we query the updated platform preferences.
-
-    [NSObject cancelPreviousPerformRequestsWithTarget:self
-              selector:@selector(updatePreferences)
-              object:nil];
-
-    [self performSelector:@selector(updatePreferences)
-          withObject:nil
-          afterDelay:1.0];
 }
 
 - (jobject)collectPreferences {


### PR DESCRIPTION
1. Replace undocumented `AppleColorPreferencesChangedNotification` with `NSSystemColorsDidChangeNotification`.
2. Replace undocumented `AppleInterfaceThemeChangedNotification` with a KVO registration for `NSApp.effectiveAppearance`.

This fix can be tested using either PlatformPreferencesChangedTest, or Monkey Tester > Tools > Platform preferences monitor.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8367370](https://bugs.openjdk.org/browse/JDK-8367370): Accent color platform preference not updating in macOS 26 (Tahoe) (**Bug** - P4)


### Reviewers
 * [Martin Fox](https://openjdk.org/census#mfox) (@beldenfox - Committer)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1895/head:pull/1895` \
`$ git checkout pull/1895`

Update a local copy of the PR: \
`$ git checkout pull/1895` \
`$ git pull https://git.openjdk.org/jfx.git pull/1895/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1895`

View PR using the GUI difftool: \
`$ git pr show -t 1895`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1895.diff">https://git.openjdk.org/jfx/pull/1895.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1895#issuecomment-3276822145)
</details>
