### PR TITLE
8358130: [Metal] Merge shader compilation tasks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2700,94 +2700,30 @@ project(":graphics") {
     }
 
     if (IS_MAC) {
-        task compileMSLPassThroughVS(group: "Build") {
-            def PASSTHROUGH_VS_SRC = file("src/main/native-prism-mtl/msl/PassThroughVS.metal")
+        task compileMetalShaders(group: "Build") {
+            description = "Compiles all .metal files in src/main/native-prism-mtl/msl"
             doLast {
                 mkdir "$buildDir/msl"
-                execOps.exec { spec ->
-                    commandLine("${metalCompiler}")
-                    args += [ "-std=${mslVersion}" ]
-                    args += [ "-c" ]
-                    args += [ "$PASSTHROUGH_VS_SRC" ]
-                    args += [ "-o" ]
-                    args += [ "$buildDir/msl/PassThroughVS.air" ]
+                def shaderFiles = fileTree(dir: "src/main/native-prism-mtl/msl", include: "**/*.metal")
+                shaderFiles.files.each { file ->
+                    def outputFile = new File("$buildDir/msl", file.name.replace(".metal", ".air"))
+                    execOps.exec { spec ->
+                        commandLine("${metalCompiler}")
+                        args += [ "-std=${mslVersion}" ]
+                        args += [ "-c" ]
+                        args += [ "$file.absolutePath" ]
+                        args += [ "-o" ]
+                        args += [ "$outputFile.absolutePath" ]
+                    }
                 }
             }
         }
-        nativePrism.dependsOn compileMSLPassThroughVS;
-
-        task compileMSLClearRttShaders(group: "Build") {
-            def CLEAR_RTT_VFS_SRC = file("src/main/native-prism-mtl/msl/ClearRttShaders.metal")
-            doLast {
-                mkdir "$buildDir/msl"
-                execOps.exec { spec ->
-                    commandLine("${metalCompiler}")
-                    args += [ "-std=${mslVersion}" ]
-                    args += [ "-c" ]
-                    args += [ "$CLEAR_RTT_VFS_SRC" ]
-                    args += [ "-o" ]
-                    args += [ "$buildDir/msl/ClearRttShaders.air" ]
-                }
-            }
-        }
-        nativePrism.dependsOn compileMSLClearRttShaders;
-
-        task compileMSLComputeKernels(group: "Build") {
-            def COMPUTE_KERNELS_SRC = file("src/main/native-prism-mtl/msl/ComputeKernels.metal")
-            doLast {
-                mkdir "$buildDir/msl"
-                execOps.exec { spec ->
-                    commandLine("${metalCompiler}")
-                    args += [ "-std=${mslVersion}" ]
-                    args += [ "-c" ]
-                    args += [ "$COMPUTE_KERNELS_SRC" ]
-                    args += [ "-o" ]
-                    args += [ "$buildDir/msl/ComputeKernels.air" ]
-                }
-            }
-        }
-        nativePrism.dependsOn compileMSLComputeKernels;
-
-        task compileMSLPhongVS(group: "Build") {
-            def PHONG_VS_SRC = file("src/main/native-prism-mtl/msl/PhongVS.metal")
-            doLast {
-                mkdir "$buildDir/msl"
-                execOps.exec { spec ->
-                    commandLine("${metalCompiler}")
-                    args += [ "-std=${mslVersion}" ]
-                    args += [ "-c" ]
-                    args += [ "$PHONG_VS_SRC" ]
-                    args += [ "-o" ]
-                    args += [ "$buildDir/msl/PhongVS.air" ]
-                }
-            }
-        }
-        nativePrism.dependsOn compileMSLPhongVS;
-
-        task compileMSLPhongPS(group: "Build") {
-            def PHONG_PS_SRC = file("src/main/native-prism-mtl/msl/PhongPS.metal")
-            doLast {
-                mkdir "$buildDir/msl"
-                execOps.exec { spec ->
-                    commandLine("${metalCompiler}")
-                    args += [ "-std=${mslVersion}" ]
-                    args += [ "-c" ]
-                    args += [ "$PHONG_PS_SRC" ]
-                    args += [ "-o" ]
-                    args += [ "$buildDir/msl/PhongPS.air" ]
-                }
-            }
-        }
-        nativePrism.dependsOn compileMSLPhongPS;
+        nativePrism.dependsOn compileMetalShaders;
 
         task linkMSLShader(group: "Build") {
             dependsOn(compileDecoraMSLShaders,
                       compilePrismMSLShaders,
-                      compileMSLPassThroughVS,
-                      compileMSLClearRttShaders,
-                      compileMSLComputeKernels,
-                      compileMSLPhongVS,
-                      compileMSLPhongPS)
+                      compileMetalShaders)
             doLast {
                 mkdir "$buildDir/msl/com/sun/prism/mtl/msl"
                 def shaderFiles = fileTree(dir: "$buildDir/msl", include: "**/*.air")


### PR DESCRIPTION
The `build.gradle` file contains separate tasks for compiling each standalone metal shader file.
The 5 tasks are combined into a single task.

Verification:
1. Verify that build completes successfully, and the 5 **.metal** files are correctly compiled and 5 **.air** files are generated in directory : _modules/javafx.graphics/build/msl_
`ClearRttShaders.air`,  `ComputeKernels.air`,  `PassThroughVS.air`,  `PhongPS.air`,  `PhongVS.air`
3. Basic sanity testing

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8358130](https://bugs.openjdk.org/browse/JDK-8358130): [Metal] Merge shader compilation tasks (**Bug** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Jayathirth D V](https://openjdk.org/census#jdv) (@jayathirthrao - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1984/head:pull/1984` \
`$ git checkout pull/1984`

Update a local copy of the PR: \
`$ git checkout pull/1984` \
`$ git pull https://git.openjdk.org/jfx.git pull/1984/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1984`

View PR using the GUI difftool: \
`$ git pr show -t 1984`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1984.diff">https://git.openjdk.org/jfx/pull/1984.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1984#issuecomment-3576050370)
</details>
