### PR TITLE
JDK 8210037 : ComboBoxes in GridPane resize when popup opens

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ComboBoxListViewSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ComboBoxListViewSkin.java
@@ -289,13 +289,26 @@ public class ComboBoxListViewSkin<T> extends ComboBoxPopupControl<T> {
 
     /** {@inheritDoc} */
     @Override protected double computePrefWidth(double height, double topInset, double rightInset, double bottomInset, double leftInset) {
-        double superPrefWidth = super.computePrefWidth(height, topInset, rightInset, bottomInset, leftInset);
-        double listViewWidth = listView.prefWidth(height);
-        double pw = Math.max(superPrefWidth, listViewWidth);
-
         reconfigurePopup();
-
-        return pw;
+        double superPrefWidth = super.computePrefWidth(height, topInset, rightInset, bottomInset, leftInset);
+        // reconfigurePopup() calls setPrefSize(newWidth, newHeight) on the listView to
+        // stabilise the popup's displayed size while it is open (relates to JDK-8116801, JDK-8123876).
+        // That call pins listView.prefWidth() to the popup's current pixel width. Once the
+        // popup closes, the pinned value is stale: a parent layout container (like a GridPane)
+        // that re measures this ComboBox will read the inflated popup width instead of the
+        // natural control width, producing asymmetric column widths ( related to JDK-8210037).
+        // To avoid this, bypass the potentially pinned prefWidth when the popup is not
+        // showing and compute the natural list view width directly instead.
+        double listViewWidth;
+        if (comboBox.isShowing()) {
+            listViewWidth = listView.prefWidth(height);
+        } else {
+            listViewWidth = computeListViewPrefWidth(height);
+            if (listView.getItems().isEmpty() && listView.getPlaceholder() != null) {
+                listViewWidth = Math.max(listView.getPlaceholder().prefWidth(height), listViewWidth);
+            }
+        }
+        return Math.max(superPrefWidth, listViewWidth);
     }
 
     /** {@inheritDoc} */
@@ -379,6 +392,39 @@ public class ComboBoxListViewSkin<T> extends ComboBoxPopupControl<T> {
     /** {@inheritDoc} */
     @Override ComboBoxBaseBehavior getBehavior() {
         return behavior;
+    }
+
+    /**
+     * Computes the preferred width of the popup {@link ListView} by directly
+     * measuring cell content.
+     *
+     * <p>{@link Region#prefWidth(double)} short circuits to return a pinned value
+     * when {@code setPrefSize()} has been called, as {@link #reconfigurePopup()}
+     * does while the popup is showing. Calling this method directly bypasses that
+     * short circuit and returns a new measurement. Used by
+     * {@link #computePrefWidth} when the popup is not visible to prevent the pinned
+     * popup width from affecting parent layout containers such as {@code GridPane}
+     * (JDK-8210037).
+     *
+     * @param height the height hint forwarded to the skin when no ListViewSkin is present
+     * @return the dynamically computed preferred width based on cell content
+     */
+    private double computeListViewPrefWidth(double height) {
+        double pw;
+        if (listView.getSkin() instanceof ListViewSkin<?> skin) {
+            if (itemCountDirty) {
+                skin.updateItemCount();
+                itemCountDirty = false;
+            }
+            int rowsToMeasure = -1;
+            if (comboBox.getProperties().containsKey(COMBO_BOX_ROWS_TO_MEASURE_WIDTH_KEY)) {
+                rowsToMeasure = (Integer) comboBox.getProperties().get(COMBO_BOX_ROWS_TO_MEASURE_WIDTH_KEY);
+            }
+            pw = Math.max(comboBox.getWidth(), skin.getMaxCellWidth(rowsToMeasure) + 30);
+        } else {
+            pw = Math.max(100, comboBox.getWidth());
+        }
+        return Math.max(50, pw);
     }
 
     private void updateComboBoxItems() {
@@ -538,31 +584,13 @@ public class ComboBoxListViewSkin<T> extends ComboBoxPopupControl<T> {
             }
 
             @Override protected double computePrefWidth(double height) {
-                double pw;
-                if (getSkin() instanceof ListViewSkin) {
-                    ListViewSkin<?> skin = (ListViewSkin<?>)getSkin();
-                    if (itemCountDirty) {
-                        skin.updateItemCount();
-                        itemCountDirty = false;
-                    }
-
-                    int rowsToMeasure = -1;
-                    if (comboBox.getProperties().containsKey(COMBO_BOX_ROWS_TO_MEASURE_WIDTH_KEY)) {
-                        rowsToMeasure = (Integer) comboBox.getProperties().get(COMBO_BOX_ROWS_TO_MEASURE_WIDTH_KEY);
-                    }
-
-                    pw = Math.max(comboBox.getWidth(), skin.getMaxCellWidth(rowsToMeasure) + 30);
-                } else {
-                    pw = Math.max(100, comboBox.getWidth());
-                }
-
+                double pw = computeListViewPrefWidth(height);
                 // need to check the ListView pref height in the case that the
                 // placeholder node is showing
                 if (getItems().isEmpty() && getPlaceholder() != null) {
                     pw = Math.max(super.computePrefWidth(height), pw);
                 }
-
-                return Math.max(50, pw);
+                return pw;
             }
 
             @Override protected double computePrefHeight(double width) {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
@@ -72,6 +72,8 @@ import javafx.scene.control.skin.VirtualFlow;
 import javafx.scene.input.KeyCode;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.FlowPane;
+import javafx.scene.layout.GridPane;
+import javafx.scene.layout.Priority;
 import javafx.scene.layout.VBox;
 import javafx.scene.paint.Color;
 import javafx.scene.shape.Circle;
@@ -2612,5 +2614,43 @@ public class ComboBoxTest {
         assertEquals("B", comboBox.getSelectionModel().getSelectedItem());
         mouse.fireMousePressAndRelease();
         assertEquals("B", comboBox.getSelectionModel().getSelectedItem());
+    }
+
+    //JDK-8210037
+    @Test public void test_jdk_8210037_gridPaneColumnWidthsPreservedAfterComboBoxPopup() {
+        ObservableList<String> items = FXCollections.observableArrayList("Option 1", "Option 2", "Option 3");
+
+        final ComboBox<String> cb1 = new ComboBox<>(items);
+        cb1.setMaxWidth(Double.MAX_VALUE);
+        GridPane.setHgrow(cb1, Priority.ALWAYS);
+
+        final ComboBox<String> cb2 = new ComboBox<>(items);
+        cb2.setMaxWidth(Double.MAX_VALUE);
+        GridPane.setHgrow(cb2, Priority.ALWAYS);
+
+        Label lbl1 = new Label("Label 1");
+        GridPane.setHgrow(lbl1, Priority.SOMETIMES);
+
+        Label lbl2 = new Label("Label 2");
+        GridPane.setHgrow(lbl2, Priority.SOMETIMES);
+
+        GridPane grid = new GridPane();
+        grid.addRow(0, lbl1, cb1, lbl2, cb2);
+
+        sl = new StageLoader(grid);
+        sl.getStage().setWidth(800);
+        Toolkit.getToolkit().firePulse();
+
+        double width1Before = cb1.getWidth();
+        double width2Before = cb2.getWidth();
+        assertEquals(width1Before, width2Before, 1.0,
+                "ComboBox widths should be equal before popup is shown");
+
+        cb1.show();
+        cb1.hide();
+        Toolkit.getToolkit().firePulse();
+
+        assertEquals(cb1.getWidth(), cb2.getWidth(), 1.0,
+                "ComboBox widths should remain equal after popup is shown and hidden");
     }
 }


### PR DESCRIPTION
So the issue was that when two or more ComboBox controls with `Priority.ALWAYS` HGrow are placed in a GridPane, opening and closing one ComboBox's popup caused the column widths to become unequal.

The root cause I believe is in r`econfigurePopup( )` in `ComboBoxPopupControl. ` While the popup is showing, it calls `setPrefSize( )` on the popup content (the ListView) to stabilize its displayed size. This pins the ListView's preferred width to the current popup dimensions. When the popup closes and the GridPane performs its next layout pass, `computePrefWidth `in `ComboBoxListViewSkin `reads `listView.prefWidth( )` which for the ComboBox whose popup was just open returns the stale pinned value, while the other ComboBox computes dynamically. This asymmetry causes GridPane to allocate unequal column widths.

I first tried resetting setPrefSize to `USE_COMPUTED_SIZE` in the `WINDOW_HIDDEN` handler. This approach does look clean I guess but doesn't work cause the GridPane layout pass that reads computePrefWidth happens while the popup is still showing, so the reset fires too late and the asymmetric value is already committed.

The fix I've used :
Guard computePrefWidth in `ComboBoxListViewSkin`: when the popup is not showing, we compute the ListView width dynamically via a new private method `computeListViewPrefWidth( )` instead of reading the potentially stale `listView.prefWidth( )`.

**When the popup is showing, the pinned value is still used directly and this preserves the existing popup stability behavior from JDK-8116801 and JDK-8123876.**

The measurement logic in `computeListViewPrefWidth` was already present in the anonymous ListView subclass's computePrefWidth override. All I did was extract it into a named method to eliminate the duplication.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[ \] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2182/head:pull/2182` \
`$ git checkout pull/2182`

Update a local copy of the PR: \
`$ git checkout pull/2182` \
`$ git pull https://git.openjdk.org/jfx.git pull/2182/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2182`

View PR using the GUI difftool: \
`$ git pr show -t 2182`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2182.diff">https://git.openjdk.org/jfx/pull/2182.diff</a>

</details>
