### PR TITLE
8387119: Tests for ScrollEvent redirection

### DIFF
--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/input/ScrollEventTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/input/ScrollEventTest.java
@@ -882,10 +882,10 @@ public class ScrollEventTest {
         // 5. Inertia scroll arrives after the target has been removed.
         scrollEvent(stub, ScrollEvent.SCROLL, 200, 200, true);
 
-        assertEquals(1, receivedScrollEvents.size(), "Inertia scroll must be delivered after the " +
-                "original target is removed from the scene");
-        assertSame(background, receivedScrollEvents.getFirst().getTarget(), "Inertia scroll should be " +
-                "retargeted to the node now under the cursor");
+        assertEquals(1, receivedScrollEvents.size(),
+                "Inertia Scroll must be delivered after the original target is removed from the Scene");
+        assertSame(background, receivedScrollEvents.getFirst().getTarget(),
+                "Inertia Scroll should be retargeted to the Node that was picked at the event coordinates");
         assertTrue(receivedScrollEvents.getFirst().isInertia());
     }
 
@@ -928,10 +928,10 @@ public class ScrollEventTest {
         // 5. Inertia scroll arrives after the target has been removed.
         scrollEvent(stub, ScrollEvent.SCROLL, 200, 200, true);
 
-        assertEquals(1, receivedScrollEvents.size(), "Inertia scroll must be delivered after the " +
-                "original target is removed from the scene");
-        assertSame(scene, receivedScrollEvents.getFirst().getTarget(), "Inertia scroll should be " +
-                "retargeted to the scene");
+        assertEquals(1, receivedScrollEvents.size(),
+                "Inertia Scroll must be delivered after the original target is removed from the Scene");
+        assertSame(scene, receivedScrollEvents.getFirst().getTarget(),
+                "Inertia Scroll should be retargeted to the Scene as there is no Node to pick");
         assertTrue(receivedScrollEvents.getFirst().isInertia());
     }
 
@@ -975,10 +975,10 @@ public class ScrollEventTest {
         // 3. Finish the scroll event.
         scrollEvent(stub, ScrollEvent.SCROLL_FINISHED, 200, 200, false);
 
-        assertEquals(1, receivedScrollEvents.size(), "Scroll must be delivered after the " +
-                "original target is removed from the scene");
-        assertSame(background, receivedScrollEvents.getFirst().getTarget(), "Scroll should be " +
-                "retargeted to the node now under the cursor");
+        assertEquals(1, receivedScrollEvents.size(),
+                "Scroll must be delivered after the original target is removed from the Scene");
+        assertSame(background, receivedScrollEvents.getFirst().getTarget(),
+                "Scroll should be retargeted to the Node that was picked at the event coordinates");
         assertFalse(receivedScrollEvents.getFirst().isInertia());
     }
 
@@ -1021,10 +1021,10 @@ public class ScrollEventTest {
         // 3. Finish the scroll event.
         scrollEvent(stub, ScrollEvent.SCROLL_FINISHED, 200, 200, false);
 
-        assertEquals(1, receivedScrollEvents.size(), "Scroll must be delivered after the " +
-                "original target is removed from the scene");
-        assertSame(scene, receivedScrollEvents.getFirst().getTarget(), "Scroll should be " +
-                "retargeted to the node now under the cursor");
+        assertEquals(1, receivedScrollEvents.size(),
+                "Scroll must be delivered after the original target is removed from the Scene");
+        assertSame(scene, receivedScrollEvents.getFirst().getTarget(),
+                "Scroll should be retargeted to the Scene as there is no Node to pick");
         assertFalse(receivedScrollEvents.getFirst().isInertia());
     }
 

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/input/ScrollEventTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/input/ScrollEventTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,11 @@
 package test.javafx.scene.input;
 
 import com.sun.javafx.scene.SceneHelper;
+import com.sun.javafx.tk.Toolkit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import test.com.sun.javafx.pgstub.StubScene;
+import test.com.sun.javafx.pgstub.StubToolkit;
 import test.com.sun.javafx.test.MouseEventGenerator;
 import javafx.event.Event;
 import javafx.geometry.Point3D;
@@ -40,6 +44,10 @@ import javafx.scene.shape.Rectangle;
 import javafx.stage.Stage;
 
 import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -51,6 +59,18 @@ public class ScrollEventTest {
     private boolean scrolled;
     private boolean scrolled2;
     private PickResult pickRes;
+    private Stage stage;
+
+    @BeforeEach
+    public void setUp() {
+        stage = new Stage();
+        stage.show();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        stage.hide();
+    }
 
     @Test public void testShortConstructor() {
         Rectangle node = new Rectangle();
@@ -819,6 +839,131 @@ public class ScrollEventTest {
 
         assertNotNull(s);
         assertFalse(s.isEmpty());
+    }
+
+    /**
+     * Verifies that scroll inertia events are retargeted to the picked node when the original gesture target node
+     * has been removed from the scene graph.
+     */
+    @Test
+    public void testScrollInertiaRetargetedToPickedNodeWhenTargetRemovedFromScene() {
+        final StubToolkit toolkit = (StubToolkit) Toolkit.getToolkit();
+
+        Rectangle background = new Rectangle(0, 0, 400, 400);
+        Rectangle scrollTarget = new Rectangle(100, 100, 200, 200);
+        Group root = new Group(background, scrollTarget);
+        Scene scene = new Scene(root, 400, 400);
+        stage.setScene(scene);
+        toolkit.firePulse();
+
+        List<ScrollEvent> receivedScrollEvents = new ArrayList<>();
+        scene.addEventFilter(ScrollEvent.SCROLL, receivedScrollEvents::add);
+
+        StubScene stub = (StubScene) SceneHelper.getPeer(scene);
+
+        // 1. Start a scroll gesture over scrollTarget at (200, 200).
+        stub.getListener().scrollEvent(
+                ScrollEvent.SCROLL_STARTED,
+                0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0,
+                200, 200, 200, 200,
+                false, false, false, false, false, false);
+
+        // 2. Send a normal scroll event.
+        stub.getListener().scrollEvent(
+                ScrollEvent.SCROLL,
+                0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0,
+                200, 200, 200, 200,
+                false, false, false, false, false, false);
+
+        assertEquals(1, receivedScrollEvents.size());
+        assertSame(scrollTarget, receivedScrollEvents.getFirst().getTarget());
+
+        // 3. Finish the scroll event.
+        stub.getListener().scrollEvent(
+                ScrollEvent.SCROLL_FINISHED,
+                0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0,
+                200, 200, 200, 200,
+                false, false, false, false, false, false);
+
+        // 4. Remove the target.
+        root.getChildren().remove(scrollTarget);
+        toolkit.firePulse();
+        receivedScrollEvents.clear();
+
+        // 5. Inertia scroll arrives after the original target has been removed.
+        stub.getListener().scrollEvent(
+                ScrollEvent.SCROLL,
+                0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0,
+                200, 200, 200, 200,
+                false, false, false, false, false, true);
+
+        assertEquals(1, receivedScrollEvents.size(), "Inertia scroll must be delivered after the " +
+                "original target is removed from the scene");
+        assertSame(background, receivedScrollEvents.getFirst().getTarget(), "Inertia scroll should be " +
+                "retargeted to the node now under the cursor");
+        assertTrue(receivedScrollEvents.getFirst().isInertia());
+    }
+
+    /**
+     * Verifies that scroll inertia events are retargeted to the Scene when the original gesture target node
+     * has been removed from the scene graph and there is no other node to pick underneath.
+     */
+    @Test
+    public void testScrollInertiaRetargetedToSceneWhenTargetRemovedFromScene() {
+        final StubToolkit toolkit = (StubToolkit) Toolkit.getToolkit();
+
+        Rectangle background = new Rectangle(0, 0, 400, 400);
+        Group root = new Group(background);
+        Scene scene = new Scene(root, 400, 400);
+        stage.setScene(scene);
+        toolkit.firePulse();
+
+        List<ScrollEvent> receivedScrollEvents = new ArrayList<>();
+        scene.addEventFilter(ScrollEvent.SCROLL, receivedScrollEvents::add);
+
+        StubScene stub = (StubScene) SceneHelper.getPeer(scene);
+
+        // 1. Start a scroll gesture over background at (200, 200).
+        stub.getListener().scrollEvent(
+                ScrollEvent.SCROLL_STARTED,
+                0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0,
+                200, 200, 200, 200,
+                false, false, false, false, false, false);
+
+        // 2. Send a normal scroll event.
+        stub.getListener().scrollEvent(
+                ScrollEvent.SCROLL,
+                0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0,
+                200, 200, 200, 200,
+                false, false, false, false, false, false);
+
+        assertEquals(1, receivedScrollEvents.size());
+        assertSame(background, receivedScrollEvents.getFirst().getTarget());
+
+        // 3. Finish the scroll event.
+        stub.getListener().scrollEvent(
+                ScrollEvent.SCROLL_FINISHED,
+                0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0,
+                200, 200, 200, 200,
+                false, false, false, false, false, false);
+
+        // 4. Remove the target.
+        root.getChildren().remove(background);
+        toolkit.firePulse();
+        receivedScrollEvents.clear();
+
+        // 5. Inertia scroll arrives after the original target has been removed.
+        stub.getListener().scrollEvent(
+                ScrollEvent.SCROLL,
+                0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0,
+                200, 200, 200, 200,
+                false, false, false, false, false, true);
+
+        assertEquals(1, receivedScrollEvents.size(), "Inertia scroll must be delivered after the " +
+                "original target is removed from the scene");
+        assertSame(scene, receivedScrollEvents.getFirst().getTarget(), "Inertia scroll should be " +
+                "retargeted to the scene");
+        assertTrue(receivedScrollEvents.getFirst().isInertia());
     }
 
     private Scene createScene() {

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/input/ScrollEventTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/input/ScrollEventTest.java
@@ -27,6 +27,7 @@ package test.javafx.scene.input;
 
 import com.sun.javafx.scene.SceneHelper;
 import com.sun.javafx.tk.Toolkit;
+import javafx.event.EventType;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import test.com.sun.javafx.pgstub.StubScene;
@@ -846,7 +847,7 @@ public class ScrollEventTest {
      * has been removed from the scene graph.
      */
     @Test
-    public void testScrollInertiaRetargetedToPickedNodeWhenTargetRemovedFromScene() {
+    public void testInertiaScrollRetargetedToPickedNodeWhenTargetRemovedFromScene() {
         final StubToolkit toolkit = (StubToolkit) Toolkit.getToolkit();
 
         Rectangle background = new Rectangle(0, 0, 400, 400);
@@ -861,41 +862,25 @@ public class ScrollEventTest {
 
         StubScene stub = (StubScene) SceneHelper.getPeer(scene);
 
-        // 1. Start a scroll gesture over scrollTarget at (200, 200).
-        stub.getListener().scrollEvent(
-                ScrollEvent.SCROLL_STARTED,
-                0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0,
-                200, 200, 200, 200,
-                false, false, false, false, false, false);
+        // 1. Start a scroll gesture over scrollTarget.
+        scrollEvent(stub, ScrollEvent.SCROLL_STARTED, 200, 200, false);
 
         // 2. Send a normal scroll event.
-        stub.getListener().scrollEvent(
-                ScrollEvent.SCROLL,
-                0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0,
-                200, 200, 200, 200,
-                false, false, false, false, false, false);
+        scrollEvent(stub, ScrollEvent.SCROLL, 200, 200, false);
 
         assertEquals(1, receivedScrollEvents.size());
         assertSame(scrollTarget, receivedScrollEvents.getFirst().getTarget());
 
         // 3. Finish the scroll event.
-        stub.getListener().scrollEvent(
-                ScrollEvent.SCROLL_FINISHED,
-                0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0,
-                200, 200, 200, 200,
-                false, false, false, false, false, false);
+        scrollEvent(stub, ScrollEvent.SCROLL_FINISHED, 200, 200, false);
 
         // 4. Remove the target.
         root.getChildren().remove(scrollTarget);
         toolkit.firePulse();
         receivedScrollEvents.clear();
 
-        // 5. Inertia scroll arrives after the original target has been removed.
-        stub.getListener().scrollEvent(
-                ScrollEvent.SCROLL,
-                0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0,
-                200, 200, 200, 200,
-                false, false, false, false, false, true);
+        // 5. Inertia scroll arrives after the target has been removed.
+        scrollEvent(stub, ScrollEvent.SCROLL, 200, 200, true);
 
         assertEquals(1, receivedScrollEvents.size(), "Inertia scroll must be delivered after the " +
                 "original target is removed from the scene");
@@ -909,7 +894,7 @@ public class ScrollEventTest {
      * has been removed from the scene graph and there is no other node to pick underneath.
      */
     @Test
-    public void testScrollInertiaRetargetedToSceneWhenTargetRemovedFromScene() {
+    public void testInertiaScrollRetargetedToSceneWhenTargetRemovedFromScene() {
         final StubToolkit toolkit = (StubToolkit) Toolkit.getToolkit();
 
         Rectangle background = new Rectangle(0, 0, 400, 400);
@@ -923,47 +908,124 @@ public class ScrollEventTest {
 
         StubScene stub = (StubScene) SceneHelper.getPeer(scene);
 
-        // 1. Start a scroll gesture over background at (200, 200).
-        stub.getListener().scrollEvent(
-                ScrollEvent.SCROLL_STARTED,
-                0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0,
-                200, 200, 200, 200,
-                false, false, false, false, false, false);
+        // 1. Start a scroll gesture over background.
+        scrollEvent(stub, ScrollEvent.SCROLL_STARTED, 200, 200, false);
 
         // 2. Send a normal scroll event.
-        stub.getListener().scrollEvent(
-                ScrollEvent.SCROLL,
-                0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0,
-                200, 200, 200, 200,
-                false, false, false, false, false, false);
+        scrollEvent(stub, ScrollEvent.SCROLL, 200, 200, false);
 
         assertEquals(1, receivedScrollEvents.size());
         assertSame(background, receivedScrollEvents.getFirst().getTarget());
 
         // 3. Finish the scroll event.
-        stub.getListener().scrollEvent(
-                ScrollEvent.SCROLL_FINISHED,
-                0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0,
-                200, 200, 200, 200,
-                false, false, false, false, false, false);
+        scrollEvent(stub, ScrollEvent.SCROLL_FINISHED, 200, 200, false);
 
         // 4. Remove the target.
         root.getChildren().remove(background);
         toolkit.firePulse();
         receivedScrollEvents.clear();
 
-        // 5. Inertia scroll arrives after the original target has been removed.
-        stub.getListener().scrollEvent(
-                ScrollEvent.SCROLL,
-                0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0,
-                200, 200, 200, 200,
-                false, false, false, false, false, true);
+        // 5. Inertia scroll arrives after the target has been removed.
+        scrollEvent(stub, ScrollEvent.SCROLL, 200, 200, true);
 
         assertEquals(1, receivedScrollEvents.size(), "Inertia scroll must be delivered after the " +
                 "original target is removed from the scene");
         assertSame(scene, receivedScrollEvents.getFirst().getTarget(), "Inertia scroll should be " +
                 "retargeted to the scene");
         assertTrue(receivedScrollEvents.getFirst().isInertia());
+    }
+
+    /**
+     * Verifies that scroll events are retargeted to the picked node when the original gesture target node
+     * has been removed from the scene graph.
+     */
+    @Test
+    public void testScrollRetargetedToPickedNodeWhenTargetRemovedFromScene() {
+        final StubToolkit toolkit = (StubToolkit) Toolkit.getToolkit();
+
+        Rectangle background = new Rectangle(0, 0, 400, 400);
+        Rectangle scrollTarget = new Rectangle(100, 100, 200, 200);
+        Group root = new Group(background, scrollTarget);
+        Scene scene = new Scene(root, 400, 400);
+        stage.setScene(scene);
+        toolkit.firePulse();
+
+        List<ScrollEvent> receivedScrollEvents = new ArrayList<>();
+        scene.addEventFilter(ScrollEvent.SCROLL, receivedScrollEvents::add);
+
+        StubScene stub = (StubScene) SceneHelper.getPeer(scene);
+
+        // 1. Start a scroll gesture over scrollTarget.
+        scrollEvent(stub, ScrollEvent.SCROLL_STARTED, 200, 200, false);
+
+        // 2. Send a normal scroll event.
+        scrollEvent(stub, ScrollEvent.SCROLL, 200, 200, false);
+
+        assertEquals(1, receivedScrollEvents.size());
+        assertSame(scrollTarget, receivedScrollEvents.getFirst().getTarget());
+
+        // 3. Remove the target.
+        root.getChildren().remove(scrollTarget);
+        toolkit.firePulse();
+        receivedScrollEvents.clear();
+
+        // 4. Send another normal scroll event.
+        scrollEvent(stub, ScrollEvent.SCROLL, 200, 200, false);
+
+        // 3. Finish the scroll event.
+        scrollEvent(stub, ScrollEvent.SCROLL_FINISHED, 200, 200, false);
+
+        assertEquals(1, receivedScrollEvents.size(), "Scroll must be delivered after the " +
+                "original target is removed from the scene");
+        assertSame(background, receivedScrollEvents.getFirst().getTarget(), "Scroll should be " +
+                "retargeted to the node now under the cursor");
+        assertFalse(receivedScrollEvents.getFirst().isInertia());
+    }
+
+    /**
+     * Verifies that scroll events are retargeted to the Scene when the original gesture target node
+     * has been removed from the scene graph and there is no other node to pick underneath.
+     */
+    @Test
+    public void testScrollRetargetedToSceneWhenTargetRemovedFromScene() {
+        final StubToolkit toolkit = (StubToolkit) Toolkit.getToolkit();
+
+        Rectangle background = new Rectangle(0, 0, 400, 400);
+        Group root = new Group(background);
+        Scene scene = new Scene(root, 400, 400);
+        stage.setScene(scene);
+        toolkit.firePulse();
+
+        List<ScrollEvent> receivedScrollEvents = new ArrayList<>();
+        scene.addEventFilter(ScrollEvent.SCROLL, receivedScrollEvents::add);
+
+        StubScene stub = (StubScene) SceneHelper.getPeer(scene);
+
+        // 1. Start a scroll gesture over background.
+        scrollEvent(stub, ScrollEvent.SCROLL_STARTED, 200, 200, false);
+
+        // 2. Send a normal scroll event.
+        scrollEvent(stub, ScrollEvent.SCROLL, 200, 200, false);
+
+        assertEquals(1, receivedScrollEvents.size());
+        assertSame(background, receivedScrollEvents.getFirst().getTarget());
+
+        // 3. Remove the target.
+        root.getChildren().remove(background);
+        toolkit.firePulse();
+        receivedScrollEvents.clear();
+
+        // 4. Send another normal scroll event.
+        scrollEvent(stub, ScrollEvent.SCROLL, 200, 200, false);
+
+        // 3. Finish the scroll event.
+        scrollEvent(stub, ScrollEvent.SCROLL_FINISHED, 200, 200, false);
+
+        assertEquals(1, receivedScrollEvents.size(), "Scroll must be delivered after the " +
+                "original target is removed from the scene");
+        assertSame(scene, receivedScrollEvents.getFirst().getTarget(), "Scroll should be " +
+                "retargeted to the node now under the cursor");
+        assertFalse(receivedScrollEvents.getFirst().isInertia());
     }
 
     private Scene createScene() {
@@ -981,5 +1043,13 @@ public class ScrollEventTest {
         stage.show();
 
         return scene;
+    }
+
+    private void scrollEvent(StubScene stub, EventType<ScrollEvent> event, double x, double y, boolean inertia) {
+        stub.getListener().scrollEvent(
+                event,
+                0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0,
+                x, y, x, y,
+                false, false, false, false, false, inertia);
     }
 }


### PR DESCRIPTION
Tests for the fix made in https://github.com/openjdk/jfx/pull/2171.

I figured out that `ScrollEventTest` already has a way to test `Scene` `ScrollEvent`s.
This is done by invoking the `ScenePeerListener.scrollEvent(..)` method in the tests.

This is the very same way the `GlassViewEventHandler` will do in a normal application (which is usually invoked from `com.sun.glass.ui.View.notifyScroll(..)`).

cc @beldenfox 
This tests the picked `Node` and the `Scene`, if there is no `Node` to pick. 
~Let me know what you think, I will create a ticket if this is fine!~ Done.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8387119](https://bugs.openjdk.org/browse/JDK-8387119): Tests for ScrollEvent redirection (**Bug** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Martin Fox](https://openjdk.org/census#mfox) (@beldenfox - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2194/head:pull/2194` \
`$ git checkout pull/2194`

Update a local copy of the PR: \
`$ git checkout pull/2194` \
`$ git pull https://git.openjdk.org/jfx.git pull/2194/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2194`

View PR using the GUI difftool: \
`$ git pr show -t 2194`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2194.diff">https://git.openjdk.org/jfx/pull/2194.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2194#issuecomment-4778463231)
</details>
