### PR TITLE
Transparent background fill for StageStyle.EXTENDED windows

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassScene.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassScene.java
@@ -317,7 +317,8 @@ abstract class GlassScene implements TKScene {
                 return Color.WHITE;
             } else if (fillPaint.isOpaque() ||
                     (windowStage != null && windowStage.getPlatformWindow() != null &&
-                    windowStage.getPlatformWindow().isUnifiedWindow())) {
+                            (windowStage.getPlatformWindow().isUnifiedWindow() ||
+                                    windowStage.getPlatformWindow().isExtendedWindow()))) {
                 //For bare windows the transparent fill is allowed
                 if (fillPaint.getType() == Paint.Type.COLOR) {
                     return (Color)fillPaint;

--- a/modules/javafx.graphics/src/main/native-glass/win/GlassWindow.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/win/GlassWindow.cpp
@@ -338,7 +338,7 @@ LRESULT GlassWindow::WindowProc(UINT msg, WPARAM wParam, LPARAM lParam)
             }
             break;
         case WM_DWMCOMPOSITIONCHANGED:
-            if (m_isUnified && (IS_WINVISTA)) {
+            if ((m_isUnified || m_isExtended) && (IS_WINVISTA)) {
                 BOOL bEnabled = FALSE;
                 if(SUCCEEDED(::DwmIsCompositionEnabled(&bEnabled)) && bEnabled) {
                     MARGINS dwmMargins = { -1, -1, -1, -1 };


### PR DESCRIPTION
This is a small experiment for the request for a transparent background fill for extended windows. In reference to a discussion on the mailing list a few months ago: https://mail.openjdk.org/pipermail/openjfx-dev/2025-October/056849.html

This treats EXTENDED windows just as UNIFIED windows on Windows. There is still the lingering issue with UNIFIED something resulting in a blank window (https://bugs.openjdk.org/browse/JDK-8154847), but there is a workaround with `Dprism.forceUploadingPainter=true`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[ \] Commit message must refer to an issue

### Error
&nbsp;⚠️ Pull request body is missing required line: `- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2045/head:pull/2045` \
`$ git checkout pull/2045`

Update a local copy of the PR: \
`$ git checkout pull/2045` \
`$ git pull https://git.openjdk.org/jfx.git pull/2045/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2045`

View PR using the GUI difftool: \
`$ git pr show -t 2045`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2045.diff">https://git.openjdk.org/jfx/pull/2045.diff</a>

</details>
