### PR TITLE
8385666: Fix for JDK-8384806 broke combo box cell graphics

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ComboBoxListViewSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ComboBoxListViewSkin.java
@@ -359,15 +359,16 @@ public class ComboBoxListViewSkin<T> extends ComboBoxPopupControl<T> {
         } else {
             T value = comboBox.getValue();
             int index = getIndexOfComboBoxValueInItemsList();
+
+            // This guarantees that the cell is cleared even when the
+            // value is null and contained in the items (which is allowed)
+            buttonCell.updateIndex(-1);
+
             if (index > -1) {
-                // This guarantees that the cell is cleared even when the
-                // value is null and contained in the items (which is allowed)
-                buttonCell.updateIndex(-1);
                 buttonCell.updateIndex(index);
             } else {
                 // JDK-8127575 Show the ComboBox value even though it doesn't
                 // exist in the ComboBox items list (part two of fix)
-                buttonCell.updateIndex(-1);
                 boolean empty = updateDisplayText(buttonCell, value, false);
 
                 // Note that empty boolean collected above. This is used to resolve

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ComboBoxListViewSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ComboBoxListViewSkin.java
@@ -359,20 +359,24 @@ public class ComboBoxListViewSkin<T> extends ComboBoxPopupControl<T> {
         } else {
             T value = comboBox.getValue();
             int index = getIndexOfComboBoxValueInItemsList();
+            if (index > -1) {
+                buttonCell.updateIndex(-1);
+                buttonCell.updateIndex(index);
+            } else {
+                // JDK-8127575 Show the ComboBox value even though it doesn't
+                // exist in the ComboBox items list (part two of fix)
+                buttonCell.updateIndex(-1);
+                boolean empty = updateDisplayText(buttonCell, value, false);
 
-            // JDK-8127575 Show the ComboBox value even though it doesn't
-            // exist in the ComboBox items list (part two of fix)
-            buttonCell.updateIndex(index);
-            boolean empty = updateDisplayText(buttonCell, value, false);
-
-            // Note that empty boolean collected above. This is used to resolve
-            // JDK-8124141, where we were getting different styling based on whether
-            // the cell was updated via the updateIndex method above, or just
-            // by directly updating the text. We fake the pseudoclass state
-            // for empty, filled, and selected here.
-            buttonCell.pseudoClassStateChanged(PSEUDO_CLASS_EMPTY,    empty);
-            buttonCell.pseudoClassStateChanged(PSEUDO_CLASS_FILLED,   !empty);
-            buttonCell.pseudoClassStateChanged(PSEUDO_CLASS_SELECTED, true);
+                // Note that empty boolean collected above. This is used to resolve
+                // JDK-8124141, where we were getting different styling based on whether
+                // the cell was updated via the updateIndex method above, or just
+                // by directly updating the text. We fake the pseudoclass state
+                // for empty, filled, and selected here.
+                buttonCell.pseudoClassStateChanged(PSEUDO_CLASS_EMPTY,    empty);
+                buttonCell.pseudoClassStateChanged(PSEUDO_CLASS_FILLED,   !empty);
+                buttonCell.pseudoClassStateChanged(PSEUDO_CLASS_SELECTED, true);
+            }
         }
     }
 

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ComboBoxListViewSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ComboBoxListViewSkin.java
@@ -360,6 +360,8 @@ public class ComboBoxListViewSkin<T> extends ComboBoxPopupControl<T> {
             T value = comboBox.getValue();
             int index = getIndexOfComboBoxValueInItemsList();
             if (index > -1) {
+                // This guarantees that the cell is cleared even when the
+                // value is null and contained in the items (which is allowed)
                 buttonCell.updateIndex(-1);
                 buttonCell.updateIndex(index);
             } else {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
@@ -599,7 +599,8 @@ public class ComboBoxTest {
         assertNotNull(comboBox.getButtonCell().getGraphic());
         assertEquals("null-text", ((Label) comboBox.getButtonCell().getGraphic()).getText());
 
-        // Calls updateDisplayNode()
+        // A call to getDisplayNode() will call updateDisplayNode() in its implementation
+        // as that is how the skin does it
         getDisplayNode();
         assertNotNull(comboBox.getButtonCell().getGraphic());
         assertEquals("null-text", ((Label) comboBox.getButtonCell().getGraphic()).getText());

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
@@ -411,6 +411,7 @@ public class ComboBoxTest {
 
         assertEquals("NOT NULL", cell.getText());
     }
+
     @Test
     public void testTextFieldUpdateOnStringConverterChangeWithContainedNullValue() {
         ObservableList<String> items = FXCollections.observableArrayList(null, "ITEM1", "ITEM2");
@@ -490,6 +491,54 @@ public class ComboBoxTest {
         VirtualFlowTestUtils.assertCellTextEquals(list, 0, "item1");
         VirtualFlowTestUtils.assertCellTextEquals(list, 1, "item2");
         VirtualFlowTestUtils.assertCellTextEquals(list, 2, "item3");
+    }
+
+    @Test
+    public void testGraphicUpdateOnStringConverterChangeWithContainedNullValue() {
+        ObservableList<String> items = FXCollections.observableArrayList(null, "ITEM1", "ITEM2");
+        comboBox.setEditable(false);
+        comboBox.setItems(items);
+        comboBox.setValue(null);
+        comboBox.setButtonCell(new ListCell<>() {
+            @Override
+            protected void updateItem(String item, boolean empty) {
+                super.updateItem(item, empty);
+                setGraphic(new Label(item != null ? item : "null-text"));
+            }
+        });
+        assertEquals("null-text", ((Label) comboBox.getButtonCell().getGraphic()).getText());
+
+        comboBox.setConverter(new StringConverter<>() {
+            @Override
+            public String toString(String object) {
+                return object != null ? object.toString() : "null-text";
+            }
+
+            @Override
+            public String fromString(String string) {
+                return "?";
+            }
+        });
+        assertEquals("null-text", ((Label) comboBox.getButtonCell().getGraphic()).getText());
+
+        comboBox.setValue("ITEM1");
+        assertEquals("ITEM1", ((Label) comboBox.getButtonCell().getGraphic()).getText());
+
+        comboBox.setConverter(new StringConverter<>() {
+            @Override
+            public String toString(String object) {
+                return object != null ? object.toString() : "null";
+            }
+
+            @Override
+            public String fromString(String string) {
+                return "?";
+            }
+        });
+        assertEquals("ITEM1", ((Label) comboBox.getButtonCell().getGraphic()).getText());
+
+        comboBox.setValue("ITEM2");
+        assertEquals("ITEM2", ((Label) comboBox.getButtonCell().getGraphic()).getText());
     }
 
     @Test public void testNullSelectionModelDoesNotThrowNPEOnValueChange() {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
@@ -494,11 +494,10 @@ public class ComboBoxTest {
     }
 
     @Test
-    public void testGraphicUpdateOnStringConverterChangeWithContainedNullValue() {
+    public void testGraphicUpdateOnDisplayNodeUpdateWithContainedNullValue() {
         ObservableList<String> items = FXCollections.observableArrayList(null, "ITEM1", "ITEM2");
         comboBox.setEditable(false);
         comboBox.setItems(items);
-        comboBox.setValue(null);
         comboBox.setButtonCell(new ListCell<>() {
             @Override
             protected void updateItem(String item, boolean empty) {
@@ -506,39 +505,47 @@ public class ComboBoxTest {
                 setGraphic(new Label(item != null ? item : "null-text"));
             }
         });
-        assertEquals("null-text", ((Label) comboBox.getButtonCell().getGraphic()).getText());
 
-        comboBox.setConverter(new StringConverter<>() {
-            @Override
-            public String toString(String object) {
-                return object != null ? object.toString() : "null-text";
-            }
+        // Setting the button cell property might already null out the graphic
+        // if the updateDisplayNode() method is misbehaving like for JDK-8384806.
+        // Force update the cell again to have a graphic
+        // so that we can test the actual methods below
+        comboBox.getButtonCell().updateIndex(-1);
+        comboBox.getButtonCell().updateIndex(0);
 
-            @Override
-            public String fromString(String string) {
-                return "?";
-            }
-        });
-        assertEquals("null-text", ((Label) comboBox.getButtonCell().getGraphic()).getText());
+        // All of those invocations call updateDisplayNode()
+        // They should not change the button cell graphic to null
+        List<Runnable> methods = List.of(
+                () -> comboBox.setPromptText("abc"),
+                () -> comboBox.setConverter(new StringConverter<>() {
+                    @Override
+                    public String toString(String object) {
+                        return object != null ? object.toString() : "null-text";
+                    }
 
-        comboBox.setValue("ITEM1");
-        assertEquals("ITEM1", ((Label) comboBox.getButtonCell().getGraphic()).getText());
+                    @Override
+                    public String fromString(String string) {
+                        return "?";
+                    }
+                }),
+                () -> getDisplayNode()
+        );
 
-        comboBox.setConverter(new StringConverter<>() {
-            @Override
-            public String toString(String object) {
-                return object != null ? object.toString() : "null";
-            }
+        for (Runnable method : methods) {
+            comboBox.setValue(null);
+            assertNotNull(comboBox.getButtonCell().getGraphic());
+            assertEquals("null-text", ((Label) comboBox.getButtonCell().getGraphic()).getText());
 
-            @Override
-            public String fromString(String string) {
-                return "?";
-            }
-        });
-        assertEquals("ITEM1", ((Label) comboBox.getButtonCell().getGraphic()).getText());
+            method.run();
+            assertNotNull(comboBox.getButtonCell().getGraphic());
+            assertEquals("null-text", ((Label) comboBox.getButtonCell().getGraphic()).getText());
 
-        comboBox.setValue("ITEM2");
-        assertEquals("ITEM2", ((Label) comboBox.getButtonCell().getGraphic()).getText());
+            comboBox.setValue("ITEM1");
+            assertEquals("ITEM1", ((Label) comboBox.getButtonCell().getGraphic()).getText());
+
+            comboBox.setValue("ITEM2");
+            assertEquals("ITEM2", ((Label) comboBox.getButtonCell().getGraphic()).getText());
+        }
     }
 
     @Test public void testNullSelectionModelDoesNotThrowNPEOnValueChange() {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
@@ -494,7 +494,7 @@ public class ComboBoxTest {
     }
 
     @Test
-    public void testGraphicUpdateOnDisplayNodeUpdateWithContainedNullValue() {
+    public void testGraphicUpdateOnPromptTextChange() {
         ObservableList<String> items = FXCollections.observableArrayList(null, "ITEM1", "ITEM2");
         comboBox.setEditable(false);
         comboBox.setItems(items);
@@ -513,39 +513,102 @@ public class ComboBoxTest {
         comboBox.getButtonCell().updateIndex(-1);
         comboBox.getButtonCell().updateIndex(0);
 
-        // All of those invocations call updateDisplayNode()
-        // They should not change the button cell graphic to null
-        List<Runnable> methods = List.of(
-                () -> comboBox.setPromptText("abc"),
-                () -> comboBox.setConverter(new StringConverter<>() {
-                    @Override
-                    public String toString(String object) {
-                        return object != null ? object.toString() : "null-text";
-                    }
+        comboBox.setValue(null);
+        assertNotNull(comboBox.getButtonCell().getGraphic());
+        assertEquals("null-text", ((Label) comboBox.getButtonCell().getGraphic()).getText());
 
-                    @Override
-                    public String fromString(String string) {
-                        return "?";
-                    }
-                }),
-                () -> getDisplayNode()
-        );
+        // Calls updateDisplayNode()
+        comboBox.setPromptText("abc");
+        assertNotNull(comboBox.getButtonCell().getGraphic());
+        assertEquals("null-text", ((Label) comboBox.getButtonCell().getGraphic()).getText());
 
-        for (Runnable method : methods) {
-            comboBox.setValue(null);
-            assertNotNull(comboBox.getButtonCell().getGraphic());
-            assertEquals("null-text", ((Label) comboBox.getButtonCell().getGraphic()).getText());
+        comboBox.setValue("ITEM1");
+        assertEquals("ITEM1", ((Label) comboBox.getButtonCell().getGraphic()).getText());
 
-            method.run();
-            assertNotNull(comboBox.getButtonCell().getGraphic());
-            assertEquals("null-text", ((Label) comboBox.getButtonCell().getGraphic()).getText());
+        comboBox.setValue("ITEM2");
+        assertEquals("ITEM2", ((Label) comboBox.getButtonCell().getGraphic()).getText());
+    }
 
-            comboBox.setValue("ITEM1");
-            assertEquals("ITEM1", ((Label) comboBox.getButtonCell().getGraphic()).getText());
+    @Test
+    public void testGraphicUpdateOnConverterChange() {
+        ObservableList<String> items = FXCollections.observableArrayList(null, "ITEM1", "ITEM2");
+        comboBox.setEditable(false);
+        comboBox.setItems(items);
+        comboBox.setButtonCell(new ListCell<>() {
+            @Override
+            protected void updateItem(String item, boolean empty) {
+                super.updateItem(item, empty);
+                setGraphic(new Label(item != null ? item : "null-text"));
+            }
+        });
 
-            comboBox.setValue("ITEM2");
-            assertEquals("ITEM2", ((Label) comboBox.getButtonCell().getGraphic()).getText());
-        }
+        // Setting the button cell property might already null out the graphic
+        // if the updateDisplayNode() method is misbehaving like for JDK-8384806.
+        // Force update the cell again to have a graphic
+        // so that we can test the actual methods below
+        comboBox.getButtonCell().updateIndex(-1);
+        comboBox.getButtonCell().updateIndex(0);
+
+        comboBox.setValue(null);
+        assertNotNull(comboBox.getButtonCell().getGraphic());
+        assertEquals("null-text", ((Label) comboBox.getButtonCell().getGraphic()).getText());
+
+        // Calls updateDisplayNode()
+        comboBox.setConverter(new StringConverter<>() {
+            @Override
+            public String toString(String object) {
+                return object != null ? object.toString() : "null-text";
+            }
+
+            @Override
+            public String fromString(String string) {
+                return "?";
+            }
+        });
+        assertNotNull(comboBox.getButtonCell().getGraphic());
+        assertEquals("null-text", ((Label) comboBox.getButtonCell().getGraphic()).getText());
+
+        comboBox.setValue("ITEM1");
+        assertEquals("ITEM1", ((Label) comboBox.getButtonCell().getGraphic()).getText());
+
+        comboBox.setValue("ITEM2");
+        assertEquals("ITEM2", ((Label) comboBox.getButtonCell().getGraphic()).getText());
+    }
+
+    @Test
+    public void testGraphicUpdateOnGetDisplayNode() {
+        ObservableList<String> items = FXCollections.observableArrayList(null, "ITEM1", "ITEM2");
+        comboBox.setEditable(false);
+        comboBox.setItems(items);
+        comboBox.setButtonCell(new ListCell<>() {
+            @Override
+            protected void updateItem(String item, boolean empty) {
+                super.updateItem(item, empty);
+                setGraphic(new Label(item != null ? item : "null-text"));
+            }
+        });
+
+        // Setting the button cell property might already null out the graphic
+        // if the updateDisplayNode() method is misbehaving like for JDK-8384806.
+        // Force update the cell again to have a graphic
+        // so that we can test the actual methods below
+        comboBox.getButtonCell().updateIndex(-1);
+        comboBox.getButtonCell().updateIndex(0);
+
+        comboBox.setValue(null);
+        assertNotNull(comboBox.getButtonCell().getGraphic());
+        assertEquals("null-text", ((Label) comboBox.getButtonCell().getGraphic()).getText());
+
+        // Calls updateDisplayNode()
+        getDisplayNode();
+        assertNotNull(comboBox.getButtonCell().getGraphic());
+        assertEquals("null-text", ((Label) comboBox.getButtonCell().getGraphic()).getText());
+
+        comboBox.setValue("ITEM1");
+        assertEquals("ITEM1", ((Label) comboBox.getButtonCell().getGraphic()).getText());
+
+        comboBox.setValue("ITEM2");
+        assertEquals("ITEM2", ((Label) comboBox.getButtonCell().getGraphic()).getText());
     }
 
     @Test public void testNullSelectionModelDoesNotThrowNPEOnValueChange() {


### PR DESCRIPTION
This is a much simpler fix for JDK-8384806 which does not have any side effects.

This restores the old code with only a one line change instead. For reference, see https://github.com/openjdk/jfx/commit/8d917ae738120e12ac12cd0957879b7c00e59b03. We now fix the issue by clearing the cell with `buttonCell.updateIndex(-1);` as using `buttonCell.setItem(null);` was causing the original issue when the item was already null.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8385666](https://bugs.openjdk.org/browse/JDK-8385666): Fix for JDK-8384806 broke combo box cell graphics (**Bug** - P3)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Marius Hanl](https://openjdk.org/census#mhanl) (@Maran23 - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2179/head:pull/2179` \
`$ git checkout pull/2179`

Update a local copy of the PR: \
`$ git checkout pull/2179` \
`$ git pull https://git.openjdk.org/jfx.git pull/2179/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2179`

View PR using the GUI difftool: \
`$ git pr show -t 2179`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2179.diff">https://git.openjdk.org/jfx/pull/2179.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2179#issuecomment-4588976445)
</details>
