### PR TITLE
8385533: Cell "focused" PseudoClass handling is unnecessary

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/Cell.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/Cell.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -360,8 +360,6 @@ public class Cell<T> extends Labeled {
          */
         super.focusedProperty().addListener(new InvalidationListener() {
             @Override public void invalidated(Observable property) {
-                pseudoClassStateChanged(PSEUDO_CLASS_FOCUSED, isFocused()); // TODO is this necessary??
-
                 // The user has shifted focus, so we should cancel the editing on this cell
                 if (!isFocused() && isEditing()) {
                     cancelEdit();
@@ -765,8 +763,6 @@ public class Cell<T> extends Labeled {
     private static final String DEFAULT_STYLE_CLASS = "cell";
     private static final PseudoClass PSEUDO_CLASS_SELECTED =
             PseudoClass.getPseudoClass("selected");
-    private static final PseudoClass PSEUDO_CLASS_FOCUSED =
-            PseudoClass.getPseudoClass("focused");
     private static final PseudoClass PSEUDO_CLASS_EMPTY =
             PseudoClass.getPseudoClass("empty");
     private static final PseudoClass PSEUDO_CLASS_FILLED =

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/CellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/CellTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,15 +46,19 @@ import javafx.scene.control.TreeCell;
 import javafx.scene.control.TreeTableCell;
 import javafx.scene.control.TreeTableCellShim;
 import javafx.scene.control.TreeTableRow;
+import javafx.scene.layout.HBox;
 import javafx.stage.Stage;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import com.sun.javafx.tk.Toolkit;
 import test.com.sun.javafx.scene.control.infrastructure.ControlTestUtils;
+import test.com.sun.javafx.scene.control.infrastructure.StageLoader;
 
 /**
  */
 public class CellTest {
+
     private static Stream<Class> parameters() {
         return Stream.of(
                 Cell.class,
@@ -70,6 +74,15 @@ public class CellTest {
     }
 
     private Cell<String> cell;
+
+    private StageLoader stageLoader;
+
+    @AfterEach
+    public void afterEach() {
+        if (stageLoader != null) {
+            stageLoader.dispose();
+        }
+    }
 
     // @BeforeEach
     // junit5 does not support parameterized class-level tests yet
@@ -127,6 +140,22 @@ public class CellTest {
         ControlTestUtils.assertPseudoClassExists(cell, "empty");
         ControlTestUtils.assertPseudoClassDoesNotExist(cell, "filled");
         ControlTestUtils.assertPseudoClassDoesNotExist(cell, "selected");
+        ControlTestUtils.assertPseudoClassDoesNotExist(cell, "focused");
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void testFocusedPseudoClassIsSetWhenFocused(Class<?> c) {
+        setup(c);
+
+        Button button = new Button();
+        stageLoader = new StageLoader(new HBox(button, cell));
+
+        ControlTestUtils.assertPseudoClassDoesNotExist(cell, "focused");
+        cell.requestFocus();
+        ControlTestUtils.assertPseudoClassExists(cell, "focused");
+
+        button.requestFocus();
         ControlTestUtils.assertPseudoClassDoesNotExist(cell, "focused");
     }
 


### PR DESCRIPTION
The `Cell` registers a listener to the `focusedProperty`.
In the listener the `focused` `PseudoClass` is set or unset depending on the state of the `focusedProperty` (true/false).
Followed by a TODO, stating: `TODO is this necessary??`

The answer is no, this is unnecessary and already done by `Node`.
The `focusedProperty` will set or unset the "focused" `PseudoClass` in the same way that is done in `Cell`.

Mentioned first in this comment  https://github.com/openjdk/jfx/pull/1935#discussion_r3243531543

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8385533](https://bugs.openjdk.org/browse/JDK-8385533): Cell "focused" PseudoClass handling is unnecessary (**Enhancement** - P4)


### Reviewers
 * [Michael Strauß](https://openjdk.org/census#mstrauss) (@mstr2 - **Reviewer**)
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2176/head:pull/2176` \
`$ git checkout pull/2176`

Update a local copy of the PR: \
`$ git checkout pull/2176` \
`$ git pull https://git.openjdk.org/jfx.git pull/2176/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2176`

View PR using the GUI difftool: \
`$ git pr show -t 2176`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2176.diff">https://git.openjdk.org/jfx/pull/2176.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2176#issuecomment-4557895383)
</details>
