### PR TITLE
8367898: Skip StageFocusTest on Linux

### DIFF
--- a/tests/system/src/test/java/test/robot/javafx/stage/StageFocusTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/stage/StageFocusTest.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import com.sun.javafx.PlatformUtil;
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.scene.Group;
@@ -51,6 +52,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.FieldSource;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 
 // NOTE: This test does NOT extend VisualTestBase, as the focus issues mostly happen
@@ -106,6 +108,8 @@ public class StageFocusTest {
 
     @AfterEach
     public void doTeardownEach() throws InterruptedException {
+        assumeTrue(!PlatformUtil.isLinux()); // JDK-8367893
+
         hideTestStage(currentTestStage);
         currentTestStage = null;
     }
@@ -177,6 +181,8 @@ public class StageFocusTest {
     @ParameterizedTest
     @FieldSource("testStages")
     public void testStageHasFocusAfterShow(Stage stage) throws InterruptedException {
+        assumeTrue(!PlatformUtil.isLinux()); // JDK-8367893
+
         // TODO once we upgrade JUnit5 and have parameterized class-level tests
         //      this can be removed and be an actual @BeforeEach
         setupEach(stage);


### PR DESCRIPTION
Skip `StageFocusTest` on Linux until [JDK-8367893](https://bugs.openjdk.org/browse/JDK-8367893) is fixed.

Also tested on macOS and Windows to verify that the test is still run.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367898](https://bugs.openjdk.org/browse/JDK-8367898): Skip StageFocusTest on Linux (**Bug** - P3)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1909/head:pull/1909` \
`$ git checkout pull/1909`

Update a local copy of the PR: \
`$ git checkout pull/1909` \
`$ git pull https://git.openjdk.org/jfx.git pull/1909/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1909`

View PR using the GUI difftool: \
`$ git pr show -t 1909`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1909.diff">https://git.openjdk.org/jfx/pull/1909.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1909#issuecomment-3304427406)
</details>
