### PR TITLE
8364405: Intermittent MenuDoubleShortcutTest failure on Linux and macOS

### DIFF
--- a/tests/system/src/test/java/test/robot/javafx/scene/MenuDoubleShortcutTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/MenuDoubleShortcutTest.java
@@ -94,7 +94,6 @@ public class MenuDoubleShortcutTest {
     //
     // https://bugs.openjdk.org/browse/JDK-8087863
     // https://bugs.openjdk.org/browse/JDK-8088897
-    @Disabled("JDK-8364405")
     @Test
     void macSceneComesBeforeMenuBar() {
         Assumptions.assumeTrue(PlatformUtil.isMac());
@@ -106,7 +105,6 @@ public class MenuDoubleShortcutTest {
 
     // On platforms other than Mac the menu bar should process the event
     // and the scene should not.
-    @Disabled("JDK-8364405")
     @Test
     void nonMacMenuBarComesBeforeScene() {
         Assumptions.assumeFalse(PlatformUtil.isMac());
@@ -201,6 +199,7 @@ public class MenuDoubleShortcutTest {
         public void testKey(KeyCode code) {
             sceneAcceleratorFired = false;
             menuBarItemFired = false;
+            CountDownLatch testKeyLatch = new CountDownLatch(1);
             Platform.runLater(() -> {
                 KeyCode shortcutCode = (PlatformUtil.isMac() ? KeyCode.COMMAND : KeyCode.CONTROL);
                 Robot robot = new Robot();
@@ -208,7 +207,9 @@ public class MenuDoubleShortcutTest {
                 robot.keyPress(code);
                 robot.keyRelease(code);
                 robot.keyRelease(shortcutCode);
+                testKeyLatch.countDown();
             });
+            Util.waitForLatch(testKeyLatch, 5, "Timeout waiting for testKey execution.");
         }
 
         public TestResult testResult() {


### PR DESCRIPTION
MenuDoubleShortcutTest > nonMacMenuBarComesBeforeScene(on linux) & MenuDoubleShortcutTest > macSceneComesBeforeMenuBar(on macOS) fail intermittently.

In every failure we can see that no Accelerator event in fired `Key press event triggered no actions`.
To initiate accelerator event we use `testKey()` method in this test. `testKey()` method uses asynchronous `Platform.runLater()` to press accelerator shortcut. We have 100ms delay after this asynchronous event to check whether accelerators events are fired, but this is not fool-proof.

So this test is updated to make sure the asynchronous event in `testKey()` is completed by using a `CountDownLatch`. Also i tried removing the delay that we have after `testKey()` call, but it looks like 100ms delay is still needed between keyPress and event callbacks.

Updated test is run 50 times on all platforms and there are no intermittent failures seen.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8364405](https://bugs.openjdk.org/browse/JDK-8364405): Intermittent MenuDoubleShortcutTest failure on Linux and macOS (**Bug** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1906/head:pull/1906` \
`$ git checkout pull/1906`

Update a local copy of the PR: \
`$ git checkout pull/1906` \
`$ git pull https://git.openjdk.org/jfx.git pull/1906/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1906`

View PR using the GUI difftool: \
`$ git pr show -t 1906`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1906.diff">https://git.openjdk.org/jfx/pull/1906.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1906#issuecomment-3297886939)
</details>
