### PR TITLE
8381443: SystemMenuBarHelpMenuTest fails on macOS

### DIFF
--- a/tests/system/src/test/java/test/robot/javafx/scene/SystemMenuBarHelpMenuTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/SystemMenuBarHelpMenuTest.java
@@ -75,10 +75,6 @@ public class SystemMenuBarHelpMenuTest {
     private static final int MENU_BAR_X = 120;
     private static final int MENU_BAR_Y = 10;
 
-    // Estimated y offset for the Help -> About menu item, after the Spotlight search field that macOS inserts to
-    // this menu.
-    private static final int MENU_ABOUT_Y = 80;
-
     private static Robot robot;
     private static final AtomicBoolean aboutItemFired = new AtomicBoolean(false);
     private static final CountDownLatch aboutItemLatch = new CountDownLatch(1);

--- a/tests/system/src/test/java/test/robot/javafx/scene/SystemMenuBarHelpMenuTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/SystemMenuBarHelpMenuTest.java
@@ -48,7 +48,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import test.util.Util;
 
@@ -98,7 +97,6 @@ public class SystemMenuBarHelpMenuTest {
      * Verifies that after opening, the Help menu includes the Spotlight search field, which is
      * included seamlessly by the system.
      */
-    @Disabled("JDK-8381443")
     @Test
     void testHelpMenuHasSpotlight() {
         Assumptions.assumeTrue(PlatformUtil.isMac(), "System menu bar tests only apply to macOS");
@@ -116,8 +114,8 @@ public class SystemMenuBarHelpMenuTest {
 
         // Step 2: click on About
         Util.runAndWait(() -> {
-            robot.mouseMove(MENU_BAR_X, MENU_ABOUT_Y);
-            robot.mouseClick(MouseButton.PRIMARY);
+            robot.keyType(KeyCode.DOWN);
+            robot.keyType(KeyCode.ENTER);
         });
         Util.waitForLatch(aboutItemLatch, 5, "About menu item action should fire");
 
@@ -133,7 +131,6 @@ public class SystemMenuBarHelpMenuTest {
      * Verifies that after opening the system menu and then showing a modal dialog
      * the menu can still be opened again after the dialog is closed.
      */
-    @Disabled("JDK-8381443")
     @Test
     void testMenuCanBeReopenedAfterDialogClosed() {
         Assumptions.assumeTrue(PlatformUtil.isMac(), "System menu bar tests only apply to macOS");


### PR DESCRIPTION
The root cause of the test failure is that the robot does not successfully click on the "About" menu item. The test relies on hardcoded cursor coordinates and the Y coordinate value (80) is insufficient on some macOS systems with higher resolutions.

Replace the mouse click on the "About" menu item with keyboard interactions. This removes the dependency on hardcoded cursor positions and makes the test more robust across systems with different resolutions and font sizes.

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8381443](https://bugs.openjdk.org/browse/JDK-8381443): SystemMenuBarHelpMenuTest fails on macOS (**Bug** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2147/head:pull/2147` \
`$ git checkout pull/2147`

Update a local copy of the PR: \
`$ git checkout pull/2147` \
`$ git pull https://git.openjdk.org/jfx.git pull/2147/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2147`

View PR using the GUI difftool: \
`$ git pr show -t 2147`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2147.diff">https://git.openjdk.org/jfx/pull/2147.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2147#issuecomment-4237146030)
</details>
