### PR TITLE
8382886: Running a JavaFX build may not work due to duplicate entries of swt-debug.jar in the gradle cache

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3169,6 +3169,8 @@ project(":swt") {
                     into libsDir
                     from f.getParentFile()
                     include "**/*swt*.jar"
+                    exclude "**/*swt*-sources.jar"
+                    exclude "**/*swt*-javadoc.jar"
                     includeEmptyDirs = false
                     rename ".*swt.*jar", "swt-debug\\.jar"
                 }


### PR DESCRIPTION
This fixes a gradle clean build issue due to the swt dependency jar copy not excluding javadoc and sources

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8382886](https://bugs.openjdk.org/browse/JDK-8382886): Running a JavaFX build may not work due to duplicate entries of swt-debug.jar in the gradle cache (**Bug** - P4)


### Reviewers
 * [Lukasz Kostyra](https://openjdk.org/census#lkostyra) (@lukostyra - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2160/head:pull/2160` \
`$ git checkout pull/2160`

Update a local copy of the PR: \
`$ git checkout pull/2160` \
`$ git pull https://git.openjdk.org/jfx.git pull/2160/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2160`

View PR using the GUI difftool: \
`$ git pr show -t 2160`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2160.diff">https://git.openjdk.org/jfx/pull/2160.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2160#issuecomment-4358353771)
</details>
