### PR TITLE
8367045: [Linux] Dead keys not working

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/gtk/GlassApplication.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/GlassApplication.cpp
@@ -196,6 +196,10 @@ JNIEXPORT void JNICALL Java_com_sun_glass_ui_gtk_GtkApplication__1init
     gdk_window_set_events(root, static_cast<GdkEventMask>(gdk_window_get_events(root) | GDK_PROPERTY_CHANGE_MASK));
 
     platformSupport = new PlatformSupport(env, obj);
+
+    // Set ibus to sync mode
+    // This seems to have been patched on Ubuntu, but left here for compatibility
+    setenv("IBUS_ENABLE_SYNC_MODE", "1", 1);
 }
 
 /*

--- a/modules/javafx.graphics/src/main/native-glass/gtk/GlassApplication.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/GlassApplication.cpp
@@ -198,7 +198,6 @@ JNIEXPORT void JNICALL Java_com_sun_glass_ui_gtk_GtkApplication__1init
     platformSupport = new PlatformSupport(env, obj);
 
     // Set ibus to sync mode
-    // This seems to have been patched on Ubuntu, but left here for compatibility
     setenv("IBUS_ENABLE_SYNC_MODE", "1", 1);
 }
 

--- a/modules/javafx.graphics/src/main/native-glass/gtk/GlassApplication.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/GlassApplication.cpp
@@ -196,9 +196,6 @@ JNIEXPORT void JNICALL Java_com_sun_glass_ui_gtk_GtkApplication__1init
     gdk_window_set_events(root, static_cast<GdkEventMask>(gdk_window_get_events(root) | GDK_PROPERTY_CHANGE_MASK));
 
     platformSupport = new PlatformSupport(env, obj);
-
-    // Set ibus to sync mode
-    setenv("IBUS_ENABLE_SYNC_MODE", "1", 1);
 }
 
 /*

--- a/modules/javafx.graphics/src/main/native-glass/gtk/glass_window.h
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/glass_window.h
@@ -185,7 +185,6 @@ class WindowContextBase: public WindowContext {
         bool enabled;
         bool on_preedit;
         bool send_keypress;
-        bool on_key_event;
     } im_ctx;
 
     size_t events_processing_cnt;

--- a/modules/javafx.graphics/src/main/native-glass/gtk/glass_window.h
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/glass_window.h
@@ -184,7 +184,6 @@ class WindowContextBase: public WindowContext {
         GtkIMContext *ctx;
         bool enabled;
         bool on_preedit;
-        bool send_keypress;
     } im_ctx;
 
     size_t events_processing_cnt;

--- a/modules/javafx.graphics/src/main/native-glass/gtk/glass_window_ime.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/glass_window_ime.cpp
@@ -131,7 +131,7 @@ bool WindowContextBase::filterIME(GdkEvent *event) {
 
     im_ctx.on_key_event = true;
 
-    bool filtered = gtk_im_context_filter_keypress(im_ctx.ctx, key_event);
+    bool filtered = gtk_im_context_filter_keypress(im_ctx.ctx, event->key);
 
     if (filtered && im_ctx.send_keypress) {
         im_ctx.send_keypress = false;

--- a/modules/javafx.graphics/src/main/native-glass/gtk/glass_window_ime.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/glass_window_ime.cpp
@@ -100,7 +100,7 @@ static gboolean on_retrieve_surrounding(GtkIMContext* self, gpointer user_data) 
 }
 
 void WindowContextBase::commitIME(gchar *str) {
-    if (im_ctx.on_preedit || !im_ctx.on_key_event) {
+    if (im_ctx.on_preedit) {
         jstring jstr = mainEnv->NewStringUTF(str);
         EXCEPTION_OCCURED(mainEnv);
         jsize slen = mainEnv->GetStringLength(jstr);
@@ -124,11 +124,11 @@ bool WindowContextBase::hasIME() {
 }
 
 bool WindowContextBase::filterIME(GdkEvent *event) {
-    if (!hasIME() || !event || event->type != GDK_KEY_PRESS) {
+    if (!hasIME()) {
         return false;
     }
 
-    im_ctx.on_key_event = true;
+//    im_ctx.on_key_event = true;
 
     bool filtered = gtk_im_context_filter_keypress(im_ctx.ctx, &event->key);
 
@@ -137,7 +137,7 @@ bool WindowContextBase::filterIME(GdkEvent *event) {
         return false;
     }
 
-    im_ctx.on_key_event = false;
+//    im_ctx.on_key_event = false;
     return filtered;
 }
 

--- a/modules/javafx.graphics/src/main/native-glass/gtk/glass_window_ime.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/glass_window_ime.cpp
@@ -130,11 +130,6 @@ bool WindowContextBase::filterIME(GdkEvent *event) {
         return false;
     }
 
-    // Additional validation to prevent IBUS warnings
-    if (!im_ctx.ctx) {
-        return false;
-    }
-
     im_ctx.on_key_event = true;
 
     // Validate key event before passing to IBUS
@@ -191,10 +186,6 @@ void WindowContextBase::enableOrResetIME() {
         im_ctx.ctx = gtk_im_multicontext_new();
         gtk_im_context_set_client_window(GTK_IM_CONTEXT(im_ctx.ctx), gdk_window);
         gtk_im_context_set_use_preedit(GTK_IM_CONTEXT(im_ctx.ctx), true);
-
-        // Add IBUS-specific configuration to prevent type warnings
-        g_object_set(im_ctx.ctx, "input-purpose", GTK_INPUT_PURPOSE_FREE_FORM, NULL);
-        g_object_set(im_ctx.ctx, "input-hints", GTK_INPUT_HINT_NONE, NULL);
 
         g_signal_connect(im_ctx.ctx, "preedit-start", G_CALLBACK(on_preedit_start), this);
         g_signal_connect(im_ctx.ctx, "preedit-changed", G_CALLBACK(on_preedit_changed), this);

--- a/modules/javafx.graphics/src/main/native-glass/gtk/glass_window_ime.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/glass_window_ime.cpp
@@ -124,8 +124,6 @@ bool WindowContextBase::filterIME(GdkEvent *event) {
         return false;
     }
 
-//    im_ctx.on_key_event = true;
-
     bool filtered = gtk_im_context_filter_keypress(im_ctx.ctx, &event->key);
 
     if (filtered && im_ctx.send_keypress) {
@@ -133,7 +131,6 @@ bool WindowContextBase::filterIME(GdkEvent *event) {
         return false;
     }
 
-//    im_ctx.on_key_event = false;
     return filtered;
 }
 

--- a/modules/javafx.graphics/src/main/native-glass/gtk/glass_window_ime.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/glass_window_ime.cpp
@@ -100,23 +100,19 @@ static gboolean on_retrieve_surrounding(GtkIMContext* self, gpointer user_data) 
 }
 
 void WindowContextBase::commitIME(gchar *str) {
-    if (im_ctx.on_preedit) {
-        jstring jstr = mainEnv->NewStringUTF(str);
-        EXCEPTION_OCCURED(mainEnv);
-        jsize slen = mainEnv->GetStringLength(jstr);
+    jstring jstr = mainEnv->NewStringUTF(str);
+    EXCEPTION_OCCURED(mainEnv);
+    jsize slen = mainEnv->GetStringLength(jstr);
 
-        mainEnv->CallVoidMethod(jview,
-                jViewNotifyInputMethodLinux,
-                jstr,
-                slen,
-                slen,
-                0);
-        LOG_EXCEPTION(mainEnv)
+    mainEnv->CallVoidMethod(jview,
+            jViewNotifyInputMethodLinux,
+            jstr,
+            slen,
+            slen,
+            0);
+    LOG_EXCEPTION(mainEnv)
 
-        mainEnv->DeleteLocalRef(jstr);
-    } else {
-        im_ctx.send_keypress = true;
-    }
+    mainEnv->DeleteLocalRef(jstr);
 }
 
 bool WindowContextBase::hasIME() {

--- a/modules/javafx.graphics/src/main/native-glass/gtk/glass_window_ime.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/glass_window_ime.cpp
@@ -115,7 +115,6 @@ void WindowContextBase::commitIME(gchar *str) {
         LOG_EXCEPTION(mainEnv)
 
         mainEnv->DeleteLocalRef(jstr);
-
     } else {
         im_ctx.send_keypress = true;
     }
@@ -131,13 +130,6 @@ bool WindowContextBase::filterIME(GdkEvent *event) {
     }
 
     im_ctx.on_key_event = true;
-
-    // Validate key event before passing to IBUS
-    GdkEventKey *key_event = &event->key;
-    if (key_event->keyval == 0 || key_event->hardware_keycode == 0) {
-        im_ctx.on_key_event = false;
-        return false;
-    }
 
     bool filtered = gtk_im_context_filter_keypress(im_ctx.ctx, key_event);
 

--- a/modules/javafx.graphics/src/main/native-glass/gtk/glass_window_ime.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/glass_window_ime.cpp
@@ -55,7 +55,6 @@ static void on_preedit_changed(GtkIMContext *im_context, gpointer user_data) {
 
     jbyte attr = com_sun_glass_ui_View_IME_ATTR_INPUT;
     do {
-        // Fix: Use proper comparison instead of assignment
         if ((pangoAttr = pango_attr_iterator_get(iter, PANGO_ATTR_BACKGROUND)) != NULL) {
              attr = com_sun_glass_ui_View_IME_ATTR_TARGET_NOTCONVERTED;
              break;
@@ -131,7 +130,7 @@ bool WindowContextBase::filterIME(GdkEvent *event) {
 
     im_ctx.on_key_event = true;
 
-    bool filtered = gtk_im_context_filter_keypress(im_ctx.ctx, event->key);
+    bool filtered = gtk_im_context_filter_keypress(im_ctx.ctx, &event->key);
 
     if (filtered && im_ctx.send_keypress) {
         im_ctx.send_keypress = false;

--- a/modules/javafx.graphics/src/main/native-glass/gtk/glass_window_ime.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/glass_window_ime.cpp
@@ -124,7 +124,7 @@ bool WindowContextBase::hasIME() {
 }
 
 bool WindowContextBase::filterIME(GdkEvent *event) {
-    if (!hasIME() || !event || event->type != GDK_KEY_PRESS && event->type != GDK_KEY_RELEASE) {
+    if (!hasIME() || !event || event->type != GDK_KEY_PRESS) {
         return false;
     }
 

--- a/modules/javafx.graphics/src/main/native-glass/gtk/glass_window_ime.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/glass_window_ime.cpp
@@ -55,10 +55,10 @@ static void on_preedit_changed(GtkIMContext *im_context, gpointer user_data) {
 
     jbyte attr = com_sun_glass_ui_View_IME_ATTR_INPUT;
     do {
-        if ((pangoAttr = pango_attr_iterator_get(iter, PANGO_ATTR_BACKGROUND)) != NULL) {
+        if (pangoAttr = pango_attr_iterator_get(iter, PANGO_ATTR_BACKGROUND)) {
              attr = com_sun_glass_ui_View_IME_ATTR_TARGET_NOTCONVERTED;
              break;
-        } else if ((pangoAttr = pango_attr_iterator_get(iter, PANGO_ATTR_UNDERLINE)) != NULL
+        } else if ((pangoAttr = pango_attr_iterator_get(iter, PANGO_ATTR_UNDERLINE))
                 && (((PangoAttrInt *)pangoAttr)->value == PANGO_UNDERLINE_SINGLE)) {
             attr = com_sun_glass_ui_View_IME_ATTR_CONVERTED;
             break;
@@ -76,8 +76,6 @@ static void on_preedit_changed(GtkIMContext *im_context, gpointer user_data) {
             cursor_pos,
             attr);
     LOG_EXCEPTION(mainEnv)
-
-    mainEnv->DeleteLocalRef(jstr);
 }
 
 static void on_preedit_end(GtkIMContext *im_context, gpointer user_data) {
@@ -111,8 +109,6 @@ void WindowContextBase::commitIME(gchar *str) {
             slen,
             0);
     LOG_EXCEPTION(mainEnv)
-
-    mainEnv->DeleteLocalRef(jstr);
 }
 
 bool WindowContextBase::hasIME() {
@@ -157,8 +153,6 @@ void WindowContextBase::updateCaretPos() {
         mainEnv->ReleaseDoubleArrayElements(pos, nativePos, 0);
         gtk_im_context_set_cursor_location(im_ctx.ctx, &rect);
     }
-
-    mainEnv->DeleteLocalRef(pos);
 }
 
 void WindowContextBase::enableOrResetIME() {
@@ -170,7 +164,6 @@ void WindowContextBase::enableOrResetIME() {
         im_ctx.ctx = gtk_im_multicontext_new();
         gtk_im_context_set_client_window(GTK_IM_CONTEXT(im_ctx.ctx), gdk_window);
         gtk_im_context_set_use_preedit(GTK_IM_CONTEXT(im_ctx.ctx), true);
-
         g_signal_connect(im_ctx.ctx, "preedit-start", G_CALLBACK(on_preedit_start), this);
         g_signal_connect(im_ctx.ctx, "preedit-changed", G_CALLBACK(on_preedit_changed), this);
         g_signal_connect(im_ctx.ctx, "preedit-end", G_CALLBACK(on_preedit_end), this);

--- a/modules/javafx.graphics/src/main/native-glass/gtk/glass_window_ime.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/glass_window_ime.cpp
@@ -120,14 +120,7 @@ bool WindowContextBase::filterIME(GdkEvent *event) {
         return false;
     }
 
-    bool filtered = gtk_im_context_filter_keypress(im_ctx.ctx, &event->key);
-
-    if (filtered && im_ctx.send_keypress) {
-        im_ctx.send_keypress = false;
-        return false;
-    }
-
-    return filtered;
+    return gtk_im_context_filter_keypress(im_ctx.ctx, &event->key);
 }
 
 void WindowContextBase::setOnPreEdit(bool preedit) {


### PR DESCRIPTION
The bug report is on Linux Mint which does not use ibus (the gnome default).

With this change, it continues to work on ibus, but also works works without it (on mint) and with fcitx.

It seems it's correct - but it's weird that it needed those bits before. I would say it's related to  `IBUS_ENABLE_SYNC_MODE` (see [this comment](https://github.com/openjdk/jfx/pull/1080#issuecomment-2412202297) on #1080.), but it seems to be still set to 0 on Ubuntu 24.04.

@Glavo: Can you check if Chinese input is still correct?
@andzsinszan: Can you check for Japanese?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367045](https://bugs.openjdk.org/browse/JDK-8367045): [Linux] Dead keys not working (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1922/head:pull/1922` \
`$ git checkout pull/1922`

Update a local copy of the PR: \
`$ git checkout pull/1922` \
`$ git pull https://git.openjdk.org/jfx.git pull/1922/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1922`

View PR using the GUI difftool: \
`$ git pr show -t 1922`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1922.diff">https://git.openjdk.org/jfx/pull/1922.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1922#issuecomment-3343484773)
</details>
