### PR TITLE
8382046: GHA: Update to wrapper-validation@v6, checkout@v6, cache@v5

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -58,8 +58,8 @@ jobs:
     name: "Gradle Wrapper Validation"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: gradle/actions/wrapper-validation@v4
+      - uses: actions/checkout@v6
+      - uses: gradle/actions/wrapper-validation@v6
 
 
   linux_x64_build:
@@ -82,7 +82,7 @@ jobs:
 
     steps:
       - name: Checkout the source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: jfx
 
@@ -99,7 +99,7 @@ jobs:
 # FIXME: enable cache for boot JDK
 #      - name: Restore boot JDK from cache
 #        id: bootjdk
-#        uses: actions/cache@v4
+#        uses: actions/cache@v5
 #        with:
 #          path: ~/bootjdk/${{ env.BOOT_JDK_VERSION }}
 #          key: bootjdk-${{ runner.os }}-${{ env.BOOT_JDK_VERSION }}-${{ env.BOOT_JDK_SHA256 }}-v1
@@ -168,7 +168,7 @@ jobs:
 
     steps:
       - name: Checkout the source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: jfx
 
@@ -184,7 +184,7 @@ jobs:
 # FIXME: enable cache for boot JDK
 #      - name: Restore boot JDK from cache
 #        id: bootjdk
-#        uses: actions/cache@v4
+#        uses: actions/cache@v5
 #        with:
 #          path: ~/bootjdk/${{ env.BOOT_JDK_VERSION }}
 #          key: bootjdk-${{ runner.os }}-${{ env.BOOT_JDK_VERSION }}-${{ env.BOOT_JDK_SHA256 }}-v1
@@ -255,7 +255,7 @@ jobs:
 
     steps:
       - name: Checkout the source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: jfx
 
@@ -271,7 +271,7 @@ jobs:
 # FIXME: enable cache for boot JDK
 #      - name: Restore boot JDK from cache
 #        id: bootjdk
-#        uses: actions/cache@v4
+#        uses: actions/cache@v5
 #        with:
 #          path: ~/bootjdk/${{ env.BOOT_JDK_VERSION }}
 #          key: bootjdk-${{ runner.os }}-${{ env.BOOT_JDK_VERSION }}-${{ env.BOOT_JDK_SHA256 }}-v1
@@ -340,14 +340,14 @@ jobs:
 
     steps:
       - name: Checkout the source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: jfx
 
 # FIXME: enable cache for boot JDK
 #      - name: Restore boot JDK from cache
 #        id: bootjdk
-#        uses: actions/cache@v4
+#        uses: actions/cache@v5
 #        with:
 #          path: ~/bootjdk/${{ env.BOOT_JDK_VERSION }}
 #          key: bootjdk-${{ runner.os }}-${{ env.BOOT_JDK_VERSION }}-${{ env.BOOT_JDK_SHA256 }}-v1
@@ -362,7 +362,7 @@ jobs:
 
       - name: Restore cygwin packages from cache
         id: cygwin
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/cygwin/packages
           key: cygwin-packages-${{ runner.os }}-v1


### PR DESCRIPTION
The GHA actions needs to be updated. 
Currently GHA builds show warnings, for example the build : https://github.com/arapte/jfx/actions/runs/24330731766

**Linux x64 & macOS x64 & macOS aarch64** 
`Warning: Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/`

**Windows x64**
`Warning: Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/cache@v4, actions/checkout@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/`
<br>

These warnings go away with this PR changes.
Build with this PR: https://github.com/arapte/jfx/actions/runs/24409801823

Changes:
- Update actions/checkout to v6,  Reference: https://github.com/actions/checkout/releases
- Update actions/caches to v5,  Reference: https://github.com/actions/cache/releases
- Update gradle/actions/wrapper-validation to v6, Reference: https://github.com/gradle/actions/blob/main/wrapper-validation/README.md
---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8382046](https://bugs.openjdk.org/browse/JDK-8382046): GHA: Update to wrapper-validation@<!---->v6, checkout@<!---->v6, cache@<!---->v5 (**Bug** - P3)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Marius Hanl](https://openjdk.org/census#mhanl) (@Maran23 - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2148/head:pull/2148` \
`$ git checkout pull/2148`

Update a local copy of the PR: \
`$ git checkout pull/2148` \
`$ git pull https://git.openjdk.org/jfx.git pull/2148/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2148`

View PR using the GUI difftool: \
`$ git pr show -t 2148`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2148.diff">https://git.openjdk.org/jfx/pull/2148.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2148#issuecomment-4248723481)
</details>
