### PR TITLE
8386590: GridPane - content-biased child spanning multiple columns/rows is sized ignoring hgap/vgap

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/GridPane.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/GridPane.java
@@ -1230,7 +1230,7 @@ public class GridPane extends Pane {
         computeGridMetrics();
         performingLayout = true;
         try {
-            final double[] heights = height == -1 ? null : computeHeightsToFit(height).asArray();
+            final CompositeSize heights = height == -1 ? null : computeHeightsToFit(height);
 
             return snapSpaceX(getInsets().getLeft()) +
                     computeMinWidths(heights).computeTotalWithMultiSize() +
@@ -1245,7 +1245,7 @@ public class GridPane extends Pane {
         computeGridMetrics();
         performingLayout = true;
         try {
-            final double[] widths = width == -1 ? null : computeWidthsToFit(width).asArray();
+            final CompositeSize widths = width == -1 ? null : computeWidthsToFit(width);
 
             return snapSpaceY(getInsets().getTop()) +
                     computeMinHeights(widths).computeTotalWithMultiSize() +
@@ -1259,7 +1259,7 @@ public class GridPane extends Pane {
         computeGridMetrics();
         performingLayout = true;
         try {
-            final double[] heights = height == -1 ? null : computeHeightsToFit(height).asArray();
+            final CompositeSize heights = height == -1 ? null : computeHeightsToFit(height);
 
             return snapSpaceX(getInsets().getLeft()) +
                     computePrefWidths(heights).computeTotalWithMultiSize() +
@@ -1273,7 +1273,7 @@ public class GridPane extends Pane {
         computeGridMetrics();
         performingLayout = true;
         try {
-            final double[] widths = width == -1 ? null : computeWidthsToFit(width).asArray();
+            final CompositeSize widths = width == -1 ? null : computeWidthsToFit(width);
 
             return snapSpaceY(getInsets().getTop()) +
                     computePrefHeights(widths).computeTotalWithMultiSize() +
@@ -1369,15 +1369,11 @@ public class GridPane extends Pane {
         return true;
     }
 
-    private double getTotalWidthOfNodeColumns(Node child, double[] widths) {
+    private double getTotalWidthOfNodeColumns(Node child, CompositeSize widths) {
         if (getNodeColumnSpan(child) == 1) {
-            return widths[getNodeColumnIndex(child)];
+            return widths.getSize(getNodeColumnIndex(child));
         } else {
-            double total = 0;
-            for (int i = getNodeColumnIndex(child), last = getNodeColumnEndConvertRemaining(child); i <= last; ++i) {
-                total += widths[i];
-            }
-            return total;
+            return widths.computeTotal(getNodeColumnIndex(child), getNodeColumnEndConvertRemaining(child) + 1);
         }
     }
 
@@ -1411,7 +1407,7 @@ public class GridPane extends Pane {
         return rowMaxHeight;
     }
 
-    private CompositeSize computePrefHeights(double[] widths) {
+    private CompositeSize computePrefHeights(CompositeSize widths) {
         CompositeSize result;
         if (widths == null) {
             if (rowPrefHeight != null) {
@@ -1465,7 +1461,7 @@ public class GridPane extends Pane {
         return result;
     }
 
-    private CompositeSize computeMinHeights(double[] widths) {
+    private CompositeSize computeMinHeights(CompositeSize widths) {
         CompositeSize result;
         if (widths == null) {
             if (rowMinHeight != null) {
@@ -1511,15 +1507,11 @@ public class GridPane extends Pane {
         return result;
     }
 
-    private double getTotalHeightOfNodeRows(Node child, double[] heights) {
+    private double getTotalHeightOfNodeRows(Node child, CompositeSize heights) {
         if (getNodeRowSpan(child) == 1) {
-            return heights[getNodeRowIndex(child)];
+            return heights.getSize(getNodeRowIndex(child));
         } else {
-            double total = 0;
-            for (int i = getNodeRowIndex(child), last = getNodeRowEndConvertRemaining(child); i <= last; ++i) {
-                total += heights[i];
-            }
-            return total;
+            return heights.computeTotal(getNodeRowIndex(child), getNodeRowEndConvertRemaining(child) + 1);
         }
     }
 
@@ -1553,7 +1545,7 @@ public class GridPane extends Pane {
         return columnMaxWidth;
     }
 
-    private CompositeSize computePrefWidths(double[] heights) {
+    private CompositeSize computePrefWidths(CompositeSize heights) {
         CompositeSize result;
         if (heights == null) {
             if (columnPrefWidth != null) {
@@ -1610,7 +1602,7 @@ public class GridPane extends Pane {
         return result;
     }
 
-    private CompositeSize computeMinWidths(double[] heights) {
+    private CompositeSize computeMinWidths(CompositeSize heights) {
         CompositeSize result;
         if (heights == null) {
             if (columnMinWidth != null) {
@@ -1741,12 +1733,12 @@ public class GridPane extends Pane {
             } else if (contentBias == Orientation.HORIZONTAL) {
                 widths = (CompositeSize) computePrefWidths(null).clone();
                 columnTotal = adjustColumnWidths(widths, width);
-                heights = computePrefHeights(widths.asArray());
+                heights = computePrefHeights(widths);
                 rowTotal = adjustRowHeights(heights, height);
             } else {
                 heights = (CompositeSize) computePrefHeights(null).clone();
                 rowTotal = adjustRowHeights(heights, height);
-                widths = computePrefWidths(heights.asArray());
+                widths = computePrefWidths(heights);
                 columnTotal = adjustColumnWidths(widths, width);
             }
 
@@ -1820,8 +1812,9 @@ public class GridPane extends Pane {
                                         cs = widths.getLength() - c;
                                     }
                                     double w = widths.getSize(c);
-                                    for (int j = 2; j <= cs; j++) {
-                                        w += widths.getSize(c + j - 1) + snaphgap;
+                                    for (int j = c + 1; j < cs + c; j++) {
+                                        w += widths.hasGapBefore(j) ? snaphgap : 0;
+                                        w += widths.getSize(j);
                                     }
                                     return w;
                                 },

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/GridPaneTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/GridPaneTest.java
@@ -3173,7 +3173,7 @@ public class GridPaneTest {
     static class FixedAreaRegion extends Region {
         final double SIDE = 100;
         final double AREA = SIDE * SIDE;
-        Orientation bias;
+        final Orientation bias;
 
         public FixedAreaRegion(Orientation bias) {
             this.bias = bias;
@@ -3193,7 +3193,7 @@ public class GridPaneTest {
             return width <= 0 ? SIDE : AREA / width;
         }
 
-        void checkSize() {
+        void assertSize() {
             // This should work when the Node is laid out properly.
             assertEquals(AREA, getWidth() * getHeight(), 20);
         }
@@ -3213,7 +3213,7 @@ public class GridPaneTest {
         gridpane.layout();
 
         assertEquals(70, fixedArea.getWidth());
-        fixedArea.checkSize();
+        fixedArea.assertSize();
     }
 
     @Test
@@ -3230,7 +3230,7 @@ public class GridPaneTest {
         gridpane.layout();
 
         assertEquals(70, fixedArea.getHeight());
-        fixedArea.checkSize();
+        fixedArea.assertSize();
     }
 
     @Test
@@ -3246,6 +3246,6 @@ public class GridPaneTest {
         gridpane.layout();
 
         assertEquals(100, fixedArea.getWidth());
-        fixedArea.checkSize();
+        fixedArea.assertSize();
     }
 }

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/GridPaneTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/GridPaneTest.java
@@ -3171,7 +3171,8 @@ public class GridPaneTest {
     }
 
     static class FixedAreaRegion extends Region {
-        final double AREA = 100*100;
+        final double SIDE = 100;
+        final double AREA = SIDE*SIDE;
         Orientation bias;
 
         public FixedAreaRegion(Orientation bias) {

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/GridPaneTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/GridPaneTest.java
@@ -3169,4 +3169,82 @@ public class GridPaneTest {
         assertEquals(3, gridpane.getHgap(), 0);
         assertEquals(8, gridpane.getVgap(), 0);
     }
+
+    static class FixedAreaRegion extends Region {
+        final double AREA = 100*100;
+        Orientation bias;
+
+        public FixedAreaRegion(Orientation bias) {
+            this.bias = bias;
+        }
+
+        @Override public Orientation getContentBias() {
+            return bias;
+        }
+
+        @Override
+        protected double computePrefWidth(double height) {
+            return height <= 0 ? 100 : AREA / height;
+        }
+
+        @Override
+        protected double computePrefHeight(double width) {
+            return width <= 0 ? 100 : AREA / width;
+        }
+
+        void checkSize() {
+            // This should work when the Node is laid out properly.
+            assertEquals(AREA, getWidth() * getHeight(), 20);
+        }
+    }
+
+    @Test
+    public void testDynamicAreaHorizontal() {
+        FixedAreaRegion fixedArea = new FixedAreaRegion(Orientation.HORIZONTAL);
+        gridpane.setHgap(5);
+        gridpane.add(fixedArea, 0, 0, 5, 1);
+
+        for (int i = 0; i < 5; i++) {
+            gridpane.add(new MockResizable(10,10,10,10,10,10), i, 1);
+        }
+
+        gridpane.resize(70, 500);
+        gridpane.layout();
+
+        assertEquals(70, fixedArea.getWidth());
+        fixedArea.checkSize();
+    }
+
+    @Test
+    public void testDynamicAreaVertical() {
+        FixedAreaRegion fixedArea = new FixedAreaRegion(Orientation.VERTICAL);
+        gridpane.setVgap(5);
+        gridpane.add(fixedArea, 0, 0, 1, 5);
+
+        for (int i = 0; i < 5; i++) {
+            gridpane.add(new MockResizable(10,10,10,10,10,10), 1, i);
+        }
+
+        gridpane.resize(500, 70);
+        gridpane.layout();
+
+        assertEquals(70, fixedArea.getHeight());
+        fixedArea.checkSize();
+    }
+
+    @Test
+    public void testLayoutBaseline() {
+        gridpane.setHgap(10);
+        FixedAreaRegion fixedArea = new FixedAreaRegion(Orientation.HORIZONTAL);
+        gridpane.add(fixedArea, 0, 0, 5, 1);
+
+        GridPane.setValignment(fixedArea, VPos.BASELINE);
+        GridPane.setFillHeight(fixedArea, false);
+
+        gridpane.resize(100, 500);
+        gridpane.layout();
+
+        assertEquals(100, fixedArea.getWidth());
+        fixedArea.checkSize();
+    }
 }

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/GridPaneTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/GridPaneTest.java
@@ -3185,12 +3185,12 @@ public class GridPaneTest {
 
         @Override
         protected double computePrefWidth(double height) {
-            return height <= 0 ? 100 : AREA / height;
+            return height <= 0 ? SIDE : AREA / height;
         }
 
         @Override
         protected double computePrefHeight(double width) {
-            return width <= 0 ? 100 : AREA / width;
+            return width <= 0 ? SIDE : AREA / width;
         }
 
         void checkSize() {

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/GridPaneTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/GridPaneTest.java
@@ -3172,7 +3172,7 @@ public class GridPaneTest {
 
     static class FixedAreaRegion extends Region {
         final double SIDE = 100;
-        final double AREA = SIDE*SIDE;
+        final double AREA = SIDE * SIDE;
         Orientation bias;
 
         public FixedAreaRegion(Orientation bias) {


### PR DESCRIPTION
This PR fixes the computeSize methods not considering the gap in some cases.

It also fixes a missed spot, in the previous PR for JDK-8092379.

Each fix is covered by simple tests which fail before and work after the change.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8386590](https://bugs.openjdk.org/browse/JDK-8386590): GridPane - content-biased child spanning multiple columns/rows is sized ignoring hgap/vgap (**Bug** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2187/head:pull/2187` \
`$ git checkout pull/2187`

Update a local copy of the PR: \
`$ git checkout pull/2187` \
`$ git pull https://git.openjdk.org/jfx.git pull/2187/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2187`

View PR using the GUI difftool: \
`$ git pr show -t 2187`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2187.diff">https://git.openjdk.org/jfx/pull/2187.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2187#issuecomment-4689803859)
</details>
