### PR TITLE
8387337: GlassClipboard: Replace deprecated hash_map and hash_set

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/win/GlassClipboard.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/win/GlassClipboard.cpp
@@ -79,18 +79,22 @@ bool operator == (const FORMATETC &fr, const FORMATETC &fl) {
          && fr.tymed    == fl.tymed;
 }
 
-size_t hash_value(const FORMATETC &fr)
+template<>
+struct std::hash<FORMATETC>
 {
-    size_t _Val = size_t(fr.cfFormat) << 21;
-    _Val += size_t(fr.dwAspect);
-    _Val <<= 5;
-    _Val += size_t(fr.lindex);
-    _Val <<= 7;
-    _Val += size_t(fr.ptd);
-    _Val >>= 13;
-    _Val += size_t(fr.tymed);
-    return _Val ^ GLASS_HASH_SEED;
-}
+    std::size_t operator()(const FORMATETC& fr) const noexcept
+    {
+        size_t _Val = size_t(fr.cfFormat) << 21;
+        _Val += size_t(fr.dwAspect);
+        _Val <<= 5;
+        _Val += size_t(fr.lindex);
+        _Val <<= 7;
+        _Val += size_t(fr.ptd);
+        _Val >>= 13;
+        _Val += size_t(fr.tymed);
+        return _Val ^ GLASS_HASH_SEED;
+    }
+};
 
 //NB! There are two suffixes for mimes:
 // ";locale" - the ASCII/UTF8 version of mime type that is not transferred to Java
@@ -145,20 +149,6 @@ struct std::hash<_bstr_t>
     {
         // TODO It would be faster to use wstring_view here, but it is in C++17 and above
         return std::hash<std::wstring>()(std::wstring(static_cast<const wchar_t*>(k)));
-    }
-};
-
-template<>
-struct std::hash<FORMATETC>
-{
-    std::size_t operator()(const FORMATETC& k) const noexcept
-    {
-        return
-            std::hash<CLIPFORMAT>()(k.cfFormat) ^
-            std::hash<DVTARGETDEVICE*>()(k.ptd) ^
-            std::hash<DWORD>()(k.dwAspect) ^
-            std::hash<LONG>()(k.lindex) ^
-            std::hash<DWORD>()(k.tymed);
     }
 };
 

--- a/modules/javafx.graphics/src/main/native-glass/win/GlassClipboard.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/win/GlassClipboard.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,9 +25,9 @@
 
 #include "common.h"
 
-#define  _SILENCE_STDEXT_HASH_DEPRECATION_WARNINGS
-#include <hash_map>
-#include <hash_set>
+#include <unordered_map>
+#include <unordered_set>
+#include <string>
 
 // The following is derived from _HASH_SEED, which is an internal constant from
 // include/xhash; since this is an internal constant we define our own rather
@@ -138,16 +138,35 @@ Mime2oscfstrPair pairs[] = {
     {MS_FILE_CONTENT, CFSTR_FILECONTENTS},
 };
 
-inline size_t hash_value(const _bstr_t &_Str) {
-    return stdext::hash_value((const wchar_t *)_Str);
-}
+template<>
+struct std::hash<_bstr_t>
+{
+    std::size_t operator()(const _bstr_t& k) const noexcept
+    {
+        // TODO It would be faster to use wstring_view here, but it is in C++17 and above
+        return std::hash<std::wstring>()(std::wstring(static_cast<const wchar_t*>(k)));
+    }
+};
 
+template<>
+struct std::hash<FORMATETC>
+{
+    std::size_t operator()(const FORMATETC& k) const noexcept
+    {
+        return
+            std::hash<CLIPFORMAT>()(k.cfFormat) ^
+            std::hash<DVTARGETDEVICE*>()(k.ptd) ^
+            std::hash<DWORD>()(k.dwAspect) ^
+            std::hash<LONG>()(k.lindex) ^
+            std::hash<DWORD>()(k.tymed);
+    }
+};
 
-typedef stdext::hash_map<_bstr_t, CLIPFORMAT> MIME2OSCF;
-typedef stdext::hash_map<CLIPFORMAT, _bstr_t> OSCF2MIME;
-typedef stdext::hash_map<FORMATETC, _bstr_t> FMC2MIME;
-typedef stdext::hash_map<FORMATETC, STGMEDIUM> FMC2DATA;
-typedef stdext::hash_set<_bstr_t> HASH_STR_SET;
+typedef std::unordered_map<_bstr_t, CLIPFORMAT> MIME2OSCF;
+typedef std::unordered_map<CLIPFORMAT, _bstr_t> OSCF2MIME;
+typedef std::unordered_map<FORMATETC, _bstr_t> FMC2MIME;
+typedef std::unordered_map<FORMATETC, STGMEDIUM> FMC2DATA;
+typedef std::unordered_set<_bstr_t> HASH_STR_SET;
 
 MIME2OSCF mime2oscf;
 OSCF2MIME oscf2mime;


### PR DESCRIPTION
[Visual Studio 2026 May Update](https://learn.microsoft.com/en-us/visualstudio/releases/2026/release-notes#may-update-1860) (see C++ > MSVC Build Tools 14.51 > Standard Library (STL) > Other notable changes) removed support for some old, deprecated and non-standard STL extensions, including `hash_map` and `hash_set`. Both of these were used in `GlassClipboard`'s Windows part. Because of this change, JavaFX does not build under Visual Studio 2026 18.6 and later.

This commit replaces deprecated `hash_map` and `hash_set` with STL-equvalent `unordered_map` and `unordered_set`. `GlassClipboard` also used (also deprecated) `hash_value` template function to calculate hashes for non-standard WinAPI object `_bstr_t` and `FORMATETC` ~~(the latter was implicitly generated by the extension)~~. Those were also replaced with STL-endorsed `std::hash` specializations. No other changes were necessary.

All tests on Windows 11 pass successfully after this change and manual testing showed no regressions.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8387337](https://bugs.openjdk.org/browse/JDK-8387337): GlassClipboard: Replace deprecated hash_map and hash_set (**Bug** - P3)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2198/head:pull/2198` \
`$ git checkout pull/2198`

Update a local copy of the PR: \
`$ git checkout pull/2198` \
`$ git pull https://git.openjdk.org/jfx.git pull/2198/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2198`

View PR using the GUI difftool: \
`$ git pr show -t 2198`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2198.diff">https://git.openjdk.org/jfx/pull/2198.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2198#issuecomment-4830854377)
</details>
