### PR TITLE
8369140: GHA: Update macOS / x64 build to use macos-15-intel runner

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -150,7 +150,7 @@ jobs:
   macos_x64_build:
     name: macOS x64
     needs: validation
-    runs-on: "macos-13"
+    runs-on: "macos-15-intel"
 
     env:
       # FIXME: read this information from a property file
@@ -212,8 +212,8 @@ jobs:
           java -version
           which ant
           ant -version
-          # We want to use Xcode 15.4, but 15.2 is the highest that the GHA macOS 13 runner supports
-          sudo xcode-select --switch /Applications/Xcode_15.2.app/Contents/Developer
+          # Production builds use Xcode 15.4, but 16.0 is the lowest that the GHA macOS 15 runner supports
+          sudo xcode-select --switch /Applications/Xcode_16.0.app/Contents/Developer
           xcodebuild -version
 
       - name: Build JavaFX artifacts


### PR DESCRIPTION
Update our GitHub Actions scripts to use the `macos-15-intel` runner for macOS / x64 test builds.

As noted in [this blog post](https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/), GitHub will retire their `macos-13` runner later this fall. We use the macos-13 runner to build on macOS / x64 (the macos-14 runner builds on macOS / aarch64).

Note that the GitHub macos-15 runners have Xcode 16.0 as the minimum version of Xcode rather than the Xcode 15.4 that we use in production. This is fine, and has the added benefit of early detection if we introduce any Xcode 16 bugs. We will continue to run macOS / aarch64 builds using the macos-14 runner with Xcode 15.4.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8369140](https://bugs.openjdk.org/browse/JDK-8369140): GHA: Update macOS / x64 build to use macos-15-intel runner (**Bug** - P4)


### Reviewers
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1928/head:pull/1928` \
`$ git checkout pull/1928`

Update a local copy of the PR: \
`$ git checkout pull/1928` \
`$ git pull https://git.openjdk.org/jfx.git pull/1928/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1928`

View PR using the GUI difftool: \
`$ git pr show -t 1928`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1928.diff">https://git.openjdk.org/jfx/pull/1928.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1928#issuecomment-3367311561)
</details>
