### PR TITLE
8383783: MediaQueryParser should reject query lists without comma separator

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/css/media/MediaQueryParser.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/css/media/MediaQueryParser.java
@@ -88,21 +88,32 @@ public final class MediaQueryParser {
     public MediaQueryList parseMediaQueryList(List<Token> tokens) {
         var stream = new TokenStream(tokens);
         var expressions = new MediaQueryList();
-        boolean lastWasComma = false;
+        boolean expectMediaCondition = true;
 
-        while (stream.consume() != null) {
-            switch (stream.current().getType()) {
+        while (stream.peek() != null) {
+            switch (stream.peek().getType()) {
                 case CssLexer.COMMA -> {
-                    if (lastWasComma || expressions.isEmpty()) {
-                        errorHandler.accept(stream.current(), "Unexpected token");
+                    Token comma = stream.consume();
+                    if (expectMediaCondition || expressions.isEmpty()) {
+                        errorHandler.accept(comma, "Unexpected token");
                     }
 
-                    lastWasComma = true;
+                    expectMediaCondition = true;
                 }
 
                 case CssLexer.IDENT, CssLexer.LPAREN -> {
-                    lastWasComma = false;
-                    stream.reconsume();
+                    if (!expectMediaCondition) {
+                        errorHandler.accept(stream.consume(), "Expected COMMA");
+
+                        while (stream.consumeIf(NOT_COMMA) != null) {
+                            // Skip forward to the next comma and replace the previous query with a
+                            // malformed segment that always evaluates to false.
+                        }
+
+                        expressions.set(expressions.size() - 1, ConstantExpression.of(false));
+                        continue;
+                    }
+
                     MediaQuery expression = parseMediaCondition(stream);
                     if (expression != null) {
                         expressions.add(expression);
@@ -115,10 +126,12 @@ public final class MediaQueryParser {
                         // Invalid expressions always evaluate to false.
                         expressions.add(ConstantExpression.of(false));
                     }
+
+                    expectMediaCondition = false;
                 }
 
                 default -> {
-                    errorHandler.accept(stream.current(), "Unexpected token");
+                    errorHandler.accept(stream.consume(), "Unexpected token");
                     return expressions;
                 }
             }

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/css/media/MediaQueryParser.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/css/media/MediaQueryParser.java
@@ -94,8 +94,9 @@ public final class MediaQueryParser {
             switch (stream.peek().getType()) {
                 case CssLexer.COMMA -> {
                     Token comma = stream.consume();
-                    if (expectMediaCondition || expressions.isEmpty()) {
+                    if (expectMediaCondition) {
                         errorHandler.accept(comma, "Unexpected token");
+                        expressions.add(ConstantExpression.of(false));
                     }
 
                     expectMediaCondition = true;
@@ -132,9 +133,21 @@ public final class MediaQueryParser {
 
                 default -> {
                     errorHandler.accept(stream.consume(), "Unexpected token");
-                    return expressions;
+
+                    while (stream.consumeIf(NOT_COMMA) != null) {
+                        // Skip forward to the next comma and replace the malformed segment
+                        // with a query that always evaluates to false.
+                    }
+
+                    expressions.add(ConstantExpression.of(false));
+                    expectMediaCondition = false;
                 }
             }
+        }
+
+        if (expectMediaCondition && !expressions.isEmpty()) {
+            errorHandler.accept(null, "Expected <media-condition>");
+            expressions.add(ConstantExpression.of(false));
         }
 
         return expressions;

--- a/modules/javafx.graphics/src/test/java/test/javafx/css/CssParser_mediaQuery_Test.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/css/CssParser_mediaQuery_Test.java
@@ -449,6 +449,43 @@ public class CssParser_mediaQuery_Test {
     }
 
     @Test
+    void missingCommaBetweenMediaQueriesEvaluatesToFalse() {
+        String stylesheetText = """
+            @media (prefers-color-scheme: dark)
+                   (prefers-reduced-motion: reduce) {
+                .foo { bar: baz; }
+            }
+            """;
+
+        Stylesheet stylesheet = new CssParserShim().parseUnmerged(stylesheetText, true);
+        var mediaRule = RuleHelper.getMediaRule(stylesheet.getRules().getFirst());
+        assertEquals(1, mediaRule.getQueries().size());
+        assertEquals(ConstantExpression.of(false), mediaRule.getQueries().getFirst());
+
+        stylesheet = new CssParser().parse(stylesheetText);
+        assertEquals(0, stylesheet.getRules().size());
+    }
+
+    @Test
+    void parserRecoversFromMissingCommaBetweenMediaQueries() {
+        Stylesheet stylesheet = new CssParser().parse("""
+            @media (prefers-color-scheme: dark)
+                   (prefers-reduced-motion: reduce),
+                   (prefers-reduced-transparency: reduce) {
+                .foo { bar: baz; }
+            }
+            """);
+
+        var mediaRule = RuleHelper.getMediaRule(stylesheet.getRules().getFirst());
+        assertEquals(
+            List.of(
+                ConstantExpression.of(false),
+                FunctionExpression.of("prefers-reduced-transparency", "reduce", _ -> null, true)
+            ),
+            mediaRule.getQueries());
+    }
+
+    @Test
     void parserRecoversWhenMediaQueryIsMalformed() {
         Stylesheet stylesheet = new CssParser().parse("""
             @media (#123foo=malformed-query), (prefers-reduced-motion: reduce) {

--- a/modules/javafx.graphics/src/test/java/test/javafx/css/CssParser_mediaQuery_Test.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/css/CssParser_mediaQuery_Test.java
@@ -486,6 +486,78 @@ public class CssParser_mediaQuery_Test {
     }
 
     @Test
+    void parserRecoversFromUnexpectedCommaInMediaQueryList() {
+        Stylesheet stylesheet = new CssParser().parse("""
+            @media (prefers-color-scheme: dark),,
+                   (prefers-reduced-motion: reduce) {
+                .foo { bar: baz; }
+            }
+            """);
+
+        var mediaRule = RuleHelper.getMediaRule(stylesheet.getRules().getFirst());
+        assertEquals(
+            List.of(
+                FunctionExpression.of("prefers-color-scheme", "dark", _ -> null, ColorScheme.DARK),
+                ConstantExpression.of(false),
+                FunctionExpression.of("prefers-reduced-motion", "reduce", _ -> null, true)
+            ),
+            mediaRule.getQueries());
+    }
+
+    @Test
+    void parserRecoversFromUnexpectedTokenInMediaQueryList() {
+        Stylesheet stylesheet = new CssParser().parse("""
+            @media (prefers-color-scheme: dark), 100px,
+                   (prefers-reduced-motion: reduce) {
+                .foo { bar: baz; }
+            }
+            """);
+
+        var mediaRule = RuleHelper.getMediaRule(stylesheet.getRules().getFirst());
+        assertEquals(
+            List.of(
+                FunctionExpression.of("prefers-color-scheme", "dark", _ -> null, ColorScheme.DARK),
+                ConstantExpression.of(false),
+                FunctionExpression.of("prefers-reduced-motion", "reduce", _ -> null, true)
+            ),
+            mediaRule.getQueries());
+    }
+
+    @Test
+    void leadingCommaInMediaQueryListEvaluatesToFalse() {
+        Stylesheet stylesheet = new CssParser().parse("""
+            @media , (prefers-color-scheme: dark) {
+                .foo { bar: baz; }
+            }
+            """);
+
+        var mediaRule = RuleHelper.getMediaRule(stylesheet.getRules().getFirst());
+        assertEquals(
+            List.of(
+                ConstantExpression.of(false),
+                FunctionExpression.of("prefers-color-scheme", "dark", _ -> null, ColorScheme.DARK)
+            ),
+            mediaRule.getQueries());
+    }
+
+    @Test
+    void trailingCommaInMediaQueryListEvaluatesToFalse() {
+        Stylesheet stylesheet = new CssParser().parse("""
+            @media (prefers-color-scheme: dark), {
+                .foo { bar: baz; }
+            }
+            """);
+
+        var mediaRule = RuleHelper.getMediaRule(stylesheet.getRules().getFirst());
+        assertEquals(
+            List.of(
+                FunctionExpression.of("prefers-color-scheme", "dark", _ -> null, ColorScheme.DARK),
+                ConstantExpression.of(false)
+            ),
+            mediaRule.getQueries());
+    }
+
+    @Test
     void parserRecoversWhenMediaQueryIsMalformed() {
         Stylesheet stylesheet = new CssParser().parse("""
             @media (#123foo=malformed-query), (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
`MediaQueryParser` currently parses query lists without a comma separator:

```css
    @media (prefers-color-scheme: dark)
           (prefers-reduced-motion: reduce) {
        .foo { bar: baz; }
    }
```

The correct grammar requires commas between queries.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8383783](https://bugs.openjdk.org/browse/JDK-8383783): MediaQueryParser should reject query lists without comma separator (**Bug** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Marius Hanl](https://openjdk.org/census#mhanl) (@Maran23 - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2162/head:pull/2162` \
`$ git checkout pull/2162`

Update a local copy of the PR: \
`$ git checkout pull/2162` \
`$ git pull https://git.openjdk.org/jfx.git pull/2162/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2162`

View PR using the GUI difftool: \
`$ git pr show -t 2162`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2162.diff">https://git.openjdk.org/jfx/pull/2162.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2162#issuecomment-4365643431)
</details>
