### PR TITLE
8370729: Precision errors in Marlin 0.9.4.6 can cause rendering errors

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/marlin/Curve.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/marlin/Curve.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -144,7 +144,9 @@ final class Curve {
     // finds points where the first and second derivative are
     // perpendicular. This happens when g(t) = f'(t)*f''(t) == 0 (where
     // * is a dot product). Unfortunately, we have to solve a cubic.
-    private int perpendiculardfddf(final double[] pts, final int off) {
+    private int perpendiculardfddf(final double[] pts, final int off,
+                                   final double A, final double B)
+    {
         assert pts.length >= off + 4;
 
         // these are the coefficients of some multiple of g(t) (not g(t),
@@ -155,7 +157,7 @@ final class Curve {
         final double c = 2.0d * (dax * cx + day * cy) + dbx * dbx + dby * dby;
         final double d = dbx * cx + dby * cy;
 
-        return Helpers.cubicRootsInAB(a, b, c, d, pts, off, 0.0d, 1.0d);
+        return Helpers.cubicRootsInAB(a, b, c, d, pts, off, A, B);
     }
 
     // Tries to find the roots of the function ROC(t)-w in [0, 1). It uses
@@ -171,35 +173,43 @@ final class Curve {
     // at most 4 sub-intervals of (0,1). ROC has asymptotes at inflection
     // points, so roc-w can have at least 6 roots. This shouldn't be a
     // problem for what we're trying to do (draw a nice looking curve).
-    int rootsOfROCMinusW(final double[] roots, final int off, final double w2, final double err) {
+    int rootsOfROCMinusW(final double[] roots, final int off, final double w2,
+                         final double A, final double B)
+    {
         // no OOB exception, because by now off<=6, and roots.length >= 10
         assert off <= 6 && roots.length >= 10;
 
         int ret = off;
-        final int end = off + perpendiculardfddf(roots, off);
+        final int end = off + perpendiculardfddf(roots, off, A, B);
+        Helpers.isort(roots, off, end);
         roots[end] = 1.0d; // always check interval end points
 
-        double t0 = 0.0d, ft0 = ROCsq(t0) - w2;
+        double t0 = 0.0d;
+        double ft0 = eliminateInf(ROCsq(t0) - w2);
+        double t1, ft1;
 
         for (int i = off; i <= end; i++) {
-            double t1 = roots[i], ft1 = ROCsq(t1) - w2;
+            t1 = roots[i];
+            ft1 = eliminateInf(ROCsq(t1) - w2);
             if (ft0 == 0.0d) {
                 roots[ret++] = t0;
             } else if (ft1 * ft0 < 0.0d) { // have opposite signs
                 // (ROC(t)^2 == w^2) == (ROC(t) == w) is true because
                 // ROC(t) >= 0 for all t.
-                roots[ret++] = falsePositionROCsqMinusX(t0, t1, w2, err);
+                roots[ret++] = falsePositionROCsqMinusX(t0, t1, ft0, ft1, w2, A); // A = err
             }
             t0 = t1;
             ft0 = ft1;
         }
-
         return ret - off;
     }
 
-    private static double eliminateInf(final double x) {
-        return (x == Double.POSITIVE_INFINITY ? Double.MAX_VALUE :
-               (x == Double.NEGATIVE_INFINITY ? Double.MIN_VALUE : x));
+    private final static double MAX_ROC_SQ = 1e20;
+
+    private static double eliminateInf(final double x2) {
+        // limit the value of x to avoid numerical problems (smaller step):
+        // must handle NaN and +Infinity:
+        return (x2 <= MAX_ROC_SQ) ? x2 : MAX_ROC_SQ;
     }
 
     // A slight modification of the false position algorithm on wikipedia.
@@ -210,17 +220,18 @@ final class Curve {
     // and turn out. Same goes for the newton's method
     // algorithm in Helpers.java
     private double falsePositionROCsqMinusX(final double t0, final double t1,
+                                            final double ft0, final double ft1,
                                             final double w2, final double err)
     {
         final int iterLimit = 100;
         int side = 0;
-        double t = t1, ft = eliminateInf(ROCsq(t) - w2);
-        double s = t0, fs = eliminateInf(ROCsq(s) - w2);
+        double s = t0, fs = eliminateInf(ft0);
+        double t = t1, ft = eliminateInf(ft1);
         double r = s, fr;
 
-        for (int i = 0; i < iterLimit && Math.abs(t - s) > err * Math.abs(t + s); i++) {
+        for (int i = 0; i < iterLimit && Math.abs(t - s) > err; i++) {
             r = (fs * t - ft * s) / (fs - ft);
-            fr = ROCsq(r) - w2;
+            fr = eliminateInf(ROCsq(r) - w2);
             if (sameSign(fr, ft)) {
                 ft = fr; t = r;
                 if (side < 0) {
@@ -241,7 +252,7 @@ final class Curve {
                 break;
             }
         }
-        return r;
+        return (Math.abs(ft) <= Math.abs(fs)) ? t : s;
     }
 
     private static boolean sameSign(final double x, final double y) {
@@ -256,9 +267,9 @@ final class Curve {
         final double dy = t * (t * day + dby) + cy;
         final double ddx = 2.0d * dax * t + dbx;
         final double ddy = 2.0d * day * t + dby;
-        final double dx2dy2 = dx * dx + dy * dy;
-        final double ddx2ddy2 = ddx * ddx + ddy * ddy;
-        final double ddxdxddydy = ddx * dx + ddy * dy;
-        return dx2dy2 * ((dx2dy2 * dx2dy2) / (dx2dy2 * ddx2ddy2 - ddxdxddydy * ddxdxddydy));
+        final double dx2dy2 = dx * dx + dy * dy; // positive
+        final double dxddyddxdy = dx * ddy - dy * ddx;
+        // may return +Infinity if dxddyddxdy = 0 or NaN if 0/0:
+        return (dx2dy2 * dx2dy2 * dx2dy2) / (dxddyddxdy * dxddyddxdy); // both positive
     }
 }

--- a/modules/javafx.graphics/src/main/java/com/sun/marlin/Helpers.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/marlin/Helpers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,11 +31,18 @@ import com.sun.marlin.stats.StatLong;
 
 final class Helpers implements MarlinConst {
 
+    private final static double T_ERR = 1e-4;
+    private final static double T_A = T_ERR;
+    private final static double T_B = 1.0 - T_ERR;
+
     private static final double EPS = 1e-9d;
 
     private Helpers() {
         throw new Error("This is a non instantiable class");
     }
+
+    /** use lower precision like former Pisces and Marlin (float-precision) */
+    static double ulp(final double value) { return Math.ulp((float)value); }
 
     static boolean within(final double x, final double y) {
         return within(x, y, EPS);
@@ -322,10 +329,10 @@ final class Helpers implements MarlinConst {
 
         // now we must subdivide at points where one of the offset curves will have
         // a cusp. This happens at ts where the radius of curvature is equal to w.
-        ret += c.rootsOfROCMinusW(ts, ret, w2, 0.0001d);
+        ret += c.rootsOfROCMinusW(ts, ret, w2, T_A, T_B);
 
-        ret = filterOutNotInAB(ts, 0, ret, 0.0001d, 0.9999d);
-        isort(ts, ret);
+        ret = filterOutNotInAB(ts, 0, ret, T_A, T_B);
+        isort(ts, 0, ret);
         return ret;
     }
 
@@ -354,7 +361,7 @@ final class Helpers implements MarlinConst {
         if ((outCodeOR & OUTCODE_BOTTOM) != 0) {
             ret += curve.yPoints(ts, ret, clipRect[1]);
         }
-        isort(ts, ret);
+        isort(ts, 0, ret);
         return ret;
     }
 
@@ -374,11 +381,11 @@ final class Helpers implements MarlinConst {
         }
     }
 
-    static void isort(final double[] a, final int len) {
-        for (int i = 1, j; i < len; i++) {
+    static void isort(final double[] a, final int off, final int len) {
+        for (int i = off + 1, j; i < len; i++) {
             final double ai = a[i];
             j = i - 1;
-            for (; j >= 0 && a[j] > ai; j--) {
+            for (; j >= off && a[j] > ai; j--) {
                 a[j + 1] = a[j];
             }
             a[j + 1] = ai;

--- a/modules/javafx.graphics/src/main/java/com/sun/marlin/Helpers.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/marlin/Helpers.java
@@ -29,7 +29,7 @@ import java.util.Arrays;
 import com.sun.marlin.stats.Histogram;
 import com.sun.marlin.stats.StatLong;
 
-final class Helpers implements MarlinConst {
+public final class Helpers implements MarlinConst {
 
     private final static double T_ERR = 1e-4;
     private final static double T_A = T_ERR;
@@ -42,7 +42,7 @@ final class Helpers implements MarlinConst {
     }
 
     /** use lower precision like former Pisces and Marlin (float-precision) */
-    static double ulp(final double value) { return Math.ulp((float)value); }
+    public static double ulp(final double value) { return Math.ulp((float)value); }
 
     static boolean within(final double x, final double y) {
         return within(x, y, EPS);

--- a/modules/javafx.graphics/src/main/java/com/sun/marlin/Stroker.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/marlin/Stroker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -877,8 +877,8 @@ public final class Stroker implements StartFlagPathConsumer2D, MarlinConst {
 
         // if p1 == p2 && p3 == p4: draw line from p1->p4, unless p1 == p4,
         // in which case ignore if p1 == p2
-        final boolean p1eqp2 = Helpers.withinD(dx1, dy1, 6.0d * Math.ulp(y2));
-        final boolean p3eqp4 = Helpers.withinD(dx4, dy4, 6.0d * Math.ulp(y4));
+        final boolean p1eqp2 = Helpers.withinD(dx1, dy1, 6.0d * Helpers.ulp(y2));
+        final boolean p3eqp4 = Helpers.withinD(dx4, dy4, 6.0d * Helpers.ulp(y4));
 
         if (p1eqp2 && p3eqp4) {
             return getLineOffsets(x1, y1, x4, y4, leftOff, rightOff);
@@ -896,7 +896,7 @@ public final class Stroker implements StartFlagPathConsumer2D, MarlinConst {
         final double l1sq = dx1 * dx1 + dy1 * dy1;
         final double l4sq = dx4 * dx4 + dy4 * dy4;
 
-        if (Helpers.within(dotsq, l1sq * l4sq, 4.0d * Math.ulp(dotsq))) {
+        if (Helpers.within(dotsq, l1sq * l4sq, 4.0d * Helpers.ulp(dotsq))) {
             return getLineOffsets(x1, y1, x4, y4, leftOff, rightOff);
         }
 
@@ -1069,8 +1069,8 @@ public final class Stroker implements StartFlagPathConsumer2D, MarlinConst {
         // equal if they're very close to each other.
 
         // if p1 == p2 or p2 == p3: draw line from p1->p3
-        final boolean p1eqp2 = Helpers.withinD(dx12, dy12, 6.0d * Math.ulp(y2));
-        final boolean p2eqp3 = Helpers.withinD(dx23, dy23, 6.0d * Math.ulp(y3));
+        final boolean p1eqp2 = Helpers.withinD(dx12, dy12, 6.0d * Helpers.ulp(y2));
+        final boolean p2eqp3 = Helpers.withinD(dx23, dy23, 6.0d * Helpers.ulp(y3));
 
         if (p1eqp2 || p2eqp3) {
             return getLineOffsets(x1, y1, x3, y3, leftOff, rightOff);
@@ -1082,7 +1082,7 @@ public final class Stroker implements StartFlagPathConsumer2D, MarlinConst {
         final double l1sq = dx12 * dx12 + dy12 * dy12;
         final double l3sq = dx23 * dx23 + dy23 * dy23;
 
-        if (Helpers.within(dotsq, l1sq * l3sq, 4.0d * Math.ulp(dotsq))) {
+        if (Helpers.within(dotsq, l1sq * l3sq, 4.0d * Helpers.ulp(dotsq))) {
             return getLineOffsets(x1, y1, x3, y3, leftOff, rightOff);
         }
 
@@ -1328,7 +1328,6 @@ public final class Stroker implements StartFlagPathConsumer2D, MarlinConst {
             lineTo(cx0, cy0);
             return;
         }
-
         // if these vectors are too small, normalize them, to avoid future
         // precision problems.
         if (Math.abs(dxs) < 0.1d && Math.abs(dys) < 0.1d) {

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/impl/shape/DMarlinPrismUtils.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/impl/shape/DMarlinPrismUtils.java
@@ -31,6 +31,7 @@ import com.sun.javafx.geom.Path2D;
 import com.sun.javafx.geom.Rectangle;
 import com.sun.javafx.geom.Shape;
 import com.sun.javafx.geom.transform.BaseTransform;
+import com.sun.marlin.Helpers;
 import com.sun.marlin.MarlinConst;
 import com.sun.marlin.MarlinProperties;
 import com.sun.marlin.MarlinRenderer;
@@ -232,7 +233,7 @@ public final class DMarlinPrismUtils {
     }
 
     private static boolean nearZero(final double num) {
-        return Math.abs(num) < 2.0d * Math.ulp(num);
+        return Math.abs(num) < 2.0d * Helpers.ulp(num);
     }
 
     private static DPathConsumer2D initRenderer(


### PR DESCRIPTION
merged changes with Java2D bug JDK-8341381 (trivial port on src only)

See https://github.com/openjdk/jdk/commit/46c23bb1a252916096876c2ae3a72f4a525dd6f9

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8370729](https://bugs.openjdk.org/browse/JDK-8370729): Precision errors in Marlin 0.9.4.6 can cause rendering errors (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2039/head:pull/2039` \
`$ git checkout pull/2039`

Update a local copy of the PR: \
`$ git checkout pull/2039` \
`$ git pull https://git.openjdk.org/jfx.git pull/2039/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2039`

View PR using the GUI difftool: \
`$ git pr show -t 2039`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2039.diff">https://git.openjdk.org/jfx/pull/2039.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2039#issuecomment-3753635312)
</details>
