### PR TITLE
8271205: [windows] Intermittent test failure in test.javafx.scene.web.MiscellaneousTest::testDOMTimer

### DIFF
--- a/modules/javafx.web/src/test/java/test/javafx/scene/web/MiscellaneousTest.java
+++ b/modules/javafx.web/src/test/java/test/javafx/scene/web/MiscellaneousTest.java
@@ -190,6 +190,8 @@ public class MiscellaneousTest extends TestBase {
             // Try various intervals
             for (int i = 0; i < timer.INTERVAL_COUNT; i++) {
                 int timeout = i * (1000 / timer.INTERVAL_COUNT);
+                // Webkit recomends minimum timeout value should be 10
+                if (timeout < 10) timeout = 10;
                 webEngine.executeScript("window.setTimeout("
                                       + "timer.call.bind(timer, Date.now(),"
                                       // pass 'i' to call to test time


### PR DESCRIPTION
Issue: [windows] Intermittent test failure in test.javafx.scene.web.MiscellaneousTest::testDOMTimer
Analysis:
setTimeout call is not a real-time function. it is considered just a minimum delay before the callback is executed. The actual time taken depends

How long it takes to process any messages ahead of the already task in the queue?
Current load on the CPU.
The number of tasks being executed by the JS engine.
current state of OS/Browser.
However, we have to set a minimum timeout value of at least 10 ms, as recommended by Webkit/w3c. Setting value of 1o ms might prevent some un-defined behavior.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8271205](https://bugs.openjdk.org/browse/JDK-8271205): [windows] Intermittent test failure in test.javafx.scene.web.MiscellaneousTest::testDOMTimer (**Bug** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1907/head:pull/1907` \
`$ git checkout pull/1907`

Update a local copy of the PR: \
`$ git checkout pull/1907` \
`$ git pull https://git.openjdk.org/jfx.git pull/1907/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1907`

View PR using the GUI difftool: \
`$ git pr show -t 1907`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1907.diff">https://git.openjdk.org/jfx/pull/1907.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1907#issuecomment-3301028483)
</details>
