### PR TITLE
8237868: java.lang.IndexOutOfBoundsException in FilteredList

### DIFF
--- a/modules/javafx.base/src/main/java/javafx/collections/ListChangeBuilder.java
+++ b/modules/javafx.base/src/main/java/javafx/collections/ListChangeBuilder.java
@@ -207,10 +207,6 @@ final class ListChangeBuilder<E> {
 
         if (last != null && last.to == idx) {
             last.removed.add(removed);
-        } else if (last != null && last.from == idx + 1) {
-            last.from--;
-            last.to--;
-            last.removed.add(0, removed);
         } else {
             insertRemoved(idx, removed);
         }

--- a/modules/javafx.base/src/test/java/test/javafx/collections/FilteredListTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/collections/FilteredListTest.java
@@ -80,8 +80,6 @@ public class FilteredListTest {
         // list has duplicates!
         list.removeAll(filteredList);
         assertEquals(copyList, list);
-
-
     }
 
     @Test

--- a/modules/javafx.base/src/test/java/test/javafx/collections/FilteredListTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/collections/FilteredListTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
 package test.javafx.collections;
 
 import com.sun.javafx.collections.ObservableListWrapper;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -36,6 +37,7 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.collections.ObservableListWrapperShim;
 import javafx.collections.transformation.FilteredList;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -55,6 +57,19 @@ public class FilteredListTest {
         mlo = new MockListObserver<>();
         filteredList = new FilteredList<>(list, predicate);
         filteredList.addListener(mlo);
+
+        Thread.currentThread().setUncaughtExceptionHandler((thread, throwable) -> {
+            if (throwable instanceof RuntimeException) {
+                throw (RuntimeException)throwable;
+            } else {
+                Thread.currentThread().getThreadGroup().uncaughtException(thread, throwable);
+            }
+        });
+    }
+
+    @AfterEach
+    void tearDown() {
+        Thread.currentThread().setUncaughtExceptionHandler(null);
     }
 
     @Test
@@ -65,6 +80,8 @@ public class FilteredListTest {
         // list has duplicates!
         list.removeAll(filteredList);
         assertEquals(copyList, list);
+
+
     }
 
     @Test
@@ -320,5 +337,21 @@ public class FilteredListTest {
         assertThrows(IndexOutOfBoundsException.class, () -> filteredList.getViewIndex(-1));
         assertThrows(IndexOutOfBoundsException.class, () -> filteredList.getViewIndex(list.size()));
         assertDoesNotThrow(() -> filteredList.getViewIndex(filteredList.size()));
+    }
+
+    @Test
+    public void testSortedThenFilteredListDoesNotThrowIOOBE() {
+        ObservableList<Long> numbers = FXCollections.observableArrayList();
+
+        ObservableList<Long> sortedList = numbers.sorted(Long::compare);
+        ObservableList<Long> filteredList = sortedList.filtered(_ -> true);
+
+        numbers.add(0L);
+        numbers.addAll(List.of(0L, 4L, 8L, 2L, 6L, 0L, 4L, 8L, 2L, 6L, 0L));
+
+        assertDoesNotThrow(() -> numbers.subList(0, numbers.size() - 1).clear());
+
+        assertEquals(List.of(0L), filteredList);
+        assertEquals(List.of(0L), sortedList);
     }
 }

--- a/modules/javafx.base/src/test/java/test/javafx/collections/ListChangeBuilderTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/collections/ListChangeBuilderTest.java
@@ -720,6 +720,30 @@ public class ListChangeBuilderTest {
         list.doEndChange();
     }
 
+    @Test
+    public void testRemoveDisjointFirstThenGaps() {
+        var list = new ExposedObservableList<>(new ArrayList<>(List.of("A", "B", "C", "D", "E", "F")));
+
+        list.addListener((ListChangeListener.Change<? extends String> change) -> {
+            assertEquals(1, change.getList().size());
+            change.next();
+
+            assertEquals(List.of("B", "C", "D", "E", "F"), change.getRemoved());
+
+            assertFalse(change.next());
+        });
+
+        list.doBeginChange();
+
+        list.remove("D");
+        list.remove("F");
+        list.remove("B");
+        list.remove("E");
+        list.remove("C");
+
+        list.doEndChange();
+    }
+
     private static class ExposedObservableList<E> extends ObservableListWrapper<E> {
         ExposedObservableList(List<E> list) {
             super(list);


### PR DESCRIPTION
This fixes an IOOBE and even improves the performance / change aggregation.
I suggest reading Jeanette's comment in the ticket, that helped a lot to understand it.

There was a code path that broke change events. 
Jeanette wondered as well in the comment why this exists at all, if this was meant to be some kind of optimization?

What I found out is: Because of this code path, we actually got 3 change events and the order was wrong. 
What we got with the test from Jeanette: `subChanges: { [B] removed at 1, [D] removed at 2, [C, E, F] removed at 1 }`

Removing the code path and just calling `insertRemoved(..)` directly will correctly find an alreadx existing sub change with `findSubChange` and aggregate the changes together. So now, we only get one event: `subChanges: { [B, C, D, E, F] removed at 1 }`. No error and we use the smart aggregation from `insertRemoved`.

My speculation why this code existed is that there may was a former bug, similar like [JDK-8208758](https://bugs.openjdk.org/browse/JDK-8208758) (#2117) where I also did a fix in the `insertRemoved(..)` method.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8237868](https://bugs.openjdk.org/browse/JDK-8237868): java.lang.IndexOutOfBoundsException in FilteredList (**Bug** - P3)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Michael Strauß](https://openjdk.org/census#mstrauss) (@mstr2 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2154/head:pull/2154` \
`$ git checkout pull/2154`

Update a local copy of the PR: \
`$ git checkout pull/2154` \
`$ git pull https://git.openjdk.org/jfx.git pull/2154/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2154`

View PR using the GUI difftool: \
`$ git pr show -t 2154`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2154.diff">https://git.openjdk.org/jfx/pull/2154.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2154#issuecomment-4271428449)
</details>
