### PR TITLE
8385737: TextLayoutUtilsContractTest fails when run with JDK 26 or later

### DIFF
--- a/modules/javafx.controls/src/test/addExports
+++ b/modules/javafx.controls/src/test/addExports
@@ -13,6 +13,7 @@
 --add-exports javafx.graphics/com.sun.javafx.application=ALL-UNNAMED
 --add-exports javafx.graphics/com.sun.javafx.font=ALL-UNNAMED
 --add-exports javafx.graphics/com.sun.javafx.geom=ALL-UNNAMED
+--add-exports javafx.graphics/com.sun.javafx.geom.transform=ALL-UNNAMED
 --add-exports javafx.graphics/com.sun.javafx.perf=ALL-UNNAMED
 --add-exports javafx.graphics/com.sun.javafx.scene=ALL-UNNAMED
 --add-exports javafx.graphics/com.sun.javafx.scene.input=ALL-UNNAMED


### PR DESCRIPTION
With JDK-26, there is a new error when running tests. It seems that this is related how records hash their values.
With `JDK_HOME` set to a JDK-26, I can reliable reproduce this error by running:
> ./gradlew :controls:test --tests TextLayoutUtilsContractTest

Fix: `com.sun.javafx.geom.transform` added to the `addExports`. This is where `BaseTransform` is located.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8385737](https://bugs.openjdk.org/browse/JDK-8385737): TextLayoutUtilsContractTest fails when run with JDK 26 or later (**Bug** - P3)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2180/head:pull/2180` \
`$ git checkout pull/2180`

Update a local copy of the PR: \
`$ git checkout pull/2180` \
`$ git pull https://git.openjdk.org/jfx.git pull/2180/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2180`

View PR using the GUI difftool: \
`$ git pr show -t 2180`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2180.diff">https://git.openjdk.org/jfx/pull/2180.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2180#issuecomment-4596913119)
</details>
