### PR TITLE
8328167: ScrollTo in ListView still doesn't work since VirtualFlow was modified

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
@@ -300,7 +300,7 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
     private final BitSet dirtyCells = new BitSet();
 
     // Tracks index that needs to be made fully visible after layout
-    private int pendingScrollToIndex = -1;
+    int pendingScrollToIndex = -1;
 
     Timeline sbTouchTimeline;
     KeyFrame sbTouchKF1;

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
@@ -940,6 +940,10 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
 
         @Override protected void invalidated() {
             super.invalidated();
+            // Any change to position supersedes a pending scrollToTop/scrollTo
+            // target — scrollbar drags, wheel, scrollTo(cell), external
+            // setPosition, or property bindings all land here.
+            pendingScrollToIndex = -1;
             adjustAbsoluteOffset();
             requestLayout();
         }
@@ -1590,6 +1594,11 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
 
             adjustPositionToIndex(index);
             addAllToPile();
+
+            // Same offset-estimation caveat as scrollToTop(int): re-verify
+            // full visibility after layout, once real cell sizes are known.
+            pendingScrollToIndex = index;
+
             requestLayout();
         }
     }

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
@@ -301,6 +301,12 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
 
     // Tracks index that needs to be made fully visible after layout
     int pendingScrollToIndex = -1;
+    // Position captured when pendingScrollToIndex was armed. Used to tell the
+    // engine's own sub-pixel re-clamp of that position apart from a genuine
+    // intervening scroll.
+    double pendingScrollToPosition = -1;
+    // Position deltas at or below this are floating-point clamp noise, not a real scroll.
+    private static final double PENDING_SCROLL_EPSILON = 1e-9;
 
     Timeline sbTouchTimeline;
     KeyFrame sbTouchKF1;
@@ -940,10 +946,16 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
 
         @Override protected void invalidated() {
             super.invalidated();
-            // Any change to position supersedes a pending scrollToTop/scrollTo
-            // target — scrollbar drags, wheel, scrollTo(cell), external
-            // setPosition, or property bindings all land here.
-            pendingScrollToIndex = -1;
+            // A genuine intervening scroll (scrollbar drag, wheel, external
+            // setPosition, property binding) supersedes a pending scrollToTop/
+            // scrollTo target. But while arming that target the engine also
+            // re-clamps the very position we just set by a sub-pixel amount,
+            // and that self-inflicted change must NOT cancel the pending
+            // correction, otherwise the post-layout visibility check never runs.
+            if (pendingScrollToIndex >= 0
+                    && Math.abs(get() - pendingScrollToPosition) > PENDING_SCROLL_EPSILON) {
+                pendingScrollToIndex = -1;
+            }
             adjustAbsoluteOffset();
             requestLayout();
         }
@@ -1598,6 +1610,7 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
             // Same offset-estimation caveat as scrollToTop(int): re-verify
             // full visibility after layout, once real cell sizes are known.
             pendingScrollToIndex = index;
+            pendingScrollToPosition = getPosition();
 
             requestLayout();
         }
@@ -1654,6 +1667,7 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
 
         // Mark this index to be checked for full visibility after layout
         pendingScrollToIndex = index;
+        pendingScrollToPosition = getPosition();
 
         requestLayout();
     }

--- a/modules/javafx.controls/src/shims/java/javafx/scene/control/skin/VirtualFlowShim.java
+++ b/modules/javafx.controls/src/shims/java/javafx/scene/control/skin/VirtualFlowShim.java
@@ -39,6 +39,10 @@ public class VirtualFlowShim<T extends IndexedCell> extends VirtualFlow<T> {
     public final ArrayLinkedList<T> cells = super.cells;
     public final ObservableList<Node> sheetChildren = super.sheetChildren;
 
+    public int getPendingScrollToIndex() {
+        return pendingScrollToIndex;
+    }
+
     @Override
     public void setViewportLength(double value) {
         super.setViewportLength(value);

--- a/modules/javafx.controls/src/shims/java/javafx/scene/control/skin/VirtualFlowShim.java
+++ b/modules/javafx.controls/src/shims/java/javafx/scene/control/skin/VirtualFlowShim.java
@@ -43,6 +43,10 @@ public class VirtualFlowShim<T extends IndexedCell> extends VirtualFlow<T> {
         return pendingScrollToIndex;
     }
 
+    public void adjustAbsoluteOffset(double delta) {
+        absoluteOffset += delta;
+    }
+
     @Override
     public void setViewportLength(double value) {
         super.setViewportLength(value);

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
@@ -2192,6 +2192,50 @@ assertEquals(0, firstCell.getIndex());
             "scrollTo(cell) must be called when cell overshoots viewport");
     }
 
+    @Test
+    // see JDK-8328167
+    public void testScrollPixelsClearsPendingScrollToIndex() {
+        // An intervening scroll (scrollbar drag, wheel, programmatic
+        // scrollTo(cell)) must invalidate a pending scrollToTop target,
+        // otherwise the post-layout correction would yank the viewport
+        // back to the stale target.
+        flow.scrollToTop(50);
+        assertEquals(50, flow.getPendingScrollToIndex());
+
+        flow.scrollPixels(25);
+        assertEquals(-1, flow.getPendingScrollToIndex(),
+            "scrollPixels must clear pendingScrollToIndex");
+    }
+
+    @Test
+    // see JDK-8328167
+    public void testSetPositionClearsPendingScrollToIndex() {
+        flow.scrollToTop(50);
+        assertEquals(50, flow.getPendingScrollToIndex());
+
+        flow.setPosition(0.1);
+        assertEquals(-1, flow.getPendingScrollToIndex(),
+            "setPosition must clear pendingScrollToIndex");
+    }
+
+    @Test
+    // see JDK-8328167
+    public void testScrollToIntFallbackSetsPendingScrollToIndex() {
+        // scrollTo(int) falls back to adjustPositionToIndex when the
+        // target cell is not visible and no neighbor is available. That
+        // path uses size estimates for unrendered cells so it needs the
+        // same post-layout visibility check as scrollToTop(int).
+        assertEquals(-1, flow.getPendingScrollToIndex());
+
+        flow.scrollTo(95);
+        assertEquals(95, flow.getPendingScrollToIndex(),
+            "scrollTo(int) fallback must set pendingScrollToIndex");
+
+        pulse();
+        assertEquals(-1, flow.getPendingScrollToIndex(),
+            "pendingScrollToIndex must be cleared after layout");
+    }
+
 }
 
 class GraphicalCellStub extends IndexedCellShim<Node> {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
@@ -2118,6 +2118,41 @@ assertEquals(0, firstCell.getIndex());
         assertEquals(flow.cells, flow.sheetChildren);
     }
 
+    @Test
+    // see JDK-8328167
+    public void testScrollToTopSetsPendingScrollToIndex() {
+        assertEquals(-1, flow.getPendingScrollToIndex(),
+            "pendingScrollToIndex must be -1 initially");
+
+        flow.scrollToTop(50);
+        assertEquals(50, flow.getPendingScrollToIndex(),
+            "scrollToTop must set pendingScrollToIndex");
+
+        pulse();
+        assertEquals(-1, flow.getPendingScrollToIndex(),
+            "pendingScrollToIndex must be cleared after layout");
+    }
+
+    @Test
+    // see JDK-8328167
+    public void testScrollToTopSetsPendingScrollToIndexNearEnd() {
+        // The bug manifested when scrolling to items near the end of
+        // the list after adding new items. Verify the flag is set for
+        // indices near the end so the post-layout visibility check runs.
+        flow.setCellCount(20);
+        pulse();
+        pulse();
+
+        flow.setCellCount(100);
+        flow.scrollToTop(98);
+        assertEquals(98, flow.getPendingScrollToIndex(),
+            "scrollToTop must set pendingScrollToIndex after adding items");
+
+        pulse();
+        assertEquals(-1, flow.getPendingScrollToIndex(),
+            "pendingScrollToIndex must be cleared after layout");
+    }
+
 }
 
 class GraphicalCellStub extends IndexedCellShim<Node> {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
@@ -35,6 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import java.util.AbstractList;
 import java.util.ArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -2151,6 +2152,44 @@ assertEquals(0, firstCell.getIndex());
         pulse();
         assertEquals(-1, flow.getPendingScrollToIndex(),
             "pendingScrollToIndex must be cleared after layout");
+    }
+
+    @Test
+    // see JDK-8328167
+    public void testScrollToTopCallsScrollToCellOnOvershoot() {
+        // Track scrollTo(cell) calls via an anonymous subclass.
+        AtomicInteger scrollToCalls = new AtomicInteger(0);
+        VirtualFlowShim<IndexedCell> testFlow = new VirtualFlowShim<>() {
+            @Override public void scrollTo(IndexedCell cell) {
+                scrollToCalls.incrementAndGet();
+                super.scrollTo(cell);
+            }
+        };
+        testFlow.setVertical(true);
+        testFlow.setCellFactory(p -> new CellStub(testFlow) {
+            @Override protected double computePrefHeight(double width) { return 25; }
+            @Override protected double computeMinHeight(double width) { return 25; }
+            @Override protected double computeMaxHeight(double width) { return 25; }
+            @Override protected double computePrefWidth(double height) { return 100; }
+            @Override protected double computeMinWidth(double height) { return 100; }
+            @Override protected double computeMaxWidth(double height) { return 100; }
+        });
+        testFlow.setCellCount(100);
+        testFlow.resize(300, 30);
+        testFlow.layout();
+        testFlow.layout();
+
+        // scrollToTop sets pendingScrollToIndex and computes absoluteOffset.
+        // Nudge absoluteOffset backward to simulate the estimation drift
+        // that occurs in the real rendering pipeline. This shifts the
+        // target cell down so its bottom extends past the viewport.
+        testFlow.scrollToTop(50);
+        testFlow.adjustAbsoluteOffset(-10);
+        scrollToCalls.set(0);
+        testFlow.layout();
+
+        assertTrue(scrollToCalls.get() > 0,
+            "scrollTo(cell) must be called when cell overshoots viewport");
     }
 
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
@@ -2236,6 +2236,22 @@ assertEquals(0, firstCell.getIndex());
             "pendingScrollToIndex must be cleared after layout");
     }
 
+    @Test
+    // see JDK-8328167
+    public void testSubPixelReclampDoesNotClearPendingScrollToIndex() {
+        // While arming a scrollTo target the engine re-clamps the position it
+        // just set by a sub-pixel amount, which lands back in invalidated().
+        // That self-inflicted change must NOT cancel the pending target, or
+        // the post-layout visibility correction would never run.
+        flow.scrollToTop(50);
+        assertEquals(50, flow.getPendingScrollToIndex());
+
+        double p = flow.getPosition();
+        flow.setPosition(Math.nextUp(p));
+        assertEquals(50, flow.getPendingScrollToIndex(),
+            "a sub-pixel position re-clamp must NOT clear pendingScrollToIndex");
+    }
+
 }
 
 class GraphicalCellStub extends IndexedCellShim<Node> {


### PR DESCRIPTION
Should fix: https://bugs.openjdk.org/browse/JDK-8328167?page=com.atlassian.jira.plugin.system.issuetabpanels%3Aall-tabpanel

I have an application with a TableView that adds items and scrolls to them, and it's very important the last added item is visible to the user. When the first item is added that triggers the scroll, and you do a `platform.runLater -> scrollTo(lastNewItem)` the scrollTo does not work.

I think this is because of something to do with rendering phases, as two nested runLaters do work it seems, but that's pretty naughty.

I tried adding a test for this but I think the way the javafx tests runs differ a bit from an actual app? I am happy to add a test maybe with a recommendation on the approach. I have a reproducer with documentation here: https://github.com/winrid/jfx-jdc-8328167-scrollto-reproducer

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Errors
&nbsp;⚠️ OCA signatory status must be verified
&nbsp;⚠️ Pull request body is missing required line: `- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).`

### Issue
 * [JDK-8328167](https://bugs.openjdk.org/browse/JDK-8328167): ScrollTo in ListView still doesn't work since VirtualFlow was modified (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2041/head:pull/2041` \
`$ git checkout pull/2041`

Update a local copy of the PR: \
`$ git checkout pull/2041` \
`$ git pull https://git.openjdk.org/jfx.git pull/2041/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2041`

View PR using the GUI difftool: \
`$ git pr show -t 2041`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2041.diff">https://git.openjdk.org/jfx/pull/2041.diff</a>

</details>
