### PR TITLE
8368166: Media query should accept multiple rules

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/css/CssParser.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/CssParser.java
@@ -4331,15 +4331,8 @@ final public class CssParser {
 
             currentToken = nextToken(lexer);
 
-            while (expectedRBraces > 0) {
-                if (!consumeRBrace(lexer)) {
-                    return;
-                }
-
-                if (mediaRule != null) {
-                    mediaRule = mediaRule.getParent();
-                }
-
+            while (expectedRBraces > 0 && currentToken != null && currentToken.getType() == CssLexer.RBRACE) {
+                mediaRule = mediaRule.getParent();
                 currentToken = nextToken(lexer);
                 expectedRBraces--;
             }
@@ -4365,25 +4358,6 @@ final public class CssParser {
                 && currentToken.getType() != CssLexer.RBRACE) {
             // Skip forward to the next SEMI or RBRACE.
         }
-    }
-
-    private boolean consumeRBrace(CssLexer lexer) {
-        if (currentToken == null || currentToken.getType() != CssLexer.RBRACE) {
-            int line = currentToken != null ? currentToken.getLine() : -1;
-            int pos = currentToken != null ? currentToken.getOffset() : -1;
-            String msg = String.format("Expected RBRACE at [%d,%d]", line, pos);
-            ParseError error = createError(msg);
-            if (LOGGER.isLoggable(Level.WARNING)) {
-                LOGGER.warning(error.toString());
-            }
-
-            reportError(error);
-            currentToken = null;
-            return false;
-        }
-
-        currentToken = lexer.nextToken();
-        return true;
     }
 
     private MediaRule mediaRule(CssLexer lexer, MediaRule mediaRule) {

--- a/modules/javafx.graphics/src/test/java/test/javafx/css/CssParser_mediaQuery_Test.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/css/CssParser_mediaQuery_Test.java
@@ -36,6 +36,7 @@ import javafx.css.CssParser;
 import javafx.css.Stylesheet;
 import org.junit.jupiter.api.Test;
 import java.util.List;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -92,6 +93,60 @@ public class CssParser_mediaQuery_Test {
         assertEquals(
             new FunctionExpression<>("prefers-reduced-motion", "reduce", _ -> null, true),
             outerMediaRule.getQueries().getFirst());
+    }
+
+    @Test
+    void parseMediaQueryWithMultipleRules() {
+        Stylesheet stylesheet = new CssParser().parse("""
+            @media (prefers-color-scheme: light) {
+                .foo1 { bar: baz; }
+                .foo2 { bar: baz; }
+            }
+            """);
+
+        assertEquals(2, stylesheet.getRules().size());
+        var rule1 = stylesheet.getRules().getFirst();
+        var rule2 = stylesheet.getRules().getLast();
+        assertEquals(Set.of("foo1"), rule1.getSelectors().getFirst().getStyleClassNames());
+        assertEquals(Set.of("foo2"), rule2.getSelectors().getFirst().getStyleClassNames());
+
+        var mediaRule = RuleHelper.getMediaRule(stylesheet.getRules().getFirst());
+        assertEquals(1, mediaRule.getQueries().size());
+        assertEquals(
+            new FunctionExpression<>("prefers-color-scheme", "light", _ -> null, ColorScheme.LIGHT),
+            mediaRule.getQueries().getFirst());
+    }
+
+    @Test
+    void parseNestedMediaQueryWithMultipleRules() {
+        Stylesheet stylesheet = new CssParser().parse("""
+            @media (prefers-reduced-motion: reduce) {
+                .foo1 { bar: baz; }
+                .foo2 { bar: baz; }
+                @media (prefers-color-scheme: light) {
+                    .foo3 { bar: baz; }
+                    .foo4 { bar: baz; }
+                }
+            }
+            """);
+
+        assertEquals(4, stylesheet.getRules().size());
+
+        var rule1 = stylesheet.getRules().get(0);
+        assertEquals(Set.of("foo1"), rule1.getSelectors().getFirst().getStyleClassNames());
+        assertNull(RuleHelper.getMediaRule(rule1).getParent());
+
+        var rule2 = stylesheet.getRules().get(1);
+        assertEquals(Set.of("foo2"), rule2.getSelectors().getFirst().getStyleClassNames());
+        assertNull(RuleHelper.getMediaRule(rule2).getParent());
+
+        var rule3 = stylesheet.getRules().get(2);
+        assertEquals(Set.of("foo3"), rule3.getSelectors().getFirst().getStyleClassNames());
+        assertNull(RuleHelper.getMediaRule(rule3).getParent().getParent());
+
+        var rule4 = stylesheet.getRules().get(3);
+        assertEquals(Set.of("foo4"), rule4.getSelectors().getFirst().getStyleClassNames());
+        assertNull(RuleHelper.getMediaRule(rule4).getParent().getParent());
     }
 
     @Test


### PR DESCRIPTION
Given a media query with more than one rule:

```css
@media (prefers-color-scheme: dark) {
    .foo1 {
        -fx-background-color: black;
    }
    .foo2 {
        -fx-background-color: white;
    }
}
```

The following CSS parser error is encountered: `Expected RBRACE`

The reason for this bug is that the CSS parser mistakenly expects that after the first rule was parsed, the media query should be terminated with a closing curly brace. This is obviously incorrect, the fix is relatively simple.