### PR TITLE
8329874: JavaFX debug builds fail on Linux

### DIFF
--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/CMakeLists.txt
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/CMakeLists.txt
@@ -1546,7 +1546,8 @@ if (CMAKE_COMPILER_IS_GNUCXX AND GCC_OFFLINEASM_SOURCE_MAP)
             FILE_PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ GROUP_READ GROUP_WRITE GROUP_READ WORLD_READ
             DESTINATION ${JavaScriptCore_SCRIPTS_DIR}
         )
-        set(LowLevelInterpreter_LAUNCHER "${RUBY_EXECUTABLE} ${JavaScriptCore_SCRIPTS_SOURCES_DIR}/postprocess-asm")
+        #use copy not actual source
+        set(LowLevelInterpreter_LAUNCHER "${RUBY_EXECUTABLE} ${JavaScriptCore_SCRIPTS_DIR}/postprocess-asm")
     else ()
     set(LowLevelInterpreter_LAUNCHER "${RUBY_EXECUTABLE} ${JavaScriptCore_SCRIPTS_SOURCES_DIR}/postprocess-asm")
     endif ()

--- a/modules/javafx.web/src/main/native/Source/WTF/wtf/RefCounted.h
+++ b/modules/javafx.web/src/main/native/Source/WTF/wtf/RefCounted.h
@@ -90,7 +90,7 @@ public:
 protected:
     RefCountedBase()
         : m_refCount(1)
-#if ASSERT_ENABLED
+#if ASSERT_ENABLED && !PLATFORM(JAVA)
         , m_isOwnedByMainThread(isMainThread())
 #endif
     {
@@ -107,7 +107,7 @@ protected:
 
     void applyRefDerefThreadingCheck() const
     {
-#if ASSERT_ENABLED
+#if ASSERT_ENABLED && !PLATFORM(JAVA)
         if (m_refCount == 1) {
             // Likely an ownership transfer across threads that may be safe.
             m_isOwnedByMainThread = isMainThread();


### PR DESCRIPTION
Issue: JavaFX debug builds fail on Linux
The failure is permission issue on javascript core scripts that generates built in functions, the script has no write and execute permission permission.

Solution : Use copy of scripts not from JavaScriptCore source with right permission  ( OWNER_EXECUTE).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8329874](https://bugs.openjdk.org/browse/JDK-8329874): JavaFX debug builds fail on Linux (**Bug** - P3)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Hima Bindu Meda](https://openjdk.org/census#hmeda) (@HimaBinduMeda - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1902/head:pull/1902` \
`$ git checkout pull/1902`

Update a local copy of the PR: \
`$ git checkout pull/1902` \
`$ git pull https://git.openjdk.org/jfx.git pull/1902/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1902`

View PR using the GUI difftool: \
`$ git pr show -t 1902`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1902.diff">https://git.openjdk.org/jfx/pull/1902.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1902#issuecomment-3289108954)
</details>
