### PR TITLE
8340378: [XWayland] FXCanvas apps and tests crash on Ubuntu 24.04

### DIFF
--- a/apps/toys/HelloFXCanvas/README.txt
+++ b/apps/toys/HelloFXCanvas/README.txt
@@ -6,4 +6,5 @@ HOW TO RUN
 2) Run "java @build/run.args --add-modules javafx.swt --enable-native-access=ALL-UNNAMED -cp apps/toys/HelloFXCanvas/dist/HelloFXCanvas.jar:build/libs/swt-debug.jar hellofxcanvas.HelloFXCanvas"
 3) In case of macOS we also need to pass -XstartOnFirstThread JVM argument to make SWT work with JavaFX
 4) In case of Windows path separator should be changed from ':' to ';'
+5) In case of Linux running on Wayland, we need to override X11 as backend for GDK, this can be done by using the command "export GDK_BACKEND=x11"
 =================================================================================================================


### PR DESCRIPTION
As mentioned in recent PR : https://github.com/openjdk/jfx/pull/1890#issue-3401783091, we need to set environment variable GDK_BACKEND=x11 for running HelloFXCanvas also.

There is no correct way of setting environment variable through Java code/Netbeans project files. So we are capturing this additional step for Linux in README.txt.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340378](https://bugs.openjdk.org/browse/JDK-8340378): [XWayland] FXCanvas apps and tests crash on Ubuntu 24.04 (**Bug** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1898/head:pull/1898` \
`$ git checkout pull/1898`

Update a local copy of the PR: \
`$ git checkout pull/1898` \
`$ git pull https://git.openjdk.org/jfx.git pull/1898/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1898`

View PR using the GUI difftool: \
`$ git pr show -t 1898`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1898.diff">https://git.openjdk.org/jfx/pull/1898.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1898#issuecomment-3284329365)
</details>
