### PR TITLE
8368219: Skip MenuDoubleShortcutTest on macOS & Linux

### DIFF
--- a/tests/system/src/test/java/test/robot/javafx/scene/MenuDoubleShortcutTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/MenuDoubleShortcutTest.java
@@ -94,6 +94,7 @@ public class MenuDoubleShortcutTest {
     //
     // https://bugs.openjdk.org/browse/JDK-8087863
     // https://bugs.openjdk.org/browse/JDK-8088897
+    @Disabled("JDK-8368074")
     @Test
     void macSceneComesBeforeMenuBar() {
         Assumptions.assumeTrue(PlatformUtil.isMac());
@@ -105,6 +106,7 @@ public class MenuDoubleShortcutTest {
 
     // On platforms other than Mac the menu bar should process the event
     // and the scene should not.
+    @Disabled("JDK-8368074")
     @Test
     void nonMacMenuBarComesBeforeScene() {
         Assumptions.assumeFalse(PlatformUtil.isMac());


### PR DESCRIPTION
MenuDoubleShortcutTest > nonMacMenuBarComesBeforeScene()/macSceneComesBeforeMenuBar() was failing intermittently and it was made more robust under [JDK-8364405](https://bugs.openjdk.org/browse/JDK-8364405) and it was verified with multiple runs and it was passing.

But looks like we still see this test failing in our CI. We need to skip this test and test fix will be worked upon under [JDK-8368074](https://bugs.openjdk.org/browse/JDK-8368074)