### PR TITLE
8384006: ComboBox text does not update on String converter update

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ComboBox.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ComboBox.java
@@ -316,9 +316,15 @@ public class ComboBox<T> extends ComboBoxBase<T> {
 
     // --- string converter
     /**
-     * Converts the user-typed input (when the ComboBox is
-     * {@link #editableProperty() editable}) to an object of type T, such that
-     * the input may be retrieved via the  {@link #valueProperty() value} property.
+     * Converts items of type T to a string representation and the other way around.
+     *
+     * The converter is used to obtain the string representation that should be displayed
+     * for the {@link #valueProperty() value} and any {@link #getItems() item}.
+     *
+     * When the ComboBox is {@link #editableProperty() editable}), the converter is used
+     * to convert the input to an object of type T, such that the input may be retrieved
+     * via the {@link #valueProperty() value} property.
+     *
      * @return the converter property
      */
     public final ObjectProperty<StringConverter<T>> converterProperty() { return converter; }

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ComboBoxListViewSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ComboBoxListViewSkin.java
@@ -179,7 +179,7 @@ public class ComboBoxListViewSkin<T> extends ComboBoxPopupControl<T> {
             listView.requestLayout();
         });
         lh.addChangeListener(control.converterProperty(), e -> {
-            updateCellFactory();
+            listView.refresh();
             updateDisplayNode();
         });
         lh.addChangeListener(control.buttonCellProperty(), e -> {

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ComboBoxListViewSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ComboBoxListViewSkin.java
@@ -178,7 +178,10 @@ public class ComboBoxListViewSkin<T> extends ComboBoxPopupControl<T> {
             if (listView == null) return;
             listView.requestLayout();
         });
-        lh.addChangeListener(control.converterProperty(), e -> updateListViewItems());
+        lh.addChangeListener(control.converterProperty(), e -> {
+            updateListViewItems();
+            updateDisplayNode();
+        });
         lh.addChangeListener(control.buttonCellProperty(), e -> {
             updateButtonCell();
             updateDisplayArea();

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ComboBoxListViewSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ComboBoxListViewSkin.java
@@ -179,7 +179,7 @@ public class ComboBoxListViewSkin<T> extends ComboBoxPopupControl<T> {
             listView.requestLayout();
         });
         lh.addChangeListener(control.converterProperty(), e -> {
-            updateListViewItems();
+            updateCellFactory();
             updateDisplayNode();
         });
         lh.addChangeListener(control.buttonCellProperty(), e -> {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
@@ -67,6 +67,7 @@ import javafx.scene.control.TabPane;
 import javafx.scene.control.TextField;
 import javafx.scene.control.Tooltip;
 import javafx.scene.control.skin.ComboBoxListViewSkin;
+import javafx.scene.control.skin.ListViewSkin;
 import javafx.scene.control.skin.VirtualFlow;
 import javafx.scene.input.KeyCode;
 import javafx.scene.layout.BorderPane;
@@ -93,6 +94,7 @@ import test.com.sun.javafx.scene.control.infrastructure.KeyEventFirer;
 import test.com.sun.javafx.scene.control.infrastructure.KeyModifier;
 import test.com.sun.javafx.scene.control.infrastructure.MouseEventFirer;
 import test.com.sun.javafx.scene.control.infrastructure.StageLoader;
+import test.com.sun.javafx.scene.control.infrastructure.VirtualFlowTestUtils;
 
 public class ComboBoxTest {
     private ComboBox<String> comboBox;
@@ -385,6 +387,33 @@ public class ComboBoxTest {
         });
 
         assertEquals("item1", field.getText());
+    }
+
+    @Test
+    public void testListUpdateOnStringConverterChange() {
+        ObservableList<String> items = FXCollections.observableArrayList("ITEM1", "ITEM2");
+        comboBox.setEditable(false);
+        comboBox.setItems(items);
+        comboBox.setValue("ITEM1");
+        comboBox.setConverter(new StringConverter<>() {
+            @Override
+            public String toString(String object) {
+                return object.toLowerCase();
+            }
+
+            @Override
+            public String fromString(String string) {
+                return "?";
+            }
+        });
+        comboBox.getItems().add("ITEM3");
+
+        ListView<String> list = (ListView<String>) ((ComboBoxListViewSkin<String>) comboBox.getSkin())
+                .getPopupContent();
+        list.setSkin(new ListViewSkin<>(list));
+        VirtualFlowTestUtils.assertCellTextEquals(list, 0, "item1");
+        VirtualFlowTestUtils.assertCellTextEquals(list, 1, "item2");
+        VirtualFlowTestUtils.assertCellTextEquals(list, 2, "item3");
     }
 
     @Test public void testNullSelectionModelDoesNotThrowNPEOnValueChange() {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
@@ -335,7 +335,8 @@ public class ComboBoxTest {
         comboBox.setEditable(false);
     }
 
-    @Test public void testCellUpdateOnStringConverterChange() {
+    @Test
+    public void testCellUpdateOnStringConverterChange() {
         ObservableList<String> items = FXCollections.observableArrayList("ITEM1", "ITEM2");
         comboBox.setEditable(false);
         comboBox.setItems(items);
@@ -360,7 +361,8 @@ public class ComboBoxTest {
         assertEquals("item1", cell.getText());
     }
 
-    @Test public void testTextFieldUpdateOnStringConverterChange() {
+    @Test
+    public void testTextFieldUpdateOnStringConverterChange() {
         ObservableList<String> items = FXCollections.observableArrayList("ITEM1", "ITEM2");
         comboBox.setEditable(true);
         comboBox.setItems(items);

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
@@ -335,6 +335,56 @@ public class ComboBoxTest {
         comboBox.setEditable(false);
     }
 
+    @Test public void testCellUpdateOnStringConverterChange() {
+        ObservableList<String> items = FXCollections.observableArrayList("ITEM1", "ITEM2");
+        comboBox.setEditable(false);
+        comboBox.setItems(items);
+        comboBox.setValue("ITEM1");
+
+        ListCell<String> cell = (ListCell<String>) ((ComboBoxListViewSkin<String>) comboBox.getSkin())
+                .getDisplayNode();
+        assertEquals("ITEM1", cell.getText());
+
+        comboBox.setConverter(new StringConverter<>() {
+            @Override
+            public String toString(String object) {
+                return object.toLowerCase();
+            }
+
+            @Override
+            public String fromString(String string) {
+                return "?";
+            }
+        });
+
+        assertEquals("item1", cell.getText());
+    }
+
+    @Test public void testTextFieldUpdateOnStringConverterChange() {
+        ObservableList<String> items = FXCollections.observableArrayList("ITEM1", "ITEM2");
+        comboBox.setEditable(true);
+        comboBox.setItems(items);
+        comboBox.setValue("ITEM1");
+
+        TextField field = (TextField) ((ComboBoxListViewSkin<String>) comboBox.getSkin())
+                .getDisplayNode();
+        assertEquals("ITEM1", field.getText());
+
+        comboBox.setConverter(new StringConverter<>() {
+            @Override
+            public String toString(String object) {
+                return object.toLowerCase();
+            }
+
+            @Override
+            public String fromString(String string) {
+                return "?";
+            }
+        });
+
+        assertEquals("item1", field.getText());
+    }
+
     @Test public void testNullSelectionModelDoesNotThrowNPEOnValueChange() {
         ObservableList<String> items = FXCollections.observableArrayList("ITEM1", "ITEM2");
 

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
@@ -338,7 +338,7 @@ public class ComboBoxTest {
     }
 
     @Test
-    public void testCellUpdateOnStringConverterChange() {
+    public void testButtonCellUpdateOnStringConverterChange() {
         ObservableList<String> items = FXCollections.observableArrayList("ITEM1", "ITEM2");
         comboBox.setEditable(false);
         comboBox.setItems(items);
@@ -370,8 +370,7 @@ public class ComboBoxTest {
         comboBox.setItems(items);
         comboBox.setValue("ITEM1");
 
-        TextField field = (TextField) ((ComboBoxListViewSkin<String>) comboBox.getSkin())
-                .getDisplayNode();
+        TextField field = (TextField) getDisplayNode();
         assertEquals("ITEM1", field.getText());
 
         comboBox.setConverter(new StringConverter<>() {
@@ -391,10 +390,17 @@ public class ComboBoxTest {
 
     @Test
     public void testListUpdateOnStringConverterChange() {
+        sl = new StageLoader(comboBox);
+        ListView<String> list = getListView();
+
         ObservableList<String> items = FXCollections.observableArrayList("ITEM1", "ITEM2");
         comboBox.setEditable(false);
         comboBox.setItems(items);
         comboBox.setValue("ITEM1");
+
+        VirtualFlowTestUtils.assertCellTextEquals(list, 0, "ITEM1");
+        VirtualFlowTestUtils.assertCellTextEquals(list, 1, "ITEM2");
+
         comboBox.setConverter(new StringConverter<>() {
             @Override
             public String toString(String object) {
@@ -408,9 +414,6 @@ public class ComboBoxTest {
         });
         comboBox.getItems().add("ITEM3");
 
-        ListView<String> list = (ListView<String>) ((ComboBoxListViewSkin<String>) comboBox.getSkin())
-                .getPopupContent();
-        list.setSkin(new ListViewSkin<>(list));
         VirtualFlowTestUtils.assertCellTextEquals(list, 0, "item1");
         VirtualFlowTestUtils.assertCellTextEquals(list, 1, "item2");
         VirtualFlowTestUtils.assertCellTextEquals(list, 2, "item3");


### PR DESCRIPTION
This PR adds a missing call to update the display value to the converter property listener

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8384006](https://bugs.openjdk.org/browse/JDK-8384006): ComboBox text does not update on String converter update (**Bug** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Marius Hanl](https://openjdk.org/census#mhanl) (@Maran23 - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2165/head:pull/2165` \
`$ git checkout pull/2165`

Update a local copy of the PR: \
`$ git checkout pull/2165` \
`$ git pull https://git.openjdk.org/jfx.git pull/2165/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2165`

View PR using the GUI difftool: \
`$ git pr show -t 2165`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2165.diff">https://git.openjdk.org/jfx/pull/2165.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2165#issuecomment-4390685873)
</details>
