### PR TITLE
8365577: Revert to OpenGL as the default JavaFX rendering pipeline for macOS

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/prism/impl/PrismSettings.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/impl/PrismSettings.java
@@ -205,9 +205,7 @@ public final class PrismSettings {
         if (PlatformUtil.isWindows()) {
             tryOrderArr = new String[] { "d3d", "sw" };
         } else if (PlatformUtil.isMac()) {
-            // Temporarily set the default rendering pipeline to Metal, to get more testing
-            // of Metal pipeline. This change will be reverted as part of JDK-8365577.
-            tryOrderArr = new String[] { "mtl", "es2", "sw" };
+            tryOrderArr = new String[] { "es2", "mtl", "sw" };
         } else if (PlatformUtil.isIOS()) {
             tryOrderArr = new String[] { "es2" };
         } else if (PlatformUtil.isAndroid()) {


### PR DESCRIPTION
On macOS, the default rendering pipeline was temporarily set to Metal.
This change reverts it to es2, by simply reverting the commit fa2127cb3a3fc11238c5c8ce4cf0d15c4000f05c for [JDK-8365576](https://bugs.openjdk.org/browse/JDK-8365576): Temporarily make Metal the default JavaFX rendering pipeline for macOS

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8365577](https://bugs.openjdk.org/browse/JDK-8365577): Revert to OpenGL as the default JavaFX rendering pipeline for macOS (**Enhancement** - P3)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Jayathirth D V](https://openjdk.org/census#jdv) (@jayathirthrao - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1930/head:pull/1930` \
`$ git checkout pull/1930`

Update a local copy of the PR: \
`$ git checkout pull/1930` \
`$ git pull https://git.openjdk.org/jfx.git pull/1930/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1930`

View PR using the GUI difftool: \
`$ git pr show -t 1930`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1930.diff">https://git.openjdk.org/jfx/pull/1930.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1930#issuecomment-3376908880)
</details>
