### PR TITLE
8210547: [Linux] Uncontrolled framerate

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassScene.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassScene.java
@@ -65,6 +65,7 @@ abstract class GlassScene implements TKScene {
     private volatile boolean entireSceneDirty = true;
 
     private boolean doPresent = true;
+    private boolean doVSync = false;
     private final AtomicBoolean painting = new AtomicBoolean(false);
 
     private final boolean depthBuffer;
@@ -305,6 +306,14 @@ abstract class GlassScene implements TKScene {
 
     public final synchronized boolean getDoPresent() {
         return doPresent;
+    }
+
+    public final synchronized void setDoVSync(boolean value) {
+        doVSync = value;
+    }
+
+    public final synchronized boolean getDoVsync() {
+        return doVSync;
     }
 
     protected Color getClearColor() {

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/PaintCollector.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/PaintCollector.java
@@ -434,10 +434,14 @@ final class PaintCollector implements CompletionListener {
                 if (!needsHint) {
                     needsHint = gs.isSynchronous();
                 }
+            }
+
+            for (final GlassScene gs : dirtyScenes) {
                 // On platforms with a window manager, we always set doPresent = true, because
                 // we always need to rerender the scene  if it's in the dirty list and we do a
                 // swap on a per-window basis
                 gs.setDoPresent(true);
+                gs.setDoVSync(needsHint && dirtyScenes.getLast() == gs);
                 try {
                     gs.repaint();
                 } catch (Throwable t) {

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/PresentingPainter.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/PresentingPainter.java
@@ -104,7 +104,7 @@ final class PresentingPainter extends ViewPainter {
 
                 /* present for vsync buffer swap */
                 if (vs.getDoPresent()) {
-                    if (!presentable.present()) {
+                    if (!presentable.present(vs.getDoVsync())) {
                         disposePresentable();
                         sceneState.getScene().entireSceneNeedsRepaint();
                     }

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/Presentable.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/Presentable.java
@@ -57,6 +57,10 @@ public interface Presentable extends RenderTarget {
      */
     public boolean present();
 
+    public default boolean present(boolean vsync) {
+        return present();
+    }
+
     public float getPixelScaleFactorX();
     public float getPixelScaleFactorY();
 }

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2SwapChain.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2SwapChain.java
@@ -183,8 +183,16 @@ class ES2SwapChain implements ES2RenderTarget, Presentable, GraphicsResource {
 
     @Override
     public boolean present() {
-        boolean presented = drawable.swapBuffers(context.getGLContext());
-        context.makeCurrent(null);
+        return drawable.swapBuffers(context.getGLContext());
+    }
+
+    @Override
+    public boolean present(boolean vsync) {
+        boolean presented = present();
+
+        if (vsync)
+            context.getGLContext().finish();
+
         return presented;
     }
 
@@ -308,6 +316,7 @@ class ES2SwapChain implements ES2RenderTarget, Presentable, GraphicsResource {
         }
 
         if (drawable != null) {
+            context.makeCurrent(null);
             drawable.dispose();
             drawable = null;
         }

--- a/modules/javafx.graphics/src/main/native-prism-es2/PrismES2Defs.h
+++ b/modules/javafx.graphics/src/main/native-prism-es2/PrismES2Defs.h
@@ -263,6 +263,7 @@ struct ContextInfoRec {
 #ifdef UNIX /* LINUX || SOLARIS */
     char *glxExtensionStr;
     PFNGLXSWAPINTERVALSGIPROC glXSwapIntervalSGI;
+    PFNGLXSWAPINTERVALEXTPROC glXSwapIntervalEXT;
 #endif /* LINUX || SOLARIS */
 
     /* gl function pointers */

--- a/modules/javafx.graphics/src/main/native-prism-es2/x11/X11GLFactory.c
+++ b/modules/javafx.graphics/src/main/native-prism-es2/x11/X11GLFactory.c
@@ -88,6 +88,9 @@ void setGLXAttrs(jint *attrs, int *glxAttrs) {
     glxAttrs[index++] = GLX_DEPTH_SIZE;
     glxAttrs[index++] = attrs[DEPTH_SIZE];
 
+    glxAttrs[index++] = GLX_CONFIG_CAVEAT;
+    glxAttrs[index++] = GLX_NONE;
+
     glxAttrs[index] = None;
 }
 


### PR DESCRIPTION
As discussed on the mailing list.

OpenGL requires an explicit glFinish() to synchronise with the video refresh.  The current usage is incorrect and against the specification.  This patch calls glFinish() after all windows have been drawn following a pulse.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8210547](https://bugs.openjdk.org/browse/JDK-8210547): [Linux] Uncontrolled framerate (**Bug** - P5)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1981/head:pull/1981` \
`$ git checkout pull/1981`

Update a local copy of the PR: \
`$ git checkout pull/1981` \
`$ git pull https://git.openjdk.org/jfx.git pull/1981/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1981`

View PR using the GUI difftool: \
`$ git pr show -t 1981`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1981.diff">https://git.openjdk.org/jfx/pull/1981.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1981#issuecomment-3567904683)
</details>
