### PR TITLE
8384814: [macOS] Trackpad scroll gestures suddenly stop

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
@@ -2011,6 +2011,19 @@ public class Scene implements EventTarget {
 
         if (gesture.target != null && (!gesture.finished || e.isInertia())) {
             pickedTarget = gesture.target.get();
+            if (pickedTarget instanceof Node) {
+                // During a scroll gesture the initial target may have
+                // scrolled out of sight and been removed from the scene
+                // graph.
+                Node pickedNode = (Node) pickedTarget;
+                if (pickedNode.getScene() == null) {
+                    gesture.target = null;
+                    pickedTarget = e.getPickResult().getIntersectedNode();
+                    if (pickedTarget != null) {
+                        gesture.target = new WeakReference<>(pickedTarget);
+                    }
+                }
+            }
         } else {
             pickedTarget = e.getPickResult().getIntersectedNode();
             if (pickedTarget == null) {

--- a/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
@@ -2021,6 +2021,8 @@ public class Scene implements EventTarget {
                     pickedTarget = e.getPickResult().getIntersectedNode();
                     if (pickedTarget != null) {
                         gesture.target = new WeakReference<>(pickedTarget);
+                    } else {
+                        pickedTarget = this;
                     }
                 }
             }


### PR DESCRIPTION
On macOS when the user swipes on a trackpad or Magic Mouse JavaFX sees this as a scroll gesture. The scene tries to ensure that all the scroll events generated by the gesture are fired at the same target to ensure that the gesture's scroll events don't get split between two ScrollPanes. For example, while a ScrollPane is being scrolled a child ScrollPane might shift until it's beneath the mouse pointer. Scroll events should not fire at the child but remain with the parent.

During the gesture the scene should target the node that's handling the scrolling (like a ScrollPane) but there's no good way to determine that. Instead it targets a descendant node, whatever was under the mouse pointer when the gesture started. This node is likely to shift during the scroll and if scrolls out of view it might get disconnected from the scene graph. At that point events fired at it will go nowhere and the gesture will abruptly stop.

This PR detects when the gesture target is removed from the scene graph and attempts to find a new target.

This bug does not reproduce on Windows since that platform doesn't generate a SCROLL_STARTED event so the Scene never selects a gesture target. All scroll events are delivered to whatever node is under the mouse pointer which will change as the scroll progresses.

This PR might fix [JDK-8088460](https://bugs.openjdk.org/browse/JDK-8088460) which shows up in Ensemble if anyone wants to test that.

Submitting fix for sanity checking and manual testing. Will investigate creating an automated test for this.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8384814](https://bugs.openjdk.org/browse/JDK-8384814): [macOS] Trackpad scroll gestures suddenly stop (**Bug** - P4)


### Reviewers
 * [Marius Hanl](https://openjdk.org/census#mhanl) (@Maran23 - Committer)
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2171/head:pull/2171` \
`$ git checkout pull/2171`

Update a local copy of the PR: \
`$ git checkout pull/2171` \
`$ git pull https://git.openjdk.org/jfx.git pull/2171/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2171`

View PR using the GUI difftool: \
`$ git pr show -t 2171`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2171.diff">https://git.openjdk.org/jfx/pull/2171.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2171#issuecomment-4481778650)
</details>
