### PR TITLE
8340564: [macOS] Intermittent build failure in native font with parallel compilation

### DIFF
--- a/buildSrc/src/main/groovy/com/sun/javafx/gradle/CCTask.groovy
+++ b/buildSrc/src/main/groovy/com/sun/javafx/gradle/CCTask.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -65,11 +65,11 @@ class CCTask extends NativeCompileTask {
             if (params != null) {
                 // A little hack. Only use the -std=c99 flag if compiling .c or .m
                 if (sourceFile.name.endsWith(".cpp") || sourceFile.name.endsWith(".cc") || sourceFile.name.endsWith(".mm")) {
-                    def stripped = params;
+                    def stripped = new ArrayList<String>(params);
                     stripped.remove("-std=c99");
                     spec.args(stripped)
                 } else {
-                    spec.args(params)
+                    spec.args(new ArrayList<String>(params));
                 }
             }
 


### PR DESCRIPTION
This PR fixes a long-standing intermittent build failure on macOS (although it could have hit any platform, we never saw it on Windows or Linux). The problem was a race condition in the custom Groovy CCTask used by gradle to compile native C / C++ code. A set of C/C++ command line options is passed in to the custom CCTask and in the case of C++ files, mutated (to remove an unwanted option). The bug is that the original list, which is passed in to each invocation of CCTask is mutated rather than making a copy and mutating that. When compilation tasks are run in parallel (which they are by default), this can lead to the exception if one thread mutates the list while another thread reads the list.

Even without the concurrency error, mutating the input list of options directly is wrong, and should never have been done. The fix is to make a copy of the input args and operate on the copy.

I was able to provoke this bug on my local system by creating a few extra dummy files in the native-font directory and then running `gradle cleanNativeFont; gradle :graphics:ccMacFont` in a loop. Without the fix it fails for me after about 10-30 iterations. With the fix, I've run > 100 and still running.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8340564](https://bugs.openjdk.org/browse/JDK-8340564): [macOS] Intermittent build failure in native font with parallel compilation (**Bug** - P3)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2186/head:pull/2186` \
`$ git checkout pull/2186`

Update a local copy of the PR: \
`$ git checkout pull/2186` \
`$ git pull https://git.openjdk.org/jfx.git pull/2186/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2186`

View PR using the GUI difftool: \
`$ git pr show -t 2186`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2186.diff">https://git.openjdk.org/jfx/pull/2186.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2186#issuecomment-4670393917)
</details>
