### PR TITLE
8379942: Some non focus-traversable Controls do not request focus when clicking on it

### DIFF
--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/ButtonBehavior.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/ButtonBehavior.java
@@ -178,9 +178,7 @@ public class ButtonBehavior<C extends ButtonBase> extends BehaviorBase<C> {
      * potentially arming the Button, this will transfer focus to the button
      */
     protected void mousePressed(MouseEvent e) {
-        if (getNode().isFocusTraversable()) {
-            getNode().requestFocus();
-        }
+        getNode().requestFocus();
 
         // arm the button if it is a valid mouse event
         // Note there appears to be a bug where if I press and hold and release
@@ -191,7 +189,7 @@ public class ButtonBehavior<C extends ButtonBase> extends BehaviorBase<C> {
                 ! (e.isMiddleButtonDown() || e.isSecondaryButtonDown() ||
                         e.isShiftDown() || e.isControlDown() || e.isAltDown() || e.isMetaDown()));
 
-        if (! getNode().isArmed() && valid) {
+        if (!getNode().isArmed() && valid) {
             getNode().arm();
         }
     }

--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/ChoiceBoxBehavior.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/ChoiceBoxBehavior.java
@@ -114,7 +114,7 @@ public class ChoiceBoxBehavior<T> extends BehaviorBase<ChoiceBox<T>> {
      */
     public void mousePressed(MouseEvent e) {
         ChoiceBox<T> choiceButton = getNode();
-        if (choiceButton.isFocusTraversable()) choiceButton.requestFocus();
+        choiceButton.requestFocus();
     }
 
     /**

--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/ComboBoxBaseBehavior.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/ComboBoxBaseBehavior.java
@@ -280,10 +280,8 @@ public class ComboBoxBaseBehavior<T> extends BehaviorBase<ComboBoxBase<T>> {
     }
 
     public void show() {
-        if (! getNode().isShowing()) {
-            if (getNode().isFocusTraversable()) {
-                getNode().requestFocus();
-            }
+        if (!getNode().isShowing()) {
+            getNode().requestFocus();
             getNode().show();
         }
     }

--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/ListViewBehavior.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/ListViewBehavior.java
@@ -398,7 +398,7 @@ public class ListViewBehavior<T> extends BehaviorBase<ListView<T>> {
             }
         }
 
-        if (! getNode().isFocused() && getNode().isFocusTraversable()) {
+        if (!getNode().isFocused()) {
             getNode().requestFocus();
         }
     }

--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/MenuButtonBehaviorBase.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/MenuButtonBehaviorBase.java
@@ -140,7 +140,7 @@ public abstract class MenuButtonBehaviorBase<C extends MenuButton> extends Butto
             }
             super.mousePressed(e);
         } else {
-            if (!control.isFocused() && control.isFocusTraversable()) {
+            if (!control.isFocused()) {
                 control.requestFocus();
             }
             if (control.isShowing()) {

--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/ScrollBarBehavior.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/ScrollBarBehavior.java
@@ -147,7 +147,9 @@ public class ScrollBarBehavior extends BehaviorBase<ScrollBar> {
         // determine the percentage of the way between min and max
         // represented by this mouse event
         final ScrollBar bar = getNode();
-        if (!bar.isFocused() && bar.isFocusTraversable()) bar.requestFocus();
+        if (!bar.isFocused()) {
+            bar.requestFocus();
+        }
         final double pos = position;
         final boolean incrementing = (pos > ((bar.getValue() - bar.getMin())/(bar.getMax() - bar.getMin())));
         timeline = new Timeline();
@@ -185,7 +187,9 @@ public class ScrollBarBehavior extends BehaviorBase<ScrollBar> {
      */
     public void decButtonPressed() {
         final ScrollBar bar = getNode();
-        if (!bar.isFocused() && bar.isFocusTraversable()) bar.requestFocus();
+        if (!bar.isFocused()) {
+            bar.requestFocus();
+        }
         stopTimeline();
         timeline = new Timeline();
         timeline.setCycleCount(Timeline.INDEFINITE);
@@ -219,7 +223,9 @@ public class ScrollBarBehavior extends BehaviorBase<ScrollBar> {
      */
     public void incButtonPressed() {
         final ScrollBar bar = getNode();
-        if (!bar.isFocused() && bar.isFocusTraversable()) bar.requestFocus();
+        if (!bar.isFocused()) {
+            bar.requestFocus();
+        }
         stopTimeline();
         timeline = new Timeline();
         timeline.setCycleCount(Timeline.INDEFINITE);
@@ -262,7 +268,9 @@ public class ScrollBarBehavior extends BehaviorBase<ScrollBar> {
         // Stop the timeline for continuous increments as drags take precedence
         stopTimeline();
 
-        if (!scrollbar.isFocused() && scrollbar.isFocusTraversable()) scrollbar.requestFocus();
+        if (!scrollbar.isFocused()) {
+            scrollbar.requestFocus();
+        }
         double newValue = (position * (scrollbar.getMax() - scrollbar.getMin())) + scrollbar.getMin();
         if (!Double.isNaN(newValue)) {
             scrollbar.setValue(Utils.clamp(scrollbar.getMin(), newValue, scrollbar.getMax()));

--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/ScrollBarBehavior.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/ScrollBarBehavior.java
@@ -147,9 +147,6 @@ public class ScrollBarBehavior extends BehaviorBase<ScrollBar> {
         // determine the percentage of the way between min and max
         // represented by this mouse event
         final ScrollBar bar = getNode();
-        if (!bar.isFocused()) {
-            bar.requestFocus();
-        }
         final double pos = position;
         final boolean incrementing = (pos > ((bar.getValue() - bar.getMin())/(bar.getMax() - bar.getMin())));
         timeline = new Timeline();
@@ -187,9 +184,7 @@ public class ScrollBarBehavior extends BehaviorBase<ScrollBar> {
      */
     public void decButtonPressed() {
         final ScrollBar bar = getNode();
-        if (!bar.isFocused()) {
-            bar.requestFocus();
-        }
+
         stopTimeline();
         timeline = new Timeline();
         timeline.setCycleCount(Timeline.INDEFINITE);
@@ -223,9 +218,6 @@ public class ScrollBarBehavior extends BehaviorBase<ScrollBar> {
      */
     public void incButtonPressed() {
         final ScrollBar bar = getNode();
-        if (!bar.isFocused()) {
-            bar.requestFocus();
-        }
         stopTimeline();
         timeline = new Timeline();
         timeline.setCycleCount(Timeline.INDEFINITE);
@@ -268,9 +260,6 @@ public class ScrollBarBehavior extends BehaviorBase<ScrollBar> {
         // Stop the timeline for continuous increments as drags take precedence
         stopTimeline();
 
-        if (!scrollbar.isFocused()) {
-            scrollbar.requestFocus();
-        }
         double newValue = (position * (scrollbar.getMax() - scrollbar.getMin())) + scrollbar.getMin();
         if (!Double.isNaN(newValue)) {
             scrollbar.setValue(Utils.clamp(scrollbar.getMin(), newValue, scrollbar.getMax()));

--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/TableViewBehaviorBase.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/TableViewBehaviorBase.java
@@ -445,7 +445,7 @@ public abstract class TableViewBehaviorBase<C extends Control, T, TC extends Tab
 //        ObservableList<? extends TablePositionBase> cells = getSelectedCells();
 //        setAnchor(cells.isEmpty() ? null : cells.get(0));
 
-        if (!getNode().isFocused() && getNode().isFocusTraversable()) {
+        if (!getNode().isFocused()) {
             getNode().requestFocus();
         }
     }

--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/TreeViewBehavior.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/TreeViewBehavior.java
@@ -295,7 +295,7 @@ public class TreeViewBehavior<T> extends BehaviorBase<TreeView<T>> {
             setAnchor(index);
         }
 
-        if (! getNode().isFocused() && getNode().isFocusTraversable()) {
+        if (!getNode().isFocused()) {
             getNode().requestFocus();
         }
     }

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ListViewSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ListViewSkin.java
@@ -216,9 +216,7 @@ public class ListViewSkin<T> extends VirtualContainerBase<ListView<T>, ListCell<
             // focus border will not be shown when the user interacts with the
             // scrollbars, and more importantly, keyboard navigation won't be
             // available to the user.
-            if (control.isFocusTraversable()) {
-                control.requestFocus();
-            }
+            control.requestFocus();
         };
         flow.getVbar().addEventFilter(MouseEvent.MOUSE_PRESSED, ml);
         flow.getHbar().addEventFilter(MouseEvent.MOUSE_PRESSED, ml);

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ScrollPaneSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ScrollPaneSkin.java
@@ -663,9 +663,7 @@ public class ScrollPaneSkin extends SkinBase<ScrollPane> {
         vsb.setOrientation(Orientation.VERTICAL);
 
         EventHandler<MouseEvent> barHandler = ev -> {
-            if (getSkinnable().isFocusTraversable()) {
-                getSkinnable().requestFocus();
-            }
+            getSkinnable().requestFocus();
         };
 
         ListenerHelper lh = ListenerHelper.get(this);

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableViewSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableViewSkin.java
@@ -96,9 +96,7 @@ public class TableViewSkin<T> extends TableViewSkinBase<T, T, TableView<T>, Tabl
             // focus border will not be shown when the user interacts with the
             // scrollbars, and more importantly, keyboard navigation won't be
             // available to the user.
-            if (control.isFocusTraversable()) {
-                control.requestFocus();
-            }
+            control.requestFocus();
         };
         lh.addEventFilter(flow.getVbar(), MouseEvent.MOUSE_PRESSED, ml);
         lh.addEventFilter(flow.getHbar(), MouseEvent.MOUSE_PRESSED, ml);

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TreeTableViewSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TreeTableViewSkin.java
@@ -102,9 +102,7 @@ public class TreeTableViewSkin<T> extends TableViewSkinBase<T, TreeItem<T>, Tree
             // focus border will not be shown when the user interacts with the
             // scrollbars, and more importantly, keyboard navigation won't be
             // available to the user.
-            if (control.isFocusTraversable()) {
-                control.requestFocus();
-            }
+            control.requestFocus();
         };
         lh.addEventFilter(flow.getVbar(), MouseEvent.MOUSE_PRESSED, ml);
         lh.addEventFilter(flow.getHbar(), MouseEvent.MOUSE_PRESSED, ml);

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TreeViewSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TreeViewSkin.java
@@ -176,9 +176,7 @@ public class TreeViewSkin<T> extends VirtualContainerBase<TreeView<T>, TreeCell<
             // focus border will not be shown when the user interacts with the
             // scrollbars, and more importantly, keyboard navigation won't be
             // available to the user.
-            if (control.isFocusTraversable()) {
-                control.requestFocus();
-            }
+            control.requestFocus();
         };
         flow.getVbar().addEventFilter(MouseEvent.MOUSE_PRESSED, ml);
         flow.getHbar().addEventFilter(MouseEvent.MOUSE_PRESSED, ml);

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
@@ -471,30 +471,6 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
                 if (Properties.IS_TOUCH_SUPPORTED) {
                     scrollBarOn();
                 }
-                // We check here to see if the current focus owner is within
-                // this VirtualFlow, and if so we back-off from requesting
-                // focus back to the VirtualFlow itself. This is particularly
-                // relevant given the bug identified in JDK-8119995. In this
-                // particular case TextInputControl was clearing selection
-                // when the focus on the TextField changed, meaning that the
-                // right-click context menu was not showing the correct
-                // options as there was no selection in the TextField.
-                boolean doFocusRequest = true;
-                Node focusOwner = getScene().getFocusOwner();
-                if (focusOwner != null) {
-                    Parent parent = focusOwner.getParent();
-                    while (parent != null) {
-                        if (parent.equals(VirtualFlow.this)) {
-                            doFocusRequest = false;
-                            break;
-                        }
-                        parent = parent.getParent();
-                    }
-                }
-
-                if (doFocusRequest) {
-                    requestFocus();
-                }
 
                 lastX = e.getX();
                 lastY = e.getY();

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
@@ -471,31 +471,29 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
                 if (Properties.IS_TOUCH_SUPPORTED) {
                     scrollBarOn();
                 }
-                if (isFocusTraversable()) {
-                    // We check here to see if the current focus owner is within
-                    // this VirtualFlow, and if so we back-off from requesting
-                    // focus back to the VirtualFlow itself. This is particularly
-                    // relevant given the bug identified in JDK-8119995. In this
-                    // particular case TextInputControl was clearing selection
-                    // when the focus on the TextField changed, meaning that the
-                    // right-click context menu was not showing the correct
-                    // options as there was no selection in the TextField.
-                    boolean doFocusRequest = true;
-                    Node focusOwner = getScene().getFocusOwner();
-                    if (focusOwner != null) {
-                        Parent parent = focusOwner.getParent();
-                        while (parent != null) {
-                            if (parent.equals(VirtualFlow.this)) {
-                                doFocusRequest = false;
-                                break;
-                            }
-                            parent = parent.getParent();
+                // We check here to see if the current focus owner is within
+                // this VirtualFlow, and if so we back-off from requesting
+                // focus back to the VirtualFlow itself. This is particularly
+                // relevant given the bug identified in JDK-8119995. In this
+                // particular case TextInputControl was clearing selection
+                // when the focus on the TextField changed, meaning that the
+                // right-click context menu was not showing the correct
+                // options as there was no selection in the TextField.
+                boolean doFocusRequest = true;
+                Node focusOwner = getScene().getFocusOwner();
+                if (focusOwner != null) {
+                    Parent parent = focusOwner.getParent();
+                    while (parent != null) {
+                        if (parent.equals(VirtualFlow.this)) {
+                            doFocusRequest = false;
+                            break;
                         }
+                        parent = parent.getParent();
                     }
+                }
 
-                    if (doFocusRequest) {
-                        requestFocus();
-                    }
+                if (doFocusRequest) {
+                    requestFocus();
                 }
 
                 lastX = e.getX();

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ButtonTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ButtonTest.java
@@ -542,9 +542,17 @@ public class ButtonTest {
         // did green revert to original after green hover=false?
         // This is the acid test. If this fails, then JDK-8126478 is present.
         assertTrue(greenStops0.equals(greenStops3));
-
     }
 
+    @Test
+    void testNonFocusTraversableButtonCanBeFocused() {
+        btn.setFocusTraversable(false);
+
+        MouseEventFirer mouseEventFirer = new MouseEventFirer(btn);
+        mouseEventFirer.fireMousePressed();
+
+        assertTrue(btn.isFocused());
+    }
 
 //  private Button button1;
 //  private Button button2;

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/cell/TextFieldTableCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/cell/TextFieldTableCellTest.java
@@ -377,7 +377,7 @@ public class TextFieldTableCellTest {
      *
      **************************************************************************/
 
-    @Test public void test_rt_32869() {
+    @Test public void testContextMenuFocusShouldStay() {
         TableColumn tc = new TableColumn();
         tc.setCellValueFactory(param -> new ReadOnlyStringWrapper("Dummy Text"));
 

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/scene/KeyboardShortcutsHandler.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/scene/KeyboardShortcutsHandler.java
@@ -295,7 +295,7 @@ public final class KeyboardShortcutsHandler extends BasicEventDispatcher {
                 firstMnemonics = mnemonic;
             }
 
-            if (NodeHelper.isTreeVisible(currentNode) && (currentNode.isFocusTraversable() && !currentNode.isDisabled())) {
+            if (NodeHelper.isTreeVisible(currentNode) && !currentNode.isDisabled()) {
                 if (firstNode == null) {
                     firstNode = currentNode;
                 } else {

--- a/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
@@ -8550,6 +8550,7 @@ public abstract sealed class Node
                         if (get()) {
                             _scene.initializeInternalEventDispatcher();
                         }
+                        focusSetDirty(_scene);
                     }
                 }
 
@@ -8583,8 +8584,9 @@ public abstract sealed class Node
      * determination.
      */
     private void focusSetDirty(Scene s) {
-        if (s != null && this == s.getFocusOwner()) {
-            s.setFocusDirty(true);
+        if (s != null &&
+            (this == s.getFocusOwner() || isFocusTraversable())) {
+                s.setFocusDirty(true);
         }
     }
 

--- a/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
@@ -8550,7 +8550,6 @@ public abstract sealed class Node
                         if (get()) {
                             _scene.initializeInternalEventDispatcher();
                         }
-                        focusSetDirty(_scene);
                     }
                 }
 
@@ -8584,9 +8583,8 @@ public abstract sealed class Node
      * determination.
      */
     private void focusSetDirty(Scene s) {
-        if (s != null &&
-            (this == s.getFocusOwner() || isFocusTraversable())) {
-                s.setFocusDirty(true);
+        if (s != null && this == s.getFocusOwner()) {
+            s.setFocusDirty(true);
         }
     }
 

--- a/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
@@ -2408,21 +2408,6 @@ public class Scene implements EventTarget {
     }
 
     /**
-     * Returns true if this scene is quiescent, i.e. it has no activity
-     * pending on it such as CSS processing or layout requests.
-     *
-     * Intended to be used for tests only
-     *
-     * @return boolean indicating whether the scene is quiescent
-     */
-    boolean isQuiescent() {
-        final Parent r = getRoot();
-        return !isFocusDirty()
-               && (r == null || (r.cssFlag == CssFlags.CLEAN &&
-                r.layoutFlag == LayoutFlags.CLEAN));
-    }
-
-    /**
      * A listener for pulses, used for testing. If non-null, this is called at
      * the very end of ScenePulseListener.pulse().
      *


### PR DESCRIPTION
As also discussed back then in the mailing list, there are weird issues around gaining focus when a `Control` is not focus traversable but got a click event.

- Some Controls do not call `requestFocus()` when they are not focus traversable and receive a mouse click
- It is very inconsistent which Controls do it and which do not. Sometimes, just a part of a `Control` will request focus, while another one will not
- Manually calling `requestFocus()` always works

It seems like there is a misconception between beeing not focus traversable and not requesting focus. The focus traversable property should only affect keyboard navigation really. A mouse click should always request a focus.

Check the Ticket for a reproducer with all `Control`s and a short list which Controls do not behave (and which do).

This PR removes the pattern that was wrongly used in some `Control`s.
From:
```
    if (getNode().isFocusTraversable()) {
        getNode().requestFocus();
    }
```
To:
```
    getNode().requestFocus();
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8379942](https://bugs.openjdk.org/browse/JDK-8379942): Some non focus-traversable Controls do not request focus when clicking on it (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2106/head:pull/2106` \
`$ git checkout pull/2106`

Update a local copy of the PR: \
`$ git checkout pull/2106` \
`$ git pull https://git.openjdk.org/jfx.git pull/2106/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2106`

View PR using the GUI difftool: \
`$ git pr show -t 2106`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2106.diff">https://git.openjdk.org/jfx/pull/2106.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2106#issuecomment-4050575186)
</details>
