### PR TITLE
8237018: Unstable test RenderLock1Test always fails on Windows

### DIFF
--- a/tests/system/src/test/java/test/renderlock/RenderLock1Test.java
+++ b/tests/system/src/test/java/test/renderlock/RenderLock1Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,13 +25,11 @@
 
 package test.renderlock;
 
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import org.junit.jupiter.api.Test;
 
 public class RenderLock1Test extends RenderLockCommon {
     @Test
     public void windowCloseTest() throws Exception {
-        assumeTrue(Boolean.getBoolean("unstable.test"));
         doWindowCloseTest();
     }
 }


### PR DESCRIPTION
`RenderLock1Test`'s instability comes from Windows focus stealing mechanism getting in the way.

The test displays an alert and relies on whether the alert's Button receives focus while other window is rendering in the background. To successfully receive focus on the test Button the application itself must be granted focus first, which [in some cases can be rejected by the OS](https://bugs.openjdk.org/browse/JDK-8351357).

On macOS I noticed no issues - the test ran 100 times in a loop and succeeded every time, no matter if Gradle ran with or without daemon. Similarly I ran the test on our CI systems on repeat 100 times and it also succeeded there.

On Linux the test does not work because when the alert-displaying Stage is closed the "lost focus" event does not fire. This is a Linux specific issue and it [already is documented in-code with an assumption](https://github.com/openjdk/jfx/blob/master/tests/system/src/test/java/test/renderlock/RenderLockCommon.java#L111).

On Windows the focus problems come from aforementioned focus stealing prevention. The solution to this is similar to other tests that showed this problem, which is to run tests using `--no-daemon` flag in Gradle. I similarily tested this by running the test using `--no-daemon` flag on repeat 100 times and the test always passed.

I think we can mark this test as stable and include it into the testing pool. 

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8237018](https://bugs.openjdk.org/browse/JDK-8237018): Unstable test RenderLock1Test always fails on Windows (**Bug** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Marius Hanl](https://openjdk.org/census#mhanl) (@Maran23 - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2151/head:pull/2151` \
`$ git checkout pull/2151`

Update a local copy of the PR: \
`$ git checkout pull/2151` \
`$ git pull https://git.openjdk.org/jfx.git pull/2151/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2151`

View PR using the GUI difftool: \
`$ git pr show -t 2151`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2151.diff">https://git.openjdk.org/jfx/pull/2151.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2151#issuecomment-4261283805)
</details>
