### PR TITLE
8380574: [TestBug] MouseEventFirer should not create a temporary Stage

### DIFF
--- a/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/infrastructure/MouseEventFirer.java
+++ b/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/infrastructure/MouseEventFirer.java
@@ -28,14 +28,10 @@ package test.com.sun.javafx.scene.control.infrastructure;
 import javafx.event.Event;
 import javafx.event.EventTarget;
 import javafx.event.EventType;
-import javafx.geometry.BoundingBox;
-import javafx.geometry.Bounds;
 import javafx.geometry.Point2D;
 import javafx.scene.Node;
-import javafx.scene.Scene;
 import javafx.scene.input.MouseButton;
 import javafx.scene.input.MouseEvent;
-import javafx.stage.Window;
 
 import java.util.Arrays;
 import java.util.List;
@@ -48,37 +44,11 @@ import java.util.List;
  * The default local coordinates are at the center of the target.
  */
 public final class MouseEventFirer {
-    private final EventTarget target;
 
-    private final Bounds targetBounds;
-    private StageLoader sl;
+    private final EventTarget target;
 
     public MouseEventFirer(EventTarget target) {
         this.target = target;
-
-        // Force the target node onto a stage so that it is accessible
-        if (target instanceof Node n) {
-            Scene s = n.getScene();
-            Window w = s == null ? null : s.getWindow();
-
-            if (w == null || w.getScene() == null) {
-                sl = new StageLoader(n);
-                targetBounds = n.getLayoutBounds();
-            } else {
-                targetBounds = n.getLayoutBounds();
-            }
-        } else if (target instanceof Scene scene) {
-            sl = new StageLoader(scene);
-            targetBounds = new BoundingBox(0, 0, scene.getWidth(), scene.getHeight());
-        } else {
-            throw new RuntimeException("EventTarget of invalid type (" + target + ")");
-        }
-    }
-
-    public void dispose() {
-        if (sl != null) {
-            sl.dispose();
-        }
     }
 
     public void fireMousePressAndRelease(KeyModifier... modifiers) {
@@ -160,15 +130,22 @@ public final class MouseEventFirer {
     }
 
     private void fireMouseEvent(EventType<MouseEvent> evtType, MouseButton button, int clickCount, double deltaX, double deltaY, KeyModifier... modifiers) {
+        if (!(target instanceof Node node)) {
+            throw new IllegalArgumentException("EventTarget: " + target + " must be a Node or needs special handling.");
+        }
+
+        if (node.getScene() == null || node.getScene().getWindow() == null) {
+            throw new IllegalArgumentException("Node: " + node + " must be in a Scene and Window " +
+                    "so that a correct MouseEvent can be fired.");
+        }
+
         // width / height of target node
-        final double w = targetBounds.getWidth();
-        final double h = targetBounds.getHeight();
+        final double w = node.getLayoutBounds().getWidth();
+        final double h = node.getLayoutBounds().getHeight();
 
         // x / y click position is centered
         final double x = w / 2.0 + deltaX;
         final double y = h / 2.0 + deltaY;
-
-        Node node = (Node) target;
 
         Point2D localP = new Point2D(x, y);
         Point2D sceneP = node.localToScene(localP);

--- a/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/infrastructure/MouseEventFirerTest.java
+++ b/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/infrastructure/MouseEventFirerTest.java
@@ -69,36 +69,42 @@ public class MouseEventFirerTest {
     @Test
     public void testLocalStandaloneDeltaNegative() {
         Button button = new Button("standalone button, a bit longish");
+        content.getChildren().setAll(button);
         assertLocal(button, - 10, - 5);
     }
 
     @Test
     public void testLocalStandaloneDelta() {
         Button button = new Button("standalone button, a bit longish");
+        content.getChildren().setAll(button);
         assertLocal(button, 10, 5);
     }
 
     @Test
     public void testLocalStandalone() {
         Button button = new Button("standalone button, a bit longish");
+        content.getChildren().setAll(button);
         assertLocal(button, 0, 0);
     }
 
     @Test
     public void testMouseCoordinatesStandaloneDeltaNegative() {
         Button button = new Button("standalone button, a bit longish");
+        content.getChildren().setAll(button);
         assertMouseCoordinatesDelta(button, - 10, - 5);
     }
 
     @Test
     public void testMouseCoordinatesStandaloneDelta() {
         Button button = new Button("standalone button, a bit longish");
+        content.getChildren().setAll(button);
         assertMouseCoordinatesDelta(button, 10, 5);
     }
 
     @Test
     public void testMouseCoordinatesStandalone() {
         Button button = new Button("standalone button, a bit longish");
+        content.getChildren().setAll(button);
         assertMouseCoordinatesDelta(button, 0, 0);
     }
 

--- a/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/infrastructure/VirtualFlowTestUtils.java
+++ b/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/infrastructure/VirtualFlowTestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -86,7 +86,6 @@ public class VirtualFlowTestUtils {
                 IndexedCell<?> childCell = (IndexedCell<?>)n;
                 MouseEventFirer mouse = new MouseEventFirer(childCell);
                 mouse.fireMousePressAndRelease(clickCount, modifiers);
-                mouse.dispose();
                 break;
             }
         } else {
@@ -96,11 +95,9 @@ public class VirtualFlowTestUtils {
                 MouseEventFirer mouse = new MouseEventFirer(cell);
                 mouse.fireMousePressed(cell.getWidth(), cell.getHeight() / 2.0, modifiers);
                 mouse.fireMouseReleased(cell.getWidth(), cell.getHeight() / 2.0, modifiers);
-                mouse.dispose();
             } else {
                 MouseEventFirer mouse = new MouseEventFirer(cell);
                 mouse.fireMousePressAndRelease(clickCount, modifiers);
-                mouse.dispose();
             }
         }
     }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ButtonTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ButtonTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -91,10 +91,6 @@ public class ButtonTest {
     @AfterEach
     public void after() {
         stage.hide();
-
-        if (mouse != null) {
-            mouse.dispose();
-        }
     }
 
     /*********************************************************************

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -2447,6 +2447,8 @@ public class ComboBoxTest {
                 comboBoxItemsList.setAll(strings1);
             }
         });
+
+        sl = new StageLoader(button);
 
         MouseEventFirer mouse = new MouseEventFirer(button);
         mouse.fireMousePressAndRelease();

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ControlUtils.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ControlUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -188,7 +188,6 @@ public class ControlUtils {
     public static void mouseClick(EventTarget target, KeyModifier... modifiers) {
         MouseEventFirer m = new MouseEventFirer(target);
         m.fireMousePressAndRelease(modifiers);
-        m.dispose();
 
         Toolkit.getToolkit().firePulse();
     }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewMouseInputTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewMouseInputTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import javafx.collections.FXCollections;
 import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
-import javafx.scene.Scene;
 import javafx.scene.control.Button;
 import javafx.scene.control.Cell;
 import javafx.scene.control.FocusModel;
@@ -535,7 +534,6 @@ public class TableViewMouseInputTest {
 
         MouseEventFirer mouse = new MouseEventFirer(row);
         mouse.fireMousePressAndRelease(1, 100, 10);
-        mouse.dispose();
     }
 
     @Test public void test_rt_37069() {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -2230,7 +2230,6 @@ public class TableViewTest {
         if (useMouseToInitiateEdit) {
             MouseEventFirer mouse = new MouseEventFirer(cell);
             mouse.fireMousePressAndRelease(2, 10, 10);  // click 10 pixels in and 10 pixels down
-            mouse.dispose();
         } else {
             table.edit(0,first);
         }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeAndTableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeAndTableViewTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -215,7 +215,6 @@ public class TreeAndTableViewTest {
         MouseEventFirer m = new MouseEventFirer(t);
         m.fireMousePressAndRelease(modifiers);
         m.fireMouseEvent(MouseEvent.MOUSE_RELEASED, modifiers);
-        m.dispose();
 
         Toolkit.getToolkit().firePulse();
     }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewMouseInputTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewMouseInputTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -532,7 +532,7 @@ public class TreeTableViewMouseInputTest {
         }
         tableView.setRoot(root);
 
-        StageLoader sl = new StageLoader(tableView);
+        stageLoader = new StageLoader(tableView);
 
         tableView.setShowRoot(true);
         final MultipleSelectionModel sm = tableView.getSelectionModel();
@@ -557,9 +557,6 @@ public class TreeTableViewMouseInputTest {
         mouse.fireMousePressAndRelease();
         assertTrue(root.isExpanded());
         assertEquals(9, tableView.getExpandedItemCount());
-
-        mouse.dispose();
-        sl.dispose();
     }
 
     private int rt_30626_count = 0;
@@ -686,7 +683,6 @@ public class TreeTableViewMouseInputTest {
 
         MouseEventFirer mouse = new MouseEventFirer(row);
         mouse.fireMousePressAndRelease(1, 100, 10);
-        mouse.dispose();
     }
 
     @Test public void test_rt_36509() {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -3316,7 +3316,6 @@ public class TreeTableViewTest {
         if (useMouseToInitiateEdit) {
             MouseEventFirer mouse = new MouseEventFirer(cell);
             mouse.fireMousePressAndRelease(2, 10, 10);  // click 10 pixels in and 10 pixels down
-            mouse.dispose();
         } else {
             table.edit(0,first);
         }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/cell/TextFieldTableCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/cell/TextFieldTableCellTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,19 +30,15 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import javafx.beans.property.ReadOnlyStringWrapper;
 import javafx.collections.FXCollections;
 import javafx.scene.control.TableCell;
 import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableView;
-import javafx.scene.control.TextField;
 import javafx.scene.control.cell.TextFieldTableCell;
-import javafx.scene.input.MouseButton;
 import javafx.util.Callback;
 import javafx.util.StringConverter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import test.com.sun.javafx.scene.control.infrastructure.MouseEventFirer;
 
 public class TextFieldTableCellTest {
 
@@ -370,44 +366,4 @@ public class TextFieldTableCellTest {
         assertNull(cell.getGraphic());
     }
 
-
-    /**************************************************************************
-     *
-     * Tests for specific bugs
-     *
-     **************************************************************************/
-
-    @Test public void test_rt_32869() {
-        TableColumn tc = new TableColumn();
-        tc.setCellValueFactory(param -> new ReadOnlyStringWrapper("Dummy Text"));
-
-        TableView tableView = new TableView(FXCollections.observableArrayList("TEST"));
-        tableView.getColumns().add(tc);
-        tableView.setEditable(true);
-        TextFieldTableCell<Object,Object> cell = new TextFieldTableCell<>();
-        cell.updateTableView(tableView);
-        cell.updateIndex(0);
-        cell.updateTableColumn(tc);
-        cell.setEditable(true);
-
-        tableView.edit(0, tc);
-        assertTrue(cell.isEditing());
-        assertNotNull(cell.getGraphic());
-
-        TextField textField = (TextField) cell.getGraphic();
-        MouseEventFirer mouse = new MouseEventFirer(textField);
-
-        textField.requestFocus();
-        textField.selectAll();
-        assertEquals("Dummy Text", textField.getSelectedText());
-
-        assertEquals("Dummy Text", textField.getSelectedText());
-
-        mouse.fireMousePressed(MouseButton.SECONDARY);
-        assertEquals("Dummy Text", textField.getSelectedText());
-        mouse.fireMouseReleased(MouseButton.SECONDARY);
-        assertEquals("Dummy Text", textField.getSelectedText());
-
-        mouse.dispose();
-    }
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/cell/TextFieldTableCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/cell/TextFieldTableCellTest.java
@@ -30,19 +30,29 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import javafx.beans.property.ReadOnlyStringWrapper;
 import javafx.collections.FXCollections;
+import javafx.scene.control.IndexedCell;
 import javafx.scene.control.TableCell;
 import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableView;
+import javafx.scene.control.TextField;
 import javafx.scene.control.cell.TextFieldTableCell;
+import javafx.scene.input.MouseButton;
 import javafx.util.Callback;
 import javafx.util.StringConverter;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import test.com.sun.javafx.scene.control.infrastructure.MouseEventFirer;
+import test.com.sun.javafx.scene.control.infrastructure.StageLoader;
+import test.com.sun.javafx.scene.control.infrastructure.VirtualFlowTestUtils;
 
 public class TextFieldTableCellTest {
 
     private StringConverter<Object> converter;
+    private StageLoader stageLoader;
 
     @BeforeEach
     public void setup() {
@@ -55,6 +65,13 @@ public class TextFieldTableCellTest {
                 return null;
             }
         };
+    }
+
+    @AfterEach
+    public void afterEach() {
+        if (stageLoader != null) {
+            stageLoader.dispose();
+        }
     }
 
     /**************************************************************************
@@ -364,6 +381,39 @@ public class TextFieldTableCellTest {
         tableView.edit(-1, null);
         assertFalse(cell.isEditing());
         assertNull(cell.getGraphic());
+    }
+
+    @Test public void testJDK8119995() {
+        String text = "Dummy Text";
+
+        TableColumn<String, String> tc = new TableColumn<>();
+        tc.setCellValueFactory(_ -> new ReadOnlyStringWrapper(text));
+        tc.setCellFactory(TextFieldTableCell.forTableColumn());
+
+        TableView<String> tableView = new TableView<>(FXCollections.observableArrayList("TEST"));
+        tableView.getColumns().add(tc);
+        tableView.setEditable(true);
+
+        stageLoader = new StageLoader(tableView);
+
+        tableView.edit(0, tc);
+
+        IndexedCell<String> cell = VirtualFlowTestUtils.getCell(tableView, 0, 0);
+
+        assertTrue(cell.isEditing());
+        assertNotNull(cell.getGraphic());
+
+        TextField textField = (TextField) cell.getGraphic();
+
+        textField.requestFocus();
+        textField.selectAll();
+        assertEquals(text, textField.getSelectedText());
+
+        MouseEventFirer mouse = new MouseEventFirer(textField);
+        mouse.fireMousePressed(MouseButton.SECONDARY);
+        assertEquals(text, textField.getSelectedText());
+        mouse.fireMouseReleased(MouseButton.SECONDARY);
+        assertEquals(text, textField.getSelectedText());
     }
 
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/cell/TextFieldTableCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/cell/TextFieldTableCellTest.java
@@ -415,5 +415,4 @@ public class TextFieldTableCellTest {
         mouse.fireMouseReleased(MouseButton.SECONDARY);
         assertEquals(text, textField.getSelectedText());
     }
-
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/ColorPickerSkinTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/ColorPickerSkinTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -106,7 +106,6 @@ public class ColorPickerSkinTest {
         Hyperlink hyperlink = ColorPickerPaletteShim.ColorPallette_getCustomColorLink(colorPicker);
         MouseEventFirer mouse = new MouseEventFirer(hyperlink);
         mouse.fireMousePressAndRelease();
-        mouse.dispose();
 
         Stage dialog = ColorPickerPaletteShim.ColorPallette_getCustomColorDialog(colorPicker);
         assertNotNull(dialog);


### PR DESCRIPTION
Very similar to https://github.com/openjdk/jfx/pull/1829, this PR removes the questionable behavior that the `MouseEventFirer` may create a temporary `Stage` for your `Node`.

Take the following test code:
```
Button button = new Button("Button");
MouseEventFirer mouse = new MouseEventFirer(button);
mouse.fireMousePressAndRelease();
mouse.fireMousePressAndRelease();
mouse.dispose()
```
What it does is to create a `Stage` in the first method. The second method does not. This is not immediately clear.
That is also the reason why the dispose method exists. To MAY clean it up. Or forget to call it.

This does not test a realistic scenario and the chance is quite high that developers used that methods without even knowing that it contains such logic.

So the idea is to remove the StageLoader code from MouseEventFirer and rather use it in the Test code before calling the Util methods.

For the example above, this would result in:
```
Button button = new Button("Button");
stageLoader = new StageLoader(button );
MouseEventFirer mouse = new MouseEventFirer(button);
mouse.fireMousePressAndRelease();
mouse.fireMousePressAndRelease();
```

There were only two real tests that did not have a `Stage` yet. So most of the tests already had a good setup and the questionable code did not run mostly.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issues
 * [JDK-8380574](https://bugs.openjdk.org/browse/JDK-8380574): [TestBug] MouseEventFirer should not create a temporary Stage (**Enhancement** - P4)
 * [JDK-8293356](https://bugs.openjdk.org/browse/JDK-8293356): Testbug: broken usage of MouseEventFirer/VirtualFlowTestUtils (**Bug** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Lukasz Kostyra](https://openjdk.org/census#lkostyra) (@lukostyra - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2124/head:pull/2124` \
`$ git checkout pull/2124`

Update a local copy of the PR: \
`$ git checkout pull/2124` \
`$ git pull https://git.openjdk.org/jfx.git pull/2124/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2124`

View PR using the GUI difftool: \
`$ git pr show -t 2124`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2124.diff">https://git.openjdk.org/jfx/pull/2124.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2124#issuecomment-4104824015)
</details>
