### PR TITLE
8195614: FilteredList throws ArrayIndexOutOfBoundsException if created with 1 element

### DIFF
--- a/modules/javafx.base/src/main/java/javafx/collections/transformation/FilteredList.java
+++ b/modules/javafx.base/src/main/java/javafx/collections/transformation/FilteredList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -135,6 +135,8 @@ public final class FilteredList<E> extends TransformationList<E, E>{
 
     @Override
     protected void sourceChanged(Change<? extends E> c) {
+        ensureSize(getSource().size());
+
         beginChange();
         while (c.next()) {
             if (c.wasPermutated()) {
@@ -236,7 +238,6 @@ public final class FilteredList<E> extends TransformationList<E, E>{
 
     private void addRemove(Change<? extends E> c) {
         Predicate<? super E> pred = getPredicateImpl();
-        ensureSize(getSource().size());
         final int from = findPosition(c.getFrom());
         final int to = findPosition(c.getFrom() + c.getRemovedSize());
 
@@ -269,6 +270,7 @@ public final class FilteredList<E> extends TransformationList<E, E>{
             // Add the remaining elements
             while (it.nextIndex() < c.getTo()) {
                 if (pred.test(it.next())) {
+                    ensureSize(size + 1);
                     System.arraycopy(filtered, fpos, filtered, fpos + 1, size - fpos);
                     filtered[fpos] = it.previousIndex();
                     nextAdd(fpos, fpos + 1);
@@ -282,7 +284,6 @@ public final class FilteredList<E> extends TransformationList<E, E>{
 
     private void update(Change<? extends E> c) {
         Predicate<? super E> pred = getPredicateImpl();
-        ensureSize(getSource().size());
         int sourceFrom = c.getFrom();
         int sourceTo = c.getTo();
         int filterFrom = findPosition(sourceFrom);

--- a/modules/javafx.base/src/test/java/test/javafx/collections/FilteredListTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/collections/FilteredListTest.java
@@ -27,6 +27,7 @@ package test.javafx.collections;
 
 import com.sun.javafx.collections.ObservableListWrapper;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -351,5 +352,21 @@ public class FilteredListTest {
 
         assertEquals(List.of(0L), filteredList);
         assertEquals(List.of(0L), sortedList);
+    }
+
+    @Test
+    public void testMoveItemDoesNotThrowAIOOBE() {
+        var list = new ObservableListWrapper<>(new ArrayList<>(List.of(1L)));
+        FilteredList<Long> filteredList = new FilteredList<>(list);
+
+        list.add(2L);
+        assertEquals(List.of(1L, 2L), filteredList);
+
+        ObservableListWrapperShim.beginChange(list);
+        list.remove(2L);
+        list.addFirst(2L);
+        assertDoesNotThrow(() -> ObservableListWrapperShim.endChange(list));
+
+        assertEquals(List.of(2L, 1L), filteredList);
     }
 }


### PR DESCRIPTION
This PR fixes the (rare) issue that an `ArrayIndexOutOfBoundsException` is thrown in `FilteredList`.

Some details of the problem:
- Can only be reproduced when there are multiple changes, as we need an intermediate state where we have more elements than we will have at the end after all change events
- The issue is somewhat rare: Normally, we have reserved a big enough array (`int[] filtered`) to compensate a temporary element increase. With a small size like 1, we can reproduce it easily by making two change events (In the reproducer and test, a 'move element to first index' change operation)

Details for the fix:
- `ensureSize(getSource().size());` is normally correct as our `FilteredList` will always be <= source list. 
But we can have the situation where we have temporarily more elements than the source list as we are processing all change events (e.g. add 1, remove 1).
  - To account for that, we will call `ensureSize` again when we could run into the situation where we have more elements than we reserved for
  - So that we do not over allocate the `filtered` array, I did not use the proposed change in the ticket but this one instead. We will really only (may) increase the size when we really need it
    - As we reserve more capacity in `filtered` than we may need, this does not happen often, especially not with more elements
    - Since we have a smart change event aggregation algorithm (especially since the fix in https://github.com/openjdk/jfx/pull/2154 and https://github.com/openjdk/jfx/pull/2117), we often have more compact change event where a big increase of elements temporary, which are removed in the next change are very unlikely (there will be only one change event with the elements that 'survived' the add and remove). 
      - Therefore, I do not see any performance concerns here, as `ensureSize(size + 1);` is very likely a noop, but in cases like this e will correctly reserve more capacity

/issue add JDK-8195750

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issues
 * [JDK-8195614](https://bugs.openjdk.org/browse/JDK-8195614): FilteredList throws ArrayIndexOutOfBoundsException if created with 1 element (**Bug** - P3)
 * [JDK-8195750](https://bugs.openjdk.org/browse/JDK-8195750): FilteredList throws ArrayIndexOutOfBoundsException on ListChangeEvent with multiple change (**Bug** - P3)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Michael Strauß](https://openjdk.org/census#mstrauss) (@mstr2 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2163/head:pull/2163` \
`$ git checkout pull/2163`

Update a local copy of the PR: \
`$ git checkout pull/2163` \
`$ git pull https://git.openjdk.org/jfx.git pull/2163/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2163`

View PR using the GUI difftool: \
`$ git pr show -t 2163`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2163.diff">https://git.openjdk.org/jfx/pull/2163.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2163#issuecomment-4366964241)
</details>
