### PR TITLE
8359154: Intermittent system test failures on macOS

### DIFF
--- a/tests/system/src/test/java/test/robot/javafx/scene/tableview/TableViewContextMenuSortTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/tableview/TableViewContextMenuSortTest.java
@@ -105,9 +105,9 @@ public class TableViewContextMenuSortTest {
         }
 
         /*
-        // This part of test is causing intermittent test failures on MacOS. see: JDK-8359154
-        // As a fix for JDK-8359154, this code is commented out.
-        // This code should be re-enabled with a more robust approach : JDK-8367566
+        // Skipped due to JDK-8367566
+        // This part of test is causing intermittent test failures on MacOS, see: JDK-8359154
+        // This code should be re-enabled with a more robust approach.
 
         // macOS only: Ctrl + Left click also triggers the context menu
         if (PlatformUtil.isMac()) {


### PR DESCRIPTION
Issue: 
On MacOS, several tests fail intermittently.

Fix: 
- The test TableViewContextMenuSortTest.testContextMenuRequestDoesNotSort() performs a Ctrl + Click test only on MacOS platform.
- If the Ctrl + Click is avoided, then the test failures are not observed.
- So this change comments out the part of the test in question.
- A follow-up ticket is created to investigate/update the test [JDK-8367566](https://bugs.openjdk.org/browse/JDK-8367566)

Verification:
1. Verified the headful test with full run, 12 times. The issue does not occur.
Without this change, the tests do fail more often.
2. @beldenfox shared a way to reproduce the failures, in a comment in JBS ticket : [JDK-8359154](https://bugs.openjdk.org/browse/JDK-8359154)**:** If these 5 tests are run repeatedly TableViewClickOnTroughTest, TableViewContextMenuSortTest, TableViewResizeColumnToFitContentTest, TreeTableViewChangeRootTest, and TreeTableViewResizeColumnToFitContentTest, then the issue could occur in 'n' iterations < 120. 
With this change, no test failure is observed. Several times, tested 120 iterations.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8359154](https://bugs.openjdk.org/browse/JDK-8359154): Intermittent system test failures on macOS (**Bug** - P3)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**) Review applies to [052cb57e](https://git.openjdk.org/jfx/pull/1899/files/052cb57e3c26899544c4b33a1cd8a5d8a46ce3aa)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1899/head:pull/1899` \
`$ git checkout pull/1899`

Update a local copy of the PR: \
`$ git checkout pull/1899` \
`$ git pull https://git.openjdk.org/jfx.git pull/1899/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1899`

View PR using the GUI difftool: \
`$ git pr show -t 1899`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1899.diff">https://git.openjdk.org/jfx/pull/1899.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1899#issuecomment-3286436461)
</details>
