### PR TITLE
8368631: Avoid updating disposed MTLTexture

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/prism/mtl/MTLTexture.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/mtl/MTLTexture.java
@@ -202,6 +202,10 @@ class MTLTexture<T extends MTLTextureData> extends BaseTexture<MTLTextureResourc
                         int srcw, int srch,
                         int srcscan, boolean skipFlush) {
 
+        if (!resource.isValid()) {
+            return;
+        }
+
         switch (format.getDataType()) {
             case PixelFormat.DataType.INT -> updateTextureInt(buffer, format,
                 dstx, dsty, srcx, srcy, srcw, srch, srcscan);


### PR DESCRIPTION
Issue: 
Calling MTLTexture.update() method on a disposed MTLTexture object would cause a crash.
The root cause of this behavior is [JDK-8368629](https://bugs.openjdk.org/browse/JDK-8368629).

Fix:
Avoid MTLTexture.update() if texture is disposed.
The crash should be fixed now and the root cause will be followed up using [JDK-8368629](https://bugs.openjdk.org/browse/JDK-8368629)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8368631](https://bugs.openjdk.org/browse/JDK-8368631): Avoid updating disposed MTLTexture (**Bug** - P2)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Ajit Ghaisas](https://openjdk.org/census#aghaisas) (@aghaisas - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1919/head:pull/1919` \
`$ git checkout pull/1919`

Update a local copy of the PR: \
`$ git checkout pull/1919` \
`$ git pull https://git.openjdk.org/jfx.git pull/1919/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1919`

View PR using the GUI difftool: \
`$ git pr show -t 1919`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1919.diff">https://git.openjdk.org/jfx/pull/1919.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1919#issuecomment-3333731901)
</details>
