### PR TITLE
Remove dependency on java.desktop from javafx.base and javafx.graphics

### DIFF
--- a/modules/javafx.base/src/main/java/module-info.java
+++ b/modules/javafx.base/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,7 @@
  * @since 9
  */
 module javafx.base {
-    requires java.desktop;
+    requires static java.desktop;
     requires static jdk.jfr;
 
     exports javafx.beans;

--- a/modules/javafx.graphics/src/main/java/module-info.java
+++ b/modules/javafx.graphics/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,9 +40,10 @@
  * @since 9
  */
 module javafx.graphics {
-    requires java.desktop;
     requires java.xml;
     requires jdk.unsupported;
+
+    requires static java.desktop;
 
     requires transitive javafx.base;
 


### PR DESCRIPTION
This PR makes the `java.desktop` requirement static for `javafx.base` and `javafx.graphics`.
With this changes, a JavaFX app without `Swing` and the `WebView` will be much smaller (results below).

Consequences:
- `java.desktop` need to be loaded (required) when using anything from the `javafx.beans.property.adapter` package (the property classes from `java.beans.XXX` are used here)
- `java.desktop` need to be loaded (required) when using printing, that is e.g. `PrinterJob.createPrinterJob().showPrintDialog(..)`

Results:
- Removing `java.desktop` gives a huge size boost! I benchmarked the following values when using `jlink` with: [`zip-6`, `--no-man-pages`, `--no-header-files`, `--strip-debug`, `--strip-java-debug-attributes`] to build an own runtime

Tried on a real application (here called `myapp`) with JDK-25 on Windows 11 that has dependencies to: [`javafx-base`,  `javafx-graphics`, `javafx-fxml`, `javafx-controls`]

---

`master`

`70.009.288 Bytes`

```
myapp
java.base@25
java.datatransfer@25
java.desktop@25
java.prefs@25
java.scripting@25
java.xml@25
javafx.base@26-internal
javafx.controls@26-internal
javafx.fxml@26-internal
javafx.graphics@26-internal
jdk.localedata@25
jdk.unsupported@25
```

-------------------------------------

`This PR`

`57.266.538 Bytes`

```
myapp
java.base@25
java.scripting@25
java.xml@25
javafx.base@26-internal
javafx.controls@26-internal
javafx.fxml@26-internal
javafx.graphics@26-internal
jdk.localedata@25
jdk.unsupported@25
```

---

`This PR` + https://github.com/openjdk/jfx/pull/1957

`57.249.459 Bytes`

```
myapp
java.base@25
java.scripting@25
java.xml@25
javafx.base@26-internal
javafx.controls@26-internal
javafx.fxml@26-internal
javafx.graphics@26-internal
jdk.localedata@25
```

---

So we save around 13MB. If building a native package, e.g. an `.msi` installer, this will be even higher.

This change however probably need some discussion, if we want to go that direction + add a note in the release notes, that if one of the two things mentioned above are needed, an requirement to `java.desktop` is needed (in case of a modular project).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change requires a CSR request matching fixVersion jfx27 to be approved (needs to be created)
- [ ] Change must be properly reviewed (2 reviews required, with at least 2 [Reviewers](https://openjdk.org/bylaws#reviewer))

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1958/head:pull/1958` \
`$ git checkout pull/1958`

Update a local copy of the PR: \
`$ git checkout pull/1958` \
`$ git pull https://git.openjdk.org/jfx.git pull/1958/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1958`

View PR using the GUI difftool: \
`$ git pr show -t 1958`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1958.diff">https://git.openjdk.org/jfx/pull/1958.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1958#issuecomment-3478222689)
</details>
