### PR TITLE
8380935: TextFieldSkin caret width calculation is broken

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TextFieldSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TextFieldSkin.java
@@ -252,11 +252,14 @@ public class TextFieldSkin extends TextInputControlSkin<TextField> {
                  * caret position is not updated.
                  * The caret pos is invalid in this case,
                  * hence it should be updated when caret path size is not 4 */
+
+                if (caretPath.getElements().size() != 0) {
+                    caretWidth = Math.round(caretPath.getLayoutBounds().getWidth());
+                }
+
                 updateTextNodeCaretPos(control.getCaretPosition());
             } else if (caretPath.getElements().size() == 4) {
                 // The caret is split. Ignore and keep the previous width value.
-            } else {
-                caretWidth = Math.round(caretPath.getLayoutBounds().getWidth());
             }
         });
 

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TextFieldSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TextFieldSkin.java
@@ -247,19 +247,21 @@ public class TextFieldSkin extends TextInputControlSkin<TextField> {
         caretPath.layoutXProperty().bind(textTranslateX);
         textNode.caretShapeProperty().addListener(observable -> {
             caretPath.getElements().setAll(textNode.caretShapeProperty().get());
-            if (caretPath.getElements().size() != 4) {
-                /* On replacing same text using keyboard shortcut,
-                 * caret position is not updated.
-                 * The caret pos is invalid in this case,
-                 * hence it should be updated when caret path size is not 4 */
 
-                if (caretPath.getElements().size() != 0) {
+            /* On replacing same text using keyboard shortcut,
+             * caret position is not updated.
+             * The caret pos is invalid in this case,
+             * hence it should be updated when caret path size is not 4 */
+            boolean hasSplitCaret = caretPath.getElements().size() == 4;
+
+            // If the caret is split, ignore and keep the previous width value.
+            if (!hasSplitCaret) {
+                boolean hasCaret = caretPath.getElements().size() > 0;
+                if (hasCaret) {
                     caretWidth = Math.round(caretPath.getLayoutBounds().getWidth());
                 }
 
                 updateTextNodeCaretPos(control.getCaretPosition());
-            } else if (caretPath.getElements().size() == 4) {
-                // The caret is split. Ignore and keep the previous width value.
             }
         });
 

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TextFieldTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TextFieldTest.java
@@ -623,11 +623,11 @@ public class TextFieldTest {
         stage.show();
 
         assertTrue(txtField.getWidth() > TextInputSkinShim.getTextNode(txtField).getLayoutBounds().getWidth());
-        assertEquals(TextInputSkinShim.getTextTranslateX(txtField), 1, 0.0);
+        assertEquals(1, TextInputSkinShim.getTextTranslateX(txtField), 0.0);
 
         txtField.setText("This is a long text. this is  long text.");
         assertTrue(txtField.getWidth() < TextInputSkinShim.getTextNode(txtField).getLayoutBounds().getWidth());
-        assertEquals(0, TextInputSkinShim.getTextTranslateX(txtField), 0.0);
+        assertEquals(1, TextInputSkinShim.getTextTranslateX(txtField), 0.0);
     }
 
     @Test

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TextFieldTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TextFieldTest.java
@@ -623,7 +623,7 @@ public class TextFieldTest {
         stage.show();
 
         assertTrue(txtField.getWidth() > TextInputSkinShim.getTextNode(txtField).getLayoutBounds().getWidth());
-        assertEquals(TextInputSkinShim.getTextTranslateX(txtField), 0, 0.0);
+        assertEquals(TextInputSkinShim.getTextTranslateX(txtField), 1, 0.0);
 
         txtField.setText("This is a long text. this is  long text.");
         assertTrue(txtField.getWidth() < TextInputSkinShim.getTextNode(txtField).getLayoutBounds().getWidth());
@@ -646,7 +646,7 @@ public class TextFieldTest {
 
         txtField.setText("This is a long text. this is  long text.");
         assertTrue(txtField.getWidth() < TextInputSkinShim.getTextNode(txtField).getLayoutBounds().getWidth());
-        assertEquals(0, TextInputSkinShim.getTextTranslateX(txtField), 0.0);
+        assertEquals(1, TextInputSkinShim.getTextTranslateX(txtField), 0.0);
     }
 
     @Test
@@ -665,7 +665,7 @@ public class TextFieldTest {
 
         txtField.setText("This is a long text. this is  long text.");
         assertTrue(txtField.getWidth() < TextInputSkinShim.getTextNode(txtField).getLayoutBounds().getWidth());
-        assertEquals(0, TextInputSkinShim.getTextTranslateX(txtField), 0.0);
+        assertEquals(1, TextInputSkinShim.getTextTranslateX(txtField), 0.0);
     }
 
     @Test public void stripInvalidCharacters() {


### PR DESCRIPTION
This fixes a regression caused by the fix for https://bugs.openjdk.org/browse/JDK-8282290. The old if else block was broken by the other PR, which caused the calculation for the caret width to be never run.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8380935](https://bugs.openjdk.org/browse/JDK-8380935): TextFieldSkin caret width calculation is broken (**Bug** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Marius Hanl](https://openjdk.org/census#mhanl) (@Maran23 - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2128/head:pull/2128` \
`$ git checkout pull/2128`

Update a local copy of the PR: \
`$ git checkout pull/2128` \
`$ git pull https://git.openjdk.org/jfx.git pull/2128/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2128`

View PR using the GUI difftool: \
`$ git pr show -t 2128`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2128.diff">https://git.openjdk.org/jfx/pull/2128.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2128#issuecomment-4128632039)
</details>
