### PR TITLE
8367045: [Linux] Dead keys not working

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/gtk/glass_window.h
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/glass_window.h
@@ -186,6 +186,7 @@ class WindowContextBase: public WindowContext {
         bool on_preedit;
         bool send_keypress;
         bool on_key_event;
+        bool in_preedit_window;
     } im_ctx;
 
     size_t events_processing_cnt;

--- a/modules/javafx.graphics/src/main/native-glass/gtk/glass_window_ime.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/glass_window_ime.cpp
@@ -98,7 +98,7 @@ static gboolean on_retrieve_surrounding(GtkIMContext* self, gpointer user_data) 
 }
 
 void WindowContextBase::commitIME(gchar *str) {
-    if (im_ctx.on_preedit || !im_ctx.on_key_event) {
+    if (im_ctx.in_preedit_window || !im_ctx.on_key_event) {
         jstring jstr = mainEnv->NewStringUTF(str);
         EXCEPTION_OCCURED(mainEnv);
         jsize slen = mainEnv->GetStringLength(jstr);
@@ -125,7 +125,16 @@ bool WindowContextBase::filterIME(GdkEvent *event) {
     }
 
     im_ctx.on_key_event = true;
+    // If "commit" arrives while pre-editing is active we send out an
+    // InputMethodEvent; otherwise we send out a KeyEvent. Normally the
+    // "commit" signal arrives before "preedit-end" but sometimes when
+    // processing dead keys on a system with no input method
+    // framework these signals arrive in reverse order. This flag
+    // ensures that if we're in the pre-edit window when we start
+    // filtering the event we stay there until we're done.
+    im_ctx.in_preedit_window = im_ctx.on_preedit;
     bool filtered = gtk_im_context_filter_keypress(im_ctx.ctx, &event->key);
+    im_ctx.in_preedit_window = im_ctx.on_preedit;
 
     if (filtered && im_ctx.send_keypress) {
         im_ctx.send_keypress = false;
@@ -183,6 +192,8 @@ void WindowContextBase::enableOrResetIME() {
 
     im_ctx.on_preedit = false;
     im_ctx.enabled = true;
+    im_ctx.on_key_event = false;
+    im_ctx.in_preedit_window = false;
 }
 
 void WindowContextBase::disableIME() {


### PR DESCRIPTION
This bug seems to only apply to Linux systems with no input method framework (IMF) configured. If you want to reproduce the original bug on Ubuntu 24.04 you need to go into Settings > System > "Region & Language" > "Manage installed languages" > Language and verify that "Keyboard input method system" is set to "none". If you change this setting you should reboot the system.

Normally at the end of a dead-key sequence the IMF sends us a "commit" with the composed character followed by a "preedit-end" signal. When no IMF is configured these signals arrive in reverse order. This is not the way any IMF works and is confusing the heuristic we use to determine whether to send a KeyEvent or an InputMethodEvent.

To insulate ourselves against this signal ordering issue we add a new flag that ensures that if we're in the preedit window when we start filtering an event we stay there until filtering is done.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8367045](https://bugs.openjdk.org/browse/JDK-8367045): [Linux] Dead keys not working (**Bug** - P3)


### Reviewers
 * [Lukasz Kostyra](https://openjdk.org/census#lkostyra) (@lukostyra - **Reviewer**)
 * [Thiago Milczarek Sayao](https://openjdk.org/census#tsayao) (@tsayao - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1924/head:pull/1924` \
`$ git checkout pull/1924`

Update a local copy of the PR: \
`$ git checkout pull/1924` \
`$ git pull https://git.openjdk.org/jfx.git pull/1924/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1924`

View PR using the GUI difftool: \
`$ git pr show -t 1924`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1924.diff">https://git.openjdk.org/jfx/pull/1924.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1924#issuecomment-3353326309)
</details>
