### PR TITLE
8387020: StyleManagerTest#testSetApplicationUserAgentStylesheetFromDataURI does not correctly reset the Application user agent stylesheet

### DIFF
--- a/modules/javafx.graphics/src/test/java/test/com/sun/javafx/css/StyleManagerTest.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/javafx/css/StyleManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1163,6 +1163,7 @@ public class StyleManagerTest {
         var root = new StackPane(rect);
         rect.getStyleClass().add("rect");
 
+        String userAgentStylesheet = Application.getUserAgentStylesheet();
         try {
             // Stylesheet content: .rect { -fx-fill: blue; }
             Application.setUserAgentStylesheet("data:base64,LnJlY3QgeyAtZngtZmlsbDogYmx1ZTsgfQ==");
@@ -1171,7 +1172,7 @@ public class StyleManagerTest {
 
             assertEquals(Color.BLUE, rect.getFill());
         } finally {
-            Application.setUserAgentStylesheet("data:,");
+            Application.setUserAgentStylesheet(userAgentStylesheet);
         }
     }
 }


### PR DESCRIPTION
Found while reviewing https://github.com/openjdk/jfx/pull/2184#discussion_r3452349547.

If this particular test runs before `TextInputControlModenaTest`, it will set the `Application` user agent stylesheet to `"data:,"` and not null.
The contract of `Application.setUserAgentStylesheet(..)` is that a `null` value will restore the platform default stylesheets, which is `Modena`. So we need to reset this value when changed in a test.

In our case, it is always `null`, but I still followed the pattern we use in other tests (like for `Locale`).

This can very easily tested by copying the test into `TextInputControlModenaTest` and see that the `testHighlightTextInput` will fail - and succeed with this change.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8387020](https://bugs.openjdk.org/browse/JDK-8387020): StyleManagerTest#testSetApplicationUserAgentStylesheetFromDataURI does not correctly reset the Application user agent stylesheet (**Bug** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Ziad El Midaoui](https://openjdk.org/census#zelmidaoui) (@Ziad-Mid - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2195/head:pull/2195` \
`$ git checkout pull/2195`

Update a local copy of the PR: \
`$ git checkout pull/2195` \
`$ git pull https://git.openjdk.org/jfx.git pull/2195/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2195`

View PR using the GUI difftool: \
`$ git pr show -t 2195`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2195.diff">https://git.openjdk.org/jfx/pull/2195.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2195#issuecomment-4768807196)
</details>
