### PR TITLE
DRAFT v2 - 8252373: [macOS] Stage with owner disappears when moved to another screen

### DIFF
--- a/apps/toys/Hello/src/main/java/hello/HelloModality.java
+++ b/apps/toys/Hello/src/main/java/hello/HelloModality.java
@@ -35,10 +35,13 @@ import javafx.scene.Scene;
 import javafx.scene.control.Button;
 import javafx.scene.control.CheckBox;
 import javafx.scene.control.RadioButton;
+import javafx.scene.control.ToggleButton;
 import javafx.scene.control.ToggleGroup;
+import javafx.scene.control.Tooltip;
 import javafx.stage.FileChooser;
 import javafx.stage.Modality;
 import javafx.stage.Stage;
+import javafx.stage.Window;
 import javafx.stage.StageStyle;
 
 public class HelloModality extends Application {
@@ -65,6 +68,13 @@ public class HelloModality extends Application {
         checker.setLayoutX(25);
         checker.setLayoutY(40);
         root.getChildren().add(checker);
+
+        // Setup AlwaysOnTop checker
+        final CheckBox onTopChecker = new CheckBox("AlwaysOnTop");
+        onTopChecker.setSelected(false);
+        onTopChecker.setLayoutX(25);
+        onTopChecker.setLayoutY(70);
+        root.getChildren().add(onTopChecker);
 
         // Setup Modality Selection
         final ToggleGroup modalityGroup = new ToggleGroup();
@@ -112,6 +122,7 @@ public class HelloModality extends Application {
         root.getChildren().add(suButton);
 
         Button button = new Button("Create Dialog");
+        button.setTooltip(new Tooltip("Creates a new stage"));
         button.setLayoutX(100);
         button.setLayoutY(200);
         button.setOnAction(new EventHandler<ActionEvent>() {
@@ -120,6 +131,9 @@ public class HelloModality extends Application {
 
                 boolean owned = checker.isSelected();
                 dialog.initOwner(owned ? stage : null);
+
+                boolean alwaysOnTop = onTopChecker.isSelected();
+                dialog.setAlwaysOnTop(alwaysOnTop);
 
                 Modality modality;
                 if (applicationButton.isSelected()) {
@@ -153,7 +167,8 @@ public class HelloModality extends Application {
                 Group dialogRoot = (Group) dialogScene.getRoot();
 
                 Button dialogButton = new Button("Dismiss");
-                dialogButton.setLayoutX(275);
+                dialogButton.setTooltip(new Tooltip("Hides (closes) this stage"));
+                dialogButton.setLayoutX(375);
                 dialogButton.setLayoutY(200);
                 dialogButton.setOnAction(new EventHandler<ActionEvent>() {
                     @Override public void handle(ActionEvent e) {
@@ -170,6 +185,7 @@ public class HelloModality extends Application {
         root.getChildren().add(button);
 
         Button button2 = new Button("Click Me");
+        button2.setTooltip(new Tooltip("Prints a message"));
         button2.setLayoutX(200);
         button2.setLayoutY(200);
         button2.setOnAction(new EventHandler<ActionEvent>() {
@@ -178,6 +194,18 @@ public class HelloModality extends Application {
             }
         });
         root.getChildren().add(button2);
+
+        ToggleButton onTopButton = new ToggleButton("AlwaysOnTop");
+        onTopButton.setTooltip(new Tooltip("Toggles the alwaysOnTop property"));
+        onTopButton.setSelected(stage.isAlwaysOnTop());
+        onTopButton.setLayoutX(275);
+        onTopButton.setLayoutY(200);
+        onTopButton.setOnAction(new EventHandler<ActionEvent>() {
+            @Override public void handle(ActionEvent e) {
+                stage.setAlwaysOnTop(onTopButton.isSelected());
+            }
+        });
+        root.getChildren().add(onTopButton);
 
         // Owned file dialog checkbox
         final CheckBox ownedFileChooser = new CheckBox("Owned file chooser");

--- a/apps/toys/Hello/src/main/java/hello/HelloModality.java
+++ b/apps/toys/Hello/src/main/java/hello/HelloModality.java
@@ -26,8 +26,10 @@
 package hello;
 
 import java.io.File;
+import java.util.Optional;
 
 import javafx.application.Application;
+import javafx.collections.ListChangeListener;
 import javafx.event.ActionEvent;
 import javafx.event.EventHandler;
 import javafx.scene.Group;
@@ -40,8 +42,8 @@ import javafx.scene.control.ToggleGroup;
 import javafx.scene.control.Tooltip;
 import javafx.stage.FileChooser;
 import javafx.stage.Modality;
+import javafx.stage.Screen;
 import javafx.stage.Stage;
-import javafx.stage.Window;
 import javafx.stage.StageStyle;
 
 public class HelloModality extends Application {
@@ -56,7 +58,6 @@ public class HelloModality extends Application {
     }
 
     Scene createScene(final Stage stage) {
-
         Group root = new Group();
         int xyOffset = offset * counter++;
         if (xyOffset > 200) xyOffset = 0;
@@ -73,8 +74,19 @@ public class HelloModality extends Application {
         final CheckBox onTopChecker = new CheckBox("AlwaysOnTop");
         onTopChecker.setSelected(false);
         onTopChecker.setLayoutX(25);
-        onTopChecker.setLayoutY(70);
+        onTopChecker.setLayoutY(65);
         root.getChildren().add(onTopChecker);
+
+        // Setup secondary screen checker
+        final CheckBox secondaryScreenChecker = new CheckBox("2nd Screen");
+        secondaryScreenChecker.setSelected(false);
+        secondaryScreenChecker.setDisable(Screen.getScreens().size() < 2);
+        secondaryScreenChecker.setLayoutX(25);
+        secondaryScreenChecker.setLayoutY(90);
+        Screen.getScreens().addListener((ListChangeListener.Change<? extends Screen> change) -> {
+            secondaryScreenChecker.setDisable(Screen.getScreens().size() < 2);
+        });
+        root.getChildren().add(secondaryScreenChecker);
 
         // Setup Modality Selection
         final ToggleGroup modalityGroup = new ToggleGroup();
@@ -177,8 +189,23 @@ public class HelloModality extends Application {
                 });
                 dialogRoot.getChildren().add(dialogButton);
 
-
                 dialog.setScene(dialogScene);
+
+                if (secondaryScreenChecker.isSelected()) {
+                    Optional<Screen> otherScreen = Screen.getScreens()
+                            .stream()
+                            .filter(scr -> !Screen.getPrimary().equals(scr))
+                            .findFirst();
+                    otherScreen.ifPresent(scr -> {
+                        double x = (scr.getVisualBounds().getWidth() - scene.getWidth()) / 2.0 +
+                                scr.getVisualBounds().getMinX();
+                        double y = (scr.getVisualBounds().getHeight()- scene.getHeight()) / 2.0 +
+                                scr.getVisualBounds().getMinY();
+                        dialog.setX(x);
+                        dialog.setY(y);
+                    });
+                }
+
                 dialog.show();
             }
         });

--- a/apps/toys/Hello/src/main/java/hello/HelloModality.java
+++ b/apps/toys/Hello/src/main/java/hello/HelloModality.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -121,7 +121,7 @@ public class HelloModality extends Application {
         root.getChildren().add(stButton);
         root.getChildren().add(suButton);
 
-        Button button = new Button("Create Dialog");
+        Button button = new Button("Create Stage");
         button.setTooltip(new Tooltip("Creates a new stage"));
         button.setLayoutX(100);
         button.setLayoutY(200);

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow+Java.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow+Java.m
@@ -191,7 +191,6 @@ extern NSSize maxScreenDimensions;
 
     // If this window doesn't belong to an owned windows hierarchy that
     // holds the grab currently, then the grab should be released.
-    // KCR: check
     for (GlassWindow * window = self; window; window = window->owner) {
         if (window->nsWindow == s_grabWindow) {
             return;
@@ -271,7 +270,7 @@ extern NSSize maxScreenDimensions;
 
 - (void)_setVisible
 {
-    NSLog(@"_setVisible: focusable %d enabled %d", self->isFocusable, self->isEnabled);
+    NSLog(@"_setVisible: focusable %d enabled %d", self->isFocusable, self->isEnabled); // KCR: REVERT BACK TO LOG
 
     if (self->isFocusable == YES && self->isEnabled == YES)
     {
@@ -287,7 +286,6 @@ extern NSSize maxScreenDimensions;
     {
         [self->owner reorderChildWindows];
     }
-
     // Make sure we synchronize scale factors which could have changed while
     // we were not visible without invoking the overrides we watch.
     if ([self->nsWindow screen] && (self->view != nil)) {

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow+Java.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow+Java.m
@@ -273,12 +273,10 @@ extern NSSize maxScreenDimensions;
 {
     NSLog(@"_setVisible: focusable %d enabled %d", self->isFocusable, self->isEnabled);
 
-    BOOL focus = NO;
     if (self->isFocusable == YES && self->isEnabled == YES)
     {
         [self->nsWindow makeMainWindow];
         [self->nsWindow makeKeyAndOrderFront:nil];
-        focus = YES;
     }
     else
     {
@@ -287,7 +285,7 @@ extern NSSize maxScreenDimensions;
 
     if (self->owner != nil)
     {
-        [self->owner reorderChildWindows:focus];
+        [self->owner reorderChildWindows];
     }
 
     // Make sure we synchronize scale factors which could have changed while

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow+Java.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow+Java.m
@@ -285,14 +285,6 @@ extern NSSize maxScreenDimensions;
         [self->nsWindow orderFront:nil];
     }
 
-/*
-    // KCR: FIXME
-    if ((self->ownerNSWindow != nil) && ([self->nsWindow parentWindow] == nil))
-    {
-        [self->ownerNSWindow addChildWindow:self->nsWindow ordered:NSWindowAbove];
-    }
-*/
-
     if (self->owner != nil)
     {
         [self->owner reorderChildWindows:focus];

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow+Java.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow+Java.m
@@ -191,6 +191,7 @@ extern NSSize maxScreenDimensions;
 
     // If this window doesn't belong to an owned windows hierarchy that
     // holds the grab currently, then the grab should be released.
+    // KCR: FIXME
     for (NSWindow * window = self->nsWindow; window; window = [window parentWindow]) {
         if (window == s_grabWindow) {
             return;

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow+Java.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow+Java.m
@@ -282,6 +282,7 @@ extern NSSize maxScreenDimensions;
         [self->nsWindow orderFront:nil];
     }
 
+    // KCR: FIXME
     if ((self->owner != nil) && ([self->nsWindow parentWindow] == nil))
     {
         [self->owner addChildWindow:self->nsWindow ordered:NSWindowAbove];

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow+Overrides.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow+Overrides.m
@@ -59,15 +59,11 @@
 
 #pragma mark --- Delegate
 
-// KCR: DEBUG BEGIN
-/*
 - (void)windowDidChangeScreen:(NSNotification *)notification
 {
-    NSLog(@"windowDidChangeScreen: %p", [self->nsWindow screen]);
-    //[self fixChildWindow];
+    NSLog(@"windowDidChangeScreen: %p  screen: %p", self, [self->nsWindow screen]); // KCR: Comment out
+    [self reorderChildWindows];
 }
-*/
-// KCR: DEBUG END
 
 - (void)windowDidBecomeKey:(NSNotification *)notification
 {
@@ -220,7 +216,7 @@
 
 - (void)windowWillEnterFullScreen:(NSNotification *)notification
 {
-    //NSLog(@"windowWillEnterFullScreen");
+    NSLog(@"windowWillEnterFullScreen"); // KCR: Coment back out
 
     NSUInteger mask = [self->nsWindow styleMask];
     self->isWindowResizable = ((mask & NSWindowStyleMaskResizable) != 0);
@@ -234,18 +230,21 @@
     if (nsWindow.toolbar != nil) {
         nsWindow.toolbar.visible = NO;
     }
+    [self setMoveToActiveSpaceChildWindows:YES];
 }
 
 - (void)windowDidEnterFullScreen:(NSNotification *)notification
 {
-    //NSLog(@"windowDidEnterFullScreen");
+    NSLog(@"windowDidEnterFullScreen"); // KCR: Coment back out
     [(GlassViewDelegate*)[self->view delegate] sendJavaFullScreenEvent:YES withNativeWidget:YES];
     [GlassApplication leaveFullScreenExitingLoopIfNeeded];
+    [self reorderChildWindows];
+    [self setMoveToActiveSpaceChildWindows:NO];
 }
 
 - (void)windowWillExitFullScreen:(NSNotification *)notification
 {
-    //NSLog(@"windowWillExitFullScreen");
+    NSLog(@"windowWillExitFullScreen"); // KCR: Coment back out
 
     // When we exit full-screen mode, hide the standard window buttons if they were previously hidden.
     if (!self->isStandardButtonsVisible) {
@@ -257,7 +256,7 @@
 
 - (void)windowDidExitFullScreen:(NSNotification *)notification
 {
-    //NSLog(@"windowDidExitFullScreen");
+    NSLog(@"windowDidExitFullScreen"); // KCR: Coment back out
 
     if (nsWindow.toolbar != nil) {
         nsWindow.toolbar.visible = YES;
@@ -268,6 +267,7 @@
 
     [delegate sendJavaFullScreenEvent:NO withNativeWidget:YES];
     [GlassApplication leaveFullScreenExitingLoopIfNeeded];
+    [self reorderChildWindows];
 }
 
 - (BOOL)windowShouldClose:(NSNotification *)notification

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow+Overrides.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow+Overrides.m
@@ -59,17 +59,17 @@
 
 #pragma mark --- Delegate
 
-// KCR: FIXME: temporary for debugging, delete when no longer needed
+// KCR: DEBUG BEGIN
 - (void)windowDidChangeScreen:(NSNotification *)notification
 {
     NSLog(@"windowDidChangeScreen: %p", [self->nsWindow screen]);
     //[self fixChildWindow];
 }
-
+// KCR: DEBUG END
 
 - (void)windowDidBecomeKey:(NSNotification *)notification
 {
-    NSLog(@"windowDidBecomeKey: %p", self);
+    NSLog(@"windowDidBecomeKey: %p", self); // KCR: Comment out
     GET_MAIN_JENV;
     if (!self->isEnabled)
     {
@@ -92,7 +92,7 @@
 
 - (void)windowDidResignKey:(NSNotification *)notification
 {
-    NSLog(@"windowDidResignKey: %p", self);
+    NSLog(@"windowDidResignKey: %p", self); // KCR: Comment out
     [self _ungrabFocus];
 
     GET_MAIN_JENV_NOWARN;
@@ -106,20 +106,20 @@
 
 - (void)windowWillClose:(NSNotification *)notification
 {
-    NSLog(@"windowWillClose");
+    NSLog(@"windowWillClose"); // KCR: Comment out
     // Remove self from list of child windows
     if (self->owner != nil) {
         [self->owner removeChildWindow:self];
-//        [self->owner reorderChildWindows];
+//        [self->owner reorderChildWindows]; // KCR: REMOVE IF NOT NEEDED
     }
 
     // Finally, close owned windows to mimic MS Windows behavior
     if (self->childWindows != nil) {
         NSArray *children = [[NSArray alloc] initWithArray:self->childWindows];
-        NSLog(@"    childWindows: %p", self->childWindows);
+        NSLog(@"    childWindows: %p", self->childWindows); // KCR: DEBUG
         // FIXME: make a copy
         for (GlassWindow *child in children) {
-            NSLog(@"    close: %p", child);
+            NSLog(@"    close: %p", child); // KCR: DEBUG
             [child->nsWindow close];
         }
         [children release];

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow+Overrides.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow+Overrides.m
@@ -62,6 +62,7 @@
 #pragma mark --- Delegate
 
 
+// KCR: remove this hack
 /*
 - (void)fixChildWindow
 {
@@ -161,6 +162,7 @@
           origin.x, origin.y, [self->nsWindow screen]);
     [self _sendJavaWindowMoveEventForFrame:[self _flipFrame]];
 
+    // KCR: FIXME
     NSWindow *parent = [self->nsWindow parentWindow];
     if (parent)
     {

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow+Overrides.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow+Overrides.m
@@ -60,11 +60,13 @@
 #pragma mark --- Delegate
 
 // KCR: DEBUG BEGIN
+/*
 - (void)windowDidChangeScreen:(NSNotification *)notification
 {
     NSLog(@"windowDidChangeScreen: %p", [self->nsWindow screen]);
     //[self fixChildWindow];
 }
+*/
 // KCR: DEBUG END
 
 - (void)windowDidBecomeKey:(NSNotification *)notification
@@ -110,16 +112,15 @@
     // Remove self from list of child windows
     if (self->owner != nil) {
         [self->owner removeChildWindow:self];
-//        [self->owner reorderChildWindows]; // KCR: REMOVE IF NOT NEEDED
     }
 
     // Finally, close owned windows to mimic MS Windows behavior
     if (self->childWindows != nil) {
         NSArray *children = [[NSArray alloc] initWithArray:self->childWindows];
-        NSLog(@"    childWindows: %p", self->childWindows); // KCR: DEBUG
+//        NSLog(@"    childWindows: %p", self->childWindows); // KCR: DEBUG
         // FIXME: make a copy
         for (GlassWindow *child in children) {
-            NSLog(@"    close: %p", child); // KCR: DEBUG
+            NSLog(@"    close child: %p", child); // KCR: DEBUG
             [child->nsWindow close];
         }
         [children release];

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow+Overrides.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow+Overrides.m
@@ -181,14 +181,25 @@
     [self _sendJavaWindowResizeEvent:com_sun_glass_events_WindowEvent_RESIZE forFrame:frame];
 }
 
+- (void)windowWillMiniaturize:(NSNotification *)notification
+{
+    NSLog(@"windowWillMiniaturize: %p", self); // KCR: Comment out
+    // KCR: FIXME: set flag to inhibit reorder until minimize is done (presuming it is effective)
+}
+
 - (void)windowDidMiniaturize:(NSNotification *)notification
 {
+    NSLog(@"windowDidMiniaturize: %p", self); // KCR: Comment out
     [self _sendJavaWindowResizeEvent:com_sun_glass_events_WindowEvent_MINIMIZE forFrame:[self _flipFrame]];
+    [self minimizeChildWindows:YES];
 }
 
 - (void)windowDidDeminiaturize:(NSNotification *)notification
 {
+    NSLog(@"windowDidDeminiaturize: %p", self); // KCR: Comment out
     [self _sendJavaWindowResizeEvent:com_sun_glass_events_WindowEvent_RESTORE forFrame:[self _flipFrame]];
+    [self minimizeChildWindows:NO];
+    [self reorderChildWindows];
 }
 
 - (BOOL)windowShouldZoom:(NSWindow *)window toFrame:(NSRect)newFrame

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow+Overrides.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow+Overrides.m
@@ -101,15 +101,12 @@
     if (env != NULL) {
         (*env)->CallVoidMethod(env, self->jWindow, jWindowNotifyFocus, com_sun_glass_events_WindowEvent_FOCUS_LOST);
     }
-
-    // Fix up order
-    [self reorderChildWindows];
 }
 
 - (void)windowWillClose:(NSNotification *)notification
 {
     NSLog(@"windowWillClose"); // KCR: Comment out
-    // Remove self from list of child windows
+    // Remove self from list of owner's child windows
     if (self->owner != nil) {
         [self->owner removeChildWindow:self];
     }
@@ -123,6 +120,11 @@
             [child->nsWindow close];
         }
         [children release];
+    }
+
+    // If we have an owner, reorder its remaining children
+    if (self->owner != nil) {
+        [self->owner reorderChildWindows];
     }
 
     // Call the notification method

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow+Overrides.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow+Overrides.m
@@ -116,9 +116,8 @@
 
     // Finally, close owned windows to mimic MS Windows behavior
     if (self->childWindows != nil) {
+        // Iterate over an immutable copy
         NSArray *children = [[NSArray alloc] initWithArray:self->childWindows];
-//        NSLog(@"    childWindows: %p", self->childWindows); // KCR: DEBUG
-        // FIXME: make a copy
         for (GlassWindow *child in children) {
             NSLog(@"    close child: %p", child); // KCR: DEBUG
             [child->nsWindow close];

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow+Overrides.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow+Overrides.m
@@ -95,6 +95,7 @@
 
 - (void)windowDidBecomeKey:(NSNotification *)notification
 {
+    NSLog(@"windowDidBecomeKey: %p", self);
     GET_MAIN_JENV;
     if (!self->isEnabled)
     {
@@ -110,6 +111,9 @@
         [NSApp setMainMenu:self->menubar->menu];
     }
     [[NSApp mainMenu] update];
+
+    // Fix up order
+    [self reorderChildWindows:YES];
 }
 
 - (void)windowDidResignKey:(NSNotification *)notification
@@ -156,12 +160,15 @@
 
 - (void)windowDidMove:(NSNotification *)notification
 {
+/*
     NSLog(@"");
     NSPoint origin = [self->nsWindow frame].origin;
     NSLog(@"windowDidMove: %f, %f  screen: %p",
           origin.x, origin.y, [self->nsWindow screen]);
+*/
     [self _sendJavaWindowMoveEventForFrame:[self _flipFrame]];
 
+/*
     // KCR: FIXME
     NSWindow *parent = [self->nsWindow parentWindow];
     if (parent)
@@ -183,6 +190,7 @@
                   childOrigin.x, childOrigin.y, [child screen]);
         }
     }
+*/
 }
 
 - (void)windowDidChangeBackingProperties:(NSNotification *)notification

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow+Overrides.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow+Overrides.m
@@ -87,7 +87,7 @@
     [[NSApp mainMenu] update];
 
     // Fix up window stacking order
-    [self reorderChildWindows:YES];
+    [self reorderChildWindows];
 }
 
 - (void)windowDidResignKey:(NSNotification *)notification
@@ -101,7 +101,7 @@
     }
 
     // Fix up order
-    [self reorderChildWindows:NO];
+    [self reorderChildWindows];
 }
 
 - (void)windowWillClose:(NSNotification *)notification
@@ -110,7 +110,7 @@
     // Remove self from list of child windows
     if (self->owner != nil) {
         [self->owner removeChildWindow:self];
-//        [self->owner reorderChildWindows:NO];
+//        [self->owner reorderChildWindows];
     }
 
     // Finally, close owned windows to mimic MS Windows behavior

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow.h
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow.h
@@ -39,10 +39,10 @@
     // A reference to an NSWindow or NSPanel descendant - the native window
     NSWindow            *nsWindow;
 
-    // KCR: keep our own owner window and list of child windows
-    // (we don't create an actual child of the owner NSWindow)
-    NSMutableArray<GlassWindow*> *childWindows;
+    // Owner glass window and list of owned "child" glass windows
+    // (we don't create NSWindow children)
     GlassWindow         *owner;
+    NSMutableArray<GlassWindow*> *childWindows;
 
     GlassView3D<GlassView>   *view;
     NSScreen            *currentScreen;
@@ -75,7 +75,7 @@
     BOOL                isWindowResizable;
 }
 
-//
+// Helper methods for owned windows
 - (void) addChildWindow:(GlassWindow*)childWindow;
 - (void) removeChildWindow:(GlassWindow*)childWindow;
 - (void) reorderChildWindows;

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow.h
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow.h
@@ -63,7 +63,7 @@
 
     BOOL                isClosed;
 
-    NSWindowLevel       winLevel; // Desired level for this window
+    NSWindowLevel       prefLevel; // Preferred level for this window
 
     // We track whether an explicit size/location have been assigned to the window
     // in order to differentiate between an explicitly assigned zero bounds, and the
@@ -78,7 +78,8 @@
 //
 - (void) addChildWindow:(GlassWindow*)childWindow;
 - (void) removeChildWindow:(GlassWindow*)childWindow;
-- (void) reorderChildWindows:(BOOL)unused;
+- (void) reorderChildWindows;
+- (void) setLevelChildWindows;
 
 // NSWindow overrides delegate methods
 - (void)close;

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow.h
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow.h
@@ -79,7 +79,6 @@
 - (void) addChildWindow:(GlassWindow*)childWindow;
 - (void) removeChildWindow:(GlassWindow*)childWindow;
 - (void) reorderChildWindows;
-- (void) setLevelChildWindows;
 
 // NSWindow overrides delegate methods
 - (void)close;

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow.h
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow.h
@@ -39,8 +39,8 @@
     // A reference to an NSWindow or NSPanel descendant - the native window
     NSWindow            *nsWindow;
 
-    // KCR: keep our own list of children (not added as child of owner window)
-    NSMutableArray<GlassWindow> childWindows;
+    // KCR: keep our own owner window and list of child windows (we don't create an actual child of the owner NSWindow)
+    NSMutableArray<GlassWindow*> *childWindows;
     GlassWindow         *ownerWindow;
 
     NSWindow            *owner;

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow.h
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow.h
@@ -63,6 +63,8 @@
 
     BOOL                isClosed;
 
+    NSWindowLevel       winLevel; // Desired level for this window
+
     // We track whether an explicit size/location have been assigned to the window
     // in order to differentiate between an explicitly assigned zero bounds, and the
     // deafult bounds (which are also zeros - see a comment in _createWindowCommon().)
@@ -75,7 +77,8 @@
 
 //
 - (void) addChildWindow:(GlassWindow*)childWindow;
-- (void) reorderChildWindows:(BOOL)focus;
+- (void) removeChildWindow:(GlassWindow*)childWindow;
+- (void) reorderChildWindows:(BOOL)unused;
 
 // NSWindow overrides delegate methods
 - (void)close;

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow.h
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow.h
@@ -39,11 +39,11 @@
     // A reference to an NSWindow or NSPanel descendant - the native window
     NSWindow            *nsWindow;
 
-    // KCR: keep our own owner window and list of child windows (we don't create an actual child of the owner NSWindow)
+    // KCR: keep our own owner window and list of child windows
+    // (we don't create an actual child of the owner NSWindow)
     NSMutableArray<GlassWindow*> *childWindows;
-    GlassWindow         *ownerWindow;
+    GlassWindow         *owner;
 
-    NSWindow            *owner;
     GlassView3D<GlassView>   *view;
     NSScreen            *currentScreen;
     GlassMenubar        *menubar;
@@ -72,6 +72,10 @@
 @private
     BOOL                isWindowResizable;
 }
+
+//
+- (void) addChildWindow:(GlassWindow*)childWindow;
+- (void) reorderChildWindows:(BOOL)focus;
 
 // NSWindow overrides delegate methods
 - (void)close;

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow.h
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow.h
@@ -80,6 +80,7 @@
 - (void) removeChildWindow:(GlassWindow*)childWindow;
 - (void) reorderChildWindows;
 - (void) minimizeChildWindows:(BOOL)minimize;
+- (void) setMoveToActiveSpaceChildWindows:(BOOL)moveToActiveSpace;
 
 // NSWindow overrides delegate methods
 - (void)close;

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow.h
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow.h
@@ -79,6 +79,7 @@
 - (void) addChildWindow:(GlassWindow*)childWindow;
 - (void) removeChildWindow:(GlassWindow*)childWindow;
 - (void) reorderChildWindows;
+- (void) minimizeChildWindows:(BOOL)minimize;
 
 // NSWindow overrides delegate methods
 - (void)close;

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow.h
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow.h
@@ -39,6 +39,10 @@
     // A reference to an NSWindow or NSPanel descendant - the native window
     NSWindow            *nsWindow;
 
+    // KCR: keep our own list of children (not added as child of owner window)
+    NSMutableArray<GlassWindow> childWindows;
+    GlassWindow         *ownerWindow;
+
     NSWindow            *owner;
     GlassView3D<GlassView>   *view;
     NSScreen            *currentScreen;

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow.m
@@ -382,6 +382,24 @@ GLASS_NS_WINDOW_IMPLEMENTATION
     }
 }
 
+- (void) minimizeChildWindows:(BOOL)minimize
+{
+    NSLog(@"minimizeChildWindows: %p  minimize:%d", self, minimize); // KCR: Change to "LOG"
+    if (self->childWindows != nil) {
+//        NSLog(@"    childWindows: %p", self->childWindows); // KCR: DEBUG
+        for (GlassWindow *child in self->childWindows)
+        {
+//            NSLog(@"    child: %p", child); // KCR: DEBUG
+            if (minimize) {
+                [child->nsWindow orderOut:child];
+            } else {
+                [child->nsWindow orderFront:child];
+            }
+            [child minimizeChildWindows:minimize];
+        }
+    }
+}
+
 - (NSColor*)setBackgroundColor:(NSColor *)color
 {
     if (self->isTransparent == NO)

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow.m
@@ -246,7 +246,6 @@ GLASS_NS_WINDOW_IMPLEMENTATION
      * descendants created.  Without it, the menu  will
      * not be seen by the assistive technology.
      */
-    // KCR: Check this to see whether it is affected by my change
     __block BOOL ignored = [super accessibilityIsIgnored];
     NSArray* children = [self accessibilityAttributeValue: NSAccessibilityChildrenAttribute];
     if (children) {
@@ -290,9 +289,6 @@ GLASS_NS_WINDOW_IMPLEMENTATION
 
 @implementation GlassWindow
 
-    // KCR: FIXME -- we will need to get a Glass Window here, which might
-    // not be available for the full screen window itself
-            // KCR: FIXME
 - (void)close
 {
     [self _ungrabFocus];
@@ -472,7 +468,7 @@ static jlong _createWindowCommonDo(JNIEnv *env, jobject jWindow, jlong jOwnerPtr
 
         if (jOwnerPtr != 0L)
         {
-            // KCR
+            // KCR: FIXME
             window->ownerWindow = getGlassWindow(env, jOwnerPtr);
             window->owner = window->ownerWindow->nsWindow; // not retained (use weak reference?)
         }
@@ -1232,6 +1228,7 @@ JNIEXPORT jboolean JNICALL Java_com_sun_glass_ui_mac_MacWindow__1setVisible
         else
         {
             [window _ungrabFocus];
+            // KCR: FIXME
             if (window->owner != nil)
             {
                 LOG("   removeChildWindow: %p", window);

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow.m
@@ -1298,12 +1298,6 @@ JNIEXPORT jboolean JNICALL Java_com_sun_glass_ui_mac_MacWindow__1setVisible
         else
         {
             [window _ungrabFocus];
-            // KCR: FIXME
-            if (window->owner != nil)
-            {
-                NSLog(@"   KCR: FIXME: removeChildWindow: %p", window);
-                // KCR: DO: [window->owner removeChildWindow:window];
-            }
             [window->nsWindow orderOut:window->nsWindow];
         }
         now = [window->nsWindow isVisible] ? JNI_TRUE : JNI_FALSE;


### PR DESCRIPTION
This is a preliminary draft PR to fix [JDK-8252373](https://bugs.openjdk.org/browse/JDK-8252373) where an owned stage will disappear on macOS if it is moved to another screen with the Mission Control setting of "Displays have separate spaces" enabled (which it is by default).

This implements a proof of concept where we manage owned windows ourself in glass rather than relying on NSWindow's childWindow feature which we currently do. This matches what AWT does.

### Status

* Window stacking is implemented and works correctly based on my testing -- also tested with alwaysOnTop and full screen
* Window closing still works as before where closing an owner window will close all owned (child) windows
* NOT YET IMPLEMENTED: iconifying an owner window should iconify all owned (child) windows

Note: this PR currently has some logging information, which will be commented out or removed when I put out the real PR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1926/head:pull/1926` \
`$ git checkout pull/1926`

Update a local copy of the PR: \
`$ git checkout pull/1926` \
`$ git pull https://git.openjdk.org/jfx.git pull/1926/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1926`

View PR using the GUI difftool: \
`$ git pr show -t 1926`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1926.diff">https://git.openjdk.org/jfx/pull/1926.diff</a>

</details>
