### PR TITLE
8368511: Incorrect "Group" name after click on link in JavaFX CSS Reference Guide

### DIFF
--- a/modules/javafx.graphics/src/main/docs/javafx/scene/doc-files/cssref.html
+++ b/modules/javafx.graphics/src/main/docs/javafx/scene/doc-files/cssref.html
@@ -1943,7 +1943,7 @@
         </tr>
         </tbody>
     </table>
-    <h4><a id="popupwindow">Group</a></h4>
+    <h4><a id="popupwindow">PopupWindow</a></h4>
     <p class="styleclass">Style class: :root.popup</p>
     <p>PopupWindow does not have any properties that can be styled by CSS, but a PopupWindow does have its own Scene.
         Scene's root gets the :root pseudo-class by default. If the Scene is the root scene of a PopupWindow, then the


### PR DESCRIPTION
Changed `Group` name to `PopupWindow` in `cssref.html`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8368511](https://bugs.openjdk.org/browse/JDK-8368511): Incorrect "Group" name after click on link in JavaFX CSS Reference Guide (**Bug** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1923/head:pull/1923` \
`$ git checkout pull/1923`

Update a local copy of the PR: \
`$ git checkout pull/1923` \
`$ git pull https://git.openjdk.org/jfx.git pull/1923/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1923`

View PR using the GUI difftool: \
`$ git pr show -t 1923`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1923.diff">https://git.openjdk.org/jfx/pull/1923.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1923#issuecomment-3348128779)
</details>
