### PR TITLE
8368021: Window buttons of extended RTL stage are on the wrong side

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/scene/NodeHelper.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/scene/NodeHelper.java
@@ -221,6 +221,14 @@ public abstract class NodeHelper {
         nodeAccessor.layoutBoundsChanged(node);
     }
 
+    public static void nodeResolvedOrientationInvalidated(Node node) {
+        nodeAccessor.nodeResolvedOrientationInvalidated(node);
+    }
+
+    public static void setInheritOrientationFromScene(Node node, boolean value) {
+        nodeAccessor.setInheritOrientationFromScene(node, value);
+    }
+
     public static void setShowMnemonics(Node node, boolean value) {
         nodeAccessor.setShowMnemonics(node, value);
     }
@@ -383,6 +391,8 @@ public abstract class NodeHelper {
         void syncPeer(Node node);
         <P extends NGNode> P getPeer(Node node);
         void layoutBoundsChanged(Node node);
+        void nodeResolvedOrientationInvalidated(Node node);
+        void setInheritOrientationFromScene(Node node, boolean value);
         void setShowMnemonics(Node node, boolean value);
         boolean isShowMnemonics(Node node);
         BooleanProperty showMnemonicsProperty(Node node);

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/ViewSceneOverlay.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/ViewSceneOverlay.java
@@ -27,6 +27,7 @@ package com.sun.javafx.tk.quantum;
 
 import com.sun.javafx.scene.NodeHelper;
 import com.sun.javafx.scene.SceneHelper;
+import javafx.geometry.NodeOrientation;
 import javafx.scene.Node;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
@@ -49,7 +50,9 @@ final class ViewSceneOverlay {
     ViewSceneOverlay(Scene scene, ViewPainter painter) {
         this.scene = scene;
         this.painter = painter;
-        this.subscription = scene.rootProperty().subscribe(this::onSceneRootChanged);
+        this.subscription = Subscription.combine(
+            scene.rootProperty().subscribe(this::onSceneRootChanged),
+            scene.effectiveNodeOrientationProperty().subscribe(this::onEffectiveNodeOrientationInvalidated));
     }
 
     public void dispose() {
@@ -95,6 +98,7 @@ final class ViewSceneOverlay {
         if (this.root != null) {
             NodeHelper.setParent(this.root, null);
             NodeHelper.setScenes(this.root, null, null);
+            NodeHelper.setInheritOrientationFromScene(this.root, false);
         }
 
         this.root = root;
@@ -102,6 +106,7 @@ final class ViewSceneOverlay {
         if (root != null) {
             NodeHelper.setParent(root, scene.getRoot());
             NodeHelper.setScenes(root, scene, null);
+            NodeHelper.setInheritOrientationFromScene(root, true);
         }
 
         rootDirty = true;
@@ -140,6 +145,12 @@ final class ViewSceneOverlay {
     private void onSceneRootChanged(Parent sceneRoot) {
         if (root != null) {
             NodeHelper.setParent(root, sceneRoot);
+        }
+    }
+
+    private void onEffectiveNodeOrientationInvalidated(NodeOrientation unused) {
+        if (root != null) {
+            NodeHelper.nodeResolvedOrientationInvalidated(root);
         }
     }
 }

--- a/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
@@ -525,6 +525,16 @@ public abstract sealed class Node
             }
 
             @Override
+            public void nodeResolvedOrientationInvalidated(Node node) {
+                node.nodeResolvedOrientationInvalidated();
+            }
+
+            @Override
+            public void setInheritOrientationFromScene(Node node, boolean value) {
+                node.setInheritOrientationFromScene(value);
+            }
+
+            @Override
             public <P extends NGNode> P getPeer(Node node) {
                 return node.getPeer();
             }
@@ -1174,8 +1184,8 @@ public abstract sealed class Node
         if (oldScene != null) {
             oldScene.clearNodeMnemonics(this);
         }
-        if (getParent() == null) {
-            // if we are the root we need to handle scene change
+
+        if (getParent() == null || isInheritOrientationFromScene(resolvedNodeOrientation)) {
             parentResolvedOrientationInvalidated();
         }
 
@@ -6537,6 +6547,13 @@ public abstract sealed class Node
     private static final byte AUTOMATIC_ORIENTATION_RTL = 2;
     private static final byte AUTOMATIC_ORIENTATION_MASK = 2;
 
+    /**
+     * Indicates that the effective node orientation only depends on the explicit value set on this node
+     * and on the scene (if the node orientation is inherited), but not on the parent. This flag must only
+     * be set with {@link NodeHelper#setInheritOrientationFromScene(Node, boolean)} for scene overlays.
+     */
+    private static final byte INHERIT_ORIENTATION_FROM_SCENE = 4;
+
     private byte resolvedNodeOrientation =
             EFFECTIVE_ORIENTATION_LTR | AUTOMATIC_ORIENTATION_LTR;
 
@@ -6635,6 +6652,10 @@ public abstract sealed class Node
                 (byte) (calcEffectiveNodeOrientation()
                             | calcAutomaticNodeOrientation());
 
+        if (isInheritOrientationFromScene(oldResolvedNodeOrientation)) {
+            resolvedNodeOrientation |= INHERIT_ORIENTATION_FROM_SCENE;
+        }
+
         if ((effectiveNodeOrientationProperty != null)
                 && (getEffectiveOrientation(resolvedNodeOrientation)
                         != getEffectiveOrientation(
@@ -6655,6 +6676,10 @@ public abstract sealed class Node
     }
 
     private Node getMirroringOrientationParent() {
+        if (isInheritOrientationFromScene(resolvedNodeOrientation)) {
+            return null;
+        }
+
         Node parentValue = getParent();
         while (parentValue != null) {
             if (parentValue.usesMirroring()) {
@@ -6672,6 +6697,10 @@ public abstract sealed class Node
     }
 
     private Node getOrientationParent() {
+        if (isInheritOrientationFromScene(resolvedNodeOrientation)) {
+            return null;
+        }
+
         final Node parentValue = getParent();
         if (parentValue != null) {
             return parentValue;
@@ -6763,6 +6792,18 @@ public abstract sealed class Node
     private static byte getAutomaticOrientation(
             final byte resolvedNodeOrientation) {
         return (byte) (resolvedNodeOrientation & AUTOMATIC_ORIENTATION_MASK);
+    }
+
+    private static boolean isInheritOrientationFromScene(byte resolvedNodeOrientation) {
+        return (resolvedNodeOrientation & INHERIT_ORIENTATION_FROM_SCENE) != 0;
+    }
+
+    private void setInheritOrientationFromScene(boolean value) {
+        if (value) {
+            resolvedNodeOrientation |= INHERIT_ORIENTATION_FROM_SCENE;
+        } else {
+            resolvedNodeOrientation &= ~INHERIT_ORIENTATION_FROM_SCENE;
+        }
     }
 
     private final class EffectiveOrientationProperty

--- a/modules/javafx.graphics/src/test/java/test/com/sun/glass/ui/HeaderButtonOverlayTest.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/glass/ui/HeaderButtonOverlayTest.java
@@ -89,9 +89,10 @@ public class HeaderButtonOverlayTest {
                 .-FX-INTERNAL-header-button { -fx-pref-width: 20; }
             """), false, false, true);
 
-        var unused = new Scene(overlay);
+        var scene = new Scene(overlay);
+        scene.setNodeOrientation(NodeOrientation.RIGHT_TO_LEFT);
+
         var children = overlay.getChildrenUnmodifiable();
-        overlay.setNodeOrientation(NodeOrientation.RIGHT_TO_LEFT);
         overlay.resize(200, 100);
         overlay.applyCss();
         overlay.layout();
@@ -144,9 +145,10 @@ public class HeaderButtonOverlayTest {
                 .-FX-INTERNAL-header-button { -fx-pref-width: 20; -fx-pref-height: 10; }
             """), false, false, true);
 
-        var unused = new Scene(overlay);
+        var scene = new Scene(overlay);
+        scene.setNodeOrientation(NodeOrientation.RIGHT_TO_LEFT);
+
         var children = overlay.getChildrenUnmodifiable();
-        overlay.setNodeOrientation(NodeOrientation.RIGHT_TO_LEFT);
         overlay.resize(200, 100);
         overlay.applyCss();
         overlay.layout();
@@ -197,9 +199,10 @@ public class HeaderButtonOverlayTest {
                 .-FX-INTERNAL-header-button { -fx-pref-width: 20; }
             """), false, false, true);
 
-        var unused = new Scene(overlay);
+        var scene = new Scene(overlay);
+        scene.setNodeOrientation(NodeOrientation.RIGHT_TO_LEFT);
+
         var children = overlay.getChildrenUnmodifiable();
-        overlay.setNodeOrientation(NodeOrientation.RIGHT_TO_LEFT);
         overlay.resize(200, 100);
         overlay.applyCss();
         overlay.layout();
@@ -252,9 +255,10 @@ public class HeaderButtonOverlayTest {
                 .-FX-INTERNAL-header-button { -fx-pref-width: 20; -fx-pref-height: 10; }
             """), false, false, true);
 
-        var unused = new Scene(overlay);
+        var scene = new Scene(overlay);
+        scene.setNodeOrientation(NodeOrientation.RIGHT_TO_LEFT);
+
         var children = overlay.getChildrenUnmodifiable();
-        overlay.setNodeOrientation(NodeOrientation.RIGHT_TO_LEFT);
         overlay.resize(200, 100);
         overlay.applyCss();
         overlay.layout();
@@ -307,9 +311,10 @@ public class HeaderButtonOverlayTest {
                 .-FX-INTERNAL-close-button { -fx-button-order: 3; }
             """), false, false, true);
 
-        var unused = new Scene(overlay);
+        var scene = new Scene(overlay);
+        scene.setNodeOrientation(NodeOrientation.RIGHT_TO_LEFT);
+
         var children = overlay.getChildrenUnmodifiable();
-        overlay.setNodeOrientation(NodeOrientation.RIGHT_TO_LEFT);
         overlay.resize(200, 100);
         overlay.applyCss();
         overlay.layout();
@@ -524,8 +529,9 @@ public class HeaderButtonOverlayTest {
     }
 
     private static void assertLayoutBounds(Node node, double x, double y, double width, double height) {
-        assertEquals(x, node.getLayoutX());
-        assertEquals(y, node.getLayoutY());
+        var bounds = node.localToScene(node.getBoundsInLocal());
+        assertEquals(x, bounds.getMinX());
+        assertEquals(y, bounds.getMinY());
         assertSize(node, width, height);
     }
 

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/Node_effectiveOrientation_Test.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/Node_effectiveOrientation_Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package test.javafx.scene;
 
+import com.sun.javafx.scene.NodeHelper;
 import test.com.sun.javafx.test.NodeOrientationTestBase;
 import java.util.stream.Stream;
 import javafx.geometry.NodeOrientation;
@@ -32,6 +33,7 @@ import javafx.scene.Group;
 import javafx.scene.Node;
 import javafx.scene.Scene;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -182,4 +184,21 @@ public final class Node_effectiveOrientation_Test
         return collectState(node, EFFECTIVE_ORIENTATION_ENCODER);
     }
 
+    @Test
+    public void overlayOrientationIsInheritedOnlyFromSceneOrientation() {
+        var node = new Group();
+        node.setNodeOrientation(NodeOrientation.INHERIT);
+        NodeHelper.setInheritOrientationFromScene(node, true);
+        var parent = new Group(node);
+        parent.setNodeOrientation(NodeOrientation.RIGHT_TO_LEFT);
+        var scene = new Scene(parent);
+        scene.setNodeOrientation(NodeOrientation.LEFT_TO_RIGHT);
+
+        NodeHelper.nodeResolvedOrientationInvalidated(node);
+        assertEquals(NodeOrientation.LEFT_TO_RIGHT, node.getEffectiveNodeOrientation());
+
+        scene.setNodeOrientation(NodeOrientation.RIGHT_TO_LEFT);
+        NodeHelper.nodeResolvedOrientationInvalidated(node);
+        assertEquals(NodeOrientation.RIGHT_TO_LEFT, node.getEffectiveNodeOrientation());
+    }
 }

--- a/tests/manual/monkey/src/com/oracle/tools/fx/monkey/tools/StageTesterWindow.java
+++ b/tests/manual/monkey/src/com/oracle/tools/fx/monkey/tools/StageTesterWindow.java
@@ -137,16 +137,18 @@ public final class StageTesterWindow extends Stage {
                 newStage.initOwner(StageTesterWindow.this);
             }
 
+            var nodeOrientation = NodeOrientation.valueOf(nodeOrientationComboBox.getValue());
+
             Parent root = switch (headerBarComboBox.getValue().toLowerCase(Locale.ROOT)) {
-                case "simple" -> createSimpleHeaderBarRoot(newStage, false);
-                case "simple / custom buttons" -> createSimpleHeaderBarRoot(newStage, true);
-                case "split" -> createSplitHeaderBarRoot(newStage, false);
-                case "split / custom buttons" -> createSplitHeaderBarRoot(newStage, true);
-                default -> new BorderPane(createWindowActions(newStage));
+                case "simple" -> createSimpleHeaderBarRoot(newStage, nodeOrientation, false);
+                case "simple / custom buttons" -> createSimpleHeaderBarRoot(newStage, nodeOrientation, true);
+                case "split" -> createSplitHeaderBarRoot(newStage, nodeOrientation, false);
+                case "split / custom buttons" -> createSplitHeaderBarRoot(newStage, nodeOrientation, true);
+                default -> new BorderPane(createWindowActions(newStage, nodeOrientation));
             };
 
             var scene = new Scene(root);
-            scene.setNodeOrientation(NodeOrientation.valueOf(nodeOrientationComboBox.getValue()));
+            scene.setNodeOrientation(nodeOrientation);
 
             newStage.setWidth(800);
             newStage.setHeight(500);
@@ -166,7 +168,7 @@ public final class StageTesterWindow extends Stage {
         setTitle("Stage Tester");
     }
 
-    private Parent createSimpleHeaderBarRoot(Stage stage, boolean customWindowButtons) {
+    private Parent createSimpleHeaderBarRoot(Stage stage, NodeOrientation nodeOrientation, boolean customWindowButtons) {
         var headerBar = new HeaderBar();
         headerBar.setBackground(Background.fill(Color.LIGHTSKYBLUE));
         headerBar.setCenter(new TextField() {{ setPromptText("Search..."); setMaxWidth(300); }});
@@ -234,12 +236,12 @@ public final class StageTesterWindow extends Stage {
 
         var borderPane = new BorderPane();
         borderPane.setTop(headerBar);
-        borderPane.setCenter(createWindowActions(stage));
+        borderPane.setCenter(createWindowActions(stage, nodeOrientation));
 
         return borderPane;
     }
 
-    private Parent createSplitHeaderBarRoot(Stage stage, boolean customWindowButtons) {
+    private Parent createSplitHeaderBarRoot(Stage stage, NodeOrientation nodeOrientation, boolean customWindowButtons) {
         var leftHeaderBar = new HeaderBar();
         leftHeaderBar.setBackground(Background.fill(Color.VIOLET));
         leftHeaderBar.setLeading(new Button("\u2728"));
@@ -277,7 +279,7 @@ public final class StageTesterWindow extends Stage {
 
         var left = new BorderPane();
         left.setTop(leftHeaderBar);
-        left.setCenter(createWindowActions(stage));
+        left.setCenter(createWindowActions(stage, nodeOrientation));
 
         var right = new BorderPane();
         right.setTop(rightHeaderBar);
@@ -304,7 +306,14 @@ public final class StageTesterWindow extends Stage {
         return List.of(iconifyButton, maximizeButton, closeButton);
     }
 
-    private Parent createWindowActions(Stage stage) {
+    private Parent createWindowActions(Stage stage, NodeOrientation nodeOrientation) {
+        var nodeOrientations = Arrays.stream(NodeOrientation.values()).map(Enum::name).toList();
+        var nodeOrientationComboBox = new ComboBox<>(FXCollections.observableArrayList(nodeOrientations));
+        nodeOrientationComboBox.getSelectionModel().select(nodeOrientation.ordinal());
+        nodeOrientationComboBox.getSelectionModel().selectedItemProperty().addListener((_, _, orientation) -> {
+            stage.getScene().setNodeOrientation(NodeOrientation.valueOf(orientation));
+        });
+
         var toggleFullScreenButton = new Button("Enter/Exit Full Screen");
         toggleFullScreenButton.setOnAction(event -> stage.setFullScreen(!stage.isFullScreen()));
 
@@ -317,7 +326,8 @@ public final class StageTesterWindow extends Stage {
         var closeButton = new Button("Close");
         closeButton.setOnAction(event -> stage.close());
 
-        var root = new VBox(toggleFullScreenButton, toggleMaximizedButton, toggleIconifiedButton, closeButton);
+        var root = new VBox(nodeOrientationComboBox, toggleFullScreenButton, toggleMaximizedButton,
+                            toggleIconifiedButton, closeButton);
         root.setSpacing(10);
         root.setAlignment(Pos.CENTER);
         return root;


### PR DESCRIPTION
When an extended stage is shown with RTL orientation (either using a RTL window + `Scene.nodeOrientation == INHERIT`, or using a LTR window and `Scene.nodeOrientation == RIGHT_TO_LEFT`), the default window buttons are placed on the wrong side of the window. This bug only manifests on Windows and Linux, both of which use `HeaderButtonOverlay` to render the default window buttons.

`HeaderButtonOverlay` is not a part of the scene graph, it is shown on top of the scene graph as an overlay (like the warning overlay that appears when entering full-screen mode). For [CSS-related reasons](https://github.com/openjdk/jfx/pull/1605#issuecomment-2967977276), the parent of an overlay is the scene root (but the scene root doesn't know that). This implementation detail can mess up the calculation of orientation flags and mirroring transforms in `Node`, as depending on the `NodeOrientation` of the root node, the code may mistakenly mirror (or not mirror) the orientation.

The solution I've come up with is as follows: the overlay node is marked with the `Node.INHERIT_ORIENTATION_FROM_SCENE` flag, which causes it to resolve its effective orientation against the scene only, and never against the root node. With this change, the effective orientation and mirroring transforms are computed correctly.

The easiest way to test this fix is with Monkey Tester -> Tools -> Stage Tester.