### PR TITLE
8382883: JavaFX on Linux crashed after some time when ES2Context.makeCurrent() was called

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2Context.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2Context.java
@@ -142,6 +142,10 @@ class ES2Context extends BaseShaderContext {
         return ES2PhongShader.getShader(meshView, this);
     }
 
+    void invalidateCurrentDrawable() {
+        currentDrawable = null;
+    }
+
     void makeCurrent(GLDrawable drawable) {
         if (drawable == null) {
             drawable = dummyGLDrawable;

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2SwapChain.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2SwapChain.java
@@ -184,7 +184,7 @@ class ES2SwapChain implements ES2RenderTarget, Presentable, GraphicsResource {
     @Override
     public boolean present() {
         boolean presented = drawable.swapBuffers(context.getGLContext());
-        context.makeCurrent(null);
+        context.invalidateCurrentDrawable();  // no OpenGL call, just invalidating the drawable
         return presented;
     }
 
@@ -308,6 +308,7 @@ class ES2SwapChain implements ES2RenderTarget, Presentable, GraphicsResource {
         }
 
         if (drawable != null) {
+        	context.makeCurrent(null); // drawable must not be current when disposed
             drawable.dispose();
             drawable = null;
         }

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2SwapChain.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2SwapChain.java
@@ -308,7 +308,7 @@ class ES2SwapChain implements ES2RenderTarget, Presentable, GraphicsResource {
         }
 
         if (drawable != null) {
-        	context.makeCurrent(null); // drawable must not be current when disposed
+            context.makeCurrent(null); // drawable must not be current when disposed
             drawable.dispose();
             drawable = null;
         }


### PR DESCRIPTION
Hi all,
this is the topic I opened on the mailing list for this ticket: https://mail.openjdk.org/archives/list/openjfx-dev@openjdk.org/thread/XJB272UTZSNRYTQTHSALXYY4VO23DCIU/

Additional notes to the problem:
- The error happend with a dated driver, but updating it to a recent version did not fix the problem.
- I could not reproduce the problem with a similar notebook with the same old(!) driver, but newer GPU revision.
- I can verify that the fix below seems to fix the problem: the application runs now for 5 days straight, which did never happen before with that machine. The application runs on the FX 17, so my 'long term test' is with that branch.

Notes to the patch:
- This patch reduces the GL calls between frames.
- During normal rendering, currentDrawable is now null between present() and createGraphics() (which sets it back to a real drawable), but it is then never read. Outside that window, the only reader is clearContext() on the shutdown path, which already has a null guard. currentDrawable is only written in invalidateCurrentDrawable() and makeCurrent(), and only read in makeCurrent() and clearContext().
- On the shutdown path (clearContext), dummy.swapBuffers() would no longer be called, which I believe is fine.
- ES2SwapChain.dispose() on master calls drawable.dispose(), which requires the drawable to be non-current. Since present() no longer parks the context on the dummy, that step moves into the dispose path: context.makeCurrent(null) before drawable.dispose().

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8382883](https://bugs.openjdk.org/browse/JDK-8382883): JavaFX on Linux crashed after some time when ES2Context.makeCurrent() was called (**Bug** - P4)


### Reviewers
 * [Jayathirth D V](https://openjdk.org/census#jdv) (@jayathirthrao - Committer)
 * [Lukasz Kostyra](https://openjdk.org/census#lkostyra) (@lukostyra - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2159/head:pull/2159` \
`$ git checkout pull/2159`

Update a local copy of the PR: \
`$ git checkout pull/2159` \
`$ git pull https://git.openjdk.org/jfx.git pull/2159/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2159`

View PR using the GUI difftool: \
`$ git pr show -t 2159`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2159.diff">https://git.openjdk.org/jfx/pull/2159.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2159#issuecomment-4307240066)
</details>
