### PR TITLE
8354539: [macOS] ComboBox and Spinner disable system menu bar shortcuts

### DIFF
--- a/modules/javafx.base/src/main/java/com/sun/javafx/event/EventUtil.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/event/EventUtil.java
@@ -29,7 +29,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import javafx.event.Event;
 import javafx.event.EventDispatchChain;
-import javafx.event.EventDispatcher;
 import javafx.event.EventTarget;
 
 public final class EventUtil {
@@ -73,14 +72,5 @@ public final class EventUtil {
         final EventDispatchChain targetDispatchChain =
                 eventTarget.buildEventDispatchChain(eventDispatchChain);
         return targetDispatchChain.dispatchEvent(event);
-    }
-
-    public static Event dispatch(Event event, EventDispatcher dispatcher) {
-        if (dispatcher == null || event == null) {
-            return null;
-        }
-        var chain = new EventDispatchChainImpl();
-        chain.append(dispatcher);
-        return chain.dispatchEvent(event);
     }
 }

--- a/modules/javafx.base/src/main/java/com/sun/javafx/event/EventUtil.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/event/EventUtil.java
@@ -29,6 +29,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import javafx.event.Event;
 import javafx.event.EventDispatchChain;
+import javafx.event.EventDispatcher;
 import javafx.event.EventTarget;
 
 public final class EventUtil {
@@ -72,5 +73,14 @@ public final class EventUtil {
         final EventDispatchChain targetDispatchChain =
                 eventTarget.buildEventDispatchChain(eventDispatchChain);
         return targetDispatchChain.dispatchEvent(event);
+    }
+
+    public static Event dispatch(Event event, EventDispatcher dispatcher) {
+        if (dispatcher == null || event == null) {
+            return null;
+        }
+        var chain = new EventDispatchChainImpl();
+        chain.append(dispatcher);
+        return chain.dispatchEvent(event);
     }
 }

--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/skin/Utils.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/skin/Utils.java
@@ -49,10 +49,12 @@ import javafx.beans.InvalidationListener;
 import javafx.beans.Observable;
 import javafx.beans.value.ObservableValue;
 import javafx.collections.ObservableList;
+import javafx.event.Event;
 import javafx.geometry.Bounds;
 import javafx.geometry.HPos;
 import javafx.geometry.Point2D;
 import javafx.geometry.VPos;
+import javafx.scene.Node;
 import javafx.scene.Scene;
 import javafx.scene.control.ContextMenu;
 import javafx.scene.control.MenuItem;
@@ -66,6 +68,7 @@ import javafx.scene.text.TextBoundsType;
 import com.sun.javafx.scene.NodeHelper;
 import com.sun.javafx.scene.control.ContextMenuContent;
 import com.sun.javafx.scene.control.behavior.MnemonicInfo;
+import com.sun.javafx.event.EventDispatchChainImpl;
 import com.sun.javafx.scene.text.FontHelper;
 import com.sun.javafx.scene.text.TextLayout;
 import com.sun.javafx.tk.Toolkit;
@@ -988,5 +991,15 @@ public class Utils {
 
     public static URL getResource(String str) {
         return Utils.class.getResource(str);
+    }
+
+    // Dispatches the event to the Node's dispatcher and returns
+    // true if the event was consumed.
+    public static boolean dispatchToNode(Event event, Node node) {
+        var dispatcher = node.getEventDispatcher();
+        if (dispatcher == null) return false;
+        var chain = new EventDispatchChainImpl();
+        chain.append(dispatcher);
+        return (chain.dispatchEvent(event.copyFor(node, node)) == null);
     }
 }

--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/skin/Utils.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/skin/Utils.java
@@ -993,8 +993,8 @@ public class Utils {
         return Utils.class.getResource(str);
     }
 
-    // Dispatches the event to the Node's dispatcher and returns
-    // true if the event was consumed.
+    // Dispatches the event only to the Node's dispatcher, not its entire
+    // dispatch chain. Returns true if the event was consumed.
     public static boolean dispatchToNode(Event event, Node node) {
         var dispatcher = node.getEventDispatcher();
         if (dispatcher == null) return false;

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ComboBoxPopupControl.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ComboBoxPopupControl.java
@@ -53,6 +53,7 @@ import com.sun.javafx.scene.control.FakeFocusTextField;
 import com.sun.javafx.scene.control.ListenerHelper;
 import com.sun.javafx.scene.control.Properties;
 import com.sun.javafx.scene.control.behavior.TextInputControlBehavior;
+import com.sun.javafx.scene.control.skin.Utils;
 import com.sun.javafx.scene.input.ExtendedInputMethodRequests;
 import com.sun.javafx.scene.traversal.Algorithm;
 import com.sun.javafx.scene.traversal.Direction;
@@ -171,18 +172,12 @@ public abstract class ComboBoxPopupControl<T> extends ComboBoxBaseSkin<T> {
                     // Fix for the regression noted in a comment in JDK-8115009.
                     // This forwards the event down into the TextField when
                     // the key event is actually received by the ComboBox.
-                    if (forwardToTextField(ke)) {
+                    if (Utils.dispatchToNode(ke, textField)) {
                         ke.consume();
                     }
                 }
             }
         });
-    }
-
-    // Returns 'true' if the event was consumed.
-    private boolean forwardToTextField(KeyEvent event) {
-        return EventUtil.dispatch(event.copyFor(textField, textField),
-            textField.getEventDispatcher()) == null;
     }
 
     @Override
@@ -614,7 +609,7 @@ public abstract class ComboBoxPopupControl<T> extends ComboBoxBaseSkin<T> {
             if (doConsume && comboBoxBase.getOnAction() != null) {
                 ke.consume();
             } else if (textField != null) {
-                forwardToTextField(ke);
+                Utils.dispatchToNode(ke, textField);
             }
         } else if (ke.getCode() == KeyCode.F10 || ke.getCode() == KeyCode.ESCAPE) {
             // JDK-8115456: The TextField fires F10 and ESCAPE key events

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ComboBoxPopupControl.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ComboBoxPopupControl.java
@@ -28,6 +28,7 @@ package javafx.scene.control.skin;
 import javafx.beans.value.ObservableValue;
 import javafx.css.Styleable;
 import javafx.event.EventHandler;
+import javafx.event.EventDispatchChain;
 import javafx.geometry.Bounds;
 import javafx.geometry.HPos;
 import javafx.geometry.Point2D;
@@ -47,6 +48,7 @@ import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.Region;
 import javafx.stage.WindowEvent;
 import javafx.util.StringConverter;
+import com.sun.javafx.event.EventDispatchChainImpl;
 import com.sun.javafx.scene.ParentHelper;
 import com.sun.javafx.scene.control.FakeFocusTextField;
 import com.sun.javafx.scene.control.ListenerHelper;
@@ -170,11 +172,22 @@ public abstract class ComboBoxPopupControl<T> extends ComboBoxBaseSkin<T> {
                     // Fix for the regression noted in a comment in JDK-8115009.
                     // This forwards the event down into the TextField when
                     // the key event is actually received by the ComboBox.
-                    textField.fireEvent(ke.copyFor(textField, textField));
-                    ke.consume();
+                    if (forwardToTextField(ke)) {
+                        ke.consume();
+                    }
                 }
             }
         });
+    }
+
+    // Returns 'true' if the event was consumed.
+    private boolean forwardToTextField(KeyEvent event) {
+        var dispatcher = textField.getEventDispatcher();
+        if (dispatcher == null) return false;
+
+        EventDispatchChain chain = new EventDispatchChainImpl();
+        chain.append(textField.getEventDispatcher());
+        return chain.dispatchEvent(event.copyFor(textField, textField)) == null;
     }
 
     @Override
@@ -606,7 +619,7 @@ public abstract class ComboBoxPopupControl<T> extends ComboBoxBaseSkin<T> {
             if (doConsume && comboBoxBase.getOnAction() != null) {
                 ke.consume();
             } else if (textField != null) {
-                textField.fireEvent(ke);
+                forwardToTextField(ke);
             }
         } else if (ke.getCode() == KeyCode.F10 || ke.getCode() == KeyCode.ESCAPE) {
             // JDK-8115456: The TextField fires F10 and ESCAPE key events

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ComboBoxPopupControl.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ComboBoxPopupControl.java
@@ -28,7 +28,6 @@ package javafx.scene.control.skin;
 import javafx.beans.value.ObservableValue;
 import javafx.css.Styleable;
 import javafx.event.EventHandler;
-import javafx.event.EventDispatchChain;
 import javafx.geometry.Bounds;
 import javafx.geometry.HPos;
 import javafx.geometry.Point2D;
@@ -48,7 +47,7 @@ import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.Region;
 import javafx.stage.WindowEvent;
 import javafx.util.StringConverter;
-import com.sun.javafx.event.EventDispatchChainImpl;
+import com.sun.javafx.event.EventUtil;
 import com.sun.javafx.scene.ParentHelper;
 import com.sun.javafx.scene.control.FakeFocusTextField;
 import com.sun.javafx.scene.control.ListenerHelper;
@@ -182,12 +181,8 @@ public abstract class ComboBoxPopupControl<T> extends ComboBoxBaseSkin<T> {
 
     // Returns 'true' if the event was consumed.
     private boolean forwardToTextField(KeyEvent event) {
-        var dispatcher = textField.getEventDispatcher();
-        if (dispatcher == null) return false;
-
-        EventDispatchChain chain = new EventDispatchChainImpl();
-        chain.append(dispatcher);
-        return chain.dispatchEvent(event.copyFor(textField, textField)) == null;
+        return EventUtil.dispatch(event.copyFor(textField, textField),
+            textField.getEventDispatcher()) == null;
     }
 
     @Override

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ComboBoxPopupControl.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ComboBoxPopupControl.java
@@ -186,7 +186,7 @@ public abstract class ComboBoxPopupControl<T> extends ComboBoxBaseSkin<T> {
         if (dispatcher == null) return false;
 
         EventDispatchChain chain = new EventDispatchChainImpl();
-        chain.append(textField.getEventDispatcher());
+        chain.append(dispatcher);
         return chain.dispatchEvent(event.copyFor(textField, textField)) == null;
     }
 

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/SpinnerSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/SpinnerSkin.java
@@ -46,6 +46,7 @@ import com.sun.javafx.scene.ParentHelper;
 import com.sun.javafx.scene.control.FakeFocusTextField;
 import com.sun.javafx.scene.control.ListenerHelper;
 import com.sun.javafx.scene.control.behavior.SpinnerBehavior;
+import com.sun.javafx.scene.control.skin.Utils;
 import com.sun.javafx.scene.traversal.Algorithm;
 import com.sun.javafx.scene.traversal.Direction;
 import com.sun.javafx.scene.traversal.ParentTraversalEngine;
@@ -195,7 +196,7 @@ public class SpinnerSkin<T> extends SkinBase<Spinner<T>> {
                 // Fix for the regression noted in a comment in JDK-8115009.
                 // This forwards the event down into the TextField when
                 // the key event is actually received by the Spinner.
-                if (forwardToTextField(ke) && ke.getCode() != KeyCode.ENTER) {
+                if (Utils.dispatchToNode(ke, textField) && ke.getCode() != KeyCode.ENTER) {
                     ke.consume();
                 }
             }
@@ -243,12 +244,6 @@ public class SpinnerSkin<T> extends SkinBase<Spinner<T>> {
             // Stop spinning when sceneProperty is modified
             behavior.stopSpinning();
         });
-    }
-
-    // Returns 'true' if the event was consumed.
-    private boolean forwardToTextField(KeyEvent event) {
-        return EventUtil.dispatch(event.copyFor(textField, textField),
-            textField.getEventDispatcher()) == null;
     }
 
     private boolean isIncDecKeyEvent(KeyEvent ke) {

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/SpinnerSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/SpinnerSkin.java
@@ -252,7 +252,7 @@ public class SpinnerSkin<T> extends SkinBase<Spinner<T>> {
         if (dispatcher == null) return false;
 
         EventDispatchChain chain = new EventDispatchChainImpl();
-        chain.append(textField.getEventDispatcher());
+        chain.append(dispatcher);
         return chain.dispatchEvent(event.copyFor(textField, textField)) == null;
     }
 

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/SpinnerSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/SpinnerSkin.java
@@ -27,6 +27,7 @@ package javafx.scene.control.skin;
 import java.util.List;
 
 import javafx.css.PseudoClass;
+import javafx.event.EventDispatchChain;
 import javafx.geometry.HPos;
 import javafx.geometry.VPos;
 import javafx.scene.AccessibleAction;
@@ -41,6 +42,7 @@ import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.StackPane;
 
+import com.sun.javafx.event.EventDispatchChainImpl;
 import com.sun.javafx.scene.ParentHelper;
 import com.sun.javafx.scene.control.FakeFocusTextField;
 import com.sun.javafx.scene.control.ListenerHelper;
@@ -194,23 +196,9 @@ public class SpinnerSkin<T> extends SkinBase<Spinner<T>> {
                 // Fix for the regression noted in a comment in JDK-8115009.
                 // This forwards the event down into the TextField when
                 // the key event is actually received by the Spinner.
-                textField.fireEvent(ke.copyFor(textField, textField));
-
-                if (ke.getCode() == KeyCode.ENTER) return;
-
-                ke.consume();
-            }
-        });
-
-        // This event filter is to enable keyboard events being delivered to the
-        // spinner when the user has mouse clicked into the TextField area of the
-        // Spinner control. Without this the up/down/left/right arrow keys don't
-        // work when you click inside the TextField area (but they do in the case
-        // of tabbing in).
-        lh.addEventFilter(textField, KeyEvent.ANY, (ke) -> {
-            if (! control.isEditable() || isIncDecKeyEvent(ke)) {
-                control.fireEvent(ke.copyFor(control, control));
-                ke.consume();
+                if (forwardToTextField(ke) && ke.getCode() != KeyCode.ENTER) {
+                    ke.consume();
+                }
             }
         });
 
@@ -256,6 +244,16 @@ public class SpinnerSkin<T> extends SkinBase<Spinner<T>> {
             // Stop spinning when sceneProperty is modified
             behavior.stopSpinning();
         });
+    }
+
+    // Returns 'true' if the event was consumed.
+    private boolean forwardToTextField(KeyEvent event) {
+        var dispatcher = textField.getEventDispatcher();
+        if (dispatcher == null) return false;
+
+        EventDispatchChain chain = new EventDispatchChainImpl();
+        chain.append(textField.getEventDispatcher());
+        return chain.dispatchEvent(event.copyFor(textField, textField)) == null;
     }
 
     private boolean isIncDecKeyEvent(KeyEvent ke) {

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/SpinnerSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/SpinnerSkin.java
@@ -27,7 +27,6 @@ package javafx.scene.control.skin;
 import java.util.List;
 
 import javafx.css.PseudoClass;
-import javafx.event.EventDispatchChain;
 import javafx.geometry.HPos;
 import javafx.geometry.VPos;
 import javafx.scene.AccessibleAction;
@@ -42,7 +41,7 @@ import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.StackPane;
 
-import com.sun.javafx.event.EventDispatchChainImpl;
+import com.sun.javafx.event.EventUtil;
 import com.sun.javafx.scene.ParentHelper;
 import com.sun.javafx.scene.control.FakeFocusTextField;
 import com.sun.javafx.scene.control.ListenerHelper;
@@ -248,12 +247,8 @@ public class SpinnerSkin<T> extends SkinBase<Spinner<T>> {
 
     // Returns 'true' if the event was consumed.
     private boolean forwardToTextField(KeyEvent event) {
-        var dispatcher = textField.getEventDispatcher();
-        if (dispatcher == null) return false;
-
-        EventDispatchChain chain = new EventDispatchChainImpl();
-        chain.append(dispatcher);
-        return chain.dispatchEvent(event.copyFor(textField, textField)) == null;
+        return EventUtil.dispatch(event.copyFor(textField, textField),
+            textField.getEventDispatcher()) == null;
     }
 
     private boolean isIncDecKeyEvent(KeyEvent ke) {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
@@ -2545,7 +2545,8 @@ public class ComboBoxTest {
     }
 
     // Ensure initial shortcut event is not consumed
-    @Test public void testShortcutNotConsumed() {
+    @Test
+    public void testShortcutNotConsumed() {
         assumeTrue(Utils.isMac());
         final ComboBox<String> cb = new ComboBox<>(FXCollections.observableArrayList("a", "b", "c"));
         cb.setEditable(true);

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
@@ -70,6 +70,7 @@ import javafx.scene.control.skin.ComboBoxListViewSkin;
 import javafx.scene.control.skin.ListViewSkin;
 import javafx.scene.control.skin.VirtualFlow;
 import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.VBox;
@@ -89,6 +90,7 @@ import com.sun.javafx.scene.control.inputmap.InputMap.KeyMapping;
 import com.sun.javafx.scene.control.inputmap.KeyBinding;
 import com.sun.javafx.tk.Toolkit;
 import com.sun.javafx.util.Utils;
+import com.sun.javafx.event.EventUtil;
 import test.com.sun.javafx.scene.control.infrastructure.ControlSkinFactory;
 import test.com.sun.javafx.scene.control.infrastructure.KeyEventFirer;
 import test.com.sun.javafx.scene.control.infrastructure.KeyModifier;
@@ -2539,5 +2541,19 @@ public class ComboBoxTest {
         assertEquals("B", comboBox.getSelectionModel().getSelectedItem());
         mouse.fireMousePressAndRelease();
         assertEquals("B", comboBox.getSelectionModel().getSelectedItem());
+    }
+
+    // Ensure initial shortcut event is not consumed
+    @Test public void testShortcutNotConsumed() {
+        final ComboBox<String> cb = new ComboBox<>(FXCollections.observableArrayList("a", "b", "c"));
+        cb.setEditable(true);
+        sl = new StageLoader(cb);
+        cb.requestFocus();
+
+        var isMac = Utils.isMac();
+        KeyCode code = isMac ? KeyCode.Q : KeyCode.X;
+        var event = new KeyEvent(KeyEvent.KEY_PRESSED, "", "", code, false, !isMac, false, isMac);
+        boolean consumed = (EventUtil.fireEvent(cb, event) == null);
+        assertFalse(consumed, "Initial shortcut event was consumed");
     }
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
@@ -34,6 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static test.com.sun.javafx.scene.control.infrastructure.ControlTestUtils.assertStyleClassContains;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -2545,14 +2546,13 @@ public class ComboBoxTest {
 
     // Ensure initial shortcut event is not consumed
     @Test public void testShortcutNotConsumed() {
+        assumeTrue(Utils.isMac());
         final ComboBox<String> cb = new ComboBox<>(FXCollections.observableArrayList("a", "b", "c"));
         cb.setEditable(true);
         sl = new StageLoader(cb);
         cb.requestFocus();
 
-        var isMac = Utils.isMac();
-        KeyCode code = isMac ? KeyCode.Q : KeyCode.X;
-        var event = new KeyEvent(KeyEvent.KEY_PRESSED, "", "", code, false, !isMac, false, isMac);
+        var event = new KeyEvent(KeyEvent.KEY_PRESSED, "", "", KeyCode.Q, false, false, false, true);
         boolean consumed = (EventUtil.fireEvent(cb, event) == null);
         assertFalse(consumed, "Initial shortcut event was consumed");
     }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/SpinnerTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/SpinnerTest.java
@@ -64,6 +64,7 @@ import javafx.scene.control.SpinnerShim;
 import javafx.scene.control.SpinnerValueFactory;
 import javafx.scene.control.SpinnerValueFactoryShim;
 import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.VBox;
 import javafx.scene.Scene;
@@ -75,6 +76,9 @@ import test.com.sun.javafx.pgstub.StubToolkit;
 import test.com.sun.javafx.scene.control.infrastructure.KeyEventFirer;
 import com.sun.javafx.tk.Toolkit;
 import test.com.sun.javafx.scene.control.infrastructure.StageLoader;
+
+import com.sun.javafx.util.Utils;
+import com.sun.javafx.event.EventUtil;
 
 import static javafx.scene.control.SpinnerValueFactoryShim.*;
 
@@ -1648,6 +1652,35 @@ public class SpinnerTest {
         assertTrue(escapeCancelPass, canMsg);
     }
 
+    // Test to ensure shortcut key press is not consumed
+    @Test public void testShortcutNotConsumed() {
+        Toolkit tk = Toolkit.getToolkit();
+
+        assertTrue(tk instanceof StubToolkit);  // Ensure it's StubToolkit
+
+        intSpinner.setEditable(true);
+
+        VBox root = new VBox(intSpinner);
+        Scene scene = new Scene(root);
+        Stage stage = new Stage();
+        stage.setScene(scene);
+        stage.setWidth(200);
+        stage.setHeight(200);
+
+        stage.show();
+        intSpinner.requestFocus();
+        tk.firePulse();
+
+        var isMac = Utils.isMac();
+        KeyCode code = isMac ? KeyCode.Q : KeyCode.X;
+        var event = new KeyEvent(KeyEvent.KEY_PRESSED, "", "", code, false, !isMac, false, isMac);
+        boolean consumed = (EventUtil.fireEvent(intSpinner, event) == null);
+
+        assertFalse(consumed, "Initial shortcut event was consumed");
+        stage.hide();
+    }
+
+
     @Test public void spinnerDelayTest() {
         Spinner<Double> spinner = new Spinner<>(-100, 100, 2.5, 0.5);
 
@@ -1694,7 +1727,7 @@ public class SpinnerTest {
             spinner.requestFocus();
             tk.firePulse();
 
-            KeyEventFirer keyboard = new KeyEventFirer(spinner.getEditor());
+            KeyEventFirer keyboard = new KeyEventFirer(spinner);
             keyboard.doKeyPress(KeyCode.UP);
             tk.firePulse();
 

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/SpinnerTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/SpinnerTest.java
@@ -1654,6 +1654,7 @@ public class SpinnerTest {
 
     // Test to ensure shortcut key press is not consumed
     @Test public void testShortcutNotConsumed() {
+        Assumptions.assumeTrue(Utils.isMac());
         Toolkit tk = Toolkit.getToolkit();
 
         assertTrue(tk instanceof StubToolkit);  // Ensure it's StubToolkit
@@ -1671,9 +1672,7 @@ public class SpinnerTest {
         intSpinner.requestFocus();
         tk.firePulse();
 
-        var isMac = Utils.isMac();
-        KeyCode code = isMac ? KeyCode.Q : KeyCode.X;
-        var event = new KeyEvent(KeyEvent.KEY_PRESSED, "", "", code, false, !isMac, false, isMac);
+        var event = new KeyEvent(KeyEvent.KEY_PRESSED, "", "", KeyCode.Q, false, false, false, true);
         boolean consumed = (EventUtil.fireEvent(intSpinner, event) == null);
 
         assertFalse(consumed, "Initial shortcut event was consumed");


### PR DESCRIPTION
This PR alters the way ComboBox and Spinner deliver KeyEvents to their TextField editors. When a ComboBox or Spinner is the focus owner it is the target of all key events. Currently the skin installs a filter to catch key events and re-fire most of them at the TextEdit. The skin copies the event, fires the copy at the TextField, and then consumes the original event. This confuses the system menu bar logic on macOS; only the original event can trigger a menu item and that event is always being consumed.

In this PR only the original key event makes its way up and down the event dispatch chain. To drive the TextField the skin delivers the event copy directly to the TextField's event dispatcher and only consumes the original event if the TextField consumes the copy.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8354539](https://bugs.openjdk.org/browse/JDK-8354539): [macOS] ComboBox and Spinner disable system menu bar shortcuts (**Bug** - P3)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Michael Strauß](https://openjdk.org/census#mstrauss) (@mstr2 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2166/head:pull/2166` \
`$ git checkout pull/2166`

Update a local copy of the PR: \
`$ git checkout pull/2166` \
`$ git pull https://git.openjdk.org/jfx.git pull/2166/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2166`

View PR using the GUI difftool: \
`$ git pr show -t 2166`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2166.diff">https://git.openjdk.org/jfx/pull/2166.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2166#issuecomment-4433074265)
</details>
