### PR TITLE
8380926: HeavyweightDialog does not check for a valid stage

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/HeavyweightDialog.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/HeavyweightDialog.java
@@ -315,7 +315,7 @@ class HeavyweightDialog extends FXDialog {
             stage.renderScaleYProperty().unbind();
 
             Scene oldScene = oldStage.getScene();
-            if (oldScene != null && scene != null && dialogScene != null) {
+            if (oldScene != null && dialogScene != null) {
                 Bindings.unbindContent(dialogScene.getStylesheets(), oldScene.getStylesheets());
             }
         }
@@ -327,7 +327,7 @@ class HeavyweightDialog extends FXDialog {
             stage.renderScaleYProperty().bind(newStage.renderScaleYProperty());
 
             Scene newScene = newStage.getScene();
-            if (newScene != null && scene != null && dialogScene != null) {
+            if (newScene != null && dialogScene != null) {
                 Bindings.bindContent(dialogScene.getStylesheets(), newScene.getStylesheets());
             }
         }

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/HeavyweightDialog.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/HeavyweightDialog.java
@@ -52,7 +52,7 @@ class HeavyweightDialog extends FXDialog {
     final Stage stage = new Stage() {
         @Override public void centerOnScreen() {
             Window owner = HeavyweightDialog.this.getOwner();
-            if (owner != null) {
+            if (owner != null && owner.getScene() != null && owner.isShowing() && (!(owner instanceof Stage ownerStage) || !ownerStage.isIconified())) {
                 positionStage();
             } else {
                 if (getWidth() > 0 && getHeight() > 0) {
@@ -309,27 +309,25 @@ class HeavyweightDialog extends FXDialog {
     private void updateStageBindings(Window oldOwner, Window newOwner) {
         final Scene dialogScene = stage.getScene();
 
-        if (oldOwner != null && oldOwner instanceof Stage) {
-            Stage oldStage = (Stage) oldOwner;
+        if (oldOwner instanceof Stage oldStage) {
             Bindings.unbindContent(stage.getIcons(), oldStage.getIcons());
             stage.renderScaleXProperty().unbind();
             stage.renderScaleYProperty().unbind();
 
             Scene oldScene = oldStage.getScene();
-            if (scene != null && dialogScene != null) {
+            if (oldScene != null && scene != null && dialogScene != null) {
                 Bindings.unbindContent(dialogScene.getStylesheets(), oldScene.getStylesheets());
             }
         }
 
         // put the icons and stylesheets of the owner window into the dialog
-        if (newOwner instanceof Stage) {
-            Stage newStage = (Stage) newOwner;
+        if (newOwner instanceof Stage newStage) {
             Bindings.bindContent(stage.getIcons(), newStage.getIcons());
             stage.renderScaleXProperty().bind(newStage.renderScaleXProperty());
             stage.renderScaleYProperty().bind(newStage.renderScaleYProperty());
 
             Scene newScene = newStage.getScene();
-            if (scene != null && dialogScene != null) {
+            if (newScene != null && scene != null && dialogScene != null) {
                 Bindings.bindContent(dialogScene.getStylesheets(), newScene.getStylesheets());
             }
         }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/AlertTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/AlertTest.java
@@ -30,11 +30,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import java.util.Locale;
 import javafx.application.Platform;
+import javafx.scene.Scene;
 import javafx.scene.control.Alert;
 import javafx.scene.control.ButtonType;
 import javafx.scene.control.Dialog;
 import javafx.scene.control.DialogShim;
 import javafx.scene.control.HeavyweightDialogShim;
+import javafx.scene.layout.Region;
 import javafx.stage.Stage;
 import javafx.stage.WindowEvent;
 import org.junit.jupiter.api.AfterEach;
@@ -334,5 +336,39 @@ public class AlertTest {
         dialog.initOwner(new Stage());
         assertResultValue(ButtonType.CANCEL, dialog, true);
         assertCloseRequestAccepted(dialog, true);
+    }
+
+    @Test public void alert_owner_iconifiedCentering() {
+        dialog = new Alert(Alert.AlertType.NONE, "Hello World!");
+        dialog.getDialogPane().getButtonTypes().addAll(ButtonType.APPLY, ButtonType.CANCEL);
+        Stage owner = new Stage();
+        owner.setScene(new Scene(new Region()));
+        owner.setIconified(true);
+        owner.show();
+        dialog.initOwner(owner);
+        dialog.setWidth(960);
+        dialog.setHeight(500);
+        dialog.show();
+        var x = dialog.getX();
+        var y = dialog.getY();
+        dialog.hide();
+        assertEquals(480.0, x);
+        assertEquals(224.0, y);
+    }
+
+    @Test public void alert_owner_hiddenCentering() {
+        dialog = new Alert(Alert.AlertType.NONE, "Hello World!");
+        dialog.getDialogPane().getButtonTypes().addAll(ButtonType.APPLY, ButtonType.CANCEL);
+        Stage owner = new Stage();
+        owner.setScene(new Scene(new Region()));
+        dialog.initOwner(owner);
+        dialog.setWidth(960);
+        dialog.setHeight(500);
+        dialog.show();
+        var x = dialog.getX();
+        var y = dialog.getY();
+        dialog.hide();
+        assertEquals(480.0, x);
+        assertEquals(224.0, y);
     }
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/AlertTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/AlertTest.java
@@ -327,4 +327,12 @@ public class AlertTest {
         assertEquals("Cancel", englishStr);
         assertEquals("Avbryt", swedishStr);
     }
+
+    @Test public void alert_owner_noScene() {
+        dialog = new Alert(Alert.AlertType.NONE, "Hello World!");
+        dialog.getDialogPane().getButtonTypes().addAll(ButtonType.APPLY, ButtonType.CANCEL);
+        dialog.initOwner(new Stage());
+        assertResultValue(ButtonType.CANCEL, dialog, true);
+        assertCloseRequestAccepted(dialog, true);
+    }
 }


### PR DESCRIPTION
This fixes issues with Alerts when the owner stage is not a valid stage with a scene and currently showing

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8380926](https://bugs.openjdk.org/browse/JDK-8380926): HeavyweightDialog does not check for a valid stage (**Bug** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Marius Hanl](https://openjdk.org/census#mhanl) (@Maran23 - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2127/head:pull/2127` \
`$ git checkout pull/2127`

Update a local copy of the PR: \
`$ git checkout pull/2127` \
`$ git pull https://git.openjdk.org/jfx.git pull/2127/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2127`

View PR using the GUI difftool: \
`$ git pr show -t 2127`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2127.diff">https://git.openjdk.org/jfx/pull/2127.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2127#issuecomment-4127787679)
</details>
