### PR TITLE
8364117: Skip failing test TableViewContextMenuSortTest on Windows

### DIFF
--- a/tests/system/src/test/java/test/robot/javafx/scene/tableview/TableViewContextMenuSortTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/tableview/TableViewContextMenuSortTest.java
@@ -57,6 +57,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class TableViewContextMenuSortTest {
 
@@ -77,6 +78,8 @@ public class TableViewContextMenuSortTest {
 
     @Test
     public void testContextMenuRequestDoesNotSort() {
+        assumeTrue(!PlatformUtil.isWindows()); // JDK-8364116
+
         Node header = table.lookupAll(".column-header").stream()
                 .filter(Objects::nonNull)
                 .filter(n -> n.getStyleClass().contains("table-column"))


### PR DESCRIPTION
Skipping failing test on Windows only. The problem does not exist on macOS and Linux.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8364117](https://bugs.openjdk.org/browse/JDK-8364117): Skip failing test TableViewContextMenuSortTest on Windows (**Bug** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1914/head:pull/1914` \
`$ git checkout pull/1914`

Update a local copy of the PR: \
`$ git checkout pull/1914` \
`$ git pull https://git.openjdk.org/jfx.git pull/1914/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1914`

View PR using the GUI difftool: \
`$ git pr show -t 1914`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1914.diff">https://git.openjdk.org/jfx/pull/1914.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1914#issuecomment-3312082962)
</details>
