### PR TITLE
8386698: PlatformUtil has unused fields and methods

### DIFF
--- a/modules/javafx.base/src/main/java/com/sun/javafx/PlatformUtil.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/PlatformUtil.java
@@ -37,11 +37,9 @@ import java.util.Properties;
 public class PlatformUtil {
 
     private static final String os = System.getProperty("os.name");
-    private static final String version = System.getProperty("os.version");
     private static final boolean embedded;
     private static final String embeddedType;
     private static final boolean useEGL;
-    private static final boolean doEGLCompositing;
     // a property used to denote a non-default impl for this host
     private static String javafxPlatform;
 
@@ -53,18 +51,10 @@ public class PlatformUtil {
         embedded = Boolean.getBoolean("com.sun.javafx.isEmbedded");
         embeddedType = System.getProperty("glass.platform", "").toLowerCase(Locale.ROOT);
         useEGL = Boolean.getBoolean("use.egl");
-
-        if (useEGL) {
-            doEGLCompositing = Boolean.getBoolean("doNativeComposite");
-        } else {
-            doEGLCompositing = false;
-        }
     }
 
     private static final boolean ANDROID = "android".equals(javafxPlatform) || "Dalvik".equals(System.getProperty("java.vm.name"));
     private static final boolean WINDOWS = os.startsWith("Windows");
-    private static final boolean WINDOWS_VISTA_OR_LATER = WINDOWS && versionNumberGreaterThanOrEqualTo(6.0f);
-    private static final boolean WINDOWS_7_OR_LATER = WINDOWS && versionNumberGreaterThanOrEqualTo(6.1f);
     private static final boolean MAC = os.startsWith("Mac");
     private static final boolean LINUX = os.startsWith("Linux") && !ANDROID;
     private static final boolean SOLARIS = os.startsWith("SunOS");
@@ -73,41 +63,10 @@ public class PlatformUtil {
     private static final boolean HEADLESS = "headless".equals(embeddedType);
 
     /**
-     * Utility method used to determine whether the version number as
-     * reported by system properties is greater than or equal to a given
-     * value.
-     *
-     * @param value The value to test against.
-     * @return false if the version number cannot be parsed as a float,
-     *         otherwise the comparison against value.
-     */
-    private static boolean versionNumberGreaterThanOrEqualTo(float value) {
-        try {
-            return Float.parseFloat(version) >= value;
-        } catch (Exception e) {
-            return false;
-        }
-    }
-
-    /**
      * Returns true if the operating system is a form of Windows.
      */
     public static boolean isWindows(){
         return WINDOWS;
-    }
-
-    /**
-     * Returns true if the operating system is at least Windows Vista(v6.0).
-     */
-    public static boolean isWinVistaOrLater(){
-        return WINDOWS_VISTA_OR_LATER;
-    }
-
-    /**
-     * Returns true if the operating system is at least Windows 7(v6.1).
-     */
-    public static boolean isWin7OrLater(){
-        return WINDOWS_7_OR_LATER;
     }
 
     /**
@@ -126,25 +85,6 @@ public class PlatformUtil {
 
     public static boolean useEGL() {
         return useEGL;
-    }
-
-    public static boolean useEGLWindowComposition() {
-        return doEGLCompositing;
-    }
-
-    public static boolean useGLES2() {
-        String useGles2 = System.getProperty("use.gles2");
-        if ("true".equals(useGles2))
-            return true;
-        else
-            return false;
-    }
-
-    /**
-     * Returns true if the operating system is a form of Unix, including Linux.
-     */
-    public static boolean isSolaris(){
-        return SOLARIS;
     }
 
     /**
@@ -180,6 +120,10 @@ public class PlatformUtil {
      */
     public static boolean isIOS(){
         return IOS;
+    }
+
+    public static boolean isAndroid() {
+        return ANDROID;
     }
 
     /**
@@ -281,11 +225,6 @@ public class PlatformUtil {
                                                  File.separator + propertyFilename);
         if (javafxRuntimePathProperties.exists()) {
            loadPropertiesFromFile(javafxRuntimePathProperties);
-           return;
         }
-    }
-
-    public static boolean isAndroid() {
-       return ANDROID;
     }
 }


### PR DESCRIPTION
When I did https://github.com/openjdk/jfx/pull/2146, I touched `PlatformUtil` and saw that some methods and fields are unused and will probably never be used.

Example:
- `isWinVistaOrLater()`
- `useGLES2()`

So I removed them. Also checked that they are not called by native code.
~I kept `isHeadless()`, as it was used in a test at one point and might be needed again at some point.~
Moved `isAndroid` right below the other `isXXX` methods.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8386698](https://bugs.openjdk.org/browse/JDK-8386698): PlatformUtil has unused fields and methods (**Enhancement** - P4)


### Reviewers
 * [Lukasz Kostyra](https://openjdk.org/census#lkostyra) (@lukostyra - **Reviewer**)
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Johan Vos](https://openjdk.org/census#jvos) (@johanvos - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2190/head:pull/2190` \
`$ git checkout pull/2190`

Update a local copy of the PR: \
`$ git checkout pull/2190` \
`$ git pull https://git.openjdk.org/jfx.git pull/2190/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2190`

View PR using the GUI difftool: \
`$ git pr show -t 2190`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2190.diff">https://git.openjdk.org/jfx/pull/2190.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2190#issuecomment-4715578614)
</details>
