### PR TITLE
8367374: JavaFX debug builds fail on Windows

### DIFF
--- a/modules/javafx.web/src/main/native/Source/ThirdParty/icu/CMakeLists.txt
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/icu/CMakeLists.txt
@@ -1,12 +1,13 @@
 # http://userguide.icu-project.org/howtouseicu#TOC-C-With-Your-Own-Build-System
 if(WIN32)
-set(CMAKE_CXX_FLAGS "" CACHE STRING "Clear CXX flags for this sub-project" FORCE)
-set(CMAKE_CXX_COMPILER "${MSVC_BIN_DIR}/cl.exe")
-#set(CMAKE_C_COMPILER "${MSVC_BIN_DIR}/cl.exe")
-set(CMAKE_LINKER "${MSVC_BIN_DIR}/link.exe")
-set(CMAKE_PROGRAM "${MSVC_BIN_DIR}/nmake.exe")
-set(CMAKE_AR "${MSVC_BIN_DIR}/lib.exe")
-add_compile_options(/FS)
+  set(CMAKE_CXX_FLAGS "" CACHE STRING "Clear CXX flags for this sub-project" FORCE)
+  set(CMAKE_BUILD_TYPE Release CACHE STRING "Build type" FORCE)
+  set(CMAKE_C_COMPILER   "${MSVC_BIN_DIR}/cl.exe" CACHE FILEPATH "" FORCE)
+  set(CMAKE_CXX_COMPILER "${MSVC_BIN_DIR}/cl.exe" CACHE FILEPATH "" FORCE)
+  set(CMAKE_LINKER       "${MSVC_BIN_DIR}/link.exe" CACHE FILEPATH "" FORCE)
+  set(CMAKE_AR           "${MSVC_BIN_DIR}/lib.exe" CACHE FILEPATH "" FORCE)
+
+  add_compile_options(/FS)
 endif()
 
 set(ICU_PUBLIC_DEFINES
@@ -620,6 +621,7 @@ add_custom_command(
 if (MSVC)
     # On Windows, data_as_asm could generates .obj file directly.
     set(ICU_DATA_SYMBOL_FILE "${CMAKE_BINARY_DIR}/icu/data/${ICU_DATA_FILE_NAME}_dat.obj")
+    message(STATUS "ICU_DATA_SYMBOL_FILE = ${ICU_DATA_SYMBOL_FILE}")
     set_source_files_properties(${ICU_DATA_SYMBOL_FILE} PROPERTIES EXTERNAL_OBJECT TRUE GENERATED TRUE)
 else ()
     set(ICU_DATA_SYMBOL_FILE "${CMAKE_BINARY_DIR}/icu/data/${ICU_DATA_FILE_NAME}_dat.S")


### PR DESCRIPTION
Issue:  data_as_asm tool fails to generate cpp object from ICU symbols file when webkit builds in debug mode.
Solution: The ICU third party lib already using MSVC to build , Make ICU build in Release mode.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8367374](https://bugs.openjdk.org/browse/JDK-8367374): JavaFX debug builds fail on Windows (**Bug** - P3)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Hima Bindu Meda](https://openjdk.org/census#hmeda) (@HimaBinduMeda - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1901/head:pull/1901` \
`$ git checkout pull/1901`

Update a local copy of the PR: \
`$ git checkout pull/1901` \
`$ git pull https://git.openjdk.org/jfx.git pull/1901/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1901`

View PR using the GUI difftool: \
`$ git pr show -t 1901`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1901.diff">https://git.openjdk.org/jfx/pull/1901.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1901#issuecomment-3289101690)
</details>
