### PR TITLE
8366805: Skip failing MenuDoubleShortcutTest on macOS

### DIFF
--- a/tests/system/src/test/java/test/robot/javafx/scene/MenuDoubleShortcutTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/MenuDoubleShortcutTest.java
@@ -94,6 +94,7 @@ public class MenuDoubleShortcutTest {
     //
     // https://bugs.openjdk.org/browse/JDK-8087863
     // https://bugs.openjdk.org/browse/JDK-8088897
+    @Disabled("JDK-8364405")
     @Test
     void macSceneComesBeforeMenuBar() {
         Assumptions.assumeTrue(PlatformUtil.isMac());


### PR DESCRIPTION
Skip macOS specific MenuDoubleShortcutTest.macSceneComesBeforeMenuBar() test until the issue is fixed under [JDK-8364405](https://bugs.openjdk.org/browse/JDK-8364405)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8366805](https://bugs.openjdk.org/browse/JDK-8366805): Skip failing MenuDoubleShortcutTest on macOS (**Bug** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1896/head:pull/1896` \
`$ git checkout pull/1896`

Update a local copy of the PR: \
`$ git checkout pull/1896` \
`$ git pull https://git.openjdk.org/jfx.git pull/1896/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1896`

View PR using the GUI difftool: \
`$ git pr show -t 1896`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1896.diff">https://git.openjdk.org/jfx/pull/1896.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1896#issuecomment-3279377308)
</details>
