### PR TITLE
8367602: Regression: TabPane with wrapped label calculates wrong initial size

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TabPaneSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TabPaneSkin.java
@@ -57,6 +57,7 @@ import javafx.event.ActionEvent;
 import javafx.event.EventHandler;
 import javafx.geometry.Bounds;
 import javafx.geometry.HPos;
+import javafx.geometry.Orientation;
 import javafx.geometry.Point2D;
 import javafx.geometry.Pos;
 import javafx.geometry.Side;
@@ -292,7 +293,11 @@ public class TabPaneSkin extends SkinBase<TabPane> {
         // The TabPane can only be as wide as it widest content width.
         double maxw = 0.0;
         for (TabContentRegion contentRegion: tabContentRegions) {
-            maxw = Math.max(maxw, snapSizeX(contentRegion.prefWidth(-1)));
+            double dependentHeight = contentRegion.getContentBias() == Orientation.VERTICAL
+                ? Math.max(0, contentRegion.prefHeight(-1) - topInset - bottomInset)
+                : -1;
+
+            maxw = Math.max(maxw, snapSizeX(contentRegion.prefWidth(dependentHeight)));
         }
 
         final boolean isHorizontal = isHorizontal();
@@ -310,7 +315,11 @@ public class TabPaneSkin extends SkinBase<TabPane> {
         // The TabPane can only be as high as it highest content height.
         double maxh = 0.0;
         for (TabContentRegion contentRegion: tabContentRegions) {
-            maxh = Math.max(maxh, snapSizeY(contentRegion.prefHeight(-1)));
+            double dependentWidth = contentRegion.getContentBias() == Orientation.HORIZONTAL
+                ? Math.max(0, contentRegion.prefWidth(-1) - leftInset - rightInset)
+                : -1;
+
+            maxh = Math.max(maxh, snapSizeY(contentRegion.prefHeight(dependentWidth)));
         }
 
         final boolean isHorizontal = isHorizontal();


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367602](https://bugs.openjdk.org/browse/JDK-8367602): Regression: TabPane with wrapped label calculates wrong initial size (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1908/head:pull/1908` \
`$ git checkout pull/1908`

Update a local copy of the PR: \
`$ git checkout pull/1908` \
`$ git pull https://git.openjdk.org/jfx.git pull/1908/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1908`

View PR using the GUI difftool: \
`$ git pr show -t 1908`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1908.diff">https://git.openjdk.org/jfx/pull/1908.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1908#issuecomment-3301589126)
</details>
