### PR TITLE
8360586: JavaFX build uses deprecated features that will be removed in gradle 9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,7 +76,6 @@ import java.util.zip.ZipOutputStream
 import java.lang.Runtime.Version
 
 import org.gradle.process.ExecOperations
-import org.gradle.process.JavaExecSpec
 
 def execOps = project.services.get(ExecOperations)
 
@@ -885,7 +884,7 @@ void fetchExternalTools(String configName, List packages, File destdir, boolean 
                         // use native tar to support symlinks
                         pkgdir.mkdirs()
                         def execOps = project.services.get(ExecOperations)
-                        execOps.exec { ExecSpec spec ->
+                        execOps.exec { spec ->
                             workingDir pkgdir
                             commandLine "tar", "zxf", "${srcball}"
                          }
@@ -968,7 +967,7 @@ void ant(String conf,   // platform configuration
     cmdArgs += target
 
     def execOps = project.services.get(ExecOperations)
-    execOps.exec { ExecSpec spec ->
+    execOps.exec { spec ->
         workingDir = dir
         environment("JDK_HOME", JDK_HOME)
         environment("JAVA_HOME", JDK_HOME)
@@ -2026,7 +2025,7 @@ void addJCov(p, test) {
     test.doLast {
         def reportFile = p.file("build/reports/jcov/report.xml")
         if (reportFile.exists()) {
-            execOps.javaexec { JavaExecSpec spec ->
+            execOps.javaexec { spec ->
                 workingDir = p.file("build/reports/jcov")
                 classpath = p.files(p.configurations.testClasspath.files.find { it.name.startsWith('jcov') })
                 mainClass = "com.sun.tdk.jcov.Helper"
@@ -2550,7 +2549,7 @@ project(":graphics") {
                     futures.add(executor.submit(new Runnable() {
                         @Override public void run() {
                             try {
-                                execOps.exec { ExecSpec spec ->
+                                execOps.exec { spec ->
                                     commandLine cmd
                                 }
                             } finally {
@@ -2591,7 +2590,7 @@ project(":graphics") {
     // The GenAllDecoraShader.java class generates all the Decora shaders
     addJSL(project, "Decora", "com/sun/scenario/effect/impl/hw", decoraAddExports) { sourceDir, destinationDir ->
         [[fileName: "GenAllDecoraShaders", generator: "GenAllDecoraShaders", outputs: "-all"]].each { settings ->
-            execOps.javaexec { JavaExecSpec spec ->
+            execOps.javaexec { spec ->
                 executable = JAVA
                 workingDir = project.projectDir
                 mainClass = settings.generator
@@ -2686,7 +2685,7 @@ project(":graphics") {
         def inputFiles = fileTree(dir: sourceDir)
         inputFiles.include "**/*.jsl"
         inputFiles.each { file ->
-            execOps.javaexec { JavaExecSpec spec ->
+            execOps.javaexec { spec ->
                 executable = JAVA
                 workingDir = project.projectDir
                 mainClass = "CompileJSL"
@@ -2705,7 +2704,7 @@ project(":graphics") {
             def PASSTHROUGH_VS_SRC = file("src/main/native-prism-mtl/msl/PassThroughVS.metal")
             doLast {
                 mkdir "$buildDir/msl"
-                execOps.exec { ExecSpec spec ->
+                execOps.exec { spec ->
                     commandLine("${metalCompiler}")
                     args += [ "-std=${mslVersion}" ]
                     args += [ "-c" ]
@@ -2721,7 +2720,7 @@ project(":graphics") {
             def CLEAR_RTT_VFS_SRC = file("src/main/native-prism-mtl/msl/ClearRttShaders.metal")
             doLast {
                 mkdir "$buildDir/msl"
-                execOps.exec { ExecSpec spec ->
+                execOps.exec { spec ->
                     commandLine("${metalCompiler}")
                     args += [ "-std=${mslVersion}" ]
                     args += [ "-c" ]
@@ -2737,7 +2736,7 @@ project(":graphics") {
             def COMPUTE_KERNELS_SRC = file("src/main/native-prism-mtl/msl/ComputeKernels.metal")
             doLast {
                 mkdir "$buildDir/msl"
-                execOps.exec { ExecSpec spec ->
+                execOps.exec { spec ->
                     commandLine("${metalCompiler}")
                     args += [ "-std=${mslVersion}" ]
                     args += [ "-c" ]
@@ -2753,7 +2752,7 @@ project(":graphics") {
             def PHONG_VS_SRC = file("src/main/native-prism-mtl/msl/PhongVS.metal")
             doLast {
                 mkdir "$buildDir/msl"
-                execOps.exec { ExecSpec spec ->
+                execOps.exec { spec ->
                     commandLine("${metalCompiler}")
                     args += [ "-std=${mslVersion}" ]
                     args += [ "-c" ]
@@ -2769,7 +2768,7 @@ project(":graphics") {
             def PHONG_PS_SRC = file("src/main/native-prism-mtl/msl/PhongPS.metal")
             doLast {
                 mkdir "$buildDir/msl"
-                execOps.exec { ExecSpec spec ->
+                execOps.exec { spec ->
                     commandLine("${metalCompiler}")
                     args += [ "-std=${mslVersion}" ]
                     args += [ "-c" ]
@@ -2792,7 +2791,7 @@ project(":graphics") {
             doLast {
                 mkdir "$buildDir/msl/com/sun/prism/mtl/msl"
                 def shaderFiles = fileTree(dir: "$buildDir/msl", include: "**/*.air")
-                execOps.exec { ExecSpec spec ->
+                execOps.exec { spec ->
                     commandLine("${metalLinker}")
                     shaderFiles.each { shaderFile ->
                         args += shaderFile
@@ -2949,7 +2948,7 @@ project(":controls") {
         cssFiles.each { css ->
             logger.info("converting CSS to BSS ${css}");
 
-            execOps.javaexec { JavaExecSpec spec ->
+            execOps.javaexec { spec ->
                 executable = JAVA
                 workingDir = project.projectDir
                 jvmArgs += patchModuleArgs
@@ -3363,7 +3362,7 @@ project(":media") {
             modulePath += File.pathSeparator + "${rootProject.projectDir}/modules/javafx.graphics/build/classes/java/main"
             modulePath += File.pathSeparator + "${rootProject.projectDir}/modules/javafx.base/build/classes/java/main"
 
-            execOps.exec { ExecSpec spec ->
+            execOps.exec { spec ->
                 commandLine("$JAVA");
                 args += patchModuleArgs
                 args += [ "--module-path=$modulePath" ]
@@ -3395,7 +3394,7 @@ project(":media") {
             }
 
             doLast {
-                execOps.exec { ExecSpec spec ->
+                execOps.exec { spec ->
                     commandLine ("make", "${makeJobsFlag}", "-C", "${nativeSrcDir}/jfxmedia/projects/${projectDir}")
                     args("JAVA_HOME=${JDK_HOME}", "GENERATED_HEADERS_DIR=${generatedHeadersDir}",
                          "OUTPUT_DIR=${nativeOutputDir}", "BUILD_TYPE=${buildType}", "BASE_NAME=jfxmedia",
@@ -3424,7 +3423,7 @@ project(":media") {
             def buildGStreamer = task("build${t.capital}GStreamer") {
                 enabled = IS_COMPILE_MEDIA
                 doLast {
-                    execOps.exec { ExecSpec spec ->
+                    execOps.exec { spec ->
                         commandLine ("make", "${makeJobsFlag}", "-C", "${nativeSrcDir}/gstreamer/projects/${projectDir}/gstreamer-lite")
                         args("OUTPUT_DIR=${nativeOutputDir}", "BUILD_TYPE=${buildType}", "BASE_NAME=gstreamer-lite",
                              "ARCH=${ARCH_NAME}", "CC=${mediaProperties.compiler}",
@@ -3442,7 +3441,7 @@ project(":media") {
                 enabled = IS_COMPILE_MEDIA
 
                 doLast {
-                    execOps.exec { ExecSpec spec ->
+                    execOps.exec { spec ->
                         commandLine ("make", "${makeJobsFlag}", "-C", "${nativeSrcDir}/gstreamer/projects/${projectDir}/fxplugins")
                         args("OUTPUT_DIR=${nativeOutputDir}", "BUILD_TYPE=${buildType}", "BASE_NAME=fxplugins",
                              "ARCH=${ARCH_NAME}",
@@ -3550,11 +3549,11 @@ project(":media") {
                                 File cfgFile = file(configFile)
                                 if (!cfgFile.exists()) {
                                     // Add execute permissions to version.sh, otherwise build fails
-                                    execOps.exec { ExecSpec spec ->
+                                    execOps.exec { spec ->
                                         workingDir("$libavDir")
                                         commandLine("chmod", "+x", "version.sh")
                                     }
-                                    execOps.exec { ExecSpec spec ->
+                                    execOps.exec { spec ->
                                         workingDir("$libavDir")
                                         if (IS_BUILD_WORKING_LIBAV) {
                                             commandLine(cfgCMDArgs + commonCfgArgs + codecsCfgArgs)
@@ -3563,7 +3562,7 @@ project(":media") {
                                         }
                                     }
                                 }
-                                execOps.exec { ExecSpec spec ->
+                                execOps.exec { spec ->
                                     workingDir("$libavDir")
                                     commandLine("make")
                                 }
@@ -3618,11 +3617,11 @@ project(":media") {
                                         file.write(data, "UTF-8")
                                     }
                                     // Add execute permissions to version.sh, otherwise build fails
-                                    execOps.exec { ExecSpec spec ->
+                                    execOps.exec { spec ->
                                         workingDir("$libavDir")
                                         commandLine("chmod", "+x", "version.sh")
                                     }
-                                    execOps.exec { ExecSpec spec ->
+                                    execOps.exec { spec ->
                                         workingDir("$libavDir")
                                         if (IS_BUILD_WORKING_LIBAV) {
                                             commandLine(cfgCMDArgs + commonCfgArgs + codecsCfgArgs + extraCfgArgs)
@@ -3631,7 +3630,7 @@ project(":media") {
                                         }
                                     }
                                 }
-                                execOps.exec { ExecSpec spec ->
+                                execOps.exec { spec ->
                                     workingDir("$libavDir")
                                     commandLine("make")
                                 }
@@ -3692,7 +3691,7 @@ project(":media") {
                                     def versionFile = "${libavDir}/version.sh"
                                     File verFile = file(versionFile)
                                     if (verFile.exists()) {
-                                        execOps.exec { ExecSpec spec ->
+                                        execOps.exec { spec ->
                                             workingDir("$libavDir")
                                             commandLine("chmod", "+x", "version.sh")
                                         }
@@ -3700,7 +3699,7 @@ project(":media") {
                                         versionFile = "${libavDir}/ffbuild/version.sh"
                                         verFile = file(versionFile)
                                         if (verFile.exists()) {
-                                            execOps.exec { ExecSpec spec ->
+                                            execOps.exec { spec ->
                                                 workingDir("${libavDir}/ffbuild")
                                                 commandLine("chmod")
                                                 args += "+x"
@@ -3708,7 +3707,7 @@ project(":media") {
                                             }
                                         }
                                     }
-                                    execOps.exec { ExecSpec spec ->
+                                    execOps.exec { spec ->
                                         workingDir("$libavDir")
                                         if (IS_BUILD_WORKING_LIBAV) {
                                             commandLine(cfgCMDArgs + commonCfgArgs + codecsCfgArgs)
@@ -3717,7 +3716,7 @@ project(":media") {
                                         }
                                     }
                                 }
-                                execOps.exec { ExecSpec spec ->
+                                execOps.exec { spec ->
                                     workingDir("$libavDir")
                                     commandLine("make")
                                 }
@@ -3752,7 +3751,7 @@ project(":media") {
                                 def libavDir = "${project.ext.libav.basedir}-${version}"
                                 File dir = file(libavDir)
                                 if (dir.exists()) {
-                                    execOps.exec { ExecSpec spec ->
+                                    execOps.exec { spec ->
                                         commandLine ("make", "${makeJobsFlag}", "-C", "${nativeSrcDir}/gstreamer/projects/linux/avplugin")
                                         args("CC=${mediaProperties.compiler}", "LINKER=${mediaProperties.linker}",
                                              "OUTPUT_DIR=${nativeOutputDir}", "BUILD_TYPE=${buildType}",
@@ -3767,7 +3766,7 @@ project(":media") {
                                 def libavDir = "${project.ext.libav.libavffmpeg.basedir}-${version}"
                                 File dir = file(libavDir)
                                 if (dir.exists()) {
-                                    execOps.exec { ExecSpec spec ->
+                                    execOps.exec { spec ->
                                         commandLine ("make", "${makeJobsFlag}", "-C", "${nativeSrcDir}/gstreamer/projects/linux/avplugin")
                                         args("CC=${mediaProperties.compiler}", "LINKER=${mediaProperties.linker}",
                                              "OUTPUT_DIR=${nativeOutputDir}", "BUILD_TYPE=${buildType}",
@@ -3782,7 +3781,7 @@ project(":media") {
                                 def libavDir = "${project.ext.libav.ffmpeg.basedir}-${version}"
                                 File dir = file(libavDir)
                                 if (dir.exists()) {
-                                    execOps.exec { ExecSpec spec ->
+                                    execOps.exec { spec ->
                                         commandLine ("make", "${makeJobsFlag}", "-C", "${nativeSrcDir}/gstreamer/projects/linux/avplugin")
                                         args("CC=${mediaProperties.compiler}", "LINKER=${mediaProperties.linker}",
                                              "OUTPUT_DIR=${nativeOutputDir}", "BUILD_TYPE=${buildType}",
@@ -3794,7 +3793,7 @@ project(":media") {
                             }
                         } else {
                             // Building fxavcodec plugin (libav plugin)
-                            execOps.exec { ExecSpec spec ->
+                            execOps.exec { spec ->
                                 commandLine ("make", "${makeJobsFlag}", "-C", "${nativeSrcDir}/gstreamer/projects/linux/avplugin")
                                 args("CC=${mediaProperties.compiler}", "LINKER=${mediaProperties.linker}",
                                      "OUTPUT_DIR=${nativeOutputDir}", "BUILD_TYPE=${buildType}",
@@ -3811,28 +3810,28 @@ project(":media") {
                     doLast {
                         def rcOutputDir = "${nativeOutputDir}/${buildType}"
                         mkdir rcOutputDir
-                        execOps.exec { ExecSpec spec ->
+                        execOps.exec { spec ->
                             environment(WINDOWS_NATIVE_COMPILE_ENVIRONMENT)
                             commandLine (WIN.media.rcCompiler)
                             args(WIN.media.glibRcFlags)
                             args("/Fo${rcOutputDir}/${WIN.media.glibRcFile}", WIN.media.rcSource)
                         }
 
-                        execOps.exec { ExecSpec spec ->
+                        execOps.exec { spec ->
                             environment(WINDOWS_NATIVE_COMPILE_ENVIRONMENT)
                             commandLine (WIN.media.rcCompiler)
                             args(WIN.media.gstreamerRcFlags)
                             args("/Fo${rcOutputDir}/${WIN.media.gstreamerRcFile}", WIN.media.rcSource)
                         }
 
-                        execOps.exec { ExecSpec spec ->
+                        execOps.exec { spec ->
                             environment(WINDOWS_NATIVE_COMPILE_ENVIRONMENT)
                             commandLine (WIN.media.rcCompiler)
                             args(WIN.media.fxpluginsRcFlags)
                             args("/Fo${rcOutputDir}/${WIN.media.fxpluginsRcFile}", WIN.media.rcSource)
                         }
 
-                        execOps.exec { ExecSpec spec ->
+                        execOps.exec { spec ->
                             environment(WINDOWS_NATIVE_COMPILE_ENVIRONMENT)
                             commandLine (WIN.media.rcCompiler)
                             args(WIN.media.jfxmediaRcFlags)
@@ -3844,7 +3843,7 @@ project(":media") {
                 def buildGlib = task("build${t.capital}Glib", dependsOn: [buildResources]) {
                     enabled = IS_COMPILE_MEDIA
                     doLast {
-                        execOps.exec { ExecSpec spec ->
+                        execOps.exec { spec ->
                             environment(WINDOWS_NATIVE_COMPILE_ENVIRONMENT)
                             commandLine ("make", "${makeJobsFlag}", "-C", "${nativeSrcDir}/gstreamer/projects/${projectDir}/glib-lite")
                             args("OUTPUT_DIR=${nativeOutputDir}", "BUILD_TYPE=${buildType}", "BASE_NAME=glib-lite",
@@ -3859,13 +3858,13 @@ project(":media") {
                 def buildGlib = task("build${t.capital}Glib") {
                     enabled = IS_COMPILE_MEDIA
                     doLast {
-                        execOps.exec { ExecSpec spec ->
+                        execOps.exec { spec ->
                             commandLine ("make", "${makeJobsFlag}", "-C", "${nativeSrcDir}/gstreamer/projects/${projectDir}/libffi")
                             args("OUTPUT_DIR=${nativeOutputDir}", "BUILD_TYPE=${buildType}", "BASE_NAME=ffi", "ARCH=$TARGET_ARCH")
                             args ("CC=${mediaProperties.compiler}", "LINKER=${mediaProperties.linker}", "AR=${mediaProperties.ar}")
                         }
 
-                        execOps.exec { ExecSpec spec ->
+                        execOps.exec { spec ->
                             commandLine ("make", "${makeJobsFlag}", "-C", "${nativeSrcDir}/gstreamer/projects/${projectDir}/glib-lite")
                             args("OUTPUT_DIR=${nativeOutputDir}", "BUILD_TYPE=${buildType}", "BASE_NAME=glib-lite", "ARCH=$TARGET_ARCH")
                             args ("CC=${mediaProperties.compiler}", "LINKER=${mediaProperties.linker}")
@@ -4049,13 +4048,13 @@ project(":web") {
             enabled =  (IS_COMPILE_WEBKIT)
 
             doLast {
-                execOps.exec { ExecSpec spec ->
+                execOps.exec { spec ->
                     workingDir("$webkitOutputDir")
                     commandLine("perl", "$projectDir/src/main/native/Tools/Scripts/set-webkit-configuration", "--$webkitConfig")
                     environment(["WEBKIT_OUTPUTDIR" : webkitOutputDir])
                 }
 
-                execOps.exec { ExecSpec spec ->
+                execOps.exec { spec ->
                     workingDir("$webkitOutputDir")
                     def cmakeArgs = "-DENABLE_TOOLS=1"
                     def makeArgs = "-j $NUM_COMPILE_THREADS"
@@ -5119,7 +5118,7 @@ compileTargets { t ->
             if (IS_WINDOWS && IS_USE_CYGWIN) {
                 doLast {
                     if (IS_CHMOD_ARTIFACTS) {
-                        execOps.exec { ExecSpec spec ->
+                        execOps.exec { spec ->
                             workingDir(sdkArtifactsDir)
                             commandLine("chmod", "-R", "755", ".")
                         }
@@ -5821,7 +5820,7 @@ compileTargets { t ->
                     // exclude the Microsoft DLLs (VSDLLNames and WinSDKDLLNames)
 
                     inputFiles.each { file ->
-                        execOps.exec { ExecSpec spec ->
+                        execOps.exec { spec ->
                             def cmd = [ strip, stripArgs, file ].flatten()
                             commandLine(cmd)
                         }
@@ -5838,7 +5837,7 @@ compileTargets { t ->
                     // exclude the Microsoft DLLs (VSDLLNames and WinSDKDLLNames)
 
                     inputFiles.each { file ->
-                        execOps.exec { ExecSpec spec ->
+                        execOps.exec { spec ->
                             def cmd = [ signCmd, signArgs, file ].flatten()
                             commandLine(cmd)
                         }
@@ -5896,7 +5895,7 @@ compileTargets { t ->
                     inputFiles.include("*.so")
 
                     inputFiles.each { file ->
-                        execOps.exec { ExecSpec spec ->
+                        execOps.exec { spec ->
                             def cmd = [ strip, stripArgs, file ].flatten()
                             commandLine(cmd)
                         }
@@ -5913,7 +5912,7 @@ compileTargets { t ->
                     // exclude the Microsoft DLLs (VSDLLNames and WinSDKDLLNames)
 
                     inputFiles.each { file ->
-                        execOps.exec { ExecSpec spec ->
+                        execOps.exec { spec ->
                             def cmd = [ signCmd, signArgs, file ].flatten()
                             commandLine(cmd)
                         }
@@ -5949,7 +5948,7 @@ compileTargets { t ->
                     inputFiles.include("*.so")
 
                     inputFiles.each { file ->
-                        execOps.exec { ExecSpec spec ->
+                        execOps.exec { spec ->
                             def cmd = [ strip, stripArgs, file ].flatten()
                             commandLine(cmd)
                         }
@@ -5966,7 +5965,7 @@ compileTargets { t ->
                     // exclude the Microsoft DLLs (VSDLLNames and WinSDKDLLNames)
 
                     inputFiles.each { file ->
-                        execOps.exec { ExecSpec spec ->
+                        execOps.exec { spec ->
                             def cmd = [ signCmd, signArgs, file ].flatten()
                             commandLine(cmd)
                         }
@@ -6193,7 +6192,7 @@ compileTargets { t ->
                 doLast {
                     mkdir jmodsDir
                     delete(jmodFile);
-                    execOps.exec { ExecSpec spec ->
+                    execOps.exec { spec ->
                         commandLine(JMOD)
                         args("create")
                         args("--class-path")

--- a/build.gradle
+++ b/build.gradle
@@ -75,6 +75,11 @@ import java.util.zip.ZipFile
 import java.util.zip.ZipOutputStream
 import java.lang.Runtime.Version
 
+import org.gradle.process.ExecOperations
+import org.gradle.process.JavaExecSpec
+
+def execOps = project.services.get(ExecOperations)
+
 /******************************************************************************
  *                              Utility methods                               *
  *****************************************************************************/
@@ -879,7 +884,8 @@ void fetchExternalTools(String configName, List packages, File destdir, boolean 
                     if (IS_LINUX || IS_MAC) {
                         // use native tar to support symlinks
                         pkgdir.mkdirs()
-                        exec {
+                        def execOps = project.services.get(ExecOperations)
+                        execOps.exec { ExecSpec spec ->
                             workingDir pkgdir
                             commandLine "tar", "zxf", "${srcball}"
                          }
@@ -961,7 +967,8 @@ void ant(String conf,   // platform configuration
 
     cmdArgs += target
 
-    exec {
+    def execOps = project.services.get(ExecOperations)
+    execOps.exec { ExecSpec spec ->
         workingDir = dir
         environment("JDK_HOME", JDK_HOME)
         environment("JAVA_HOME", JDK_HOME)
@@ -2019,7 +2026,7 @@ void addJCov(p, test) {
     test.doLast {
         def reportFile = p.file("build/reports/jcov/report.xml")
         if (reportFile.exists()) {
-            p.javaexec {
+            execOps.javaexec { JavaExecSpec spec ->
                 workingDir = p.file("build/reports/jcov")
                 classpath = p.files(p.configurations.testClasspath.files.find { it.name.startsWith('jcov') })
                 mainClass = "com.sun.tdk.jcov.Helper"
@@ -2543,7 +2550,7 @@ project(":graphics") {
                     futures.add(executor.submit(new Runnable() {
                         @Override public void run() {
                             try {
-                                exec {
+                                execOps.exec { ExecSpec spec ->
                                     commandLine cmd
                                 }
                             } finally {
@@ -2584,7 +2591,7 @@ project(":graphics") {
     // The GenAllDecoraShader.java class generates all the Decora shaders
     addJSL(project, "Decora", "com/sun/scenario/effect/impl/hw", decoraAddExports) { sourceDir, destinationDir ->
         [[fileName: "GenAllDecoraShaders", generator: "GenAllDecoraShaders", outputs: "-all"]].each { settings ->
-            javaexec {
+            execOps.javaexec { JavaExecSpec spec ->
                 executable = JAVA
                 workingDir = project.projectDir
                 mainClass = settings.generator
@@ -2679,7 +2686,7 @@ project(":graphics") {
         def inputFiles = fileTree(dir: sourceDir)
         inputFiles.include "**/*.jsl"
         inputFiles.each { file ->
-            javaexec {
+            execOps.javaexec { JavaExecSpec spec ->
                 executable = JAVA
                 workingDir = project.projectDir
                 mainClass = "CompileJSL"
@@ -2698,7 +2705,7 @@ project(":graphics") {
             def PASSTHROUGH_VS_SRC = file("src/main/native-prism-mtl/msl/PassThroughVS.metal")
             doLast {
                 mkdir "$buildDir/msl"
-                exec {
+                execOps.exec { ExecSpec spec ->
                     commandLine("${metalCompiler}")
                     args += [ "-std=${mslVersion}" ]
                     args += [ "-c" ]
@@ -2714,7 +2721,7 @@ project(":graphics") {
             def CLEAR_RTT_VFS_SRC = file("src/main/native-prism-mtl/msl/ClearRttShaders.metal")
             doLast {
                 mkdir "$buildDir/msl"
-                exec {
+                execOps.exec { ExecSpec spec ->
                     commandLine("${metalCompiler}")
                     args += [ "-std=${mslVersion}" ]
                     args += [ "-c" ]
@@ -2730,7 +2737,7 @@ project(":graphics") {
             def COMPUTE_KERNELS_SRC = file("src/main/native-prism-mtl/msl/ComputeKernels.metal")
             doLast {
                 mkdir "$buildDir/msl"
-                exec {
+                execOps.exec { ExecSpec spec ->
                     commandLine("${metalCompiler}")
                     args += [ "-std=${mslVersion}" ]
                     args += [ "-c" ]
@@ -2746,7 +2753,7 @@ project(":graphics") {
             def PHONG_VS_SRC = file("src/main/native-prism-mtl/msl/PhongVS.metal")
             doLast {
                 mkdir "$buildDir/msl"
-                exec {
+                execOps.exec { ExecSpec spec ->
                     commandLine("${metalCompiler}")
                     args += [ "-std=${mslVersion}" ]
                     args += [ "-c" ]
@@ -2762,7 +2769,7 @@ project(":graphics") {
             def PHONG_PS_SRC = file("src/main/native-prism-mtl/msl/PhongPS.metal")
             doLast {
                 mkdir "$buildDir/msl"
-                exec {
+                execOps.exec { ExecSpec spec ->
                     commandLine("${metalCompiler}")
                     args += [ "-std=${mslVersion}" ]
                     args += [ "-c" ]
@@ -2785,7 +2792,7 @@ project(":graphics") {
             doLast {
                 mkdir "$buildDir/msl/com/sun/prism/mtl/msl"
                 def shaderFiles = fileTree(dir: "$buildDir/msl", include: "**/*.air")
-                exec {
+                execOps.exec { ExecSpec spec ->
                     commandLine("${metalLinker}")
                     shaderFiles.each { shaderFile ->
                         args += shaderFile
@@ -2942,7 +2949,7 @@ project(":controls") {
         cssFiles.each { css ->
             logger.info("converting CSS to BSS ${css}");
 
-            javaexec {
+            execOps.javaexec { JavaExecSpec spec ->
                 executable = JAVA
                 workingDir = project.projectDir
                 jvmArgs += patchModuleArgs
@@ -3356,7 +3363,7 @@ project(":media") {
             modulePath += File.pathSeparator + "${rootProject.projectDir}/modules/javafx.graphics/build/classes/java/main"
             modulePath += File.pathSeparator + "${rootProject.projectDir}/modules/javafx.base/build/classes/java/main"
 
-            exec {
+            execOps.exec { ExecSpec spec ->
                 commandLine("$JAVA");
                 args += patchModuleArgs
                 args += [ "--module-path=$modulePath" ]
@@ -3388,7 +3395,7 @@ project(":media") {
             }
 
             doLast {
-                exec {
+                execOps.exec { ExecSpec spec ->
                     commandLine ("make", "${makeJobsFlag}", "-C", "${nativeSrcDir}/jfxmedia/projects/${projectDir}")
                     args("JAVA_HOME=${JDK_HOME}", "GENERATED_HEADERS_DIR=${generatedHeadersDir}",
                          "OUTPUT_DIR=${nativeOutputDir}", "BUILD_TYPE=${buildType}", "BASE_NAME=jfxmedia",
@@ -3417,7 +3424,7 @@ project(":media") {
             def buildGStreamer = task("build${t.capital}GStreamer") {
                 enabled = IS_COMPILE_MEDIA
                 doLast {
-                    exec {
+                    execOps.exec { ExecSpec spec ->
                         commandLine ("make", "${makeJobsFlag}", "-C", "${nativeSrcDir}/gstreamer/projects/${projectDir}/gstreamer-lite")
                         args("OUTPUT_DIR=${nativeOutputDir}", "BUILD_TYPE=${buildType}", "BASE_NAME=gstreamer-lite",
                              "ARCH=${ARCH_NAME}", "CC=${mediaProperties.compiler}",
@@ -3435,7 +3442,7 @@ project(":media") {
                 enabled = IS_COMPILE_MEDIA
 
                 doLast {
-                    exec {
+                    execOps.exec { ExecSpec spec ->
                         commandLine ("make", "${makeJobsFlag}", "-C", "${nativeSrcDir}/gstreamer/projects/${projectDir}/fxplugins")
                         args("OUTPUT_DIR=${nativeOutputDir}", "BUILD_TYPE=${buildType}", "BASE_NAME=fxplugins",
                              "ARCH=${ARCH_NAME}",
@@ -3543,11 +3550,11 @@ project(":media") {
                                 File cfgFile = file(configFile)
                                 if (!cfgFile.exists()) {
                                     // Add execute permissions to version.sh, otherwise build fails
-                                    exec {
+                                    execOps.exec { ExecSpec spec ->
                                         workingDir("$libavDir")
                                         commandLine("chmod", "+x", "version.sh")
                                     }
-                                    exec {
+                                    execOps.exec { ExecSpec spec ->
                                         workingDir("$libavDir")
                                         if (IS_BUILD_WORKING_LIBAV) {
                                             commandLine(cfgCMDArgs + commonCfgArgs + codecsCfgArgs)
@@ -3556,7 +3563,7 @@ project(":media") {
                                         }
                                     }
                                 }
-                                exec {
+                                execOps.exec { ExecSpec spec ->
                                     workingDir("$libavDir")
                                     commandLine("make")
                                 }
@@ -3611,11 +3618,11 @@ project(":media") {
                                         file.write(data, "UTF-8")
                                     }
                                     // Add execute permissions to version.sh, otherwise build fails
-                                    exec {
+                                    execOps.exec { ExecSpec spec ->
                                         workingDir("$libavDir")
                                         commandLine("chmod", "+x", "version.sh")
                                     }
-                                    exec {
+                                    execOps.exec { ExecSpec spec ->
                                         workingDir("$libavDir")
                                         if (IS_BUILD_WORKING_LIBAV) {
                                             commandLine(cfgCMDArgs + commonCfgArgs + codecsCfgArgs + extraCfgArgs)
@@ -3624,7 +3631,7 @@ project(":media") {
                                         }
                                     }
                                 }
-                                exec {
+                                execOps.exec { ExecSpec spec ->
                                     workingDir("$libavDir")
                                     commandLine("make")
                                 }
@@ -3685,7 +3692,7 @@ project(":media") {
                                     def versionFile = "${libavDir}/version.sh"
                                     File verFile = file(versionFile)
                                     if (verFile.exists()) {
-                                        exec {
+                                        execOps.exec { ExecSpec spec ->
                                             workingDir("$libavDir")
                                             commandLine("chmod", "+x", "version.sh")
                                         }
@@ -3693,7 +3700,7 @@ project(":media") {
                                         versionFile = "${libavDir}/ffbuild/version.sh"
                                         verFile = file(versionFile)
                                         if (verFile.exists()) {
-                                            exec {
+                                            execOps.exec { ExecSpec spec ->
                                                 workingDir("${libavDir}/ffbuild")
                                                 commandLine("chmod")
                                                 args += "+x"
@@ -3701,7 +3708,7 @@ project(":media") {
                                             }
                                         }
                                     }
-                                    exec {
+                                    execOps.exec { ExecSpec spec ->
                                         workingDir("$libavDir")
                                         if (IS_BUILD_WORKING_LIBAV) {
                                             commandLine(cfgCMDArgs + commonCfgArgs + codecsCfgArgs)
@@ -3710,7 +3717,7 @@ project(":media") {
                                         }
                                     }
                                 }
-                                exec {
+                                execOps.exec { ExecSpec spec ->
                                     workingDir("$libavDir")
                                     commandLine("make")
                                 }
@@ -3745,7 +3752,7 @@ project(":media") {
                                 def libavDir = "${project.ext.libav.basedir}-${version}"
                                 File dir = file(libavDir)
                                 if (dir.exists()) {
-                                    exec {
+                                    execOps.exec { ExecSpec spec ->
                                         commandLine ("make", "${makeJobsFlag}", "-C", "${nativeSrcDir}/gstreamer/projects/linux/avplugin")
                                         args("CC=${mediaProperties.compiler}", "LINKER=${mediaProperties.linker}",
                                              "OUTPUT_DIR=${nativeOutputDir}", "BUILD_TYPE=${buildType}",
@@ -3760,7 +3767,7 @@ project(":media") {
                                 def libavDir = "${project.ext.libav.libavffmpeg.basedir}-${version}"
                                 File dir = file(libavDir)
                                 if (dir.exists()) {
-                                    exec {
+                                    execOps.exec { ExecSpec spec ->
                                         commandLine ("make", "${makeJobsFlag}", "-C", "${nativeSrcDir}/gstreamer/projects/linux/avplugin")
                                         args("CC=${mediaProperties.compiler}", "LINKER=${mediaProperties.linker}",
                                              "OUTPUT_DIR=${nativeOutputDir}", "BUILD_TYPE=${buildType}",
@@ -3775,7 +3782,7 @@ project(":media") {
                                 def libavDir = "${project.ext.libav.ffmpeg.basedir}-${version}"
                                 File dir = file(libavDir)
                                 if (dir.exists()) {
-                                    exec {
+                                    execOps.exec { ExecSpec spec ->
                                         commandLine ("make", "${makeJobsFlag}", "-C", "${nativeSrcDir}/gstreamer/projects/linux/avplugin")
                                         args("CC=${mediaProperties.compiler}", "LINKER=${mediaProperties.linker}",
                                              "OUTPUT_DIR=${nativeOutputDir}", "BUILD_TYPE=${buildType}",
@@ -3787,7 +3794,7 @@ project(":media") {
                             }
                         } else {
                             // Building fxavcodec plugin (libav plugin)
-                            exec {
+                            execOps.exec { ExecSpec spec ->
                                 commandLine ("make", "${makeJobsFlag}", "-C", "${nativeSrcDir}/gstreamer/projects/linux/avplugin")
                                 args("CC=${mediaProperties.compiler}", "LINKER=${mediaProperties.linker}",
                                      "OUTPUT_DIR=${nativeOutputDir}", "BUILD_TYPE=${buildType}",
@@ -3804,28 +3811,28 @@ project(":media") {
                     doLast {
                         def rcOutputDir = "${nativeOutputDir}/${buildType}"
                         mkdir rcOutputDir
-                        exec {
+                        execOps.exec { ExecSpec spec ->
                             environment(WINDOWS_NATIVE_COMPILE_ENVIRONMENT)
                             commandLine (WIN.media.rcCompiler)
                             args(WIN.media.glibRcFlags)
                             args("/Fo${rcOutputDir}/${WIN.media.glibRcFile}", WIN.media.rcSource)
                         }
 
-                        exec {
+                        execOps.exec { ExecSpec spec ->
                             environment(WINDOWS_NATIVE_COMPILE_ENVIRONMENT)
                             commandLine (WIN.media.rcCompiler)
                             args(WIN.media.gstreamerRcFlags)
                             args("/Fo${rcOutputDir}/${WIN.media.gstreamerRcFile}", WIN.media.rcSource)
                         }
 
-                        exec {
+                        execOps.exec { ExecSpec spec ->
                             environment(WINDOWS_NATIVE_COMPILE_ENVIRONMENT)
                             commandLine (WIN.media.rcCompiler)
                             args(WIN.media.fxpluginsRcFlags)
                             args("/Fo${rcOutputDir}/${WIN.media.fxpluginsRcFile}", WIN.media.rcSource)
                         }
 
-                        exec {
+                        execOps.exec { ExecSpec spec ->
                             environment(WINDOWS_NATIVE_COMPILE_ENVIRONMENT)
                             commandLine (WIN.media.rcCompiler)
                             args(WIN.media.jfxmediaRcFlags)
@@ -3837,7 +3844,7 @@ project(":media") {
                 def buildGlib = task("build${t.capital}Glib", dependsOn: [buildResources]) {
                     enabled = IS_COMPILE_MEDIA
                     doLast {
-                        exec {
+                        execOps.exec { ExecSpec spec ->
                             environment(WINDOWS_NATIVE_COMPILE_ENVIRONMENT)
                             commandLine ("make", "${makeJobsFlag}", "-C", "${nativeSrcDir}/gstreamer/projects/${projectDir}/glib-lite")
                             args("OUTPUT_DIR=${nativeOutputDir}", "BUILD_TYPE=${buildType}", "BASE_NAME=glib-lite",
@@ -3852,13 +3859,13 @@ project(":media") {
                 def buildGlib = task("build${t.capital}Glib") {
                     enabled = IS_COMPILE_MEDIA
                     doLast {
-                        exec {
+                        execOps.exec { ExecSpec spec ->
                             commandLine ("make", "${makeJobsFlag}", "-C", "${nativeSrcDir}/gstreamer/projects/${projectDir}/libffi")
                             args("OUTPUT_DIR=${nativeOutputDir}", "BUILD_TYPE=${buildType}", "BASE_NAME=ffi", "ARCH=$TARGET_ARCH")
                             args ("CC=${mediaProperties.compiler}", "LINKER=${mediaProperties.linker}", "AR=${mediaProperties.ar}")
                         }
 
-                        exec {
+                        execOps.exec { ExecSpec spec ->
                             commandLine ("make", "${makeJobsFlag}", "-C", "${nativeSrcDir}/gstreamer/projects/${projectDir}/glib-lite")
                             args("OUTPUT_DIR=${nativeOutputDir}", "BUILD_TYPE=${buildType}", "BASE_NAME=glib-lite", "ARCH=$TARGET_ARCH")
                             args ("CC=${mediaProperties.compiler}", "LINKER=${mediaProperties.linker}")
@@ -4042,13 +4049,13 @@ project(":web") {
             enabled =  (IS_COMPILE_WEBKIT)
 
             doLast {
-                exec {
+                execOps.exec { ExecSpec spec ->
                     workingDir("$webkitOutputDir")
                     commandLine("perl", "$projectDir/src/main/native/Tools/Scripts/set-webkit-configuration", "--$webkitConfig")
                     environment(["WEBKIT_OUTPUTDIR" : webkitOutputDir])
                 }
 
-                exec {
+                execOps.exec { ExecSpec spec ->
                     workingDir("$webkitOutputDir")
                     def cmakeArgs = "-DENABLE_TOOLS=1"
                     def makeArgs = "-j $NUM_COMPILE_THREADS"
@@ -5112,7 +5119,7 @@ compileTargets { t ->
             if (IS_WINDOWS && IS_USE_CYGWIN) {
                 doLast {
                     if (IS_CHMOD_ARTIFACTS) {
-                        exec {
+                        execOps.exec { ExecSpec spec ->
                             workingDir(sdkArtifactsDir)
                             commandLine("chmod", "-R", "755", ".")
                         }
@@ -5814,7 +5821,7 @@ compileTargets { t ->
                     // exclude the Microsoft DLLs (VSDLLNames and WinSDKDLLNames)
 
                     inputFiles.each { file ->
-                        exec {
+                        execOps.exec { ExecSpec spec ->
                             def cmd = [ strip, stripArgs, file ].flatten()
                             commandLine(cmd)
                         }
@@ -5831,7 +5838,7 @@ compileTargets { t ->
                     // exclude the Microsoft DLLs (VSDLLNames and WinSDKDLLNames)
 
                     inputFiles.each { file ->
-                        exec {
+                        execOps.exec { ExecSpec spec ->
                             def cmd = [ signCmd, signArgs, file ].flatten()
                             commandLine(cmd)
                         }
@@ -5889,7 +5896,7 @@ compileTargets { t ->
                     inputFiles.include("*.so")
 
                     inputFiles.each { file ->
-                        exec {
+                        execOps.exec { ExecSpec spec ->
                             def cmd = [ strip, stripArgs, file ].flatten()
                             commandLine(cmd)
                         }
@@ -5906,7 +5913,7 @@ compileTargets { t ->
                     // exclude the Microsoft DLLs (VSDLLNames and WinSDKDLLNames)
 
                     inputFiles.each { file ->
-                        exec {
+                        execOps.exec { ExecSpec spec ->
                             def cmd = [ signCmd, signArgs, file ].flatten()
                             commandLine(cmd)
                         }
@@ -5942,7 +5949,7 @@ compileTargets { t ->
                     inputFiles.include("*.so")
 
                     inputFiles.each { file ->
-                        exec {
+                        execOps.exec { ExecSpec spec ->
                             def cmd = [ strip, stripArgs, file ].flatten()
                             commandLine(cmd)
                         }
@@ -5959,7 +5966,7 @@ compileTargets { t ->
                     // exclude the Microsoft DLLs (VSDLLNames and WinSDKDLLNames)
 
                     inputFiles.each { file ->
-                        exec {
+                        execOps.exec { ExecSpec spec ->
                             def cmd = [ signCmd, signArgs, file ].flatten()
                             commandLine(cmd)
                         }
@@ -6186,7 +6193,7 @@ compileTargets { t ->
                 doLast {
                     mkdir jmodsDir
                     delete(jmodFile);
-                    exec {
+                    execOps.exec { ExecSpec spec ->
                         commandLine(JMOD)
                         args("create")
                         args("--class-path")

--- a/buildSrc/linux.gradle
+++ b/buildSrc/linux.gradle
@@ -23,6 +23,11 @@
  * questions.
  */
 
+import org.gradle.process.ExecOperations
+import org.gradle.process.JavaExecSpec
+
+def execOps = project.services.get(ExecOperations)
+
 ext.LINUX = [:]
 
 // Glass Gtk is built with GTK+ 3. It is not compatible with other major GTK versions (e.g., GTK 2 or GTK 4).
@@ -95,7 +100,7 @@ def gtk3LinkFlags = [ ];
 
 setupTools("linux_gtk3",
     { propFile ->
-        def checkGTK3Version = exec {
+        def checkGTK3Version = execOps.exec { ExecSpec spec ->
             commandLine "${toolchainDir}pkg-config", "--exists", "gtk+-3.0 >= " + gtk3MinVersion
             ignoreExitValue = true
         }
@@ -106,14 +111,14 @@ setupTools("linux_gtk3",
         }
 
         ByteArrayOutputStream results2 = new ByteArrayOutputStream();
-        exec {
+        execOps.exec { ExecSpec spec ->
             commandLine("${toolchainDir}pkg-config", "--cflags", "gtk+-3.0", "gthread-2.0", "xtst", "gio-unix-2.0")
             setStandardOutput(results2);
         }
         propFile << "cflagsGTK3=" << results2.toString().trim() << "\n";
 
         ByteArrayOutputStream results4 = new ByteArrayOutputStream();
-        exec {
+        execOps.exec { ExecSpec spec ->
             commandLine("${toolchainDir}pkg-config", "--libs", "gtk+-3.0", "gthread-2.0", "xtst", "gio-unix-2.0")
             setStandardOutput(results4);
         }
@@ -136,14 +141,14 @@ def pangoLinkFlags = [];
 setupTools("linux_pango_tools",
     { propFile ->
         ByteArrayOutputStream results = new ByteArrayOutputStream();
-        exec {
+        execOps.exec { ExecSpec spec ->
             commandLine "${toolchainDir}pkg-config", "--cflags", "pangoft2"
             standardOutput = results
         }
         propFile << "cflags=" << results.toString().trim() << "\n";
 
         results = new ByteArrayOutputStream();
-        exec {
+        execOps.exec { ExecSpec spec ->
             commandLine "${toolchainDir}pkg-config", "--libs", "pangoft2"
             standardOutput = results
         }
@@ -167,14 +172,14 @@ def freetypeLinkFlags = []
 setupTools("linux_freetype_tools",
     { propFile ->
         ByteArrayOutputStream results = new ByteArrayOutputStream();
-        exec {
+        execOps.exec { ExecSpec spec ->
             commandLine "${toolchainDir}pkg-config", "--cflags", "freetype2"
             standardOutput = results
         }
         propFile << "cflags=" << results.toString().trim() << "\n";
 
         results = new ByteArrayOutputStream();
-        exec {
+        execOps.exec { ExecSpec spec ->
             commandLine "${toolchainDir}pkg-config", "--libs", "freetype2"
             standardOutput = results
         }

--- a/buildSrc/linux.gradle
+++ b/buildSrc/linux.gradle
@@ -24,7 +24,6 @@
  */
 
 import org.gradle.process.ExecOperations
-import org.gradle.process.JavaExecSpec
 
 def execOps = project.services.get(ExecOperations)
 
@@ -100,7 +99,7 @@ def gtk3LinkFlags = [ ];
 
 setupTools("linux_gtk3",
     { propFile ->
-        def checkGTK3Version = execOps.exec { ExecSpec spec ->
+        def checkGTK3Version = execOps.exec { spec ->
             commandLine "${toolchainDir}pkg-config", "--exists", "gtk+-3.0 >= " + gtk3MinVersion
             ignoreExitValue = true
         }
@@ -111,14 +110,14 @@ setupTools("linux_gtk3",
         }
 
         ByteArrayOutputStream results2 = new ByteArrayOutputStream();
-        execOps.exec { ExecSpec spec ->
+        execOps.exec { spec ->
             commandLine("${toolchainDir}pkg-config", "--cflags", "gtk+-3.0", "gthread-2.0", "xtst", "gio-unix-2.0")
             setStandardOutput(results2);
         }
         propFile << "cflagsGTK3=" << results2.toString().trim() << "\n";
 
         ByteArrayOutputStream results4 = new ByteArrayOutputStream();
-        execOps.exec { ExecSpec spec ->
+        execOps.exec { spec ->
             commandLine("${toolchainDir}pkg-config", "--libs", "gtk+-3.0", "gthread-2.0", "xtst", "gio-unix-2.0")
             setStandardOutput(results4);
         }
@@ -141,14 +140,14 @@ def pangoLinkFlags = [];
 setupTools("linux_pango_tools",
     { propFile ->
         ByteArrayOutputStream results = new ByteArrayOutputStream();
-        execOps.exec { ExecSpec spec ->
+        execOps.exec { spec ->
             commandLine "${toolchainDir}pkg-config", "--cflags", "pangoft2"
             standardOutput = results
         }
         propFile << "cflags=" << results.toString().trim() << "\n";
 
         results = new ByteArrayOutputStream();
-        execOps.exec { ExecSpec spec ->
+        execOps.exec { spec ->
             commandLine "${toolchainDir}pkg-config", "--libs", "pangoft2"
             standardOutput = results
         }
@@ -172,14 +171,14 @@ def freetypeLinkFlags = []
 setupTools("linux_freetype_tools",
     { propFile ->
         ByteArrayOutputStream results = new ByteArrayOutputStream();
-        execOps.exec { ExecSpec spec ->
+        execOps.exec { spec ->
             commandLine "${toolchainDir}pkg-config", "--cflags", "freetype2"
             standardOutput = results
         }
         propFile << "cflags=" << results.toString().trim() << "\n";
 
         results = new ByteArrayOutputStream();
-        execOps.exec { ExecSpec spec ->
+        execOps.exec { spec ->
             commandLine "${toolchainDir}pkg-config", "--libs", "freetype2"
             standardOutput = results
         }

--- a/buildSrc/mac.gradle
+++ b/buildSrc/mac.gradle
@@ -23,6 +23,11 @@
  * questions.
  */
 
+import org.gradle.process.ExecOperations
+import org.gradle.process.JavaExecSpec
+
+def execOps = project.services.get(ExecOperations)
+
 ext.MAC = [:]
 
 MAC.canBuild = IS_MAC && IS_64
@@ -71,7 +76,7 @@ setupTools("mac_tools",
         } else if (!file(defaultSdkPath).isDirectory()) {
             // Get list of all macosx sdks
             ByteArrayOutputStream results = new ByteArrayOutputStream();
-            def xcodeBuildResult = exec {
+            def xcodeBuildResult = execOps.exec { ExecSpec spec ->
                 commandLine("xcodebuild", "-version", "-showsdks");
                 setStandardOutput(results);
                 ignoreExitValue(true);
@@ -91,14 +96,14 @@ setupTools("mac_tools",
                 }
 
                 results = new ByteArrayOutputStream();
-                exec {
+                execOps.exec { ExecSpec spec ->
                     commandLine("xcodebuild", "-version", "-sdk", sdk, "Path");
                     setStandardOutput(results);
                 }
             } else {
                 // try with command line developer tools
                 results = new ByteArrayOutputStream();
-                exec {
+                execOps.exec { ExecSpec spec ->
                     commandLine("xcrun", "--show-sdk-path");
                     setStandardOutput(results);
                 }
@@ -178,7 +183,7 @@ if (hasProperty('toolchainDir')) {
 } else {
     toolchainDir = ""
     ByteArrayOutputStream path = new ByteArrayOutputStream();
-    exec {
+    execOps.exec { ExecSpec spec ->
         // xcrun -f --sdk macosx metal
         commandLine("xcrun", "-f", "--sdk", "macosx", "metal");
         setStandardOutput(path);
@@ -187,7 +192,7 @@ if (hasProperty('toolchainDir')) {
     metalCompiler = path.toString().trim();
 
     path = new ByteArrayOutputStream();
-    exec {
+    execOps.exec { ExecSpec spec ->
         // xcrun -f --sdk macosx metallib
         commandLine("xcrun", "-f", "--sdk", "macosx", "metallib");
         setStandardOutput(path);

--- a/buildSrc/mac.gradle
+++ b/buildSrc/mac.gradle
@@ -24,7 +24,6 @@
  */
 
 import org.gradle.process.ExecOperations
-import org.gradle.process.JavaExecSpec
 
 def execOps = project.services.get(ExecOperations)
 
@@ -76,7 +75,7 @@ setupTools("mac_tools",
         } else if (!file(defaultSdkPath).isDirectory()) {
             // Get list of all macosx sdks
             ByteArrayOutputStream results = new ByteArrayOutputStream();
-            def xcodeBuildResult = execOps.exec { ExecSpec spec ->
+            def xcodeBuildResult = execOps.exec { spec ->
                 commandLine("xcodebuild", "-version", "-showsdks");
                 setStandardOutput(results);
                 ignoreExitValue(true);
@@ -96,14 +95,14 @@ setupTools("mac_tools",
                 }
 
                 results = new ByteArrayOutputStream();
-                execOps.exec { ExecSpec spec ->
+                execOps.exec { spec ->
                     commandLine("xcodebuild", "-version", "-sdk", sdk, "Path");
                     setStandardOutput(results);
                 }
             } else {
                 // try with command line developer tools
                 results = new ByteArrayOutputStream();
-                execOps.exec { ExecSpec spec ->
+                execOps.exec { spec ->
                     commandLine("xcrun", "--show-sdk-path");
                     setStandardOutput(results);
                 }
@@ -183,7 +182,7 @@ if (hasProperty('toolchainDir')) {
 } else {
     toolchainDir = ""
     ByteArrayOutputStream path = new ByteArrayOutputStream();
-    execOps.exec { ExecSpec spec ->
+    execOps.exec { spec ->
         // xcrun -f --sdk macosx metal
         commandLine("xcrun", "-f", "--sdk", "macosx", "metal");
         setStandardOutput(path);
@@ -192,7 +191,7 @@ if (hasProperty('toolchainDir')) {
     metalCompiler = path.toString().trim();
 
     path = new ByteArrayOutputStream();
-    execOps.exec { ExecSpec spec ->
+    execOps.exec { spec ->
         // xcrun -f --sdk macosx metallib
         commandLine("xcrun", "-f", "--sdk", "macosx", "metallib");
         setStandardOutput(path);

--- a/buildSrc/src/main/groovy/com/sun/javafx/gradle/CCTask.groovy
+++ b/buildSrc/src/main/groovy/com/sun/javafx/gradle/CCTask.groovy
@@ -26,6 +26,10 @@
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.Optional
+import org.gradle.process.ExecOperations
+import org.gradle.process.ExecSpec
+
+import javax.inject.Inject
 
 class CCTask extends NativeCompileTask {
     @Input String compiler;
@@ -33,6 +37,11 @@ class CCTask extends NativeCompileTask {
     @Optional @InputDirectory File headers;
     @Optional @Input Closure eachOutputFile; // will be given a File and must return a File
     @Input boolean exe = false;
+
+    @Inject
+    CCTask(ExecOperations execOperations) {
+        super(execOperations);
+    }
 
     protected File outputFile(File sourceFile) {
         final String outFileName = sourceFile.getName().substring(0, sourceFile.getName().lastIndexOf("."));
@@ -50,8 +59,8 @@ class CCTask extends NativeCompileTask {
 
         // TODO the PDB file is never being built -- maybe because it is only built during
         // debug builds, otherwise that flag is ignored "/Fd" or "-Fd"
-        project.exec({
-            commandLine(compiler);
+        execCompile { ExecSpec spec ->
+            spec.commandLine(compiler);
 
             // Add in any additional compilation params
             if (params != null) {
@@ -59,42 +68,42 @@ class CCTask extends NativeCompileTask {
                 if (sourceFile.name.endsWith(".cpp") || sourceFile.name.endsWith(".cc") || sourceFile.name.endsWith(".mm")) {
                     def stripped = params;
                     stripped.remove("-std=c99");
-                    args(stripped)
+                    spec.args(stripped)
                 } else {
-                    args(params)
+                    spec.args(params)
                 }
-            };
+            }
 
-            if (headers != null) args("-I$headers");
+            if (headers != null) spec.args("-I$headers");
 
             // Add the source roots in as include directories
             sourceRoots.each { root ->
                 final File file = root instanceof File ? (File) root : project.file(root)
-                if (file.isDirectory()) args("-I$file");
+                if (file.isDirectory()) spec.args("-I$file");
             }
 
             // Add the name of the source file to compile
             if (project.IS_WINDOWS) {
                 if (exe) {
                     final File exeFile = new File("$output/${lastDot > 0 ? outputFile.name.substring(0, lastDot) + '.exe' : outputFile.name + '.exe'}");
-                    args(/*"/Fd$pdbFile",*/ "/Fo$outputFile", "/Fe$exeFile", "$sourceFile")
+                    spec.args(/*"/Fd$pdbFile",*/ "/Fo$outputFile", "/Fe$exeFile", "$sourceFile")
                 } else {
-                    args(/*"/Fd$pdbFile",*/ "/Fo$outputFile", "$sourceFile");
+                    spec.args(/*"/Fd$pdbFile",*/ "/Fo$outputFile", "$sourceFile");
                 }
             } else {
-                args(/*"-Fd$pdbFile",*/ "-o", "$outputFile", "$sourceFile");
+                spec.args(/*"-Fd$pdbFile",*/ "-o", "$outputFile", "$sourceFile");
             }
 
             // Add any optional linker options -- used now rarely but can be
             // used for any cc task which isn't going to be followed by a
             // link task
             if (linkerOptions != null && !linkerOptions.isEmpty()) {
-                args(linkerOptions);
+                spec.args(linkerOptions);
             }
 
             if (project.IS_WINDOWS){
-                environment(project.WINDOWS_NATIVE_COMPILE_ENVIRONMENT);
+                spec.environment(project.WINDOWS_NATIVE_COMPILE_ENVIRONMENT);
             }
-        });
+        }
     }
 }

--- a/buildSrc/src/main/groovy/com/sun/javafx/gradle/CCTask.groovy
+++ b/buildSrc/src/main/groovy/com/sun/javafx/gradle/CCTask.groovy
@@ -27,7 +27,6 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.Optional
 import org.gradle.process.ExecOperations
-import org.gradle.process.ExecSpec
 
 import javax.inject.Inject
 
@@ -59,7 +58,7 @@ class CCTask extends NativeCompileTask {
 
         // TODO the PDB file is never being built -- maybe because it is only built during
         // debug builds, otherwise that flag is ignored "/Fd" or "-Fd"
-        execCompile { ExecSpec spec ->
+        execCompile { spec ->
             spec.commandLine(compiler);
 
             // Add in any additional compilation params

--- a/buildSrc/src/main/groovy/com/sun/javafx/gradle/CompileHLSLTask.groovy
+++ b/buildSrc/src/main/groovy/com/sun/javafx/gradle/CompileHLSLTask.groovy
@@ -24,7 +24,6 @@
  */
 
 import org.gradle.process.ExecOperations
-import org.gradle.process.ExecSpec
 
 import javax.inject.Inject
 
@@ -39,7 +38,7 @@ class CompileHLSLTask extends NativeCompileTask {
     }
 
     protected void doCompile(File sourceFile, File outputFile){
-        execCompile { ExecSpec spec ->
+        execCompile { spec ->
             spec.commandLine = [
                 "$project.FXC",
                 "/nologo",

--- a/buildSrc/src/main/groovy/com/sun/javafx/gradle/CompileHLSLTask.groovy
+++ b/buildSrc/src/main/groovy/com/sun/javafx/gradle/CompileHLSLTask.groovy
@@ -23,15 +23,31 @@
  * questions.
  */
 
+import org.gradle.process.ExecOperations
+import org.gradle.process.ExecSpec
+
+import javax.inject.Inject
+
 class CompileHLSLTask extends NativeCompileTask {
+    @Inject
+    CompileHLSLTask(ExecOperations execOperations) {
+        super(execOperations);
+    }
+
     protected File outputFile(File sourceFile) {
         new File("$output/${sourceFile.name.replace('.hlsl', '.obj')}");
     }
 
     protected void doCompile(File sourceFile, File outputFile){
-        project.exec({
-            commandLine = ["$project.FXC", "/nologo", "/T", "ps_3_0", "/Fo", "$outputFile", "$sourceFile"]
-            environment(project.WINDOWS_NATIVE_COMPILE_ENVIRONMENT);
-        });
+        execCompile { ExecSpec spec ->
+            spec.commandLine = [
+                "$project.FXC",
+                "/nologo",
+                "/T", "ps_3_0",
+                "/Fo", "$outputFile",
+                "$sourceFile"
+            ]
+            spec.environment(project.WINDOWS_NATIVE_COMPILE_ENVIRONMENT);
+        }
     }
 }

--- a/buildSrc/src/main/groovy/com/sun/javafx/gradle/CompileMSLTask.groovy
+++ b/buildSrc/src/main/groovy/com/sun/javafx/gradle/CompileMSLTask.groovy
@@ -23,16 +23,33 @@
  * questions.
  */
 
+import org.gradle.process.ExecOperations
+import org.gradle.process.ExecSpec
+
+import javax.inject.Inject
+
 class CompileMSLTask extends NativeCompileTask {
+    @Inject
+    CompileMSLTask(ExecOperations execOperations) {
+        super(execOperations);
+    }
+
     protected File outputFile(File sourceFile) {
         new File("$output/${sourceFile.name.replace('.metal', '.air')}");
     }
 
     protected void doCompile(File sourceFile, File outputFile){
         def headerDir = 'gensrc/mtl-headers';
-        def includeDir = "$project.buildDir/$headerDir"
-        project.exec({
-            commandLine = ["${project.metalCompiler}", "-Wdeprecated", "-std=macos-metal2.4", "-I", "$includeDir", "-c", "$sourceFile", "-o", "$outputFile"]
-        });
+        def includeDir = "$project.buildDir/$headerDir";
+        execCompile { ExecSpec spec ->
+            spec.commandLine = [
+                "${project.metalCompiler}",
+                "-Wdeprecated",
+                "-std=macos-metal2.4",
+                "-I", "$includeDir",
+                "-c", "$sourceFile",
+                "-o", "$outputFile"
+            ]
+        }
     }
 }

--- a/buildSrc/src/main/groovy/com/sun/javafx/gradle/CompileMSLTask.groovy
+++ b/buildSrc/src/main/groovy/com/sun/javafx/gradle/CompileMSLTask.groovy
@@ -24,7 +24,6 @@
  */
 
 import org.gradle.process.ExecOperations
-import org.gradle.process.ExecSpec
 
 import javax.inject.Inject
 
@@ -41,7 +40,7 @@ class CompileMSLTask extends NativeCompileTask {
     protected void doCompile(File sourceFile, File outputFile){
         def headerDir = 'gensrc/mtl-headers';
         def includeDir = "$project.buildDir/$headerDir";
-        execCompile { ExecSpec spec ->
+        execCompile { spec ->
             spec.commandLine = [
                 "${project.metalCompiler}",
                 "-Wdeprecated",

--- a/buildSrc/src/main/groovy/com/sun/javafx/gradle/CompileResourceTask.groovy
+++ b/buildSrc/src/main/groovy/com/sun/javafx/gradle/CompileResourceTask.groovy
@@ -25,7 +25,6 @@
 
 import org.gradle.api.tasks.Input
 import org.gradle.process.ExecOperations
-import org.gradle.process.ExecSpec
 
 import javax.inject.Inject
 
@@ -44,7 +43,7 @@ class CompileResourceTask extends NativeCompileTask {
     }
 
     protected void doCompile(File sourceFile, File outputFile){
-        execCompile { ExecSpec spec ->
+        execCompile { spec ->
             spec.commandLine(compiler);
             if (rcParams) spec.args(rcParams);
             spec.args("/Fo$outputFile", "$sourceFile");

--- a/buildSrc/src/main/groovy/com/sun/javafx/gradle/CompileResourceTask.groovy
+++ b/buildSrc/src/main/groovy/com/sun/javafx/gradle/CompileResourceTask.groovy
@@ -24,10 +24,19 @@
  */
 
 import org.gradle.api.tasks.Input
+import org.gradle.process.ExecOperations
+import org.gradle.process.ExecSpec
+
+import javax.inject.Inject
 
 class CompileResourceTask extends NativeCompileTask {
     @Input List<String> rcParams = new ArrayList<String>();
     @Input String compiler;
+
+    @Inject
+    CompileResourceTask(ExecOperations execOperations) {
+        super(execOperations);
+    }
 
     protected File outputFile(File sourceFile) {
         final String outFileName = sourceFile.getName().substring(0, sourceFile.getName().lastIndexOf("."));
@@ -35,11 +44,11 @@ class CompileResourceTask extends NativeCompileTask {
     }
 
     protected void doCompile(File sourceFile, File outputFile){
-        project.exec({
-            commandLine(compiler);
-            if (rcParams) args(rcParams);
-            args("/Fo$outputFile", "$sourceFile");
-            environment(project.WINDOWS_NATIVE_COMPILE_ENVIRONMENT);
-        });
+        execCompile { ExecSpec spec ->
+            spec.commandLine(compiler);
+            if (rcParams) spec.args(rcParams);
+            spec.args("/Fo$outputFile", "$sourceFile");
+            spec.environment(project.WINDOWS_NATIVE_COMPILE_ENVIRONMENT);
+        }
     }
 }

--- a/buildSrc/src/main/groovy/com/sun/javafx/gradle/ExportedSymbolsTask.groovy
+++ b/buildSrc/src/main/groovy/com/sun/javafx/gradle/ExportedSymbolsTask.groovy
@@ -29,12 +29,22 @@ import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
+import org.gradle.process.ExecOperations
+import org.gradle.process.ExecSpec
+
+import javax.inject.Inject
 
 class ExportedSymbolsTask extends DefaultTask {
     @OutputFile File outputFile;
     @InputDirectory File libDir;
     @Optional @Input List<String> excludes;
 
+    private final ExecOperations execOperations;
+
+    @Inject
+    ExportedSymbolsTask(ExecOperations execOperations) {
+        this.execOperations = execOperations;
+    }
 
     @TaskAction void generateExportedSymbols() {
         // Get symbols only from .a libraries
@@ -49,11 +59,11 @@ class ExportedSymbolsTask extends DefaultTask {
         def baos = new ByteArrayOutputStream();
 
         // Execute nm on .a libraries
-        project.exec({
-            commandLine("nm", "-jg");
-            args(libNames);
-            setStandardOutput(baos);
-        });
+        execOperations.exec { ExecSpec spec ->
+            spec.commandLine("nm", "-jg");
+            spec.args(libNames);
+            spec.setStandardOutput(baos);
+        };
 
         def bais = new ByteArrayInputStream(baos.toByteArray());
 

--- a/buildSrc/src/main/groovy/com/sun/javafx/gradle/ExportedSymbolsTask.groovy
+++ b/buildSrc/src/main/groovy/com/sun/javafx/gradle/ExportedSymbolsTask.groovy
@@ -30,7 +30,6 @@ import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import org.gradle.process.ExecOperations
-import org.gradle.process.ExecSpec
 
 import javax.inject.Inject
 
@@ -59,7 +58,7 @@ class ExportedSymbolsTask extends DefaultTask {
         def baos = new ByteArrayOutputStream();
 
         // Execute nm on .a libraries
-        execOperations.exec { ExecSpec spec ->
+        execOperations.exec { spec ->
             spec.commandLine("nm", "-jg");
             spec.args(libNames);
             spec.setStandardOutput(baos);

--- a/buildSrc/src/main/groovy/com/sun/javafx/gradle/JavaHeaderTask.groovy
+++ b/buildSrc/src/main/groovy/com/sun/javafx/gradle/JavaHeaderTask.groovy
@@ -31,12 +31,23 @@ import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.util.PatternFilterable
 import org.gradle.api.tasks.util.PatternSet
+import org.gradle.process.ExecOperations
+import org.gradle.process.ExecSpec
+
+import javax.inject.Inject
 
 class JavaHeaderTask extends DefaultTask {
     @OutputDirectory File output;
     @Input List sourceRoots = new ArrayList();
     @Input FileCollection classpath;
     private final PatternFilterable patternSet = new PatternSet();
+
+    private final ExecOperations execOperations;
+
+    @Inject
+    JavaHeaderTask(ExecOperations execOperations) {
+        this.execOperations = execOperations;
+    }
 
 //    @InputFiles public void setSource(Object source) {
 //        sourceRoots.clear();
@@ -89,10 +100,10 @@ class JavaHeaderTask extends DefaultTask {
             })
         }
         // Execute javah
-        project.exec({
-            commandLine("$project.JAVAH", "-d", "$output", "-classpath", "${classpath.asPath}");
-            args(classNames);
-        });
+        execOperations.exec { ExecSpec spec ->
+            spec.commandLine("$project.JAVAH", "-d", "$output", "-classpath", "${classpath.asPath}");
+            spec.args(classNames);
+        }
     }
 }
 

--- a/buildSrc/src/main/groovy/com/sun/javafx/gradle/JavaHeaderTask.groovy
+++ b/buildSrc/src/main/groovy/com/sun/javafx/gradle/JavaHeaderTask.groovy
@@ -32,7 +32,6 @@ import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.util.PatternFilterable
 import org.gradle.api.tasks.util.PatternSet
 import org.gradle.process.ExecOperations
-import org.gradle.process.ExecSpec
 
 import javax.inject.Inject
 
@@ -100,7 +99,7 @@ class JavaHeaderTask extends DefaultTask {
             })
         }
         // Execute javah
-        execOperations.exec { ExecSpec spec ->
+        execOperations.exec { spec ->
             spec.commandLine("$project.JAVAH", "-d", "$output", "-classpath", "${classpath.asPath}");
             spec.args(classNames);
         }

--- a/buildSrc/src/main/groovy/com/sun/javafx/gradle/LinkTask.groovy
+++ b/buildSrc/src/main/groovy/com/sun/javafx/gradle/LinkTask.groovy
@@ -29,7 +29,6 @@ import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import org.gradle.process.ExecOperations
-import org.gradle.process.ExecSpec
 
 import javax.inject.Inject
 
@@ -49,7 +48,7 @@ class LinkTask extends DefaultTask {
     @TaskAction void compile() {
         // Link & generate the library (.dll, .so, .dylib)
         lib.getParentFile().mkdirs();
-        execOperations.exec { ExecSpec spec ->
+        execOperations.exec { spec ->
             spec.commandLine(linker);
             if ((project.IS_LINUX) && (project.IS_STATIC_BUILD)) {
                 if (linker.equals("ld")) {

--- a/buildSrc/src/main/groovy/com/sun/javafx/gradle/LinkTask.groovy
+++ b/buildSrc/src/main/groovy/com/sun/javafx/gradle/LinkTask.groovy
@@ -28,7 +28,10 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
+import org.gradle.process.ExecOperations
+import org.gradle.process.ExecSpec
 
+import javax.inject.Inject
 
 class LinkTask extends DefaultTask {
     @Input List<String> linkParams = new ArrayList<String>();
@@ -36,39 +39,45 @@ class LinkTask extends DefaultTask {
     @OutputFile File lib;
     @Input String linker;
 
+    private final ExecOperations execOperations;
+
+    @Inject
+    LinkTask(ExecOperations execOperations) {
+        this.execOperations = execOperations;
+    }
+
     @TaskAction void compile() {
         // Link & generate the library (.dll, .so, .dylib)
         lib.getParentFile().mkdirs();
-        project.exec({
-            commandLine(linker);
+        execOperations.exec { ExecSpec spec ->
+            spec.commandLine(linker);
             if ((project.IS_LINUX) && (project.IS_STATIC_BUILD)) {
                 if (linker.equals("ld")) {
-                    args("-r");
-                    args("-o");
+                    spec.args("-r");
+                    spec.args("-o");
                 } else {
-                    args("rcs");
+                    spec.args("rcs");
                 }
-                args("$lib");
+                spec.args("$lib");
             }
             // Exclude parfait files (.bc)
-            args(objectDir.listFiles().sort().findAll{ !it.getAbsolutePath().endsWith(".bc") });
+            spec.args(objectDir.listFiles().sort().findAll{ !it.getAbsolutePath().endsWith(".bc") });
             if (project.IS_WINDOWS) {
-                args("/out:$lib");
+                spec.args("/out:$lib");
             } else {
                 if (! ((project.IS_LINUX) && (project.IS_STATIC_BUILD))) {
-                    args("-o", "$lib");
+                    spec.args("-o", "$lib");
                 }
             }
-            if (project.IS_DEBUG_NATIVE && !project.IS_WINDOWS) args("-g");
-            if (linkParams != null) args(linkParams);
+            if (project.IS_DEBUG_NATIVE && !project.IS_WINDOWS) spec.args("-g");
+            if (linkParams != null) spec.args(linkParams);
             if (project.IS_WINDOWS){
                 final String libPath = lib.toString();
                 final String libPrefix = libPath.substring(0, libPath.lastIndexOf("."))
-                args("/pdb:${libPrefix}.pdb",
-                    "/map:${libPrefix}.map");
-                environment(project.WINDOWS_NATIVE_COMPILE_ENVIRONMENT);
+                spec.args("/pdb:${libPrefix}.pdb",
+                          "/map:${libPrefix}.map");
+                spec.environment(project.WINDOWS_NATIVE_COMPILE_ENVIRONMENT);
             }
-        });
+        }
     }
 }
-

--- a/buildSrc/src/main/groovy/com/sun/javafx/gradle/LipoTask.groovy
+++ b/buildSrc/src/main/groovy/com/sun/javafx/gradle/LipoTask.groovy
@@ -27,11 +27,22 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
+import org.gradle.process.ExecOperations
+import org.gradle.process.ExecSpec
 
+import javax.inject.Inject
 
 class LipoTask extends DefaultTask {
     @InputDirectory File libDir;
     @OutputFile File lib;
+
+    private final ExecOperations execOperations;
+
+    @Inject
+    LipoTask(ExecOperations execOperations) {
+        this.execOperations = execOperations;
+    }
+
     @TaskAction void compile() {
         List<String> libNames = [];
         List<File> files = libDir.listFiles();
@@ -43,10 +54,10 @@ class LipoTask extends DefaultTask {
             }
         }
         // Create a fat library (.a)
-        project.exec({
-            commandLine("lipo", "-create", "-output", "$lib");
-            args(libNames);
-        });
+        execOperations.exec { ExecSpec spec ->
+            spec.commandLine("lipo", "-create", "-output", "$lib");
+            spec.args(libNames);
+        }
     }
 }
 

--- a/buildSrc/src/main/groovy/com/sun/javafx/gradle/LipoTask.groovy
+++ b/buildSrc/src/main/groovy/com/sun/javafx/gradle/LipoTask.groovy
@@ -28,7 +28,6 @@ import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import org.gradle.process.ExecOperations
-import org.gradle.process.ExecSpec
 
 import javax.inject.Inject
 
@@ -54,7 +53,7 @@ class LipoTask extends DefaultTask {
             }
         }
         // Create a fat library (.a)
-        execOperations.exec { ExecSpec spec ->
+        execOperations.exec { spec ->
             spec.commandLine("lipo", "-create", "-output", "$lib");
             spec.args(libNames);
         }

--- a/buildSrc/src/main/groovy/com/sun/javafx/gradle/NativeCompileTask.groovy
+++ b/buildSrc/src/main/groovy/com/sun/javafx/gradle/NativeCompileTask.groovy
@@ -23,6 +23,7 @@
  * questions.
  */
 
+import org.gradle.api.Action
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
@@ -31,6 +32,10 @@ import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.util.PatternFilterable
 import org.gradle.api.tasks.util.PatternSet
+import org.gradle.process.ExecOperations
+import org.gradle.process.ExecSpec
+
+import javax.inject.Inject
 
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CountDownLatch
@@ -45,6 +50,13 @@ class NativeCompileTask extends DefaultTask {
     @OutputDirectory File output;
     @InputFiles List<File> allFiles = [];
     private final PatternFilterable patternSet = new PatternSet();
+
+    private final ExecOperations execOperations;
+
+    @Inject
+    NativeCompileTask(ExecOperations execOperations) {
+        this.execOperations = execOperations;
+    }
 
     public NativeCompileTask source(Object... sources) {
         for (Object source : sources) {
@@ -77,6 +89,11 @@ class NativeCompileTask extends DefaultTask {
                 allFiles += file.isDirectory() ? file.listFiles() : file;
             }
         }
+    }
+
+    // Replacement for project.exec, subclasses call this.
+    protected void execCompile(Action<ExecSpec> action) {
+        execOperations.exec(action);
     }
 
     @TaskAction void compile() {

--- a/buildSrc/win.gradle
+++ b/buildSrc/win.gradle
@@ -23,6 +23,11 @@
  * questions.
  */
 
+import org.gradle.process.ExecOperations
+import org.gradle.process.JavaExecSpec
+
+def execOps = project.services.get(ExecOperations)
+
 ext.WIN = [:]
 
 WIN.canBuild = IS_WINDOWS
@@ -64,7 +69,7 @@ setupTools("windows_tools",
             // Create the properties file
             ByteArrayOutputStream results = new ByteArrayOutputStream();
             String winsdkDir = System.getenv().get("WINSDK_DIR");
-            exec({
+            execOps.exec { ExecSpec spec ->
                 environment([
                         "WINSDKPATH" : winsdkDir == null ? "" : winsdkDir,
                         "CONF"       : "/$CONF", // TODO does this mean the generated properties must be reset when in a different configuration?
@@ -73,7 +78,7 @@ setupTools("windows_tools",
                 ]);
                 commandLine("cmd", "/q", "/c", "buildSrc\\genVSproperties.bat");
                 setStandardOutput(results);
-            });
+            }
             BufferedReader reader = new BufferedReader(new StringReader(results.toString().trim()));
             reader.readLine();
             reader.readLine();

--- a/buildSrc/win.gradle
+++ b/buildSrc/win.gradle
@@ -24,7 +24,6 @@
  */
 
 import org.gradle.process.ExecOperations
-import org.gradle.process.JavaExecSpec
 
 def execOps = project.services.get(ExecOperations)
 
@@ -69,7 +68,7 @@ setupTools("windows_tools",
             // Create the properties file
             ByteArrayOutputStream results = new ByteArrayOutputStream();
             String winsdkDir = System.getenv().get("WINSDK_DIR");
-            execOps.exec { ExecSpec spec ->
+            execOps.exec { spec ->
                 environment([
                         "WINSDKPATH" : winsdkDir == null ? "" : winsdkDir,
                         "CONF"       : "/$CONF", // TODO does this mean the generated properties must be reset when in a different configuration?


### PR DESCRIPTION
**Issue**:
Below two Gradle 9.0.0 specific warnings are observed with current grade 8.14.2
1. The `Project.exec(Closure)` method has been deprecated. This is scheduled to be removed in Gradle 9.0
2. Using method `javaexec(Closure)` has been deprecated. This is scheduled to be removed in Gradle 9.0.

Both these methods are removed in Gradle 9.0.0.
Hence they should be replaced with appropriate APIs.
Refer: https://docs.gradle.org/8.14.2/userguide/upgrading_version_8.html#deprecated_project_exec

**Fix**:
Both warnings can be fixed by replacing the calls with` ExecOperations.exec(Action)`.
There are two different scenarios where we use the above two APIs.
- Gradle files
- Groovy class files
=> In Both the scenarios, we have to use the `ExecOperations.exec(Action)`, but the approach differs.

1. Gradle file
    - The calls are simply replaced as,
        * `Project.exec {` is replaced with `execOps.exec { ExecSpec spec ->`
        * `Project.javaexex {`  is replaced with `execOps.javaexec { JavaExecSpec spec ->`
2. For Groovy classes
    - `ExecOperations` needs to be **injected** using `@Inject` tag
    1. `NativeCompileTask` class
        - In the `NativeCompileTask` class, a method `execCompile()` is added which executes an action.
        - The child classes of `NativeCompileTask`, use this `execCompile()` method.
    2. Other classes are not related to each other. They independently execute the respective action.

**Verification**:
1. Run all gradle tasks with **—warning-mode all** option, with gradle 8.14.2 
2. No Gradle 9.0.0 specific warning is seen in build log
4. Build/all tasks complete successfully.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8360586](https://bugs.openjdk.org/browse/JDK-8360586): JavaFX build uses deprecated features that will be removed in gradle 9 (**Bug** - P3)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Joeri Sykora](https://openjdk.org/census#sykora) (@tiainen - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1918/head:pull/1918` \
`$ git checkout pull/1918`

Update a local copy of the PR: \
`$ git checkout pull/1918` \
`$ git pull https://git.openjdk.org/jfx.git pull/1918/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1918`

View PR using the GUI difftool: \
`$ git pr show -t 1918`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1918.diff">https://git.openjdk.org/jfx/pull/1918.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1918#issuecomment-3325573564)
</details>
