### PR TITLE
8378895: Reduce object allocations in Renderer.getPeerInstance()

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/scenario/effect/impl/Renderer.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/scenario/effect/impl/Renderer.java
@@ -83,7 +83,7 @@ public abstract class Renderer {
     }
 
     public static final String rootPkg = "com.sun.scenario.effect";
-    private static final Map<FilterContext, Renderer> rendererMap = new HashMap<>(1);
+    private static final Map<FilterContext, Renderer> rendererMap = HashMap.newHashMap(1);
 
     private static final class PeerCacheKey {
         String name;

--- a/modules/javafx.graphics/src/main/java/com/sun/scenario/effect/impl/Renderer.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/scenario/effect/impl/Renderer.java
@@ -96,7 +96,7 @@ public abstract class Renderer {
 
         @Override
         public boolean equals(Object o) {
-            return o instanceof PeerCacheKey other
+            return o instanceof PeerCacheKey other // 'o' is never 'this'
                 && unrollCount == other.unrollCount
                 && name.equals(other.name);
         }

--- a/modules/javafx.graphics/src/main/java/com/sun/scenario/effect/impl/prism/ps/PPSRenderer.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/scenario/effect/impl/prism/ps/PPSRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -169,15 +169,11 @@ public class PPSRenderer extends PrRenderer {
      * May be called multiple times.
      */
     protected void dispose() {
-        // even if new peers are added from another thread while we're executing
-        // this on the rendering thread, they won't have any native resources
-        // since we're on the rendering thread, so no need to synchronize
-        for (EffectPeer peer : getPeers()) {
-            peer.dispose();
-        }
         synchronized (this) {
             state = DISPOSED;
         }
+
+        clearPeers();
         rf.removeFactoryListener(listener);
         rf = null;
         screen = null;

--- a/modules/javafx.graphics/src/test/addExports
+++ b/modules/javafx.graphics/src/test/addExports
@@ -59,6 +59,7 @@
 --add-exports javafx.graphics/com.sun.scenario=ALL-UNNAMED
 --add-opens javafx.graphics/com.sun.javafx.css.parser=ALL-UNNAMED
 --add-opens javafx.graphics/com.sun.scenario.animation=ALL-UNNAMED
+--add-opens javafx.graphics/com.sun.scenario.effect.impl=ALL-UNNAMED
 --add-opens javafx.graphics/javafx.css=ALL-UNNAMED
 --add-opens javafx.graphics/javafx.scene=ALL-UNNAMED
 --add-opens javafx.graphics/javafx.scene.robot=ALL-UNNAMED

--- a/modules/javafx.graphics/src/test/addExports
+++ b/modules/javafx.graphics/src/test/addExports
@@ -52,6 +52,9 @@
 --add-exports javafx.graphics/com.sun.scenario.animation=ALL-UNNAMED
 --add-exports javafx.graphics/com.sun.scenario.animation.shared=ALL-UNNAMED
 --add-exports javafx.graphics/com.sun.scenario.effect=ALL-UNNAMED
+--add-exports javafx.graphics/com.sun.scenario.effect.impl=ALL-UNNAMED
+--add-exports javafx.graphics/com.sun.scenario.effect.impl.state=ALL-UNNAMED
+--add-exports javafx.graphics/com.sun.scenario.effect.impl.prism=ALL-UNNAMED
 --add-exports javafx.graphics/com.sun.scenario.effect.light=ALL-UNNAMED
 --add-exports javafx.graphics/com.sun.scenario=ALL-UNNAMED
 --add-opens javafx.graphics/com.sun.javafx.css.parser=ALL-UNNAMED

--- a/modules/javafx.graphics/src/test/java/test/com/sun/scenario/effect/impl/RendererTest.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/scenario/effect/impl/RendererTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.com.sun.scenario.effect.impl;
+
+import com.sun.javafx.geom.Rectangle;
+import com.sun.javafx.geom.transform.BaseTransform;
+import com.sun.scenario.effect.Effect;
+import com.sun.scenario.effect.FilterContext;
+import com.sun.scenario.effect.Filterable;
+import com.sun.scenario.effect.ImageData;
+import com.sun.scenario.effect.impl.EffectPeer;
+import com.sun.scenario.effect.impl.PoolFilterable;
+import com.sun.scenario.effect.impl.Renderer;
+import com.sun.scenario.effect.impl.prism.PrFilterContext;
+import com.sun.scenario.effect.impl.state.RenderState;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class RendererTest {
+
+    @Test
+    void getPeerInstance_returnsSameInstance_forNameAndUnrollCount() {
+        Renderer renderer = new StubRenderer();
+        FilterContext fctx = PrFilterContext.getPrinterContext(new Object());
+        EffectPeer<?> testEffectA0 = renderer.getPeerInstance(fctx, "TestEffectA", 0);
+        EffectPeer<?> testEffectA1 = renderer.getPeerInstance(fctx, "TestEffectA", 1);
+        EffectPeer<?> testEffectA2 = renderer.getPeerInstance(fctx, "TestEffectA", 2);
+        EffectPeer<?> testEffectB0 = renderer.getPeerInstance(fctx, "TestEffectB", 0);
+        EffectPeer<?> testEffectB1 = renderer.getPeerInstance(fctx, "TestEffectB", 1);
+        assertNotSame(testEffectA0, testEffectA1);
+        assertNotSame(testEffectA0, testEffectA2);
+        assertSame(testEffectA0, renderer.getPeerInstance(fctx, "TestEffectA", 0));
+        assertSame(testEffectA1, renderer.getPeerInstance(fctx, "TestEffectA", 1));
+        assertSame(testEffectA2, renderer.getPeerInstance(fctx, "TestEffectA", 2));
+        assertNotSame(testEffectB0, testEffectB1);
+        assertSame(testEffectB0, renderer.getPeerInstance(fctx, "TestEffectB", 0));
+        assertSame(testEffectB1, renderer.getPeerInstance(fctx, "TestEffectB", 1));
+    }
+
+    static class StubRenderer extends Renderer {
+        @Override public Effect.AccelType getAccelType() { return null; }
+        @Override public int getCompatibleWidth(int w) { return 0; }
+        @Override public int getCompatibleHeight(int h) { return 0; }
+        @Override public PoolFilterable createCompatibleImage(int w, int h) { return null; }
+        @Override public void clearImage(Filterable image) {}
+        @Override public ImageData createImageData(FilterContext fctx, Filterable src) { return null; }
+        @Override public Filterable transform(FilterContext fctx, Filterable original, BaseTransform transform,
+                                              Rectangle origBounds, Rectangle xformBounds) { return null; }
+        @Override public ImageData transform(FilterContext fctx, ImageData original, BaseTransform transform,
+                                             Rectangle origBounds, Rectangle xformBounds) { return null; }
+        @Override public RendererState getRendererState() { return null; }
+        @Override protected Renderer getBackupRenderer() { return null; }
+        @Override public boolean isImageDataCompatible(ImageData id) { return false; }
+        @Override protected EffectPeer<?> createPeer(FilterContext fctx, String name, int unrollCount) {
+            return new EffectPeer<>(fctx, this, "StubEffect") {
+                @Override
+                public ImageData filter(Effect effect, RenderState renderState, BaseTransform transform,
+                                        Rectangle outputClip, ImageData... inputs) {
+                    return null;
+                }
+            };
+        }
+    }
+}


### PR DESCRIPTION
The current implementation of `Renderer.getPeerInstance()` looks up mappings by concatenating strings to form a combined key:
```java
peer = peerCache.get(name + "_" + unrollCount);
```

This can be improved by not using strings to store the combined key, but using a simple `PeerCacheKey` class instead.
The `Renderer` class then uses a single reusable `PeerCacheKey` object to look up mappings, making the lookup allocation-free.

/reviewers 2

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8378895](https://bugs.openjdk.org/browse/JDK-8378895): Reduce object allocations in Renderer.getPeerInstance() (**Enhancement** - P4)


### Reviewers
 * [Marius Hanl](https://openjdk.org/census#mhanl) (@Maran23 - Committer)
 * [John Hendrikx](https://openjdk.org/census#jhendrikx) (@hjohn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2091/head:pull/2091` \
`$ git checkout pull/2091`

Update a local copy of the PR: \
`$ git checkout pull/2091` \
`$ git pull https://git.openjdk.org/jfx.git pull/2091/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2091`

View PR using the GUI difftool: \
`$ git pr show -t 2091`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2091.diff">https://git.openjdk.org/jfx/pull/2091.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2091#issuecomment-3979006672)
</details>
