### PR TITLE
8359020: TabObservableList.reorder changes content of filtered list

### DIFF
--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/TabObservableList.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/TabObservableList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -71,13 +71,24 @@ public class TabObservableList<E> extends ObservableListWrapper<E> {
         // Update selected tab & index.
         fromTab.getTabPane().getSelectionModel().select(fromTab);
 
-        // Fire permutation change event.
+        firePermutationEvent(fromIndex, toIndex, direction);
+    }
+
+    private void firePermutationEvent(int fromIndex, int toIndex, int direction) {
         int permSize = Math.abs(toIndex - fromIndex) + 1;
         int[] perm = new int[permSize];
         int from = direction > 0 ? fromIndex : toIndex;
         int to = direction < 0 ? fromIndex : toIndex;
-        for (int i = 0; i < permSize; ++i) {
-            perm[i] = i + from;
+        if (direction > 0) {
+            perm[0] = to;
+            for (int i = 1; i < permSize; ++i) {
+                perm[i] = from + i - 1;
+            }
+        } else {
+            for (int i = 0; i < permSize - 1; ++i) {
+                perm[i] = from + i + 1;
+            }
+            perm[permSize - 1] = from;
         }
         fireChange(new NonIterableChange.SimplePermutationChange<>(from, to + 1, perm, this));
     }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TabPaneTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TabPaneTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,6 +41,8 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+
+import com.sun.javafx.scene.control.TabObservableList;
 import javafx.application.Platform;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.DoubleProperty;
@@ -49,6 +51,7 @@ import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleDoubleProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.value.ChangeListener;
+import javafx.collections.transformation.FilteredList;
 import javafx.css.CssMetaData;
 import javafx.css.StyleableProperty;
 import javafx.event.Event;
@@ -1277,6 +1280,43 @@ public class TabPaneTest {
     @Test
     public void testHorizontalScrollLeftSide() {
         scrollTabPane(Side.LEFT, 100, 0);
+    }
+
+    @Test
+    public void testTabsReorderPermutationReflectedInFilteredList() {
+        Tab other = new Tab("other");
+        Tab lib1 = new Tab("lib1");
+        Tab lib2 = new Tab("lib2");
+        Tab lib3 = new Tab("lib3");
+        Tab lib4 = new Tab("lib4");
+
+        TabPane tabPane = new TabPane(lib1, other, lib2, lib3, lib4);
+        TabObservableList<Tab> tabList = (TabObservableList) tabPane.getTabs();
+
+        FilteredList<Tab> filtered = new FilteredList<>(tabList, tab -> tab.getText().startsWith("lib"));
+
+        assertEquals(List.of(lib1, other, lib2, lib3, lib4), tabList);
+        assertEquals(List.of(lib1, lib2, lib3, lib4), filtered);
+
+        tabList.reorder(lib1, other);
+        assertEquals(List.of(other, lib1, lib2, lib3, lib4), tabList);
+        assertEquals(List.of(lib1, lib2, lib3, lib4), filtered);
+
+        tabList.reorder(other, lib3);
+        assertEquals(List.of(lib1, lib2, lib3, other, lib4), tabList);
+        assertEquals(List.of(lib1, lib2, lib3, lib4), filtered);
+
+        tabList.reorder(lib4, lib1);
+        assertEquals(List.of(lib4, lib1, lib2, lib3, other), tabList);
+        assertEquals(List.of(lib4, lib1, lib2, lib3), filtered);
+
+        tabList.reorder(other, lib4);
+        assertEquals(List.of(other, lib4, lib1, lib2, lib3), tabList);
+        assertEquals(List.of(lib4, lib1, lib2, lib3), filtered);
+
+        tabList.reorder(lib1, lib3);
+        assertEquals(List.of(other, lib4, lib2, lib3, lib1), tabList);
+        assertEquals(List.of(lib4, lib2, lib3, lib1), filtered);
     }
 
     private void scrollTabPane(Side side, double deltaX, double deltaY) {


### PR DESCRIPTION
Fixes that the `TabObservableList` creates wrong `permutation` change events. As they are wrong, listeners that rely on the change events like `FilteredList` will get confused and do the wrong things.

I was wondering why the `TabPaneSkin` was not affected, as it installs a listener on the tabs.
Turns out this is because the code path is not triggered when the tabs are reordered by dragging as can be seen here:

https://github.com/openjdk/jfx/blob/697a534bf494d82bf8e0ecacfebaba003dcc6c7a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TabPaneSkin.java#L606-L609

So this issue is rather rare and limited to listeners installed by the developer (and interested in permutation events).
Or using a `FilteredList` with the tabs, which will install such a listener as well.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8359020](https://bugs.openjdk.org/browse/JDK-8359020): TabObservableList.reorder changes content of filtered list (**Bug** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Michael Strauß](https://openjdk.org/census#mstrauss) (@mstr2 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2164/head:pull/2164` \
`$ git checkout pull/2164`

Update a local copy of the PR: \
`$ git checkout pull/2164` \
`$ git pull https://git.openjdk.org/jfx.git pull/2164/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2164`

View PR using the GUI difftool: \
`$ git pr show -t 2164`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2164.diff">https://git.openjdk.org/jfx/pull/2164.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2164#issuecomment-4367101613)
</details>
