### PR TITLE
8367602: Regression: TabPane with wrapped label calculates wrong initial size

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TabPaneSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TabPaneSkin.java
@@ -57,6 +57,7 @@ import javafx.event.ActionEvent;
 import javafx.event.EventHandler;
 import javafx.geometry.Bounds;
 import javafx.geometry.HPos;
+import javafx.geometry.Orientation;
 import javafx.geometry.Point2D;
 import javafx.geometry.Pos;
 import javafx.geometry.Side;
@@ -292,7 +293,11 @@ public class TabPaneSkin extends SkinBase<TabPane> {
         // The TabPane can only be as wide as it widest content width.
         double maxw = 0.0;
         for (TabContentRegion contentRegion: tabContentRegions) {
-            maxw = Math.max(maxw, snapSizeX(contentRegion.prefWidth(-1)));
+            double dependentHeight = contentRegion.getContentBias() == Orientation.VERTICAL
+                ? Math.max(0, contentRegion.prefHeight(-1) - topInset - bottomInset)
+                : -1;
+
+            maxw = Math.max(maxw, snapSizeX(contentRegion.prefWidth(dependentHeight)));
         }
 
         final boolean isHorizontal = isHorizontal();
@@ -310,7 +315,11 @@ public class TabPaneSkin extends SkinBase<TabPane> {
         // The TabPane can only be as high as it highest content height.
         double maxh = 0.0;
         for (TabContentRegion contentRegion: tabContentRegions) {
-            maxh = Math.max(maxh, snapSizeY(contentRegion.prefHeight(-1)));
+            double dependentWidth = contentRegion.getContentBias() == Orientation.HORIZONTAL
+                ? Math.max(0, contentRegion.prefWidth(-1) - leftInset - rightInset)
+                : -1;
+
+            maxh = Math.max(maxh, snapSizeY(contentRegion.prefHeight(dependentWidth)));
         }
 
         final boolean isHorizontal = isHorizontal();


### PR DESCRIPTION
Fix for regression in TabPane size calculation caused by https://bugs.openjdk.org/browse/JDK-8350149 (#1723) between versions 25-ea+8 and 25-ea+10

In Region several height calculations functions were altered to match the behavior and options of their horizontal counterparts to solve discrepancies between the behavior of vertical biased layouts and horizontal biased layouts, which other than their axis, should behave identical.

The height calculations would take a width provided by the caller, but if unavailable (set to -1) and the child was biased, it would just automatically query the child's preferred width and use that as the dependent width.

In contrast, the horizontal functions would only do this if a height was provided by the caller (not -1), and would only override this value if the property fillHeight was false (in which case it would query the child's height directly).

With the change in [JDK-8350149](https://bugs.openjdk.org/browse/JDK-8350149), the vertical calculations operate the same as the horizontal ones, as this is generally more flexible. However, the automatic behavior to query the child's size if the dependent size given was set to -1 is no longer there (as this behavior isn't how biased calculations should work).

The TabPaneSkin has chosen to directly call several width/height functions without obeying the content bias contract, which says that in case of bias, the dependent size must be calculated first and then passed to the size calculation one is interested in.

(As an aside, if TabPaneSkin had elected to put all tabs in a single StackPane, then StackPane would have correctly done these calculations, but digging into why it is done this way, with each individual Tab wrapped in its own Node (also a StackPane), is a bit out of scope for this fix).

As it is, TabPaneSkin should check the bias of the tab it is doing calculations for, and if biased, should first query the dependent size before triggering the size calculation it is interested in.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8367602](https://bugs.openjdk.org/browse/JDK-8367602): Regression: TabPane with wrapped label calculates wrong initial size (**Bug** - P3)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1900/head:pull/1900` \
`$ git checkout pull/1900`

Update a local copy of the PR: \
`$ git checkout pull/1900` \
`$ git pull https://git.openjdk.org/jfx.git pull/1900/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1900`

View PR using the GUI difftool: \
`$ git pr show -t 1900`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1900.diff">https://git.openjdk.org/jfx/pull/1900.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1900#issuecomment-3288689270)
</details>
