### PR TITLE
8367991: Update RegionBackground tests to use ScreenCaptureTestWatcher utility

### DIFF
--- a/tests/system/src/test/java/test/robot/javafx/scene/layout/RegionBackgroundFillUITest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/layout/RegionBackgroundFillUITest.java
@@ -74,18 +74,7 @@ public class RegionBackgroundFillUITest extends RegionUITestBase {
         });
         runAndWait(() -> robot = new Robot());
         Util.parkCursor(robot);
-        screenCapture = null;
-        runAndWait(() -> {
-            stage = getStage();
-            region = new Region();
-            region.setPrefSize(REGION_WIDTH, REGION_HEIGHT);
-            region.relocate(REGION_LEFT, REGION_TOP);
-            scene = new Scene(root = new Group(region), WIDTH, HEIGHT);
-            scene.setFill(SCENE_FILL);
-            stage.setScene(scene);
-            stage.setAlwaysOnTop(true);
-            stage.show();
-        });
+        initialize();
     }
 
     /**

--- a/tests/system/src/test/java/test/robot/javafx/scene/layout/RegionBackgroundFillUITest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/layout/RegionBackgroundFillUITest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,14 +27,25 @@ package test.robot.javafx.scene.layout;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import java.util.concurrent.TimeUnit;
 import javafx.scene.layout.BackgroundFill;
+import javafx.scene.Scene;
+import javafx.scene.Group;
+import javafx.scene.layout.Region;
 import javafx.scene.paint.Color;
+import javafx.scene.robot.Robot;
+import javafx.stage.Stage;
+import test.util.Util;
+import test.util.ScreenCaptureTestWatcher;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
 
 /**
  */
 @Timeout(value=20000, unit=TimeUnit.MILLISECONDS)
+@ExtendWith(ScreenCaptureTestWatcher.class)
 public class RegionBackgroundFillUITest extends RegionUITestBase {
 
     /**************************************************************************
@@ -48,6 +59,45 @@ public class RegionBackgroundFillUITest extends RegionUITestBase {
     final String EXPECTED_WARNING = "EXPECTED WARNING: This is a negative test"
         + " to verify that negative value is not accepted for -fx-background-radius."
         + " A 'No radii value may be < 0' warning message is expected.";
+
+    @BeforeEach
+    public void doSetup() {
+        runAndWait(() -> {
+            if (!stages.isEmpty()) {
+                for (final Stage stage : stages) {
+                    if (stage.isShowing()) {
+                        stage.hide();
+                    }
+                }
+                stages.clear();
+            }
+        });
+        runAndWait(() -> robot = new Robot());
+        Util.parkCursor(robot);
+        screenCapture = null;
+        runAndWait(() -> {
+            stage = getStage();
+            region = new Region();
+            region.setPrefSize(REGION_WIDTH, REGION_HEIGHT);
+            region.relocate(REGION_LEFT, REGION_TOP);
+            scene = new Scene(root = new Group(region), WIDTH, HEIGHT);
+            scene.setFill(SCENE_FILL);
+            stage.setScene(scene);
+            stage.setAlwaysOnTop(true);
+            stage.show();
+        });
+    }
+
+    /**
+     * This method is overridden and doing nothing, because we want the stage
+     * to be active until screen capture is done by ScreenCaptureTestWatcher
+     * utility on test failure. Stale test stage will be cleared before next
+     * test stage is created during setup.
+     */
+    @AfterEach
+    public void doTeardown() {
+
+    }
 
     @Test
     public void basicFill() {

--- a/tests/system/src/test/java/test/robot/javafx/scene/layout/RegionBackgroundImageUITest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/layout/RegionBackgroundImageUITest.java
@@ -66,18 +66,7 @@ public class RegionBackgroundImageUITest extends RegionUITestBase {
         });
         runAndWait(() -> robot = new Robot());
         Util.parkCursor(robot);
-        screenCapture = null;
-        runAndWait(() -> {
-            stage = getStage();
-            region = new Region();
-            region.setPrefSize(REGION_WIDTH, REGION_HEIGHT);
-            region.relocate(REGION_LEFT, REGION_TOP);
-            scene = new Scene(root = new Group(region), WIDTH, HEIGHT);
-            scene.setFill(SCENE_FILL);
-            stage.setScene(scene);
-            stage.setAlwaysOnTop(true);
-            stage.show();
-        });
+        initialize();
     }
 
     /**

--- a/tests/system/src/test/java/test/robot/javafx/scene/layout/RegionBackgroundImageUITest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/layout/RegionBackgroundImageUITest.java
@@ -27,10 +27,20 @@ package test.robot.javafx.scene.layout;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import java.util.concurrent.TimeUnit;
 import javafx.geometry.Bounds;
+import javafx.scene.Scene;
+import javafx.scene.Group;
+import javafx.scene.layout.Region;
 import javafx.scene.paint.Color;
+import javafx.scene.robot.Robot;
+import javafx.stage.Stage;
+import test.util.Util;
+import test.util.ScreenCaptureTestWatcher;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
 
 /**************************************************************************
  *                                                                        *
@@ -39,7 +49,47 @@ import org.junit.jupiter.api.Timeout;
  *                                                                        *
  *************************************************************************/
 @Timeout(value=20000, unit=TimeUnit.MILLISECONDS)
+@ExtendWith(ScreenCaptureTestWatcher.class)
 public class RegionBackgroundImageUITest extends RegionUITestBase {
+
+    @BeforeEach
+    public void doSetup() {
+        runAndWait(() -> {
+            if (!stages.isEmpty()) {
+                for (final Stage stage : stages) {
+                    if (stage.isShowing()) {
+                        stage.hide();
+                    }
+                }
+                stages.clear();
+            }
+        });
+        runAndWait(() -> robot = new Robot());
+        Util.parkCursor(robot);
+        screenCapture = null;
+        runAndWait(() -> {
+            stage = getStage();
+            region = new Region();
+            region.setPrefSize(REGION_WIDTH, REGION_HEIGHT);
+            region.relocate(REGION_LEFT, REGION_TOP);
+            scene = new Scene(root = new Group(region), WIDTH, HEIGHT);
+            scene.setFill(SCENE_FILL);
+            stage.setScene(scene);
+            stage.setAlwaysOnTop(true);
+            stage.show();
+        });
+    }
+
+    /**
+     * This method is overridden and doing nothing, because we want the stage
+     * to be active until screen capture is done by ScreenCaptureTestWatcher
+     * utility on test failure. Stale test stage will be cleared before next
+     * test stage is created during setup.
+     */
+    @AfterEach
+    public void doTeardown() {
+
+    }
 
     @Test
     public void alignedImage() {

--- a/tests/system/src/test/java/test/robot/javafx/scene/layout/RegionUITestBase.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/layout/RegionUITestBase.java
@@ -61,12 +61,20 @@ public abstract class RegionUITestBase extends VisualTestBase {
     protected Scene scene;
     protected Group root;
     protected Region region;
-    static volatile WritableImage screenCapture;
+    private volatile WritableImage screenCapture;
 
     @BeforeEach
     @Override
     public void doSetup() {
         super.doSetup();
+    }
+
+    protected void setStyle(final String style) {
+        runAndWait(() -> region.setStyle(style));
+        waitFirstFrame();
+    }
+
+    protected void initialize() {
         screenCapture = null;
         runAndWait(() -> {
             stage = getStage();
@@ -79,11 +87,6 @@ public abstract class RegionUITestBase extends VisualTestBase {
             stage.setAlwaysOnTop(true);
             stage.show();
         });
-    }
-
-    protected void setStyle(final String style) {
-        runAndWait(() -> region.setStyle(style));
-        waitFirstFrame();
     }
 
     static final double TOLERANCE = 0.07;

--- a/tests/system/src/test/java/test/robot/javafx/scene/layout/RegionUITestBase.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/layout/RegionUITestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,7 +61,7 @@ public abstract class RegionUITestBase extends VisualTestBase {
     protected Scene scene;
     protected Group root;
     protected Region region;
-    private volatile WritableImage screenCapture;
+    static volatile WritableImage screenCapture;
 
     @BeforeEach
     @Override

--- a/tests/system/src/test/java/test/robot/testharness/VisualTestBase.java
+++ b/tests/system/src/test/java/test/robot/testharness/VisualTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,10 +55,10 @@ public abstract class VisualTestBase {
     // Singleton Application instance
     private static MyApp myApp;
     // Scene instances used for testing
-    private List<Stage> stages = new ArrayList<>();
+    protected static List<Stage> stages = new ArrayList<>();
 
     // Glass Robot instance
-    Robot robot;
+    protected static Robot robot;
 
     protected Robot getRobot() {
         return robot;


### PR DESCRIPTION
We are seeing very rare intermittent failures in RegionBackgroundFillUITest & RegionBackgroundImageUITest tests in linux. We already have [JDK-8328217](https://bugs.openjdk.org/browse/JDK-8328217) to fix this issue.

To identify the root cause better, we want to capture the test content when it is failing using ScreenCaptureTestWatcher utility.

Since we wan to capture the test window before test stage is cleared. We are now clearing the test stage and next test setup. Initially tried updating this behaviour in `VisualTestBase` itself, but that causes tests like `test.robot.test3d.PointLightIlluminationTest` as it overrides the test setup functions.

This change is tested to make sure ScreenCaptureTestWatcher takes appropriate screen capture on failure and CI full headful test run is green.