### PR TITLE
8331464: ChangeListener for TableView.focusWithinProperty( ) is not always called

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ListCell.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ListCell.java
@@ -575,11 +575,11 @@ public class ListCell<T> extends IndexedCell<T> {
 
         FocusModel<T> fm = listView.getFocusModel();
         if (fm == null) {
-            setFocused(false);
+            setFocusedViaFocusModel(false);
             return;
         }
 
-        setFocused(fm.isFocused(index));
+        setFocusedViaFocusModel(fm.isFocused(index));
     }
 
     private void updateEditing() {

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TableCell.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TableCell.java
@@ -549,7 +549,7 @@ public class TableCell<S,T> extends IndexedCell<T> {
         final boolean isFocused = isFocused();
         if (! isInCellSelectionMode()) {
             if (isFocused) {
-                setFocused(false);
+                setFocusedViaFocusModel(false);
             }
             return;
         }
@@ -561,11 +561,11 @@ public class TableCell<S,T> extends IndexedCell<T> {
 
         final TableViewFocusModel<S> fm = tableView.getFocusModel();
         if (fm == null) {
-            setFocused(false);
+            setFocusedViaFocusModel(false);
             return;
         }
 
-        setFocused(fm.isFocused(index, getTableColumn()));
+        setFocusedViaFocusModel(fm.isFocused(index, getTableColumn()));
     }
 
     private void updateEditing() {

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TableRow.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TableRow.java
@@ -303,7 +303,7 @@ public class TableRow<T> extends IndexedCell<T> {
         if (sm == null || fm == null) return;
 
         boolean isFocused = ! sm.isCellSelectionEnabled() && fm.isFocused(getIndex());
-        setFocused(isFocused);
+        setFocusedViaFocusModel(isFocused);
     }
 
     private void updateEditing() {

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeCell.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeCell.java
@@ -575,11 +575,11 @@ public class TreeCell<T> extends IndexedCell<T> {
 
         FocusModel<TreeItem<T>> fm = getTreeView().getFocusModel();
         if (fm == null) {
-            setFocused(false);
+            setFocusedViaFocusModel(false);
             return;
         }
 
-        setFocused(fm.isFocused(getIndex()));
+        setFocusedViaFocusModel(fm.isFocused(getIndex()));
     }
 
     private boolean updateEditingIndex = true;

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableCell.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableCell.java
@@ -545,7 +545,7 @@ public class TreeTableCell<S,T> extends IndexedCell<T> {
         final boolean isFocused = isFocused();
         if (! isInCellSelectionMode()) {
             if (isFocused) {
-                setFocused(false);
+                setFocusedViaFocusModel(false);
             }
             return;
         }
@@ -555,11 +555,11 @@ public class TreeTableCell<S,T> extends IndexedCell<T> {
 
         TreeTableView.TreeTableViewFocusModel<S> fm = tv.getFocusModel();
         if (fm == null) {
-            setFocused(false);
+            setFocusedViaFocusModel(false);
             return;
         }
 
-        setFocused(fm.isFocused(getIndex(), getTableColumn()));
+        setFocusedViaFocusModel(fm.isFocused(getIndex(), getTableColumn()));
     }
 
     private void updateEditing() {

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableRow.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableRow.java
@@ -464,7 +464,7 @@ public class TreeTableRow<T> extends IndexedCell<T> {
         if (getIndex() == -1 || getTreeTableView() == null) return;
         if (getTreeTableView().getFocusModel() == null) return;
 
-        setFocused(getTreeTableView().getFocusModel().isFocused(getIndex()));
+        setFocusedViaFocusModel(getTreeTableView().getFocusModel().isFocused(getIndex()));
     }
 
     private void updateEditing() {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
@@ -109,6 +109,7 @@ import javafx.scene.control.skin.TableHeaderRowShim;
 import javafx.scene.control.skin.VirtualFlow;
 import javafx.scene.image.ImageView;
 import javafx.scene.input.KeyCode;
+import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.StackPane;
 import javafx.scene.layout.VBox;
@@ -6714,5 +6715,35 @@ public class TableViewTest {
 
         sm.clearSelection();
         assertEquals(List.of(), sm.getSelectedIndices());
+    }
+
+    // See JDK-8331464
+    @Test public void test_focusWithinProperty_firesOnFocusTransferToAndFromTableView() {
+        TableView<String> table = new TableView<>(
+                FXCollections.observableArrayList("A", "B", "C", "D", "E"));
+        TableColumn<String, String> col = new TableColumn<>("Items");
+        col.setCellValueFactory(r -> new SimpleStringProperty(r.getValue()));
+        table.getColumns().add(col);
+        Button button = new Button("Other");
+
+        stageLoader = new StageLoader(new HBox(table, button));
+        stageLoader.getStage().requestFocus();
+        Toolkit.getToolkit().firePulse();
+
+        table.requestFocus();
+        table.getFocusModel().focus(0);
+        Toolkit.getToolkit().firePulse();
+
+        List<String> events = new ArrayList<>();
+        table.focusWithinProperty().addListener((obs, oldVal, newVal) ->
+                events.add(newVal ? "gained" : "lost"));
+
+        button.requestFocus();
+        assertEquals(List.of("lost"), events);
+        Toolkit.getToolkit().firePulse();
+
+        table.requestFocus();
+        assertEquals(List.of("lost", "gained"), events);
+        Toolkit.getToolkit().firePulse();
     }
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
@@ -99,6 +99,7 @@ import javafx.scene.control.skin.TableColumnHeader;
 import javafx.scene.control.skin.TreeTableCellSkin;
 import javafx.scene.image.ImageView;
 import javafx.scene.input.KeyCode;
+import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.StackPane;
 import javafx.scene.layout.VBox;
@@ -8059,5 +8060,40 @@ public class TreeTableViewTest {
         expectedValues = Stream.of(0, 1, 2, 11, 12, 13, 14, 15, 16, 17, 18, 19).map(String::valueOf).toList();
         actualValues = IntStream.range(0, 12).mapToObj(i -> ttv.getTreeItem(i).getValue()).toList();
         assertEquals(expectedValues, actualValues);
+    }
+
+    // See JDK-8331464
+    @Test public void test_focusWithinProperty_firesOnFocusTransferToAndFromTreeTableView() {
+        TreeItem<String> root = new TreeItem<>("Root");
+        root.setExpanded(true);
+        root.getChildren().addAll(
+                new TreeItem<>("A"), new TreeItem<>("B"), new TreeItem<>("C"),
+                new TreeItem<>("D"), new TreeItem<>("E"));
+
+        TreeTableView<String> table = new TreeTableView<>(root);
+        TreeTableColumn<String, String> col = new TreeTableColumn<>("Items");
+        col.setCellValueFactory(r -> new ReadOnlyStringWrapper(r.getValue().getValue()));
+        table.getColumns().add(col);
+        Button button = new Button("Other");
+
+        stageLoader = new StageLoader(new HBox(table, button));
+        stageLoader.getStage().requestFocus();
+        Toolkit.getToolkit().firePulse();
+
+        table.requestFocus();
+        table.getFocusModel().focus(0);
+        Toolkit.getToolkit().firePulse();
+
+        List<String> events = new ArrayList<>();
+        table.focusWithinProperty().addListener((obs, oldVal, newVal) ->
+                events.add(newVal ? "gained" : "lost"));
+
+        button.requestFocus();
+        assertEquals(List.of("lost"), events);
+        Toolkit.getToolkit().firePulse();
+
+        table.requestFocus();
+        assertEquals(List.of("lost", "gained"), events);
+        Toolkit.getToolkit().firePulse();
     }
 }

--- a/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
@@ -8397,6 +8397,9 @@ public abstract sealed class Node
      * @see #requestFocus()
      * @defaultValue false
      */
+
+    private boolean focusModelUpdate;
+
     private final FocusPropertyBase focused = new FocusPropertyBase() {
         @Override
         protected PseudoClass getPseudoClass() {
@@ -8422,19 +8425,36 @@ public abstract sealed class Node
             if (get() != value) {
                 super.set(value);
 
-                int change = value ? 1 : -1;
-                Node node = Node.this;
+                if (!focusModelUpdate) {
+                    int change = value ? 1 : -1;
+                    Node node = Node.this;
 
-                do {
-                    node.focusWithin.adjust(change);
-                    node = node.getParent();
-                } while (node != null);
+                    do {
+                        node.focusWithin.adjust(change);
+                        node = node.getParent();
+                    } while (node != null);
+                }
             }
         }
     };
 
     protected final void setFocused(boolean value) {
         setFocusQuietly(value, false);
+        notifyFocusListeners();
+    }
+
+    protected final void setFocusedViaFocusModel(boolean value) {
+        if (focused.get() != value) {
+            focusModelUpdate = true;
+            try {
+                focused.set(value);
+            } finally {
+                focusModelUpdate = false;
+            }
+        }
+        if (!value && focusVisible.get()) {
+            focusVisible.set(false);
+        }
         notifyFocusListeners();
     }
 


### PR DESCRIPTION
The virtual cells (like List Cell and Table Cell) call `setFocused( )` in their `updateFocus( )` method to kind of replicate the control's focus model state. This call goes through the `focused.set( )` override in Node, which adjusts the `focusWithin `reference count on all ancestor nodes.

Since the owning control ( like TableView) is already the Scene focus owner contributing a count of 1, so I believe the cell's `setFocused(true)` increments it to 2. When the Scene later moves focus away, it decrements the count back to 1 (still positive) and so `focusWithinProperty `never fires.

The fix I've used is a focusModelUpdate flag on Node. When `setFocusedViaFocusModel( )` is called, this flag suppresses the `focusWithin ` reference count adjustment inside `focused.set( )` and all normal change notifications and CSS pseudo class updates are firing as usual too.

I've updated the 6 cell types to use `setFocusedViaFocusModel( )` in their `updateFocus( )` methods too.

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8331464](https://bugs.openjdk.org/browse/JDK-8331464)

### Issue
 * [JDK-8331464](https://bugs.openjdk.org/browse/JDK-8331464): ChangeListener for TableView.focusWithinProperty() is not always called (**Bug** - P4) ⚠️ Title mismatch between PR and JBS.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2178/head:pull/2178` \
`$ git checkout pull/2178`

Update a local copy of the PR: \
`$ git checkout pull/2178` \
`$ git pull https://git.openjdk.org/jfx.git pull/2178/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2178`

View PR using the GUI difftool: \
`$ git pr show -t 2178`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2178.diff">https://git.openjdk.org/jfx/pull/2178.diff</a>

</details>
