### PR TITLE
8382175: RichTextAreaDemo is not built by "gradle apps"

### DIFF
--- a/apps/samples/build.xml
+++ b/apps/samples/build.xml
@@ -13,6 +13,7 @@
         <ant dir="3DViewer" target="jar" inheritAll="true"/>
         <ant dir="Ensemble8" target="jar" inheritAll="true"/>
         <ant dir="MandelbrotSet" target="jar" inheritAll="true"/>
+    	<ant dir="RichTextAreaDemo" target="jar" inheritAll="true"/>
     </target>
 
     <target name="clean">
@@ -20,6 +21,7 @@
         <ant dir="Ensemble8" target="clean" inheritAll="true"/>
         <ant dir="MandelbrotSet" target="clean" inheritAll="true"/>
         <ant dir="Modena" target="clean" inheritAll="true"/>
+    	<ant dir="RichTextAreaDemo" target="clean" inheritAll="true"/>
     </target>
 
 </project>


### PR DESCRIPTION
Adds `RichTextAreaDemo` to the gradle build as a part of the `apps` target.

Places `RichEditorDemo.jar` into `apps/samples/RichEditorDemo/dist` .

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8382175](https://bugs.openjdk.org/browse/JDK-8382175): RichTextAreaDemo is not built by "gradle apps" (**Bug** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2149/head:pull/2149` \
`$ git checkout pull/2149`

Update a local copy of the PR: \
`$ git checkout pull/2149` \
`$ git pull https://git.openjdk.org/jfx.git pull/2149/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2149`

View PR using the GUI difftool: \
`$ git pr show -t 2149`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2149.diff">https://git.openjdk.org/jfx/pull/2149.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2149#issuecomment-4246940530)
</details>
