### PR TITLE
8382165: Emojis used in Stage.setTitle are not rendered and break application switching on Linux platform

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/gtk/GlassWindow.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/GlassWindow.cpp
@@ -293,9 +293,10 @@ JNIEXPORT jboolean JNICALL Java_com_sun_glass_ui_gtk_GtkWindow__1setTitle
     (void)obj;
 
     WindowContext* ctx = JLONG_TO_WINDOW_CTX(ptr);
-    const char* ctitle = mainEnv->GetStringUTFChars(title, NULL);
+
+    gchar * ctitle = jstring_to_utf8(env, title);
     ctx->set_title(ctitle);
-    mainEnv->ReleaseStringUTFChars(title, ctitle);
+    g_free(ctitle);
 
     return JNI_TRUE;
 }

--- a/modules/javafx.graphics/src/main/native-glass/gtk/glass_general.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/glass_general.cpp
@@ -889,3 +889,20 @@ guint glass_settings_get_guint_opt (const gchar *schema_name,
 
     return g_settings_get_uint(gset, key_name);
 }
+
+gchar* jstring_to_utf8(JNIEnv *env, jstring jstr) {
+    if (jstr == nullptr) {
+        return nullptr;
+    }
+
+    const jchar *jchars = env->GetStringChars(jstr, nullptr);
+    if (jchars == nullptr) {
+        return nullptr;
+    }
+
+    jsize len = env->GetStringLength(jstr);
+    gchar *result = g_utf16_to_utf8(jchars, len, nullptr, nullptr, nullptr);
+    env->ReleaseStringChars(jstr, jchars);
+
+    return result;
+}

--- a/modules/javafx.graphics/src/main/native-glass/gtk/glass_general.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/glass_general.cpp
@@ -890,7 +890,14 @@ guint glass_settings_get_guint_opt (const gchar *schema_name,
     return g_settings_get_uint(gset, key_name);
 }
 
-gchar* jstring_to_utf8(JNIEnv *env, jstring jstr) {
+/*
+ * GetStringUTFChars returns a modified UTF-8 string
+ * that encodes supplementary characters differently
+ * from standard UTF-8, so emojis may not be handled
+ * as expected by GTK or other Linux desktop
+ * components that expect standard UTF-8.
+ */
+ gchar* jstring_to_utf8(JNIEnv *env, jstring jstr) {
     if (jstr == nullptr) {
         return nullptr;
     }

--- a/modules/javafx.graphics/src/main/native-glass/gtk/glass_general.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/glass_general.cpp
@@ -891,6 +891,9 @@ guint glass_settings_get_guint_opt (const gchar *schema_name,
 }
 
 /*
+ * Convert from jstring to standard UTF-8 using GLib
+ * utility method g_utf16_to_utf8.
+ *
  * GetStringUTFChars returns a modified UTF-8 string
  * that encodes supplementary characters differently
  * from standard UTF-8, so emojis may not be handled

--- a/modules/javafx.graphics/src/main/native-glass/gtk/glass_general.h
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/glass_general.h
@@ -374,6 +374,9 @@ glass_settings_get_guint_opt (const gchar *schema_name,
                     const gchar *key_name,
                     int defval);
 
+
+gchar* jstring_to_utf8(JNIEnv *env, jstring jstr);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
`GetStringUTFChars` returns a modified UTF-8 string  that encodes supplementary characters differently from standard UTF-8, so emojis may not be handled as expected by GTK or other Linux desktop components that expect standard UTF-8.

See:
https://www.oracle.com/technical-resources/articles/javase/supplementary.html
https://www.javathinking.com/blog/what-is-the-java-s-internal-represention-for-string-modified-utf-8-utf-16/

There are other places where `GetStringUTFChars` is used, such as in the file open dialog, but it’s unclear whether this is affected in any real user scenarios.

Using the sample from the bug report with this fix:
<img width="778" height="574" alt="image" src="https://github.com/user-attachments/assets/6a66a746-2239-465d-ad5f-688933deb537" />


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8382165](https://bugs.openjdk.org/browse/JDK-8382165): Emojis used in Stage.setTitle are not rendered and break application switching on Linux platform (**Bug** - P4)


### Reviewers
 * [Lukasz Kostyra](https://openjdk.org/census#lkostyra) (@lukostyra - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2150/head:pull/2150` \
`$ git checkout pull/2150`

Update a local copy of the PR: \
`$ git checkout pull/2150` \
`$ git pull https://git.openjdk.org/jfx.git pull/2150/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2150`

View PR using the GUI difftool: \
`$ git pr show -t 2150`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2150.diff">https://git.openjdk.org/jfx/pull/2150.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2150#issuecomment-4251275448)
</details>
