### PR TITLE
8341852: Fix potential threading issue in WebView's RTImage

### DIFF
--- a/modules/javafx.web/src/main/java/com/sun/javafx/webkit/prism/PrismInvoker.java
+++ b/modules/javafx.web/src/main/java/com/sun/javafx/webkit/prism/PrismInvoker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package com.sun.javafx.webkit.prism;
 
+import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.locks.ReentrantLock;
@@ -78,21 +79,46 @@ public final class PrismInvoker extends Invoker {
         PlatformImpl.runLater(r);
     }
 
+    private static boolean isOnRenderThread() {
+        return Thread.currentThread().getName().startsWith("QuantumRenderer");
+    }
+
     static void invokeOnRenderThread(final Runnable r) {
         Toolkit.getToolkit().addRenderJob(new RenderJob(r));
     }
 
     static void runOnRenderThread(final Runnable r) {
-        if (Thread.currentThread().getName().startsWith("QuantumRenderer")) {
+        if (isOnRenderThread()) {
             r.run();
         } else {
-            FutureTask<Void> f = new FutureTask<>(r, null);
+            FutureTask<Void> f = new FutureTask<Void>(r, null);
             Toolkit.getToolkit().addRenderJob(new RenderJob(f));
             try {
                 // block until job is complete
                 f.get();
             } catch (ExecutionException | InterruptedException ex) {
                 log.severe("RenderJob error", ex);
+            }
+        }
+    }
+
+    static <T> T callOnRenderThread(final Callable<T> c) {
+        if (isOnRenderThread()) {
+            try {
+                return c.call();
+            } catch (Exception ex) {
+                log.severe("RenderJob error", ex);
+                return null;
+            }
+        } else {
+            FutureTask<T> f = new FutureTask<T>(c);
+            Toolkit.getToolkit().addRenderJob(new RenderJob(f));
+            try {
+                // block until job is complete
+                return f.get();
+            } catch (ExecutionException | InterruptedException ex) {
+                log.severe("RenderJob error", ex);
+                return null;
             }
         }
     }

--- a/modules/javafx.web/src/main/java/com/sun/javafx/webkit/prism/PrismInvoker.java
+++ b/modules/javafx.web/src/main/java/com/sun/javafx/webkit/prism/PrismInvoker.java
@@ -91,7 +91,7 @@ public final class PrismInvoker extends Invoker {
         if (isOnRenderThread()) {
             r.run();
         } else {
-            FutureTask<Void> f = new FutureTask<Void>(r, null);
+            FutureTask<Void> f = new FutureTask<>(r, null);
             Toolkit.getToolkit().addRenderJob(new RenderJob(f));
             try {
                 // block until job is complete
@@ -111,7 +111,7 @@ public final class PrismInvoker extends Invoker {
                 return null;
             }
         } else {
-            FutureTask<T> f = new FutureTask<T>(c);
+            FutureTask<T> f = new FutureTask<>(c);
             Toolkit.getToolkit().addRenderJob(new RenderJob(f));
             try {
                 // block until job is complete

--- a/modules/javafx.web/src/main/java/com/sun/javafx/webkit/prism/RTImage.java
+++ b/modules/javafx.web/src/main/java/com/sun/javafx/webkit/prism/RTImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -134,13 +134,23 @@ final class RTImage extends PrismImage implements ResourceFactoryListener {
             int dstx1, int dsty1, int dstx2, int dsty2,
             int srcx1, int srcy1, int srcx2, int srcy2)
     {
-        if (txt == null && g.getCompositeMode() == CompositeMode.SRC_OVER) {
+        // Because this method can be called by the Printer there is a chance
+        // these checks will run on a thread other than QuantumRenderer. To prevent
+        // any mishaps run the checks on render thread.
+        boolean canDraw = PrismInvoker.callOnRenderThread(() -> {
+            if (txt == null && g.getCompositeMode() == CompositeMode.SRC_OVER) {
+                return false;
+            }
+            if (g.getResourceFactory().isDisposed()) {
+                log.fine("RTImage::draw : skip because device has been disposed");
+                return false;
+            }
+            return true;
+        });
+        if (!canDraw) {
             return;
         }
-        if (g.getResourceFactory().isDisposed()) {
-            log.fine("RTImage::draw : skip because device has been disposed");
-            return;
-        }
+
         if (g instanceof PrinterGraphics) {
             // We're printing. Copy [txt] into a J2DTexture and draw it.
             int w = srcx2 - srcx1;
@@ -148,7 +158,11 @@ final class RTImage extends PrismImage implements ResourceFactoryListener {
             final IntBuffer pixels = IntBuffer.allocate(w * h);
 
             PrismInvoker.runOnRenderThread(() -> {
-                getTexture().readPixels(pixels);
+                // getTexture() can return null, prevent NPE if that happens
+                RTTexture tex = getTexture();
+                if (tex != null) {
+                    tex.readPixels(pixels);
+                }
             });
             Image img = Image.fromIntArgbPreData(pixels, w, h);
             Texture t = g.getResourceFactory().createTexture(

--- a/modules/javafx.web/src/main/java/com/sun/javafx/webkit/prism/RTImage.java
+++ b/modules/javafx.web/src/main/java/com/sun/javafx/webkit/prism/RTImage.java
@@ -137,7 +137,7 @@ final class RTImage extends PrismImage implements ResourceFactoryListener {
         // Because this method can be called by the Printer there is a chance
         // these checks will run on a thread other than QuantumRenderer. To prevent
         // any mishaps run the checks on render thread.
-        boolean canDraw = PrismInvoker.callOnRenderThread(() -> {
+        final boolean canDraw = PrismInvoker.callOnRenderThread(() -> {
             if (txt == null && g.getCompositeMode() == CompositeMode.SRC_OVER) {
                 return false;
             }


### PR DESCRIPTION
This change fixes a potential threading issue in RTImage.draw() method in WebView. The issue has been theorized back in [JDK-8333374](https://bugs.openjdk.org/browse/JDK-8333374), I have not managed to figure out a reliable reproducer for it, but the circumstances for it to happen are there.

Issue can happen in `RTimage.draw()` method. In 99% of cases `RTImage.draw()` will be called only by QuantumRenderer thread (that is during regular drawing to a Stage/Scene), however there is also a possibility we will call `RTImage.draw()` from a different thread, notably with a `PrinterGraphics` object (or in other words, when printing). Then there is a chance we will run some of the initial checks in parallel to QuantumRenderer thread. I found two places that can be affected - the initial checks at the beginning of the method and the `getTexture()` call inside the code block responsible for printing.

The first place was fixed by running the checks on the render thread. That way we can ensure the render thread will not overwrite the `tex` reference from the render thread while the printing thread reads it. To make this happen I added `PrismInvoker.callOnRenderThread()` which functions like `PrismInvoker.runOnRenderThread()` but with a `Callable<>` instead of a `Runnable` object.

Second place can happen if, for some reason, in between previous checks and the `getTexture()` call QuantumRenderer will modify or free RTImage's tex reference (ex. while pruning the Vram pool) - then the `getTexture()` call will return `null` (introduced as NPE prevention from [JDK-8333374](https://bugs.openjdk.org/browse/JDK-8333374)) which can cause an NPE on QuantumRenderer thread. If that happens, we skip the `readPixels()` call which will print an empty RTImage.

I verified these changes on Windows and Linux with our test suite and with manual testing via `HelloWebView` and using an old `SimplePrint.java` reproducer from [JDK-8118415](https://bugs.openjdk.org/browse/JDK-8118415); both regular drawing and printing work as they did. I found simply loading `google.com` via both apps works to trigger this draw call multiple times (`SimplePrint.java` needed to be adjusted slightly to print out the web page instead of predefined HTML code). Test suite completes successfully (there were 3 web.test failures on my end but they also happened on master and refer to other, unrelated parts of javafx.web) and printing works the same way it used to.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8341852](https://bugs.openjdk.org/browse/JDK-8341852): Fix potential threading issue in WebView's RTImage (**Bug** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2092/head:pull/2092` \
`$ git checkout pull/2092`

Update a local copy of the PR: \
`$ git checkout pull/2092` \
`$ git pull https://git.openjdk.org/jfx.git pull/2092/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2092`

View PR using the GUI difftool: \
`$ git pr show -t 2092`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2092.diff">https://git.openjdk.org/jfx/pull/2092.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2092#issuecomment-3984797499)
</details>
