### PR TITLE
8371370: [macOS] Crash after main stage with modal dialog is moved to full screen

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow+Java.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow+Java.m
@@ -251,8 +251,10 @@ extern NSSize maxScreenDimensions;
         mask &= ~(NSUInteger)NSWindowStyleMaskResizable;
         [self->nsWindow setStyleMask: mask];
 
-        // When window becomes non-resizable, remove behavior to prevent access to fullscreen/Mission Control
-        if (!self->owner && !isPopupOrUtility) {
+        // When window becomes non-resizable, remove behavior to prevent access to fullscreen/Mission Control, unless
+        // is is a borderless window
+        BOOL isTitled = (mask & NSWindowStyleMaskTitled) != 0;
+        if (!self->owner && !isPopupOrUtility && isTitled) {
             NSWindowCollectionBehavior behavior = [self->nsWindow collectionBehavior];
             behavior &= ~NSWindowCollectionBehaviorFullScreenPrimary;
             [self->nsWindow setCollectionBehavior: behavior];

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow+Java.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow+Java.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -221,21 +221,42 @@ extern NSSize maxScreenDimensions;
     }
 
     NSUInteger mask = [self->nsWindow styleMask];
+    BOOL isPopupOrUtility = (mask & NSWindowStyleMaskUtilityWindow) != 0 || (mask & NSWindowStyleMaskNonactivatingPanel) != 0;
 
     if (resizable) {
         mask |= NSWindowStyleMaskResizable;
         [self->nsWindow setStyleMask: mask];
-        [self->nsWindow setShowsResizeIndicator:YES];
 
         NSButton *zoomButton = [self->nsWindow standardWindowButton:NSWindowZoomButton];
         [zoomButton setEnabled:YES];
+
+        // When window becomes resizable, ownerless window gets the Full Screen Toggle control
+        if (!self->owner && !isPopupOrUtility) {
+            NSWindowCollectionBehavior behavior = [self->nsWindow collectionBehavior];
+            behavior |= NSWindowCollectionBehaviorFullScreenPrimary;
+            [self->nsWindow setCollectionBehavior: behavior];
+        }
     } else {
+        // Disable zoom button immediately to provide visual feedback
+        [[self->nsWindow standardWindowButton:NSWindowZoomButton] setEnabled:NO];
+
+        // If window is currently in full screen, exit fullscreen mode immediately
+        BOOL isInFullScreen = (mask & NSWindowStyleMaskFullScreen) != 0;
+        if (isInFullScreen) {
+            [self->nsWindow toggleFullScreen:nil];
+            // Defer style mask changes to windowDidExitFullScreen, when fullscreen exit animation completes
+            return;
+        }
+
         mask &= ~(NSUInteger)NSWindowStyleMaskResizable;
         [self->nsWindow setStyleMask: mask];
-        [self->nsWindow setShowsResizeIndicator:NO];
 
-        NSButton *zoomButton = [self->nsWindow standardWindowButton:NSWindowZoomButton];
-        [zoomButton setEnabled:NO];
+        // When window becomes non-resizable, remove behavior to prevent access to fullscreen/Mission Control
+        if (!self->owner && !isPopupOrUtility) {
+            NSWindowCollectionBehavior behavior = [self->nsWindow collectionBehavior];
+            behavior &= ~NSWindowCollectionBehaviorFullScreenPrimary;
+            [self->nsWindow setCollectionBehavior: behavior];
+        }
     }
 }
 

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow+Overrides.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow+Overrides.m
@@ -334,7 +334,7 @@
 
     // Fullscreen exit failed - window remains in fullscreen mode, restore buttons
     BOOL isWindowEnabled = self->isEnabled;
-    [[self->nsWindow standardWindowButton:NSWindowZoomButton] setEnabled:isWindowEnabled];
+    [[self->nsWindow standardWindowButton:NSWindowCloseButton] setEnabled:isWindowEnabled];
     [[self->nsWindow standardWindowButton:NSWindowMiniaturizeButton] setEnabled: NO];
     [[self->nsWindow standardWindowButton:NSWindowZoomButton] setEnabled: isWindowEnabled && self->isResizable];
 }

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow+Overrides.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow+Overrides.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -287,11 +287,56 @@
     GlassViewDelegate* delegate = (GlassViewDelegate*)[self->view delegate];
     [delegate setResizableForFullscreen:self->isWindowResizable];
 
+    // Recalculate the style mask to restore miniaturizable and resizable states
+    NSUInteger currentMask = [self->nsWindow styleMask];
+    NSUInteger managedBits = (NSUInteger)(NSWindowStyleMaskMiniaturizable | NSWindowStyleMaskResizable);
+    NSUInteger newMask = (currentMask & ~managedBits);
+
+    // Restore miniaturizable from saved state
+    if (self->enabledStyleMask & NSWindowStyleMaskMiniaturizable) {
+        newMask |= NSWindowStyleMaskMiniaturizable;
+    }
+    // And set resizable based on current isResizable flag
+    if (self->isResizable) {
+        newMask |= NSWindowStyleMaskResizable;
+    }
+    [self->nsWindow setStyleMask: newMask];
+
+    // Apply collection behavior changes that were deferred from _setResizable
+    BOOL isPopupOrUtility = (newMask & NSWindowStyleMaskUtilityWindow) != 0 || (newMask & NSWindowStyleMaskNonactivatingPanel) != 0;
+    if (!self->owner && !isPopupOrUtility) {
+        NSWindowCollectionBehavior behavior = [self->nsWindow collectionBehavior];
+        if (self->isResizable) {
+            behavior |= NSWindowCollectionBehaviorFullScreenPrimary;
+        } else {
+            behavior &= ~NSWindowCollectionBehaviorFullScreenPrimary;
+        }
+        [self->nsWindow setCollectionBehavior: behavior];
+    }
+
+    // Update button states based on current window state after style mask is applied
+    BOOL isWindowEnabled = self->isEnabled;
+    BOOL isMiniaturizable = ([self->nsWindow styleMask] & NSWindowStyleMaskMiniaturizable) != 0;
+    [[self->nsWindow standardWindowButton:NSWindowCloseButton] setEnabled: isWindowEnabled];
+    [[self->nsWindow standardWindowButton:NSWindowMiniaturizeButton] setEnabled: isWindowEnabled && isMiniaturizable];
+    [[self->nsWindow standardWindowButton:NSWindowZoomButton] setEnabled: isWindowEnabled && self->isResizable];
+
     [delegate sendJavaFullScreenEvent:NO withNativeWidget:YES];
     [GlassApplication leaveFullScreenExitingLoopIfNeeded];
 
     // Fix up window stacking order
     [self reorderChildWindows];
+}
+
+- (void)windowDidFailToExitFullScreen:(NSNotification *)notification
+{
+    //NSLog(@"windowDidFailToExitFullScreen");
+
+    // Fullscreen exit failed - window remains in fullscreen mode, restore buttons
+    BOOL isWindowEnabled = self->isEnabled;
+    [[self->nsWindow standardWindowButton:NSWindowZoomButton] setEnabled:isWindowEnabled];
+    [[self->nsWindow standardWindowButton:NSWindowMiniaturizeButton] setEnabled: NO];
+    [[self->nsWindow standardWindowButton:NSWindowZoomButton] setEnabled: isWindowEnabled && self->isResizable];
 }
 
 - (BOOL)windowShouldClose:(NSNotification *)notification

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow+Overrides.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow+Overrides.m
@@ -304,9 +304,10 @@
 
     // Apply collection behavior changes that were deferred from _setResizable
     BOOL isPopupOrUtility = (newMask & NSWindowStyleMaskUtilityWindow) != 0 || (newMask & NSWindowStyleMaskNonactivatingPanel) != 0;
+    BOOL isTitled = (newMask & NSWindowStyleMaskTitled) != 0;
     if (!self->owner && !isPopupOrUtility) {
         NSWindowCollectionBehavior behavior = [self->nsWindow collectionBehavior];
-        if (self->isResizable) {
+        if (self->isResizable || !isTitled) {
             behavior |= NSWindowCollectionBehaviorFullScreenPrimary;
         } else {
             behavior &= ~NSWindowCollectionBehaviorFullScreenPrimary;

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow.m
@@ -568,7 +568,12 @@ static jlong _createWindowCommonDo(JNIEnv *env, jobject jWindow, jlong jOwnerPtr
             {
                 // Only resizable ownerless windows should have the Full Screen Toggle control
                 // This behavior is applied later in _setResizable:YES when the window becomes resizable.
-                // Non-resizable ownerless windows keep the default behavior, which doesn't allow full screen access
+
+                // Non-resizable ownerless windows keep the default behavior, which doesn't allow full screen access,
+                // except if they are undecorated/borderless windows:
+                if (!isTitled) {
+                    behavior |= NSWindowCollectionBehaviorFullScreenPrimary;
+                }
             }
             else
             {

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow.m
@@ -127,7 +127,6 @@ static inline GlassView3D<GlassView> *getMacView(JNIEnv *env, jobject jview)
                                                                                         \
     [self setDelegate:delegate];                                                        \
     [self setAcceptsMouseMovedEvents:NO];                                               \
-    [self setShowsResizeIndicator:NO];                                                  \
     [self setAllowsConcurrentViewDrawing:YES];                                          \
                                                                                         \
     [self setReleasedWhenClosed:YES];                                                   \

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -567,8 +567,9 @@ static jlong _createWindowCommonDo(JNIEnv *env, jobject jWindow, jlong jOwnerPtr
             NSWindowCollectionBehavior behavior = [window->nsWindow collectionBehavior];
             if (!isPopup && !isUtility && !window->owner)
             {
-                // Only ownerless windows should have the Full Screen Toggle control
-                behavior |= (1 << 7) /* NSWindowCollectionBehaviorFullScreenPrimary */;
+                // Only resizable ownerless windows should have the Full Screen Toggle control
+                // This behavior is applied later in _setResizable:YES when the window becomes resizable.
+                // Non-resizable ownerless windows keep the default behavior, which doesn't allow full screen access
             }
             else
             {
@@ -597,6 +598,10 @@ static jlong _createWindowCommonDo(JNIEnv *env, jobject jWindow, jlong jOwnerPtr
         window->isSizeAssigned = NO;
         window->isLocationAssigned = NO;
         window->isResizable = NO;
+
+        // Initialize enabledStyleMask with current miniaturizable and resizable bits
+        window->enabledStyleMask = [window->nsWindow styleMask] & (NSWindowStyleMaskMiniaturizable | NSWindowStyleMaskResizable);
+
         [window _setResizable:NO]; // actual value will be set later with a separate JNI downcall
         [window->nsWindow setAppearance:isDarkFrame
             ? [NSAppearance appearanceNamed:NSAppearanceNameDarkAqua]
@@ -820,23 +825,56 @@ JNIEXPORT void JNICALL Java_com_sun_glass_ui_mac_MacWindow__1setEnabled
     {
         GlassWindow *window = getGlassWindow(env, jPtr);
         window->isEnabled = (BOOL)isEnabled;
+
+        NSUInteger mask = [window->nsWindow styleMask];
+        BOOL isInFullScreen = (mask & NSWindowStyleMaskFullScreen) != 0;
+        BOOL isPopupOrUtility = (mask & NSWindowStyleMaskUtilityWindow) != 0 || (mask & NSWindowStyleMaskNonactivatingPanel) != 0;
+        BOOL isRegularWindow = !window->owner && !isPopupOrUtility;
+        NSUInteger managedBits = (NSUInteger)(NSWindowStyleMaskMiniaturizable | NSWindowStyleMaskResizable);
+
+        NSButton *closeButton = [window->nsWindow standardWindowButton:NSWindowCloseButton];
         NSButton *zoomButton = [window->nsWindow standardWindowButton:NSWindowZoomButton];
-        if ((window->isEnabled) && (window->isResizable)){
-            [window->nsWindow setStyleMask: window->enabledStyleMask];
-            if (window->enabledStyleMask & NSWindowStyleMaskResizable) {
+
+        if ((window->isEnabled) && (window->isResizable)) {
+            // Restore miniaturizable and resizable styles, if not in fullscreen and is a regular window
+            if (!isInFullScreen && isRegularWindow) {
+                [window->nsWindow setStyleMask: (mask & ~managedBits) | window->enabledStyleMask];
+            }
+            // Restore zoom button state
+            if (zoomButton != nil) {
                 [zoomButton setEnabled:YES];
             }
-        }
-        else if((window->isEnabled) && (!window->isResizable)){
-            [window->nsWindow setStyleMask:
-                (window->enabledStyleMask & ~(NSUInteger) NSWindowStyleMaskResizable)];
-            [zoomButton setEnabled:NO];
-        }
-        else{
-            window->enabledStyleMask = [window->nsWindow styleMask];
-            [window->nsWindow setStyleMask:
-                (window->enabledStyleMask & ~(NSUInteger)(NSWindowStyleMaskMiniaturizable | NSWindowStyleMaskResizable))];
-            [zoomButton setEnabled:NO];
+            // Enable close button as window is re-enabled
+            if (closeButton != nil) {
+                [closeButton setEnabled:YES];
+            }
+        } else if ((window->isEnabled) && (!window->isResizable)) {
+            // Restore miniaturizable style, clear resizable style, if not in fullscreen and is a regular window
+            if (!isInFullScreen && isRegularWindow) {
+                [window->nsWindow setStyleMask:
+                    (mask & ~managedBits) | (window->enabledStyleMask & ~(NSUInteger) NSWindowStyleMaskResizable)];
+            }
+            // Disable zoom button as window is not resizable
+            if (zoomButton != nil) {
+                [zoomButton setEnabled:NO];
+            }
+            // Enable close button as window is re-enabled
+            if (closeButton != nil) {
+                [closeButton setEnabled:YES];
+            }
+        } else {
+            // Disabling the window - save both miniaturizable and resizable bits, if not in fullscreen and is a regular window
+            if (!isInFullScreen && isRegularWindow) {
+                window->enabledStyleMask = mask & managedBits;
+                [window->nsWindow setStyleMask: mask & ~managedBits];
+            }
+            // Disable both zoom and close buttons as window is disabled
+            if (zoomButton != nil) {
+                [zoomButton setEnabled:NO];
+            }
+            if (closeButton != nil) {
+                [closeButton setEnabled:NO];
+            }
         }
     }
     GLASS_POOL_EXIT;


### PR DESCRIPTION
This PR adds a fix to prevent a crash on macOS after exiting full screen mode when a modal dialog is showing (https://bugs.openjdk.org/browse/JDK-8371370).

At the same time, it prevents non-resizable windows from entering full screen mode (https://bugs.openjdk.org/browse/JDK-8379315), given that the changes for both issues were interrelated.

While no tests have been added, manual tests have been run, checking that the style mask, the window behavior and the standard window buttons state, remained consistent in different scenarios.

Also, according to https://developer.apple.com/documentation/appkit/nswindow/showsresizeindicator, the `showsResizeIndicator` property has been removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8371370](https://bugs.openjdk.org/browse/JDK-8371370): [macOS] Crash after main stage with modal dialog is moved to full screen (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2098/head:pull/2098` \
`$ git checkout pull/2098`

Update a local copy of the PR: \
`$ git checkout pull/2098` \
`$ git pull https://git.openjdk.org/jfx.git pull/2098/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2098`

View PR using the GUI difftool: \
`$ git pr show -t 2098`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2098.diff">https://git.openjdk.org/jfx/pull/2098.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2098#issuecomment-4013768459)
</details>
