### PR TITLE
8343133: Create implementation of NSAccessibilityNavigableStaticText protocol

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacAccessible.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacAccessible.java
@@ -1568,6 +1568,12 @@ final class MacAccessible extends Accessible {
                     result = getAttribute(SELECTION_END);
                     if (result == null) return null;
                     end = (Integer)result;
+                } else {
+                    Integer caret = (Integer)getAttribute(CARET_OFFSET);
+                    if (caret != null && caret >= 0) {
+                        start = caret;
+                        end = caret;
+                    }
                 }
                 if (start < 0 || end < 0 || start > end) return null;
                 String string = (String)getAttribute(TEXT);

--- a/modules/javafx.graphics/src/main/native-glass/mac/a11y/AccessibleBase.h
+++ b/modules/javafx.graphics/src/main/native-glass/mac/a11y/AccessibleBase.h
@@ -40,6 +40,8 @@ id jRole;
 - (NSString *)getJavaRole;
 - (id)requestNodeAttribute:(NSString *)attribute;
 - (id)requestNodeAttribute:(NSString *)attribute forParameter:(id)parameter;
+- (void)setNodeAttribute:(id)value forAttribute:(NSString *)attribute;
+- (NSString *)accessibilityPlaceholderValue;
 - (NSRect)accessibilityFrame;
 - (id)accessibilityParent;
 - (BOOL)isAccessibilityElement;

--- a/modules/javafx.graphics/src/main/native-glass/mac/a11y/AccessibleBase.h
+++ b/modules/javafx.graphics/src/main/native-glass/mac/a11y/AccessibleBase.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,6 +40,7 @@ id jRole;
 - (NSString *)getJavaRole;
 - (id)requestNodeAttribute:(NSString *)attribute;
 - (id)requestNodeAttribute:(NSString *)attribute forParameter:(id)parameter;
+- (BOOL)isNodeAttributeSettable:(NSString *)attribute;
 - (void)setNodeAttribute:(id)value forAttribute:(NSString *)attribute;
 - (NSString *)accessibilityPlaceholderValue;
 - (NSRect)accessibilityFrame;

--- a/modules/javafx.graphics/src/main/native-glass/mac/a11y/AccessibleBase.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/a11y/AccessibleBase.m
@@ -40,7 +40,7 @@ static NSMutableDictionary * rolesMap;
      * All JavaFX roles and corresponding available properties are defined in
      * enum javafx.scene.AccessibleRole
      */
-    rolesMap = [[NSMutableDictionary alloc] initWithCapacity:23];
+    rolesMap = [[NSMutableDictionary alloc] initWithCapacity:25];
 
     [rolesMap setObject:@"JFXButtonAccessibility" forKey:@"BUTTON"];
     [rolesMap setObject:@"JFXCheckboxAccessibility" forKey:@"CHECK_BOX"];
@@ -64,6 +64,8 @@ static NSMutableDictionary * rolesMap;
     [rolesMap setObject:@"JFXRadiobuttonAccessibility" forKey:@"TAB_ITEM"];
     [rolesMap setObject:@"JFXTabGroupAccessibility" forKey:@"TAB_PANE"];
     [rolesMap setObject:@"JFXStaticTextAccessibility" forKey:@"TEXT"];
+    [rolesMap setObject:@"JFXNavigableTextAccessibility" forKey:@"TEXT_AREA"];
+    [rolesMap setObject:@"JFXNavigableTextAccessibility" forKey:@"TEXT_FIELD"];
     [rolesMap setObject:@"JFXCheckboxAccessibility" forKey:@"TOGGLE_BUTTON"];
 
 }
@@ -107,6 +109,16 @@ static NSMutableDictionary * rolesMap;
     return self->jAccessible;
 }
 
+- (NSString *)getJavaRole
+{
+    return self->jRole;
+}
+
+- (void)setJavaRole:(NSString *)newRole
+{
+    self->jRole = [newRole copy];
+}
+
 /*
  * Request accessibility attribute by name from JavaFX Node. Returns attribute value
  * converted to the native format or NULL if attribute with that name does not exist.
@@ -118,6 +130,23 @@ static NSMutableDictionary * rolesMap;
     if (env == NULL) return NULL;
     jobject jresult = (jobject)(*env)->CallLongMethod(env, [self getJAccessible],
                                               jAccessibilityAttributeValue, (jlong)attribute);
+    GLASS_CHECK_EXCEPTION(env);
+    return variantToID(env, jresult);
+}
+
+/*
+ * Request accessibility attribute by name from JavaFX Node providing a specified parameter.
+ * Returns attribute value converted to the native format or NULL if attribute with that name does not exist.
+ * Code that uses this function needs to convert NULL to the default value of a certain type where required.
+ */
+
+- (id)requestNodeAttribute:(NSString *)attribute forParameter:(id)parameter
+{
+    GET_MAIN_JENV;
+    if (env == NULL) return NULL;
+    jobject jresult = (jobject)(*env)->CallLongMethod(env, [self getJAccessible],
+                                              jAccessibilityAttributeValueForParameter,
+                                              (jlong)attribute, (jlong)parameter);
     GLASS_CHECK_EXCEPTION(env);
     return variantToID(env, jresult);
 }
@@ -247,6 +276,9 @@ JNIEXPORT jlong JNICALL Java_com_sun_glass_ui_mac_MacAccessible__1createAccessib
     Class classType = [AccessibleBase getComponentAccessibilityClass:roleName];
     NSObject* accessible = NULL;
     accessible = [[classType alloc] initWithEnv: env accessible: jAccessible];
+    if ([accessible isKindOfClass:[AccessibleBase class]]) {
+        [(AccessibleBase *) accessible setJavaRole:roleName];
+    }
     return ptr_to_jlong(accessible);
 }
 

--- a/modules/javafx.graphics/src/main/native-glass/mac/a11y/AccessibleBase.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/a11y/AccessibleBase.m
@@ -152,6 +152,20 @@ static NSMutableDictionary * rolesMap;
 }
 
 /*
+ * Check whether an accessibility attribute on the JavaFX Node can be set.
+ */
+- (BOOL)isNodeAttributeSettable:(NSString *)attribute
+{
+    GET_MAIN_JENV;
+    if (env == NULL) return FALSE;
+    jboolean jresult = (*env)->CallBooleanMethod(env, [self getJAccessible],
+                                                 jAccessibilityIsAttributeSettable,
+                                                 (jlong)attribute);
+    GLASS_CHECK_EXCEPTION(env);
+    return jresult;
+}
+
+/*
  * Set accessibility attribute by name on the JavaFX Node.
  */
 - (void)setNodeAttribute:(id)value forAttribute:(NSString *)attribute

--- a/modules/javafx.graphics/src/main/native-glass/mac/a11y/AccessibleBase.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/a11y/AccessibleBase.m
@@ -151,6 +151,18 @@ static NSMutableDictionary * rolesMap;
     return variantToID(env, jresult);
 }
 
+/*
+ * Set accessibility attribute by name on the JavaFX Node.
+ */
+- (void)setNodeAttribute:(id)value forAttribute:(NSString *)attribute
+{
+    GET_MAIN_JENV;
+    if (env == NULL) return;
+    (*env)->CallVoidMethod(env, [self getJAccessible], jAccessibilitySetValue,
+                           (jlong)value, (jlong)attribute);
+    GLASS_CHECK_EXCEPTION(env);
+}
+
 - (id)accessibilityValue
 {
     return [self requestNodeAttribute:@"AXValue"];
@@ -189,6 +201,11 @@ static NSMutableDictionary * rolesMap;
 - (id)accessibilityTitleUIElement
 {
     return [self requestNodeAttribute:@"AXTitleUIElement"];
+}
+
+- (NSString *)accessibilityPlaceholderValue
+{
+    return [self requestNodeAttribute:@"AXPlaceholderValue"];
 }
 
 - (NSArray *)accessibilityChildren
@@ -254,12 +271,7 @@ static NSMutableDictionary * rolesMap;
 
 - (void)setAccessibilityFocused:(BOOL)value
 {
-    GET_MAIN_JENV;
-    if (env == NULL) return;
-    (*env)->CallVoidMethod(env, self->jAccessible, jAccessibilitySetValue,
-                           (jlong)[NSNumber numberWithBool:value],
-                           (jlong)@"AXFocused");
-    GLASS_CHECK_EXCEPTION(env);
+    [self setNodeAttribute:[NSNumber numberWithBool:value] forAttribute:@"AXFocused"];
 }
 
 @end

--- a/modules/javafx.graphics/src/main/native-glass/mac/a11y/JFXNavigableTextAccessibility.h
+++ b/modules/javafx.graphics/src/main/native-glass/mac/a11y/JFXNavigableTextAccessibility.h
@@ -46,4 +46,5 @@
 - (NSRange)accessibilityVisibleCharacterRange;
 - (NSAttributedString *) accessibilityAttributedStringForRange:(NSRange)range;
 - (NSInteger)accessibilityNumberOfCharacters;
+- (BOOL)accessibilityIsAttributeSettable:(NSString *)attribute;
 @end

--- a/modules/javafx.graphics/src/main/native-glass/mac/a11y/JFXNavigableTextAccessibility.h
+++ b/modules/javafx.graphics/src/main/native-glass/mac/a11y/JFXNavigableTextAccessibility.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,28 +23,21 @@
  * questions.
  */
 
-#import <Cocoa/Cocoa.h>
-#import <jni.h>
+#import "AccessibleBase.h"
+#import <AppKit/NSAccessibility.h>
 
-#define INCREMENT @"AXIncrement"
-#define DECREMENT @"AXDecrement"
+@interface JFXNavigableTextAccessibility : AccessibleBase<NSAccessibilityNavigableStaticText> {
 
-@interface AccessibleBase : NSAccessibilityElement {
-@private
-jobject jAccessible;
-id parent;
-id jRole;
-}
-- (id)initWithEnv:(JNIEnv*)env accessible:(jobject)jAccessible;
-- (jobject)getJAccessible;
-- (NSString *)getJavaRole;
-- (id)requestNodeAttribute:(NSString *)attribute;
-- (id)requestNodeAttribute:(NSString *)attribute forParameter:(id)parameter;
-- (NSRect)accessibilityFrame;
-- (id)accessibilityParent;
-- (BOOL)isAccessibilityElement;
-- (BOOL)performAccessibleAction:(NSString*)actionId;
-+ (void) initializeRolesMap;
+};
+- (NSAccessibilityRole)accessibilityRole;
+- (NSAccessibilitySubrole)accessibilitySubrole;
+- (BOOL)isAccessibilityEnabled;
+- (BOOL)isAccessibilityEdited;
+- (NSArray *)accessibilityChildren;
+- (NSString *)accessibilityValue;
+- (NSRange)accessibilitySelectedTextRange;
+- (NSString *)accessibilitySelectedText;
+- (NSRange)accessibilityVisibleCharacterRange;
+- (NSAttributedString *) accessibilityAttributedStringForRange:(NSRange)range;
+- (NSInteger)accessibilityNumberOfCharacters;
 @end
-
-jmethodID jAccessibilityAttributeNames;

--- a/modules/javafx.graphics/src/main/native-glass/mac/a11y/JFXNavigableTextAccessibility.h
+++ b/modules/javafx.graphics/src/main/native-glass/mac/a11y/JFXNavigableTextAccessibility.h
@@ -23,10 +23,10 @@
  * questions.
  */
 
-#import "AccessibleBase.h"
+#import "JFXStaticTextAccessibility.h"
 #import <AppKit/NSAccessibility.h>
 
-@interface JFXNavigableTextAccessibility : AccessibleBase<NSAccessibilityNavigableStaticText> {
+@interface JFXNavigableTextAccessibility : JFXStaticTextAccessibility<NSAccessibilityNavigableStaticText> {
 
 };
 - (NSAccessibilityRole)accessibilityRole;
@@ -34,9 +34,15 @@
 - (BOOL)isAccessibilityEnabled;
 - (BOOL)isAccessibilityEdited;
 - (NSArray *)accessibilityChildren;
-- (NSString *)accessibilityValue;
+- (NSInteger)accessibilityInsertionPointLineNumber;
+- (NSRange)accessibilityRangeForPosition:(NSPoint)point;
+- (NSRange)accessibilityRangeForIndex:(NSInteger)index;
 - (NSRange)accessibilitySelectedTextRange;
+- (void)setAccessibilitySelectedTextRanges:(NSArray<NSValue *> *)ranges;
+- (void)setAccessibilityValue:(NSString *)value;
+- (void)setAccessibilitySelectedText:(NSString *)selectedText;
 - (NSString *)accessibilitySelectedText;
+- (NSRange)accessibilitySharedCharacterRange;
 - (NSRange)accessibilityVisibleCharacterRange;
 - (NSAttributedString *) accessibilityAttributedStringForRange:(NSRange)range;
 - (NSInteger)accessibilityNumberOfCharacters;

--- a/modules/javafx.graphics/src/main/native-glass/mac/a11y/JFXNavigableTextAccessibility.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/a11y/JFXNavigableTextAccessibility.m
@@ -25,6 +25,20 @@
 
 #import "JFXNavigableTextAccessibility.h"
 
+static NSRange composedCharacterRangeForIndex(NSString *value, NSInteger index)
+{
+    if (value == nil) {
+        return NSMakeRange(NSNotFound, 0);
+    }
+
+    NSUInteger length = [value length];
+    if (index < 0 || (NSUInteger)index >= length) {
+        return NSMakeRange(NSNotFound, 0);
+    }
+
+    return [value rangeOfComposedCharacterSequenceAtIndex:(NSUInteger)index];
+}
+
 @implementation JFXNavigableTextAccessibility
 - (NSAccessibilityRole)accessibilityRole
 {
@@ -43,11 +57,6 @@
     return NSAccessibilitySecureTextFieldSubrole;
 }
 
-- (id)accessibilityParent
-{
-    return [super accessibilityParent];
-}
-
 - (BOOL)isAccessibilityEnabled
 {
     return TRUE;
@@ -62,14 +71,27 @@
     return [super accessibilityChildren];
 }
 
-- (NSRect)accessibilityFrame
+- (NSInteger)accessibilityInsertionPointLineNumber
 {
-    return [super accessibilityFrame];
+    id retVal = [self requestNodeAttribute:@"AXInsertionPointLineNumber"];
+    NSInteger lineNumber = retVal != nil ? [retVal integerValue] : 0;
+    return lineNumber;
 }
 
-- (NSString *)accessibilityValue
+- (NSRange)accessibilityRangeForPosition:(NSPoint)point
 {
-    return [super accessibilityValue];
+    id parameter = [NSValue valueWithPoint:point];
+    NSRange retVal = [[self requestNodeAttribute:@"AXRangeForPosition" forParameter:parameter] rangeValue];
+    if (retVal.location == NSNotFound) {
+        return retVal;
+    }
+
+    return composedCharacterRangeForIndex([self accessibilityValue], retVal.location);
+}
+
+- (NSRange)accessibilityRangeForIndex:(NSInteger)index
+{
+    return composedCharacterRangeForIndex([self accessibilityValue], index);
 }
 
 - (nullable NSString *)accessibilityStringForRange:(NSRange)range
@@ -113,18 +135,53 @@
 }
 
 - (void)setAccessibilitySelectedTextRange:(NSRange)range {
-// We do not need to do anything here. We just have to have it overridden.
+    [self setNodeAttribute:[NSValue valueWithRange:range]
+              forAttribute:@"AXSelectedTextRange"];
 }
 
 - (id)accessibilitySelectedTextRanges
 {
-    return nil; //For now. Once we have multiselection text area we might revisit it.
+    id retVal = [self requestNodeAttribute:@"AXSelectedTextRange"];
+    if (retVal == nil) {
+        return nil;
+    }
+
+    NSRange range = [retVal rangeValue];
+    if (range.location == NSNotFound) {
+        return @[];;
+    }
+
+    NSArray *ranges = @[[NSValue valueWithRange:range]];
+    return ranges;
+}
+
+- (void)setAccessibilitySelectedTextRanges:(NSArray<NSValue *> *)ranges
+{
+    [self setNodeAttribute:ranges forAttribute:@"AXSelectedTextRanges"];
+}
+
+- (void)setAccessibilityValue:(NSString *)value
+{
+    [self setNodeAttribute:value forAttribute:@"AXValue"];
+}
+
+- (void)setAccessibilitySelectedText:(NSString *)selectedText
+{
+    [self setNodeAttribute:selectedText forAttribute:@"AXSelectedText"];
 }
 
 - (NSString *)accessibilitySelectedText
 {
     id parameter = [NSValue valueWithRange:[self accessibilitySelectedTextRange]];
     NSString * retVal = (NSString *)[self requestNodeAttribute:@"AXStringForRange" forParameter:parameter];
+    return retVal;
+}
+
+- (NSRange)accessibilitySharedCharacterRange
+{
+    // JavaFX text controls expose a single text container, so the shared-text
+    // range is the full document range for this accessible element.
+    NSRange retVal = NSMakeRange(0, [self accessibilityNumberOfCharacters]);
     return retVal;
 }
 

--- a/modules/javafx.graphics/src/main/native-glass/mac/a11y/JFXNavigableTextAccessibility.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/a11y/JFXNavigableTextAccessibility.m
@@ -62,8 +62,10 @@ static NSRange composedCharacterRangeForIndex(NSString *value, NSInteger index)
     return TRUE;
 }
 
-- (BOOL)isAccessibilityEdited {
-    return TRUE;
+- (BOOL)isAccessibilityEdited
+{
+    id value = [self requestNodeAttribute:@"AXEdited"];
+    return value != nil ? [value boolValue] : NO;
 }
 
 - (NSArray *)accessibilityChildren
@@ -197,6 +199,25 @@ static NSRange composedCharacterRangeForIndex(NSString *value, NSInteger index)
     NSAttributedString * retVal = (NSAttributedString *)
             [self requestNodeAttribute:@"AXAttributedStringForRange" forParameter:parameter];
     return retVal;
+}
+
+- (BOOL)isAccessibilitySelectorAllowed:(SEL)selector
+{
+    if (selector == @selector(setAccessibilityValue:)) {
+        return [self isNodeAttributeSettable:@"AXValue"];
+    }
+    if (selector == @selector(setAccessibilitySelectedTextRange:)) {
+        return [self isNodeAttributeSettable:@"AXSelectedTextRange"];
+    }
+    if (selector == @selector(setAccessibilitySelectedTextRanges:)) {
+        return [self isNodeAttributeSettable:@"AXSelectedTextRanges"];
+    }
+    return [super isAccessibilitySelectorAllowed:selector];
+}
+
+- (BOOL)accessibilityIsAttributeSettable:(NSString *)attribute
+{
+    return [self isNodeAttributeSettable:attribute];
 }
 
 @end

--- a/modules/javafx.graphics/src/main/native-glass/mac/a11y/JFXNavigableTextAccessibility.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/a11y/JFXNavigableTextAccessibility.m
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#import "JFXNavigableTextAccessibility.h"
+
+@implementation JFXNavigableTextAccessibility
+- (NSAccessibilityRole)accessibilityRole
+{
+    if ([@"TEXT_FIELD" isEqualToString:[self getJavaRole]]) {
+        return NSAccessibilityTextFieldRole;
+    }
+    return NSAccessibilityTextAreaRole;
+}
+
+- (NSAccessibilitySubrole)accessibilitySubrole
+{
+    id retVal = [self requestNodeAttribute:@"AXSubrole"];
+    if (retVal == NULL) {
+        return nil;
+    }
+    return NSAccessibilitySecureTextFieldSubrole;
+}
+
+- (id)accessibilityParent
+{
+    return [super accessibilityParent];
+}
+
+- (BOOL)isAccessibilityEnabled
+{
+    return TRUE;
+}
+
+- (BOOL)isAccessibilityEdited {
+    return TRUE;
+}
+
+- (NSArray *)accessibilityChildren
+{
+    return [super accessibilityChildren];
+}
+
+- (NSRect)accessibilityFrame
+{
+    return [super accessibilityFrame];
+}
+
+- (NSString *)accessibilityValue
+{
+    return [super accessibilityValue];
+}
+
+- (NSString *)accessibilityTitle
+{
+    return [self requestNodeAttribute:@"AXTitle"];
+}
+
+- (nullable NSString *)accessibilityStringForRange:(NSRange)range
+{
+    id parameter = [NSValue valueWithRange:range];
+    NSString * retVal = (NSString *)[self requestNodeAttribute:@"AXStringForRange" forParameter:parameter];
+    return retVal;
+}
+
+- (NSInteger)accessibilityLineForIndex:(NSInteger)index
+{
+    id parameter = [NSNumber numberWithInteger:index];
+    NSInteger retVal = [[self requestNodeAttribute:@"AXLineForIndex" forParameter:parameter] integerValue];
+    return retVal;
+}
+
+- (NSRange)accessibilityRangeForLine:(NSInteger)lineNumber
+{
+    id parameter = [NSNumber numberWithInteger:lineNumber];
+    NSRange retVal = [[self requestNodeAttribute:@"AXRangeForLine" forParameter:parameter] rangeValue];
+    return retVal;
+}
+
+- (NSRect)accessibilityFrameForRange:(NSRange)range
+{
+    id parameter = [NSValue valueWithRange:range];
+    NSRect retVal = [[self requestNodeAttribute:@"AXBoundsForRange" forParameter:parameter] rectValue];
+    return retVal;
+}
+
+- (NSInteger)accessibilityNumberOfCharacters
+{
+    id retVal = [self requestNodeAttribute:@"AXNumberOfCharacters"];
+    return [retVal integerValue];
+}
+
+- (NSRange)accessibilitySelectedTextRange
+{
+    NSRange retVal = [[self requestNodeAttribute:@"AXSelectedTextRange"] rangeValue];
+    return retVal;
+}
+
+- (void)setAccessibilitySelectedTextRange:(NSRange)range {
+// We do not need to do anything here. We just have to have it overridden.
+}
+
+- (id)accessibilitySelectedTextRanges
+{
+    return nil; //For now. Once we have multiselection text area we might revisit it.
+}
+
+- (NSString *)accessibilitySelectedText
+{
+    id parameter = [NSValue valueWithRange:[self accessibilitySelectedTextRange]];
+    NSString * retVal = (NSString *)[self requestNodeAttribute:@"AXStringForRange" forParameter:parameter];
+    return retVal;
+}
+
+- (NSRange)accessibilityVisibleCharacterRange
+{
+    NSRange retVal = [[self requestNodeAttribute:@"AXVisibleCharacterRange"] rangeValue];
+    return retVal;
+}
+
+- (NSAttributedString *) accessibilityAttributedStringForRange:(NSRange)range
+{
+    id parameter = [NSValue valueWithRange:range];
+    NSAttributedString * retVal = (NSAttributedString *)
+            [self requestNodeAttribute:@"AXAttributedStringForRange" forParameter:parameter];
+    return retVal;
+}
+
+@end

--- a/modules/javafx.graphics/src/main/native-glass/mac/a11y/JFXNavigableTextAccessibility.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/a11y/JFXNavigableTextAccessibility.m
@@ -72,11 +72,6 @@
     return [super accessibilityValue];
 }
 
-- (NSString *)accessibilityTitle
-{
-    return [self requestNodeAttribute:@"AXTitle"];
-}
-
 - (nullable NSString *)accessibilityStringForRange:(NSRange)range
 {
     id parameter = [NSValue valueWithRange:range];


### PR DESCRIPTION
- Create implementation of protocol;
- Wire new implementation to TEXT_AREA and TEXT_FIELD roles;
- Add supporting method to store and request java side role;
- Add method to retrieve node attribute for the specified parameter;

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8343133](https://bugs.openjdk.org/browse/JDK-8343133): Create implementation of NSAccessibilityNavigableStaticText protocol (**Enhancement** - P3)


### Reviewers
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2130/head:pull/2130` \
`$ git checkout pull/2130`

Update a local copy of the PR: \
`$ git checkout pull/2130` \
`$ git pull https://git.openjdk.org/jfx.git pull/2130/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2130`

View PR using the GUI difftool: \
`$ git pr show -t 2130`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2130.diff">https://git.openjdk.org/jfx/pull/2130.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2130#issuecomment-4145881553)
</details>
