### PR TITLE
8368375: Skip intermittently failing SWTCursorsTest

### DIFF
--- a/modules/javafx.swt/src/test/java/test/javafx/embed/swt/SWTCursorsTest.java
+++ b/modules/javafx.swt/src/test/java/test/javafx/embed/swt/SWTCursorsTest.java
@@ -35,7 +35,7 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Disabled;
 
 import java.util.concurrent.TimeUnit;
 
@@ -44,18 +44,11 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 public class SWTCursorsTest extends SWTTest {
 
     private FXCanvas canvas;
-    private static final String os = System.getProperty("os.name");
-    private static String javafxPlatform =
-        System.getProperty("javafx.platform");
-    private static final boolean ANDROID = "android".equals(javafxPlatform) ||
-        "Dalvik".equals(System.getProperty("java.vm.name"));
 
+    @Disabled("JDK-8367599")
     @Test
     @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
     public void testImageCursor() throws Throwable {
-        // Skip this test on Linux & macOS because of JDK-8367599
-        Assumptions.assumeFalse(os.startsWith("Mac") ||
-            (os.startsWith("Linux") && !ANDROID));
         runOnSwtThread(() -> {
             Display display = Display.getCurrent();
             final Shell shell = new Shell(display);


### PR DESCRIPTION
This test is failing intermittently on macOS and Linux platforms and it will be fixed under [JDK-8367599](https://bugs.openjdk.org/browse/JDK-8367599).

We need to skip this until [JDK-8367599](https://bugs.openjdk.org/browse/JDK-8367599) is fixed.

javafx.base/com.sun.javafx.PlatformUtil helps to determine individual platforms on which test is running. But this module is exposed only to system tests and not to SWT tests. So i am replicating this test utility code in SWTCursorsTest.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8368375](https://bugs.openjdk.org/browse/JDK-8368375): Skip intermittently failing SWTCursorsTest (**Bug** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1917/head:pull/1917` \
`$ git checkout pull/1917`

Update a local copy of the PR: \
`$ git checkout pull/1917` \
`$ git pull https://git.openjdk.org/jfx.git pull/1917/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1917`

View PR using the GUI difftool: \
`$ git pr show -t 1917`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1917.diff">https://git.openjdk.org/jfx/pull/1917.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1917#issuecomment-3322853386)
</details>
