### PR TITLE
8382256: Unused method in TreeUtil can be cleaned up

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeUtil.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeUtil.java
@@ -57,46 +57,6 @@ class TreeUtil {
         }
     }
 
-    static <T> TreeItem<T> getItem(TreeItem<T> parent, int itemIndex, boolean treeItemCountDirty) {
-        if (parent == null) return null;
-
-        // if itemIndex is 0 then our parent is what we were looking for
-        if (itemIndex == 0) return parent;
-
-        // if itemIndex is > the total item count, then it is out of range
-        if (itemIndex >= getExpandedDescendantCount(parent, treeItemCountDirty)) return null;
-
-        // if we got here, then one of our descendants is the item we're after
-        List<TreeItem<T>> children = parent.getChildren();
-        if (children == null) return null;
-
-        int idx = itemIndex - 1;
-
-        TreeItem<T> child;
-        for (int i = 0, max = children.size(); i < max; i++) {
-            child = children.get(i);
-            if (idx == 0) return child;
-
-            if (child.isLeaf() || ! child.isExpanded()) {
-                idx--;
-                continue;
-            }
-
-            int expandedChildCount = getExpandedDescendantCount(child, treeItemCountDirty);
-            if (idx >= expandedChildCount) {
-                idx -= expandedChildCount;
-                continue;
-            }
-
-            TreeItem<T> result = getItem(child, idx, treeItemCountDirty);
-            if (result != null) return result;
-            idx--;
-        }
-
-        // We might get here if getItem(0) is called on an empty tree
-        return null;
-    }
-
     static <T> int getRow(TreeItem<T> item, TreeItem<T> root, boolean treeItemCountDirty, boolean isShowRoot) {
         if (item == null) {
             return -1;


### PR DESCRIPTION
After fixing [JDK-8181411](https://bugs.openjdk.org/browse/JDK-8181411) (PR: https://github.com/openjdk/jfx/pull/2142), `TreeUtil.getItem(..)` is now unused as it got replaced by a better and faster approach.

So time to clean it up.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8382256](https://bugs.openjdk.org/browse/JDK-8382256): Unused method in TreeUtil can be cleaned up (**Bug** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Ziad El Midaoui](https://openjdk.org/census#zelmidaoui) (@Ziad-Mid - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2189/head:pull/2189` \
`$ git checkout pull/2189`

Update a local copy of the PR: \
`$ git checkout pull/2189` \
`$ git pull https://git.openjdk.org/jfx.git pull/2189/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2189`

View PR using the GUI difftool: \
`$ git pr show -t 2189`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2189.diff">https://git.openjdk.org/jfx/pull/2189.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2189#issuecomment-4715486459)
</details>
