### PR TITLE
8374809: [RichTextArea] accessibility

### DIFF
--- a/modules/jfx.incubator.richtext/src/main/java/com/sun/jfx/incubator/scene/control/richtext/Params.java
+++ b/modules/jfx.incubator.richtext/src/main/java/com/sun/jfx/incubator/scene/control/richtext/Params.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,15 +25,14 @@
 
 package com.sun.jfx.incubator.scene.control.richtext;
 
-import javafx.geometry.Insets;
 import javafx.util.Duration;
 
 /**
  * Various constants.
  */
 public class Params {
-    /** number of paragraphs for accessibility segment */
-    public static final int ACCESSIBILITY_SEGMENT_SIZE = 64;
+    /** max number of paragraphs for accessible selected text */
+    public static final int ACCESSIBILITY_TEXT_MAX_PARAGRAPHS = 64;
 
     /** autoscroll animation period, milliseconds. */
     public static final int AUTO_SCROLL_PERIOD = 100;

--- a/modules/jfx.incubator.richtext/src/main/java/com/sun/jfx/incubator/scene/control/richtext/Params.java
+++ b/modules/jfx.incubator.richtext/src/main/java/com/sun/jfx/incubator/scene/control/richtext/Params.java
@@ -32,8 +32,8 @@ import javafx.util.Duration;
  * Various constants.
  */
 public class Params {
-    /** number of paragraph for accessibility window */
-    public static final int ACCESSIBILITY_WINDOW_SIZE = 64;
+    /** number of paragraphs for accessibility segment */
+    public static final int ACCESSIBILITY_SEGMENT_SIZE = 64;
 
     /** autoscroll animation period, milliseconds. */
     public static final int AUTO_SCROLL_PERIOD = 100;

--- a/modules/jfx.incubator.richtext/src/main/java/com/sun/jfx/incubator/scene/control/richtext/RTAccessibilityHelper.java
+++ b/modules/jfx.incubator.richtext/src/main/java/com/sun/jfx/incubator/scene/control/richtext/RTAccessibilityHelper.java
@@ -26,7 +26,6 @@
 package com.sun.jfx.incubator.scene.control.richtext;
 
 import java.util.Objects;
-import javafx.beans.value.ChangeListener;
 import javafx.scene.AccessibleAttribute;
 import com.sun.jfx.incubator.scene.control.richtext.util.RichUtils;
 import jfx.incubator.scene.control.richtext.RichTextArea;
@@ -56,6 +55,7 @@ public class RTAccessibilityHelper {
         // we can get rid of this pointer by making RTAccessibilityHelper extend StyledTextModel.Listener
         modelListener = (ch) -> {
             if (ch.isEdit()) {
+                RichUtils.log("ch={0}", ch);
                 if (handleTextUpdate(ch.getStart(), ch.getEnd())) {
                     control.notifyAccessibleAttributeChanged(AccessibleAttribute.TEXT);
                 }
@@ -71,8 +71,8 @@ public class RTAccessibilityHelper {
         m.removeListener(modelListener);
     }
 
-    /** returns true if update is within the a11y window */
-    public boolean handleTextUpdate(TextPos p0, TextPos p1) {
+    // returns true if update is within the a11y window 
+    private boolean handleTextUpdate(TextPos p0, TextPos p1) {
         if ((start != null) && (end != null)) {
             if (p0.compareTo(end) >= 0) {
                 return false;
@@ -86,6 +86,7 @@ public class RTAccessibilityHelper {
      * Handles selection changes.
      */
     public void handleSelectionChange(SelectionSegment old, SelectionSegment cur) {
+        RichUtils.log("sel={0}", cur);
         TextPos min0 = old == null ? null : old.getMin();
         TextPos max0 = old == null ? null : old.getMax();
         TextPos min2 = cur == null ? null : cur.getMin();

--- a/modules/jfx.incubator.richtext/src/main/java/com/sun/jfx/incubator/scene/control/richtext/RTAccessibilityHelper.java
+++ b/modules/jfx.incubator.richtext/src/main/java/com/sun/jfx/incubator/scene/control/richtext/RTAccessibilityHelper.java
@@ -25,9 +25,14 @@
 
 package com.sun.jfx.incubator.scene.control.richtext;
 
+import java.util.Objects;
+import javafx.beans.value.ChangeListener;
+import javafx.scene.AccessibleAttribute;
+import com.sun.jfx.incubator.scene.control.richtext.util.RichUtils;
 import jfx.incubator.scene.control.richtext.RichTextArea;
 import jfx.incubator.scene.control.richtext.SelectionSegment;
 import jfx.incubator.scene.control.richtext.TextPos;
+import jfx.incubator.scene.control.richtext.model.StyledTextModel;
 
 /**
  * The purpose of this class is to maintain a small String segment
@@ -43,15 +48,27 @@ public class RTAccessibilityHelper {
     private final RichTextArea control;
     private TextPos start;
     private TextPos end;
+    private final StyledTextModel.Listener modelListener;
 
     public RTAccessibilityHelper(RichTextArea t) {
         this.control = t;
+
+        // we can get rid of this pointer by making RTAccessibilityHelper extend StyledTextModel.Listener
+        modelListener = (ch) -> {
+            if (ch.isEdit()) {
+                if (handleTextUpdate(ch.getStart(), ch.getEnd())) {
+                    control.notifyAccessibleAttributeChanged(AccessibleAttribute.TEXT);
+                }
+            }
+        };
     }
 
-    /** clear a11y cache */
-    public void handleModelChange() {
-        start = null;
-        end = null;
+    public void registerModel(StyledTextModel m) {
+        m.addListener(modelListener);
+    }
+
+    public void unregisterModel(StyledTextModel m) {
+        m.removeListener(modelListener);
     }
 
     /** returns true if update is within the a11y window */
@@ -67,16 +84,35 @@ public class RTAccessibilityHelper {
 
     /**
      * Handles selection changes.
-     * @return true if a11y window has shifted and TEXT attribute needs to be sent to the platform
      */
-    public boolean handleSelectionChange(SelectionSegment sel) {
+    public void handleSelectionChange(SelectionSegment old, SelectionSegment cur) {
+        TextPos min0 = old == null ? null : old.getMin();
+        TextPos max0 = old == null ? null : old.getMax();
+        TextPos min2 = cur == null ? null : cur.getMin();
+        TextPos max2 = cur == null ? null : cur.getMax();
+
+        if (shouldUpdateTextAttribute(cur)) {
+            control.notifyAccessibleAttributeChanged(AccessibleAttribute.TEXT);
+        }
+
+        if (!Objects.equals(min0, min2)) {
+            control.notifyAccessibleAttributeChanged(AccessibleAttribute.SELECTION_START);
+        }
+
+        if (!Objects.equals(max0, max2)) {
+            control.notifyAccessibleAttributeChanged(AccessibleAttribute.SELECTION_END);
+        }
+    }
+
+    // TODO: this might be wrong...
+    private boolean shouldUpdateTextAttribute(SelectionSegment sel) {
         if (sel == null) {
             return false;
         }
 
         // no start/end: create window, return true
         // selection outside of the window: change window, return true
-        if((start == null) || (end == null) || isOutside(sel.getMin(), sel.getMax())) {
+        if ((start == null) || (end == null) || isOutside(sel.getMin(), sel.getMax())) {
             createWindow();
             return true;
         }
@@ -92,6 +128,8 @@ public class RTAccessibilityHelper {
         return false;
     }
 
+    // TODO maybe this is unnecessary:
+    // use the current caret/selection
     private void createWindow() {
         // selection is small: create window around selection
         // selection is large: create window around the caret
@@ -102,10 +140,17 @@ public class RTAccessibilityHelper {
 
         start = TextPos.ofLeading(ix0, 0);
         end = control.getParagraphEnd(ix1);
+        RichUtils.log("start={0} end={1}", start, end); // FIX
     }
 
     public String getText() {
+        String s = getText2();
+        RichUtils.log("text=[{0}]", s);
+        return s;
+    }
+    private String getText2() {
         if ((start == null) && (end == null)) {
+            // TODO maybe from the start?
             return null;
         }
 

--- a/modules/jfx.incubator.richtext/src/main/java/com/sun/jfx/incubator/scene/control/richtext/RTAccessibilityHelper.java
+++ b/modules/jfx.incubator.richtext/src/main/java/com/sun/jfx/incubator/scene/control/richtext/RTAccessibilityHelper.java
@@ -44,18 +44,18 @@ import jfx.incubator.scene.control.richtext.model.StyledTextModel;
  */
 public class RTAccessibilityHelper {
     private final RichTextArea control;
-    private TextPos start;
-    private TextPos end;
     private final StyledTextModel.Listener modelListener;
+    private AccessibilitySegment segment;
 
     public RTAccessibilityHelper(RichTextArea t) {
         this.control = t;
 
-        // we can get rid of this pointer by making RTAccessibilityHelper extend StyledTextModel.Listener
+        // we can get rid of this listener pointer by making RTAccessibilityHelper extend StyledTextModel.Listener
         modelListener = (ch) -> {
             if (ch.isEdit()) {
                 RichUtils.log("ch={0}", ch);
-                if (handleTextUpdate(ch.getStart(), ch.getEnd())) {
+                if (isAccSegmentAffected(ch.getStart(), ch.getEnd())) {
+                    segment = null;
                     control.notifyAccessibleAttributeChanged(AccessibleAttribute.TEXT);
                 }
             }
@@ -66,103 +66,17 @@ public class RTAccessibilityHelper {
         });
     }
 
-    public void registerModel(StyledTextModel m) {
-        m.addListener(modelListener);
-    }
-
-    public void unregisterModel(StyledTextModel m) {
-        m.removeListener(modelListener);
-    }
-
-    // returns true if update is within the a11y window 
-    private boolean handleTextUpdate(TextPos p0, TextPos p1) {
-        if ((start != null) && (end != null)) {
-            if (p0.compareTo(end) >= 0) {
-                return false;
-            }
-            return true;
-        }
-        return false;
-    }
-
-    private void handleSelectionChange(SelectionSegment old, SelectionSegment cur) {
-        RichUtils.log("sel={0}", cur);
-        TextPos min0 = old == null ? null : old.getMin();
-        TextPos max0 = old == null ? null : old.getMax();
-        TextPos min2 = cur == null ? null : cur.getMin();
-        TextPos max2 = cur == null ? null : cur.getMax();
-
-        if (shouldUpdateTextAttribute(cur)) {
-            control.notifyAccessibleAttributeChanged(AccessibleAttribute.TEXT);
-        }
-
-        if (!Objects.equals(min0, min2)) {
-            control.notifyAccessibleAttributeChanged(AccessibleAttribute.SELECTION_START);
-        }
-
-        if (!Objects.equals(max0, max2)) {
-            control.notifyAccessibleAttributeChanged(AccessibleAttribute.SELECTION_END);
-        }
-    }
-
-    // TODO: this might be wrong...
-    private boolean shouldUpdateTextAttribute(SelectionSegment sel) {
-        if (sel == null) {
-            return false;
-        }
-
-        // no start/end: create window, return true
-        // selection outside of the window: change window, return true
-        if ((start == null) || (end == null) || isOutside(sel.getMin(), sel.getMax())) {
-            createWindow();
-            return true;
-        }
-
-        // selection within the window: no-op, return false
-        return false;
-    }
-
-    private boolean isOutside(TextPos p0, TextPos p1) {
-        if ((start.compareTo(p1) >= 0) || (end.compareTo(p0) <= 0)) {
-            return true;
-        }
-        return false;
-    }
-
-    // TODO maybe this is unnecessary:
-    // use the current caret/selection
-    private void createWindow() {
-        // selection is small: create window around selection
-        // selection is large: create window around the caret
-        SelectionSegment sel = control.getSelection();
-        TextPos cp = sel.getCaret();
-        int ix0 = Math.max(0, cp.index() - (Params.ACCESSIBILITY_WINDOW_SIZE / 2));
-        int ix1 = Math.min(control.getParagraphCount() - 1, ix0 + Params.ACCESSIBILITY_WINDOW_SIZE);
-
-        start = TextPos.ofLeading(ix0, 0);
-        end = control.getParagraphEnd(ix1);
-        RichUtils.log("start={0} end={1}", start, end); // FIX
-    }
-
     public String getText() {
         String s = getText2();
         RichUtils.log("text=[{0}]", s);
         return s;
     }
-    private String getText2() {
-        if ((start == null) && (end == null)) {
-            // TODO maybe from the start?
+    private String getText2() { // FIX
+        AccessibilitySegment a = segment();
+        if (a == null) {
             return null;
         }
-
-        // alternative: use model.export()
-        StringBuilder sb = new StringBuilder();
-        int mx = end.index();
-        for (int ix = start.index(); ix <= mx; ix++) {
-            String s = control.getPlainText(ix);
-            sb.append(s).append("\n");
-        }
-        return sb.toString();
+        return a.text();
     }
 
     public Integer selectionStart() {
@@ -189,23 +103,143 @@ public class RTAccessibilityHelper {
         return computeOffset(sel.getCaret());
     }
 
-    private Integer computeOffset(TextPos p) {
-        if (
-            (start == null) ||
-            (end == null) ||
-            (p.compareTo(start) < 0) ||
-            (p.compareTo(end) > 0)
-        ) {
+    public void registerModel(StyledTextModel m) {
+        m.addListener(modelListener);
+    }
+
+    public void unregisterModel(StyledTextModel m) {
+        m.removeListener(modelListener);
+    }
+
+    public void handleModelChange() {
+        control.notifyAccessibleAttributeChanged(AccessibleAttribute.TEXT);
+    }
+
+    private AccessibilitySegment segment() {
+        SelectionSegment sel = control.getSelection();
+        if (sel == null) {
+            segment = null;
             return null;
         }
 
-        int off = 0;
-        int index = start.index();
-        while (index < p.index()) {
-            String s = control.getPlainText(index);
-            off += (s.length() + 1); // plus newline character
-            index++;
+        TextPos start;
+        TextPos end;
+        if (sel.isCollapsed()) {
+            // collapsed selection: report paragraph
+            int ix = sel.getMin().index();
+            start = TextPos.ofLeading(ix, 0);
+            end = control.getParagraphEnd(ix);
+        } else {
+            // selection: report selection with limit?
+            start = sel.getMin();
+            end = sel.getMax();
+            int ct = end.index() - start.index();
+            if (ct > Params.ACCESSIBILITY_SEGMENT_SIZE) {
+                end = control.getParagraphEnd(start.index() + Params.ACCESSIBILITY_SEGMENT_SIZE);
+            }
         }
-        return off + p.offset();
+
+        if (segment != null) {
+            // check if can reuse the existing segment
+            if (start.equals(segment.start) && end.equals(segment.end)) {
+                return segment;
+            }
+        }
+
+        return (segment = new AccessibilitySegment(start, end));
+    }
+
+    // returns true if the edit is within the a11y segment 
+    private boolean isAccSegmentAffected(TextPos start, TextPos end) {
+        return (segment == null) ? false : segment.isAffected(start, end);
+    }
+
+    private void handleSelectionChange(SelectionSegment old, SelectionSegment cur) {
+        RichUtils.log("sel={0}", cur);
+        TextPos min0 = old == null ? null : old.getMin();
+        TextPos max0 = old == null ? null : old.getMax();
+        TextPos min2 = cur == null ? null : cur.getMin();
+        TextPos max2 = cur == null ? null : cur.getMax();
+
+        if (shouldUpdateTextAttribute(cur)) {
+            control.notifyAccessibleAttributeChanged(AccessibleAttribute.TEXT);
+        }
+
+        if (!Objects.equals(min0, min2)) {
+            control.notifyAccessibleAttributeChanged(AccessibleAttribute.SELECTION_START);
+        }
+
+        if (!Objects.equals(max0, max2)) {
+            control.notifyAccessibleAttributeChanged(AccessibleAttribute.SELECTION_END);
+        }
+    }
+
+    private boolean shouldUpdateTextAttribute(SelectionSegment sel) {
+        if (sel == null) {
+            // was there a segment before?
+            if (segment != null) {
+                segment = null;
+                return true;
+            }
+            return false;
+        }
+        return segment().isAffected(sel.getMin(), sel.getMax());
+    }
+
+    private Integer computeOffset(TextPos p) {
+        AccessibilitySegment seg = segment();
+        return seg == null ? null : seg.computeOffset(p);
+    }
+
+    private class AccessibilitySegment {
+        private final TextPos start;
+        private final TextPos end;
+        private String text;
+
+        public AccessibilitySegment(TextPos start, TextPos end) {
+            this.start = start;
+            this.end = end;
+        }
+
+        public String text() {
+            if (text == null) {
+                // alternative: use model.export()
+                StringBuilder sb = new StringBuilder();
+                String nl = control.getLineEnding().getText();
+                int mx = end.index();
+                for (int ix = start.index(); ix <= mx; ix++) {
+                    String s = control.getPlainText(ix);
+                    sb.append(s);
+                    sb.append(nl);
+                }
+                text = sb.toString();
+            }
+            return text;
+        }
+
+        public boolean isAffected(TextPos updStart, TextPos updEnd) {
+            if (updEnd.index() < start.index()) {
+                return false;
+            } else if (updStart.index() > end.index()) {
+                return false;
+            }
+            return true;
+        }
+
+        private Integer computeOffset(TextPos p) {
+            if ((p.compareTo(start) < 0) || (p.compareTo(end) > 0)) {
+                return null;
+            }
+
+            int nl = control.getLineEnding().getText().length();
+            int off = 0;
+            int index = start.index();
+            while (index < p.index()) {
+                String s = control.getPlainText(index);
+                off += (s.length() + nl);
+                index++;
+            }
+            return off + p.offset();
+        }
     }
 }

--- a/modules/jfx.incubator.richtext/src/main/java/com/sun/jfx/incubator/scene/control/richtext/RTAccessibilityHelper.java
+++ b/modules/jfx.incubator.richtext/src/main/java/com/sun/jfx/incubator/scene/control/richtext/RTAccessibilityHelper.java
@@ -127,8 +127,8 @@ public class RTAccessibilityHelper {
             start = sel.getMin();
             end = sel.getMax();
             int ct = end.index() - start.index();
-            if (ct > Params.ACCESSIBILITY_SEGMENT_SIZE) {
-                end = control.getParagraphEnd(start.index() + Params.ACCESSIBILITY_SEGMENT_SIZE);
+            if (ct > Params.ACCESSIBILITY_TEXT_MAX_PARAGRAPHS) {
+                end = control.getParagraphEnd(start.index() + Params.ACCESSIBILITY_TEXT_MAX_PARAGRAPHS);
             }
         }
 
@@ -142,7 +142,7 @@ public class RTAccessibilityHelper {
         return (segment = new AccessibilitySegment(start, end));
     }
 
-    // returns true if the edit is within the a11y segment 
+    // returns true if the edit is within the a11y segment
     private boolean isAccSegmentAffected(TextPos start, TextPos end) {
         return (segment == null) ? false : segment.isAffected(start, end);
     }
@@ -183,7 +183,7 @@ public class RTAccessibilityHelper {
         return seg == null ? null : seg.computeOffset(p);
     }
 
-    // accessibility segment: either the selection, or 
+    // accessibility segment: either selected text, or the current paragraph
     private class AccessibilitySegment {
         private final TextPos start;
         private final TextPos end;

--- a/modules/jfx.incubator.richtext/src/main/java/com/sun/jfx/incubator/scene/control/richtext/RTAccessibilityHelper.java
+++ b/modules/jfx.incubator.richtext/src/main/java/com/sun/jfx/incubator/scene/control/richtext/RTAccessibilityHelper.java
@@ -27,7 +27,6 @@ package com.sun.jfx.incubator.scene.control.richtext;
 
 import java.util.Objects;
 import javafx.scene.AccessibleAttribute;
-import com.sun.jfx.incubator.scene.control.richtext.util.RichUtils;
 import jfx.incubator.scene.control.richtext.RichTextArea;
 import jfx.incubator.scene.control.richtext.SelectionSegment;
 import jfx.incubator.scene.control.richtext.TextPos;
@@ -53,7 +52,6 @@ public class RTAccessibilityHelper {
         // we can get rid of this listener pointer by making RTAccessibilityHelper extend StyledTextModel.Listener
         modelListener = (ch) -> {
             if (ch.isEdit()) {
-                RichUtils.log("ch={0}", ch);
                 if (isAccSegmentAffected(ch.getStart(), ch.getEnd())) {
                     segment = null;
                     control.notifyAccessibleAttributeChanged(AccessibleAttribute.TEXT);
@@ -67,11 +65,6 @@ public class RTAccessibilityHelper {
     }
 
     public String getText() {
-        String s = getText2();
-        RichUtils.log("text=[{0}]", s);
-        return s;
-    }
-    private String getText2() { // FIX
         AccessibilitySegment a = segment();
         if (a == null) {
             return null;
@@ -155,7 +148,6 @@ public class RTAccessibilityHelper {
     }
 
     private void handleSelectionChange(SelectionSegment old, SelectionSegment cur) {
-        RichUtils.log("sel={0}", cur);
         TextPos min0 = old == null ? null : old.getMin();
         TextPos max0 = old == null ? null : old.getMax();
         TextPos min2 = cur == null ? null : cur.getMin();
@@ -191,6 +183,7 @@ public class RTAccessibilityHelper {
         return seg == null ? null : seg.computeOffset(p);
     }
 
+    // accessibility segment: either the selection, or 
     private class AccessibilitySegment {
         private final TextPos start;
         private final TextPos end;

--- a/modules/jfx.incubator.richtext/src/main/java/com/sun/jfx/incubator/scene/control/richtext/RTAccessibilityHelper.java
+++ b/modules/jfx.incubator.richtext/src/main/java/com/sun/jfx/incubator/scene/control/richtext/RTAccessibilityHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,24 +48,14 @@ public class RTAccessibilityHelper {
         this.control = t;
     }
 
-    // FIX to be removed later
-    private void p(String fmt, Object... args) {
-        if (false) {
-            System.out.println(String.format(fmt, args));
-        }
-    }
-
     /** clear a11y cache */
     public void handleModelChange() {
-        p("handleModelChange");
         start = null;
         end = null;
     }
 
     /** returns true if update is within the a11y window */
     public boolean handleTextUpdate(TextPos p0, TextPos p1) {
-        p("handleTextUpdate %s %s", start, end);
-
         if ((start != null) && (end != null)) {
             if (p0.compareTo(end) >= 0) {
                 return false;

--- a/modules/jfx.incubator.richtext/src/main/java/com/sun/jfx/incubator/scene/control/richtext/RTAccessibilityHelper.java
+++ b/modules/jfx.incubator.richtext/src/main/java/com/sun/jfx/incubator/scene/control/richtext/RTAccessibilityHelper.java
@@ -34,14 +34,13 @@ import jfx.incubator.scene.control.richtext.TextPos;
 import jfx.incubator.scene.control.richtext.model.StyledTextModel;
 
 /**
- * The purpose of this class is to maintain a small String segment
- * around the RichTextArea caret to use with the accessibility API.
+ * The purpose of this class is to link the RichTextArea to the accessibility API.
  * <p>
  * These APIs generally accept a single String and integer offsets for caret position
  * and selection, which is totally impossible to implement in the context of a large
- * virtualized text model, as it a) uses TextPos for encapsulating the text position
- * instead of an int, and it may not be possible to represent selected text as a
- * String for large models.
+ * virtualized text model, as it
+ * a) uses TextPos for encapsulating the text position instead of an int, and
+ * b) it may not be possible to represent selected text as a single String for large models.
  */
 public class RTAccessibilityHelper {
     private final RichTextArea control;
@@ -61,6 +60,10 @@ public class RTAccessibilityHelper {
                 }
             }
         };
+
+        t.selectionProperty().addListener((s, old, cur) -> {
+            handleSelectionChange(old, cur);
+        });
     }
 
     public void registerModel(StyledTextModel m) {
@@ -82,10 +85,7 @@ public class RTAccessibilityHelper {
         return false;
     }
 
-    /**
-     * Handles selection changes.
-     */
-    public void handleSelectionChange(SelectionSegment old, SelectionSegment cur) {
+    private void handleSelectionChange(SelectionSegment old, SelectionSegment cur) {
         RichUtils.log("sel={0}", cur);
         TextPos min0 = old == null ? null : old.getMin();
         TextPos max0 = old == null ? null : old.getMax();

--- a/modules/jfx.incubator.richtext/src/main/java/com/sun/jfx/incubator/scene/control/richtext/RichTextAreaHelper.java
+++ b/modules/jfx.incubator.richtext/src/main/java/com/sun/jfx/incubator/scene/control/richtext/RichTextAreaHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,10 +26,8 @@
 package com.sun.jfx.incubator.scene.control.richtext;
 
 import com.sun.javafx.util.Utils;
-import com.sun.jfx.incubator.scene.control.richtext.util.ListenerHelper;
 import jfx.incubator.scene.control.richtext.RichTextArea;
 import jfx.incubator.scene.control.richtext.TextPos;
-import jfx.incubator.scene.control.richtext.skin.RichTextAreaSkin;
 
 /**
  * Manages RichTextArea Accessor.

--- a/modules/jfx.incubator.richtext/src/main/java/com/sun/jfx/incubator/scene/control/richtext/util/RichUtils.java
+++ b/modules/jfx.incubator.richtext/src/main/java/com/sun/jfx/incubator/scene/control/richtext/util/RichUtils.java
@@ -32,8 +32,10 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.text.DecimalFormat;
+import java.text.MessageFormat;
 import java.util.List;
 import java.util.Locale;
+import java.util.function.Supplier;
 import javax.imageio.ImageIO;
 import javafx.application.ColorScheme;
 import javafx.application.ConditionalFeature;
@@ -75,6 +77,10 @@ import jfx.incubator.scene.control.richtext.model.StyledTextModel;
  */
 public final class RichUtils {
 
+    /// enabled debug output
+    private static final boolean DEBUG = Boolean.getBoolean("jfx.incubator.richtext.DEBUG");
+    /// includes fileName:lineNumber in the debug output
+    private static final boolean CALLER = Boolean.getBoolean("jfx.incubator.richtext.CALLER");
     private static final DecimalFormat format = new DecimalFormat("#0.##");
 
     private RichUtils() {
@@ -757,5 +763,44 @@ public final class RichUtils {
             node = node.getParent();
         }
         return null;
+    }
+
+    public static void log(Throwable e) {
+        if (DEBUG) {
+            e.printStackTrace();
+        }
+    }
+
+    public static void log(Object x) {
+        if (DEBUG) {
+            output(x);
+        }
+    }
+
+    public static void log(String format, Object... items) {
+        if (DEBUG) {
+            String s = MessageFormat.format(format, items);
+            output(s);
+        }
+    }
+
+    public static void log(Supplier<Object> x) {
+        if (DEBUG) {
+            Object v = x.get();
+            output(v);
+        }
+    }
+
+    private static void output(Object x) {
+        if (CALLER) {
+            StackTraceElement em = new Throwable().getStackTrace()[2];
+            String f = em.getFileName();
+            if (f.endsWith(".java")) {
+                f = f.substring(0, f.length() - 5);
+            }
+            System.out.println(f + ":" + em.getLineNumber() + " " + x);
+        } else {
+            System.out.println(x);
+        }
     }
 }

--- a/modules/jfx.incubator.richtext/src/main/java/com/sun/jfx/incubator/scene/control/richtext/util/RichUtils.java
+++ b/modules/jfx.incubator.richtext/src/main/java/com/sun/jfx/incubator/scene/control/richtext/util/RichUtils.java
@@ -798,7 +798,7 @@ public final class RichUtils {
             if (f.endsWith(".java")) {
                 f = f.substring(0, f.length() - 5);
             }
-            System.out.println(f + ":" + em.getLineNumber() + " " + x);
+            System.out.println(f + "." + em.getMethodName() + ":" + em.getLineNumber() + " " + x);
         } else {
             System.out.println(x);
         }

--- a/modules/jfx.incubator.richtext/src/main/java/jfx/incubator/scene/control/richtext/RichTextArea.java
+++ b/modules/jfx.incubator.richtext/src/main/java/jfx/incubator/scene/control/richtext/RichTextArea.java
@@ -346,23 +346,8 @@ public class RichTextArea extends Control {
         setAccessibleRoleDescription("Rich Text Area");
 
         selectionModel.selectionProperty().addListener((s, old, cur) -> {
-            TextPos min0 = old == null ? null : old.getMin();
-            TextPos max0 = old == null ? null : old.getMax();
-            TextPos min2 = cur == null ? null : cur.getMin();
-            TextPos max2 = cur == null ? null : cur.getMax();
-
             if (accessibilityHelper != null) {
-                if (accessibilityHelper.handleSelectionChange(cur)) {
-                    notifyAccessibleAttributeChanged(AccessibleAttribute.TEXT);
-                }
-            }
-
-            if (!Objects.equals(min0, min2)) {
-                notifyAccessibleAttributeChanged(AccessibleAttribute.SELECTION_START);
-            }
-
-            if (!Objects.equals(max0, max2)) {
-                notifyAccessibleAttributeChanged(AccessibleAttribute.SELECTION_END);
+                accessibilityHelper.handleSelectionChange(old, cur);
             }
         });
 
@@ -688,17 +673,6 @@ public class RichTextArea extends Control {
     public final ObjectProperty<StyledTextModel> modelProperty() {
         if (model == null) {
             model = new SimpleObjectProperty<>(this, "model") {
-                // TODO does this create a memory leak?  should we bind or weak listen?
-                private final StyledTextModel.Listener li = (ch) -> {
-                    if (ch.isEdit()) {
-                        if (accessibilityHelper != null) {
-                            if (accessibilityHelper.handleTextUpdate(ch.getStart(), ch.getEnd())) {
-                                // TODO check the timing, may be runLater?
-                                notifyAccessibleAttributeChanged(AccessibleAttribute.TEXT);
-                            }
-                        }
-                    }
-                };
                 private StyledTextModel old;
 
                 @Override
@@ -729,16 +703,17 @@ public class RichTextArea extends Control {
                     }
 
                     if (old != null) {
-                        old.removeListener(li);
+                        if (accessibilityHelper != null) {
+                            accessibilityHelper.unregisterModel(old);
+                        }
                     }
                     if (m != null) {
-                        m.addListener(li);
+                        if (accessibilityHelper != null) {
+                            accessibilityHelper.registerModel(m);
+                        }
                     }
                     old = m;
 
-                    if (accessibilityHelper != null) {
-                        accessibilityHelper.handleModelChange();
-                    }
                     selectionModel.clear();
                     notifyAccessibleAttributeChanged(AccessibleAttribute.TEXT);
                 }
@@ -2493,6 +2468,10 @@ public class RichTextArea extends Control {
     private RTAccessibilityHelper accessibilityHelper() {
         if(accessibilityHelper == null) {
             accessibilityHelper = new RTAccessibilityHelper(this);
+            StyledTextModel m = getModel();
+            if (m != null) {
+                accessibilityHelper.registerModel(m);
+            }
         }
         return accessibilityHelper;
     }

--- a/modules/jfx.incubator.richtext/src/main/java/jfx/incubator/scene/control/richtext/RichTextArea.java
+++ b/modules/jfx.incubator.richtext/src/main/java/jfx/incubator/scene/control/richtext/RichTextArea.java
@@ -344,13 +344,6 @@ public class RichTextArea extends Control {
         getStyleClass().add("rich-text-area");
         setAccessibleRole(AccessibleRole.TEXT_AREA);
         setAccessibleRoleDescription("Rich Text Area");
-
-        selectionModel.selectionProperty().addListener((s, old, cur) -> {
-            if (accessibilityHelper != null) {
-                accessibilityHelper.handleSelectionChange(old, cur);
-            }
-        });
-
         setModel(model);
     }
 

--- a/modules/jfx.incubator.richtext/src/main/java/jfx/incubator/scene/control/richtext/RichTextArea.java
+++ b/modules/jfx.incubator.richtext/src/main/java/jfx/incubator/scene/control/richtext/RichTextArea.java
@@ -708,7 +708,9 @@ public class RichTextArea extends Control {
                     old = m;
 
                     selectionModel.clear();
-                    notifyAccessibleAttributeChanged(AccessibleAttribute.TEXT);
+                    if (accessibilityHelper != null) {
+                        accessibilityHelper.handleModelChange();
+                    }
                 }
             };
         }

--- a/modules/jfx.incubator.richtext/src/main/java/jfx/incubator/scene/control/richtext/model/ContentChange.java
+++ b/modules/jfx.incubator.richtext/src/main/java/jfx/incubator/scene/control/richtext/model/ContentChange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -72,25 +72,11 @@ public abstract class ContentChange {
     }
 
     /**
-     * Returns the end position before the change.
-     * @return the end position before the change
+     * Returns the end position.
+     * @return the end position
      */
     public TextPos getEnd() {
         return end;
-    }
-
-    /**
-     * Returns the end position after the change.
-     * @return the end position after the change
-     * @since 27
-     */
-    public TextPos getEndAfter() {
-        int ix = end.index() + getLinesAdded();
-        int added = getCharsAddedBottom();
-        int off = end.offset() + added;
-        int cix = end.charIndex() + added;
-        // TODO this needs to be tested: call replace() a number of times and compare
-        return new TextPos(ix, off, cix, end.isLeading());
     }
 
     /**
@@ -151,17 +137,6 @@ public abstract class ContentChange {
             public int getCharsAddedBottom() {
                 return charsAddedBottom;
             }
-
-            @Override
-            public String toString() {
-                return
-                    "ContentChange.edit{start=" + start +
-                    ", end=" + end +
-                    ", top=" + charsAddedTop +
-                    ", lines=" + linesAdded +
-                    ", btm=" + charsAddedBottom +
-                    "}";
-            }
         };
     }
 
@@ -177,14 +152,6 @@ public abstract class ContentChange {
             @Override
             public boolean isEdit() {
                 return false;
-            }
-
-            @Override
-            public String toString() {
-                return
-                    "ContentChange.style{start=" + start +
-                    ", end=" + end +
-                    "}";
             }
         };
     }

--- a/modules/jfx.incubator.richtext/src/main/java/jfx/incubator/scene/control/richtext/model/ContentChange.java
+++ b/modules/jfx.incubator.richtext/src/main/java/jfx/incubator/scene/control/richtext/model/ContentChange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -72,11 +72,25 @@ public abstract class ContentChange {
     }
 
     /**
-     * Returns the end position.
-     * @return the end position
+     * Returns the end position before the change.
+     * @return the end position before the change
      */
     public TextPos getEnd() {
         return end;
+    }
+
+    /**
+     * Returns the end position after the change.
+     * @return the end position after the change
+     * @since 27
+     */
+    public TextPos getEndAfter() {
+        int ix = end.index() + getLinesAdded();
+        int added = getCharsAddedBottom();
+        int off = end.offset() + added;
+        int cix = end.charIndex() + added;
+        // TODO this needs to be tested: call replace() a number of times and compare
+        return new TextPos(ix, off, cix, end.isLeading());
     }
 
     /**
@@ -137,6 +151,17 @@ public abstract class ContentChange {
             public int getCharsAddedBottom() {
                 return charsAddedBottom;
             }
+
+            @Override
+            public String toString() {
+                return
+                    "ContentChange.edit{start=" + start +
+                    ", end=" + end +
+                    ", top=" + charsAddedTop +
+                    ", lines=" + linesAdded +
+                    ", btm=" + charsAddedBottom +
+                    "}";
+            }
         };
     }
 
@@ -152,6 +177,14 @@ public abstract class ContentChange {
             @Override
             public boolean isEdit() {
                 return false;
+            }
+
+            @Override
+            public String toString() {
+                return
+                    "ContentChange.style{start=" + start +
+                    ", end=" + end +
+                    "}";
             }
         };
     }

--- a/modules/jfx.incubator.richtext/src/main/java/jfx/incubator/scene/control/richtext/skin/RichTextAreaSkin.java
+++ b/modules/jfx.incubator.richtext/src/main/java/jfx/incubator/scene/control/richtext/skin/RichTextAreaSkin.java
@@ -60,7 +60,6 @@ import com.sun.jfx.incubator.scene.control.richtext.Params;
 import com.sun.jfx.incubator.scene.control.richtext.RichTextAreaBehavior;
 import com.sun.jfx.incubator.scene.control.richtext.RichTextAreaHelper;
 import com.sun.jfx.incubator.scene.control.richtext.RichTextAreaSkinHelper;
-import com.sun.jfx.incubator.scene.control.richtext.TextCell;
 import com.sun.jfx.incubator.scene.control.richtext.VFlow;
 import com.sun.jfx.incubator.scene.control.richtext.util.ListenerHelper;
 import com.sun.jfx.incubator.scene.control.richtext.util.RichUtils;
@@ -518,6 +517,7 @@ public class RichTextAreaSkin extends SkinBase<RichTextArea> {
     @Override
     protected Object queryAccessibleAttribute(AccessibleAttribute attribute, Object... parameters) {
         switch (attribute) {
+        /* Not supported due to virtualization
         case BOUNDS_FOR_RANGE:
             {
                 TextPos p = getSkinnable().getCaretPosition();
@@ -531,22 +531,6 @@ public class RichTextAreaSkin extends SkinBase<RichTextArea> {
                 }
                 return null;
             }
-        case FONT:
-            {
-                StyleAttributeMap a = getSkinnable().getActiveStyleAttributeMap();
-                if (a != null) {
-                    String family = a.getFontFamily();
-                    if (family != null) {
-                        Double size = a.getFontSize();
-                        if (size != null) {
-                            return Font.font(family, size);
-                        }
-                    }
-                }
-                return null;
-            }
-        case HORIZONTAL_SCROLLBAR:
-            return hscroll;
         case LINE_FOR_OFFSET:
             {
                 TextPos p = getSkinnable().getCaretPosition();
@@ -589,6 +573,23 @@ public class RichTextAreaSkin extends SkinBase<RichTextArea> {
                 TextPos p = getSkinnable().getTextPosition(screenPoint.getX(), screenPoint.getY());
                 return p == null ? null : p.charIndex();
             }
+        */
+        case FONT:
+        {
+            StyleAttributeMap a = getSkinnable().getActiveStyleAttributeMap();
+            if (a != null) {
+                String family = a.getFontFamily();
+                if (family != null) {
+                    Double size = a.getFontSize();
+                    if (size != null) {
+                        return Font.font(family, size);
+                    }
+                }
+            }
+            return null;
+        }
+        case HORIZONTAL_SCROLLBAR:
+            return hscroll;
         case VERTICAL_SCROLLBAR:
             return vscroll;
         default:

--- a/modules/jfx.incubator.richtext/src/main/java/jfx/incubator/scene/control/richtext/skin/RichTextAreaSkin.java
+++ b/modules/jfx.incubator.richtext/src/main/java/jfx/incubator/scene/control/richtext/skin/RichTextAreaSkin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -525,7 +525,9 @@ public class RichTextAreaSkin extends SkinBase<RichTextArea> {
                     int start = (Integer)parameters[0];
                     int end = (Integer)parameters[1];
                     PathElement[] elements = getVFlow().getRangeShape(p.index(), start, end + 1);
-                    return RichUtils.pathToBoundsArray(getVFlow(), elements);
+                    if (elements != null) {
+                        return RichUtils.pathToBoundsArray(getVFlow(), elements);
+                    }
                 }
                 return null;
             }

--- a/modules/jfx.incubator.richtext/src/test/java/test/jfx/incubator/scene/control/richtext/RichTextAreaTest.java
+++ b/modules/jfx.incubator.richtext/src/test/java/test/jfx/incubator/scene/control/richtext/RichTextAreaTest.java
@@ -53,6 +53,7 @@ import javafx.scene.input.InputMethodTextRun;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.Region;
+import javafx.scene.text.Font;
 import javafx.util.Duration;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -61,7 +62,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import com.sun.jfx.incubator.scene.control.richtext.VFlow;
-import com.sun.jfx.incubator.scene.control.richtext.util.RichUtils;
 import jfx.incubator.scene.control.richtext.LineEnding;
 import jfx.incubator.scene.control.richtext.RichTextArea;
 import jfx.incubator.scene.control.richtext.RichTextAreaShim;
@@ -1094,29 +1094,29 @@ public class RichTextAreaTest {
     }
 
     @Test
-    public void accessibilityEditable() {
+    public void queryAccessibilityEditable() {
         assertEquals(true, control.queryAccessibleAttribute(AccessibleAttribute.EDITABLE));
         control.setEditable(false);
         assertEquals(false, control.queryAccessibleAttribute(AccessibleAttribute.EDITABLE));
     }
 
     @Test
-    public void accessibilityText() {
+    public void queryAccessibilityText() {
         assertEquals(null, control.queryAccessibleAttribute(AccessibleAttribute.TEXT));
         control.select(TextPos.ZERO);
         assertEquals("\n", control.queryAccessibleAttribute(AccessibleAttribute.TEXT));
-        RichUtils.log("appendText"); // FIX
         control.appendText("1\n2\n");
         assertEquals("1\n", control.queryAccessibleAttribute(AccessibleAttribute.TEXT));
         control.select(TextPos.ofLeading(1, 0));
-        assertEquals("2\n", control.queryAccessibleAttribute(AccessibleAttribute.TEXT)); // FIX
+        assertEquals("2\n", control.queryAccessibleAttribute(AccessibleAttribute.TEXT));
         control.select(TextPos.ofLeading(999, 0));
+        assertEquals("\n", control.queryAccessibleAttribute(AccessibleAttribute.TEXT));
+        control.select(TextPos.ofLeading(1, 1), new TextPos(1, 1, 1, false));
         assertEquals("2\n", control.queryAccessibleAttribute(AccessibleAttribute.TEXT));
     }
 
-// FIX
-//    @Test
-    public void accessibilitySelectionAndCaret() {
+    @Test
+    public void queryAccessibilitySelectionAndCaret() {
         control.appendText("111\n222\n");
 
         control.select(TextPos.ZERO);
@@ -1130,14 +1130,23 @@ public class RichTextAreaTest {
         assertEquals(6, control.queryAccessibleAttribute(AccessibleAttribute.CARET_OFFSET));
     }
 
- // FIX
-//    @Test
-    public void accessibilitySkin() {
+    @Test
+    public void queryAccessibilitySkin() {
+        double size = 16.0;
+        Font f = Font.getDefault();
+        StyleAttributeMap FONT = StyleAttributeMap.builder().
+            setFontFamily(f.getFamily()).
+            setFontSize(size).
+            build();
+
         control.appendText("111\n222\n");
-        control.applyStyle(TextPos.ZERO, control.getDocumentEnd(), BOLD);
+        control.applyStyle(TextPos.ZERO, control.getDocumentEnd(), FONT);
         control.select(TextPos.ZERO);
+        
         assertEquals(null, control.queryAccessibleAttribute(AccessibleAttribute.BOUNDS_FOR_RANGE, 0, 1));
-        assertEquals(BOLD, control.queryAccessibleAttribute(AccessibleAttribute.FONT));
+
+        assertEquals(size, ((Font)control.queryAccessibleAttribute(AccessibleAttribute.FONT)).getSize());
+
 //        HORIZONTAL_SCROLLBAR
 //        LINE_FOR_OFFSET
 //        LINE_START

--- a/modules/jfx.incubator.richtext/src/test/java/test/jfx/incubator/scene/control/richtext/RichTextAreaTest.java
+++ b/modules/jfx.incubator.richtext/src/test/java/test/jfx/incubator/scene/control/richtext/RichTextAreaTest.java
@@ -1102,6 +1102,7 @@ public class RichTextAreaTest {
 
     @Test
     public void queryAccessibilityText() {
+        control.setLineEnding(LineEnding.LF);
         assertEquals(null, control.queryAccessibleAttribute(AccessibleAttribute.TEXT));
         control.select(TextPos.ZERO);
         assertEquals("\n", control.queryAccessibleAttribute(AccessibleAttribute.TEXT));
@@ -1118,6 +1119,7 @@ public class RichTextAreaTest {
     @Test
     public void queryAccessibilitySelectionAndCaret() {
         control.appendText("111\n222\n");
+        control.setLineEnding(LineEnding.LF);
 
         control.select(TextPos.ZERO);
         assertEquals(0, control.queryAccessibleAttribute(AccessibleAttribute.SELECTION_START));
@@ -1139,19 +1141,21 @@ public class RichTextAreaTest {
             setFontSize(size).
             build();
 
+        control.setLineEnding(LineEnding.LF);
         control.appendText("111\n222\n");
+        control.layout();
         control.applyStyle(TextPos.ZERO, control.getDocumentEnd(), FONT);
         control.select(TextPos.ZERO);
         
-        assertEquals(null, control.queryAccessibleAttribute(AccessibleAttribute.BOUNDS_FOR_RANGE, 0, 1));
-
+        // looking for the font size only since the platform may substitute
         assertEquals(size, ((Font)control.queryAccessibleAttribute(AccessibleAttribute.FONT)).getSize());
 
-//        HORIZONTAL_SCROLLBAR
-//        LINE_FOR_OFFSET
-//        LINE_START
-//        LINE_END
-//        OFFSET_AT_POINT
-//        VERTICAL_SCROLLBAR
+        Object hsb = control.lookup(".scroll-bar:horizontal");
+        assertNotNull(hsb);
+        assertEquals(hsb, control.queryAccessibleAttribute(AccessibleAttribute.HORIZONTAL_SCROLLBAR));
+
+        Object vsb = control.lookup(".scroll-bar:vertical");
+        assertNotNull(vsb);
+        assertEquals(vsb, control.queryAccessibleAttribute(AccessibleAttribute.VERTICAL_SCROLLBAR));
     }
 }

--- a/modules/jfx.incubator.richtext/src/test/java/test/jfx/incubator/scene/control/richtext/RichTextAreaTest.java
+++ b/modules/jfx.incubator.richtext/src/test/java/test/jfx/incubator/scene/control/richtext/RichTextAreaTest.java
@@ -53,7 +53,6 @@ import javafx.scene.input.InputMethodTextRun;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.Region;
-import javafx.scene.text.Font;
 import javafx.util.Duration;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -62,6 +61,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import com.sun.jfx.incubator.scene.control.richtext.VFlow;
+import com.sun.jfx.incubator.scene.control.richtext.util.RichUtils;
 import jfx.incubator.scene.control.richtext.LineEnding;
 import jfx.incubator.scene.control.richtext.RichTextArea;
 import jfx.incubator.scene.control.richtext.RichTextAreaShim;
@@ -1105,6 +1105,7 @@ public class RichTextAreaTest {
         assertEquals(null, control.queryAccessibleAttribute(AccessibleAttribute.TEXT));
         control.select(TextPos.ZERO);
         assertEquals("\n", control.queryAccessibleAttribute(AccessibleAttribute.TEXT));
+        RichUtils.log("appendText"); // FIX
         control.appendText("1\n2\n");
         assertEquals("1\n", control.queryAccessibleAttribute(AccessibleAttribute.TEXT));
         control.select(TextPos.ofLeading(1, 0));

--- a/modules/jfx.incubator.richtext/src/test/java/test/jfx/incubator/scene/control/richtext/RichTextAreaTest.java
+++ b/modules/jfx.incubator.richtext/src/test/java/test/jfx/incubator/scene/control/richtext/RichTextAreaTest.java
@@ -505,7 +505,6 @@ public class RichTextAreaTest {
         assertEquals(new TextPos(2, 3, 2, false), control.getParagraphEnd(2));
 
         control.setModel(null);
-        // TODO this should throw an IOOBE
         assertEquals(TextPos.ZERO, control.getParagraphEnd(0));
     }
 

--- a/modules/jfx.incubator.richtext/src/test/java/test/jfx/incubator/scene/control/richtext/RichTextAreaTest.java
+++ b/modules/jfx.incubator.richtext/src/test/java/test/jfx/incubator/scene/control/richtext/RichTextAreaTest.java
@@ -41,6 +41,7 @@ import javafx.css.CssMetaData;
 import javafx.css.Styleable;
 import javafx.event.Event;
 import javafx.geometry.Insets;
+import javafx.scene.AccessibleAttribute;
 import javafx.scene.Scene;
 import javafx.scene.control.Control;
 import javafx.scene.input.Clipboard;
@@ -52,6 +53,7 @@ import javafx.scene.input.InputMethodTextRun;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.Region;
+import javafx.scene.text.Font;
 import javafx.util.Duration;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -80,13 +82,6 @@ import test.jfx.incubator.scene.util.TUtil;
 
 /**
  * Tests the RichTextArea control.
- *
- * NOTES:
- * 1. methods that involve moving the caret (backspace, delete, move*, select*, etc.) needs a real
- * text layout and therefore need to be headful (or wait for JDK-8342565).
- * 2. operations with models that contain more than one paragraph might also fail due to scrollCaretToVisible().
- *
- * TODO accessibility APIs
  */
 public class RichTextAreaTest {
     private RichTextArea control;
@@ -1097,5 +1092,57 @@ public class RichTextAreaTest {
 
         String s = RichTestUtil.getText(control, sel);
         assertEquals(text, s);
+    }
+
+    @Test
+    public void accessibilityEditable() {
+        assertEquals(true, control.queryAccessibleAttribute(AccessibleAttribute.EDITABLE));
+        control.setEditable(false);
+        assertEquals(false, control.queryAccessibleAttribute(AccessibleAttribute.EDITABLE));
+    }
+
+    @Test
+    public void accessibilityText() {
+        assertEquals(null, control.queryAccessibleAttribute(AccessibleAttribute.TEXT));
+        control.select(TextPos.ZERO);
+        assertEquals("\n", control.queryAccessibleAttribute(AccessibleAttribute.TEXT));
+        control.appendText("1\n2\n");
+        assertEquals("1\n", control.queryAccessibleAttribute(AccessibleAttribute.TEXT));
+        control.select(TextPos.ofLeading(1, 0));
+        assertEquals("2\n", control.queryAccessibleAttribute(AccessibleAttribute.TEXT)); // FIX
+        control.select(TextPos.ofLeading(999, 0));
+        assertEquals("2\n", control.queryAccessibleAttribute(AccessibleAttribute.TEXT));
+    }
+
+// FIX
+//    @Test
+    public void accessibilitySelectionAndCaret() {
+        control.appendText("111\n222\n");
+
+        control.select(TextPos.ZERO);
+        assertEquals(0, control.queryAccessibleAttribute(AccessibleAttribute.SELECTION_START));
+        assertEquals(0, control.queryAccessibleAttribute(AccessibleAttribute.SELECTION_END));
+        assertEquals(0, control.queryAccessibleAttribute(AccessibleAttribute.CARET_OFFSET));
+
+        control.select(TextPos.ofLeading(0, 1), TextPos.ofLeading(1, 2));
+        assertEquals(1, control.queryAccessibleAttribute(AccessibleAttribute.SELECTION_START));
+        assertEquals(6, control.queryAccessibleAttribute(AccessibleAttribute.SELECTION_END));
+        assertEquals(6, control.queryAccessibleAttribute(AccessibleAttribute.CARET_OFFSET));
+    }
+
+ // FIX
+//    @Test
+    public void accessibilitySkin() {
+        control.appendText("111\n222\n");
+        control.applyStyle(TextPos.ZERO, control.getDocumentEnd(), BOLD);
+        control.select(TextPos.ZERO);
+        assertEquals(null, control.queryAccessibleAttribute(AccessibleAttribute.BOUNDS_FOR_RANGE, 0, 1));
+        assertEquals(BOLD, control.queryAccessibleAttribute(AccessibleAttribute.FONT));
+//        HORIZONTAL_SCROLLBAR
+//        LINE_FOR_OFFSET
+//        LINE_START
+//        LINE_END
+//        OFFSET_AT_POINT
+//        VERTICAL_SCROLLBAR
     }
 }

--- a/modules/jfx.incubator.richtext/src/test/java/test/jfx/incubator/scene/control/richtext/RichTextAreaTest.java
+++ b/modules/jfx.incubator.richtext/src/test/java/test/jfx/incubator/scene/control/richtext/RichTextAreaTest.java
@@ -1146,7 +1146,7 @@ public class RichTextAreaTest {
         control.layout();
         control.applyStyle(TextPos.ZERO, control.getDocumentEnd(), FONT);
         control.select(TextPos.ZERO);
-        
+
         // looking for the font size only since the platform may substitute
         assertEquals(size, ((Font)control.queryAccessibleAttribute(AccessibleAttribute.FONT)).getSize());
 


### PR DESCRIPTION
Updates accessibility code in the `RichTextArea` and adds tests.

Supported attributes:

- EDITABLE
- TEXT
- SELECTION_START
- SELECTION_END
- CARET_OFFSET
- FONT
- HORIZONTAL_SCROLLBAR
- VERTICAL_SCROLLBAR


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8374809](https://bugs.openjdk.org/browse/JDK-8374809): [RichTextArea] accessibility (**Enhancement** - P4)


### Reviewers
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - Committer)
 * [Lukasz Kostyra](https://openjdk.org/census#lkostyra) (@lukostyra - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2158/head:pull/2158` \
`$ git checkout pull/2158`

Update a local copy of the PR: \
`$ git checkout pull/2158` \
`$ git pull https://git.openjdk.org/jfx.git pull/2158/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2158`

View PR using the GUI difftool: \
`$ git pr show -t 2158`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2158.diff">https://git.openjdk.org/jfx/pull/2158.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2158#issuecomment-4292203692)
</details>
