### PR TITLE
8384806: ComboBox converter does not properly update contained null values

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ComboBoxListViewSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ComboBoxListViewSkin.java
@@ -359,24 +359,23 @@ public class ComboBoxListViewSkin<T> extends ComboBoxPopupControl<T> {
         } else {
             T value = comboBox.getValue();
             int index = getIndexOfComboBoxValueInItemsList();
+
+            // JDK-8127575 Show the ComboBox value even though it doesn't
+            // exist in the ComboBox items list (part two of fix)
             if (index > -1) {
                 buttonCell.setItem(null);
-                buttonCell.updateIndex(index);
-            } else {
-                // JDK-8127575 Show the ComboBox value even though it doesn't
-                // exist in the ComboBox items list (part two of fix)
-                buttonCell.updateIndex(-1);
-                boolean empty = updateDisplayText(buttonCell, value, false);
-
-                // Note that empty boolean collected above. This is used to resolve
-                // JDK-8124141, where we were getting different styling based on whether
-                // the cell was updated via the updateIndex method above, or just
-                // by directly updating the text. We fake the pseudoclass state
-                // for empty, filled, and selected here.
-                buttonCell.pseudoClassStateChanged(PSEUDO_CLASS_EMPTY,    empty);
-                buttonCell.pseudoClassStateChanged(PSEUDO_CLASS_FILLED,   !empty);
-                buttonCell.pseudoClassStateChanged(PSEUDO_CLASS_SELECTED, true);
             }
+            buttonCell.updateIndex(index);
+            boolean empty = updateDisplayText(buttonCell, value, false);
+
+            // Note that empty boolean collected above. This is used to resolve
+            // JDK-8124141, where we were getting different styling based on whether
+            // the cell was updated via the updateIndex method above, or just
+            // by directly updating the text. We fake the pseudoclass state
+            // for empty, filled, and selected here.
+            buttonCell.pseudoClassStateChanged(PSEUDO_CLASS_EMPTY,    empty);
+            buttonCell.pseudoClassStateChanged(PSEUDO_CLASS_FILLED,   !empty);
+            buttonCell.pseudoClassStateChanged(PSEUDO_CLASS_SELECTED, true);
         }
     }
 

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ComboBoxListViewSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ComboBoxListViewSkin.java
@@ -362,9 +362,6 @@ public class ComboBoxListViewSkin<T> extends ComboBoxPopupControl<T> {
 
             // JDK-8127575 Show the ComboBox value even though it doesn't
             // exist in the ComboBox items list (part two of fix)
-            if (index > -1) {
-                buttonCell.setItem(null);
-            }
             buttonCell.updateIndex(index);
             boolean empty = updateDisplayText(buttonCell, value, false);
 

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ComboBoxPopupControl.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ComboBoxPopupControl.java
@@ -361,7 +361,7 @@ public abstract class ComboBoxPopupControl<T> extends ComboBoxBaseSkin<T> {
                 // end of fix
             } else {
                 String stringValue = c.toString(value);
-                if (value == null || stringValue == null) {
+                if (stringValue == null) {
                     textField.setText("");
                 } else if (! stringValue.equals(textField.getText())) {
                     textField.setText(stringValue);

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
@@ -413,6 +413,30 @@ public class ComboBoxTest {
 
         assertEquals("NOT NULL", cell.getText());
     }
+    @Test
+    public void testTextFieldUpdateOnStringConverterChangeWithContainedNullValue() {
+        ObservableList<String> items = FXCollections.observableArrayList(null, "ITEM1", "ITEM2");
+        comboBox.setEditable(true);
+        comboBox.setItems(items);
+        comboBox.setValue(null);
+
+        TextField field = (TextField) getDisplayNode();
+        assertEquals("", field.getText());
+
+        comboBox.setConverter(new StringConverter<>() {
+            @Override
+            public String toString(String object) {
+                return object != null ? object.toString() : "NOT NULL";
+            }
+
+            @Override
+            public String fromString(String string) {
+                return "?";
+            }
+        });
+
+        assertEquals("NOT NULL", field.getText());
+    }
 
     @Test
     public void testButtonCellUpdateOnStringConverterChangeWithUncontainedNullValue() {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
@@ -389,6 +389,58 @@ public class ComboBoxTest {
     }
 
     @Test
+    public void testButtonCellUpdateOnStringConverterChangeWithContainedNullValue() {
+        ObservableList<String> items = FXCollections.observableArrayList(null, "ITEM1", "ITEM2");
+        comboBox.setEditable(false);
+        comboBox.setItems(items);
+        comboBox.setValue(null);
+
+        ListCell<String> cell = (ListCell<String>) ((ComboBoxListViewSkin<String>) comboBox.getSkin())
+                .getDisplayNode();
+        assertNull(cell.getText());
+
+        comboBox.setConverter(new StringConverter<>() {
+            @Override
+            public String toString(String object) {
+                return object != null ? object.toString() : "NOT NULL";
+            }
+
+            @Override
+            public String fromString(String string) {
+                return "?";
+            }
+        });
+
+        assertEquals("NOT NULL", cell.getText());
+    }
+
+    @Test
+    public void testButtonCellUpdateOnStringConverterChangeWithUncontainedNullValue() {
+        ObservableList<String> items = FXCollections.observableArrayList("ITEM1", "ITEM2");
+        comboBox.setEditable(false);
+        comboBox.setItems(items);
+        comboBox.setValue(null);
+
+        ListCell<String> cell = (ListCell<String>) ((ComboBoxListViewSkin<String>) comboBox.getSkin())
+                .getDisplayNode();
+        assertNull(cell.getText());
+
+        comboBox.setConverter(new StringConverter<>() {
+            @Override
+            public String toString(String object) {
+                return object != null ? object.toString() : "NOT NULL";
+            }
+
+            @Override
+            public String fromString(String string) {
+                return "?";
+            }
+        });
+
+        assertEquals("NOT NULL", cell.getText());
+    }
+
+    @Test
     public void testListUpdateOnStringConverterChange() {
         sl = new StageLoader(comboBox);
         ListView<String> list = getListView();

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
@@ -344,8 +344,7 @@ public class ComboBoxTest {
         comboBox.setItems(items);
         comboBox.setValue("ITEM1");
 
-        ListCell<String> cell = (ListCell<String>) ((ComboBoxListViewSkin<String>) comboBox.getSkin())
-                .getDisplayNode();
+        ListCell<String> cell = (ListCell<String>) getDisplayNode();
         assertEquals("ITEM1", cell.getText());
 
         comboBox.setConverter(new StringConverter<>() {
@@ -395,8 +394,7 @@ public class ComboBoxTest {
         comboBox.setItems(items);
         comboBox.setValue(null);
 
-        ListCell<String> cell = (ListCell<String>) ((ComboBoxListViewSkin<String>) comboBox.getSkin())
-                .getDisplayNode();
+        ListCell<String> cell = (ListCell<String>) getDisplayNode();
         assertNull(cell.getText());
 
         comboBox.setConverter(new StringConverter<>() {
@@ -445,8 +443,7 @@ public class ComboBoxTest {
         comboBox.setItems(items);
         comboBox.setValue(null);
 
-        ListCell<String> cell = (ListCell<String>) ((ComboBoxListViewSkin<String>) comboBox.getSkin())
-                .getDisplayNode();
+        ListCell<String> cell = (ListCell<String>) getDisplayNode();
         assertNull(cell.getText());
 
         comboBox.setConverter(new StringConverter<>() {


### PR DESCRIPTION
This is a follow-up to the combobox converter PR. It seems like the updateDisplayNode method in the Skin does not properly handle null cases for when null is an item in the combobox. It probably incorrectly assumes that any null values is mapped to null by the stringconverter. However, if you create a custom converter, a null value can have a non-null string value.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8384806](https://bugs.openjdk.org/browse/JDK-8384806): ComboBox converter does not properly update contained null values (**Bug** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Marius Hanl](https://openjdk.org/census#mhanl) (@Maran23 - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2169/head:pull/2169` \
`$ git checkout pull/2169`

Update a local copy of the PR: \
`$ git checkout pull/2169` \
`$ git pull https://git.openjdk.org/jfx.git pull/2169/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2169`

View PR using the GUI difftool: \
`$ git pr show -t 2169`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2169.diff">https://git.openjdk.org/jfx/pull/2169.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2169#issuecomment-4466671413)
</details>
