### PR TITLE
8382049: [TestBug] Multiple StubToolkit checks in JavaFX production code

### DIFF
--- a/modules/javafx.base/src/main/java/com/sun/javafx/PlatformUtil.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/PlatformUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -287,5 +287,15 @@ public class PlatformUtil {
 
     public static boolean isAndroid() {
        return ANDROID;
+    }
+
+    /**
+     * Returns true if animations should be done.
+     *
+     * @return true if animations should be done, false otherwise
+     * @implNote To save CPU cycles, animations are not done for embedded
+     */
+    public static boolean isDoAnimations() {
+        return !isEmbedded();
     }
 }

--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/inputmap/KeyBinding.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/inputmap/KeyBinding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,6 @@
  */
 package com.sun.javafx.scene.control.inputmap;
 
-import com.sun.javafx.util.Utils;
 import com.sun.javafx.tk.Toolkit;
 import javafx.event.EventType;
 import javafx.scene.input.KeyCode;
@@ -32,7 +31,9 @@ import javafx.scene.input.KeyEvent;
 
 import java.util.Objects;
 
-import static com.sun.javafx.scene.control.inputmap.KeyBinding.OptionalBoolean.*;
+import static com.sun.javafx.scene.control.inputmap.KeyBinding.OptionalBoolean.ANY;
+import static com.sun.javafx.scene.control.inputmap.KeyBinding.OptionalBoolean.FALSE;
+import static com.sun.javafx.scene.control.inputmap.KeyBinding.OptionalBoolean.TRUE;
 
 /**
  * KeyBindings are used to describe which action should occur based on some
@@ -111,31 +112,21 @@ public class KeyBinding {
     }
 
     public final KeyBinding shortcut() {
-        if (Toolkit.getToolkit().getClass().getName().endsWith("StubToolkit")) {
-            // FIXME: We've hit the terrible StubToolkit (which only appears
-            // during testing). We will dumb down what we do here
-            if (Utils.isMac()) {
-                return meta();
-            } else {
+        switch (Toolkit.getToolkit().getPlatformShortcutKey()) {
+            case SHIFT:
+                return shift();
+
+            case CONTROL:
                 return ctrl();
-            }
-        } else {
-            switch (Toolkit.getToolkit().getPlatformShortcutKey()) {
-                case SHIFT:
-                    return shift();
 
-                case CONTROL:
-                    return ctrl();
+            case ALT:
+                return alt();
 
-                case ALT:
-                    return alt();
+            case META:
+                return meta();
 
-                case META:
-                    return meta();
-
-                default:
-                    return this;
-            }
+            default:
+                return this;
         }
     }
 

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableRowSkinBase.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableRowSkinBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,8 +43,6 @@ import javafx.scene.control.*;
 import javafx.scene.layout.Region;
 import javafx.util.Duration;
 
-import com.sun.javafx.tk.Toolkit;
-
 /**
  * TableRowSkinBase is the base skin class used by controls such as
  * {@link javafx.scene.control.TableRow} and {@link javafx.scene.control.TreeTableRow}
@@ -72,14 +70,7 @@ public abstract class TableRowSkinBase<T,
      *                                                                         *
      **************************************************************************/
 
-    // There appears to be a memory leak when using the stub toolkit. Therefore,
-    // to prevent tests from failing we disable the animations below when the
-    // stub toolkit is being used.
-    // Filed as JDK-8120657.
-    private static boolean IS_STUB_TOOLKIT = Toolkit.getToolkit().toString().contains("StubToolkit");
-
-    // lets save the CPU and not do animations when on embedded platforms
-    private static boolean DO_ANIMATIONS = ! IS_STUB_TOOLKIT && ! PlatformUtil.isEmbedded();
+    private static boolean DO_ANIMATIONS = PlatformUtil.isDoAnimations();
 
     private static final Duration FADE_DURATION = Duration.millis(200);
 

--- a/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/infrastructure/KeyModifier.java
+++ b/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/infrastructure/KeyModifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,9 +26,7 @@
 package test.com.sun.javafx.scene.control.infrastructure;
 
 import com.sun.javafx.util.Utils;
-import test.com.sun.javafx.pgstub.StubToolkit;
 import com.sun.javafx.tk.Toolkit;
-import javafx.scene.input.KeyCode;
 
 public enum KeyModifier {
     SHIFT,
@@ -37,14 +35,6 @@ public enum KeyModifier {
     META;
 
     public static KeyModifier getShortcutKey() {
-        // The StubToolkit doesn't know what the platform shortcut key is, so
-        // we have to tell it here (and lets not be cute about optimising this
-        // code as we need the platform shortcut key to be known elsewhere in the
-        // code base for keyboard navigation tests to work accurately).
-        if (Toolkit.getToolkit() instanceof StubToolkit) {
-            ((StubToolkit)Toolkit.getToolkit()).setPlatformShortcutKey(Utils.isMac() ? KeyCode.META : KeyCode.CONTROL);
-        }
-
         switch (Toolkit.getToolkit().getPlatformShortcutKey()) {
             case SHIFT:
                 return SHIFT;

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/Toolkit.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/Toolkit.java
@@ -249,7 +249,7 @@ public abstract class Toolkit {
             TOOLKIT = (Toolkit)clz.getDeclaredConstructor().newInstance();
             if (TOOLKIT.init()) {
                 if (printToolkit) {
-                    System.err.println("JavaFX: using " + forcedToolkit);
+                    System.out.println("JavaFX: using " + forcedToolkit);
                 }
                 return TOOLKIT;
             }

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/Toolkit.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/Toolkit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -225,8 +225,7 @@ public abstract class Toolkit {
             forcedToolkit = lookupToolkitClass(forcedToolkit);
         }
 
-        boolean printToolkit = verbose
-                || (userSpecifiedToolkit && !forcedToolkit.endsWith("StubToolkit"));
+        boolean printToolkit = verbose || userSpecifiedToolkit;
 
         try {
             Class clz = null;

--- a/modules/javafx.graphics/src/test/java/test/com/sun/javafx/pgstub/StubToolkit.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/javafx/pgstub/StubToolkit.java
@@ -781,7 +781,7 @@ public class StubToolkit extends Toolkit {
         return false;
     }
 
-    private KeyCode platformShortcutKey = null;
+    private KeyCode platformShortcutKey;
 
     public void setPlatformShortcutKey(final KeyCode platformShortcutKey) {
         this.platformShortcutKey = platformShortcutKey;

--- a/modules/javafx.graphics/src/test/java/test/com/sun/javafx/pgstub/StubToolkit.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/javafx/pgstub/StubToolkit.java
@@ -35,6 +35,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Future;
+
+import com.sun.javafx.util.Utils;
 import javafx.application.ConditionalFeature;
 import javafx.geometry.Dimension2D;
 import javafx.scene.image.Image;
@@ -779,7 +781,7 @@ public class StubToolkit extends Toolkit {
         return false;
     }
 
-    private KeyCode platformShortcutKey = KeyCode.SHORTCUT;
+    private KeyCode platformShortcutKey = null;
 
     public void setPlatformShortcutKey(final KeyCode platformShortcutKey) {
         this.platformShortcutKey = platformShortcutKey;
@@ -787,6 +789,10 @@ public class StubToolkit extends Toolkit {
 
     @Override
     public KeyCode getPlatformShortcutKey() {
+        if (platformShortcutKey == null) {
+            return Utils.isMac() ? KeyCode.META : KeyCode.CONTROL;
+        }
+
         return platformShortcutKey;
     }
 


### PR DESCRIPTION
This PR removes all `StubToolkit` checks from JavaFX production code.
There are only a few.

Two notes:

Note 1: `TableRowSkinBase`s `DO_ANIMATIONS` is now `true` for tests. It was not before due to a leak (as far as I could find when digging [JDK-8120657](https://bugs.openjdk.org/browse/JDK-8120657)). But I could not find any problem, even running all tests with `-Xmx512m`
Checking tests that trigger the affected code path and creating a heapdump after, I could not see anything weird:
> Heapdump after `TreeTableViewResizeTest`:
<img width="859" height="542" alt="image" src="https://github.com/user-attachments/assets/744d27f2-73e7-4213-ae6f-63b0c2b10f7a" />
<img width="858" height="347" alt="image" src="https://github.com/user-attachments/assets/0a873611-ae76-4ea9-82b6-bad4cba84fd3" />

Note 2: Now when the tests run in CI, `JavaFX: using test.com.sun.javafx.pgstub.StubToolkit` is now printed 12 times (probably the amount of Unit Test Threads):
<img width="1451" height="514" alt="image" src="https://github.com/user-attachments/assets/c0a9f49d-5d37-4df6-a15a-4aa4cb1b4b83" />
If this is a problem, we can decide if we want to change the print code in `Toolkit` (in a follow-up). 
-> Changed to `System.out` in this PR.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8382049](https://bugs.openjdk.org/browse/JDK-8382049): [TestBug] Multiple StubToolkit checks in JavaFX production code (**Enhancement** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Michael Strauß](https://openjdk.org/census#mstrauss) (@mstr2 - **Reviewer**)
 * [Lukasz Kostyra](https://openjdk.org/census#lkostyra) (@lukostyra - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2146/head:pull/2146` \
`$ git checkout pull/2146`

Update a local copy of the PR: \
`$ git checkout pull/2146` \
`$ git pull https://git.openjdk.org/jfx.git pull/2146/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2146`

View PR using the GUI difftool: \
`$ git pr show -t 2146`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2146.diff">https://git.openjdk.org/jfx/pull/2146.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2146#issuecomment-4232657281)
</details>
