### PR TITLE
8385956: Skip failing DialogRepeatedShowHideTest on Wayland

### DIFF
--- a/tests/system/src/test/java/test/robot/javafx/scene/dialog/DialogRepeatedShowHideTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/dialog/DialogRepeatedShowHideTest.java
@@ -64,7 +64,7 @@ public class DialogRepeatedShowHideTest {
 
     @Test
     public void dialogSizeOnReShownTest() throws Exception {
-        assumeTrue(!Util.isOnWayland()); // JDK-8385956
+        assumeTrue(!Util.isOnWayland()); // JDK-8375347
         Thread.sleep(400);
         clickButton();
         hide();

--- a/tests/system/src/test/java/test/robot/javafx/scene/dialog/DialogRepeatedShowHideTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/dialog/DialogRepeatedShowHideTest.java
@@ -46,6 +46,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import test.util.Util;
 
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
 //see JDK8193502
 @Timeout(value=15000, unit=TimeUnit.MILLISECONDS)
 public class DialogRepeatedShowHideTest {
@@ -62,6 +64,7 @@ public class DialogRepeatedShowHideTest {
 
     @Test
     public void dialogSizeOnReShownTest() throws Exception {
+        assumeTrue(!Util.isOnWayland()); // JDK-8385956
         Thread.sleep(400);
         clickButton();
         hide();


### PR DESCRIPTION
Skipping DialogRepeatedShowHideTest Test on Wayland until [JDK-8375347](https://bugs.openjdk.org/browse/JDK-8375347) is fixed

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8385956](https://bugs.openjdk.org/browse/JDK-8385956): Skip failing DialogRepeatedShowHideTest on Wayland (**Bug** - P3)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2183/head:pull/2183` \
`$ git checkout pull/2183`

Update a local copy of the PR: \
`$ git checkout pull/2183` \
`$ git pull https://git.openjdk.org/jfx.git pull/2183/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2183`

View PR using the GUI difftool: \
`$ git pr show -t 2183`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2183.diff">https://git.openjdk.org/jfx/pull/2183.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2183#issuecomment-4627513693)
</details>
