### PR TITLE
8387655: java.lang.NullPointerException: Cannot invoke "java.lang.Boolean.booleanValue()" because "newValue" is null

### DIFF
--- a/modules/javafx.base/src/main/java/com/sun/javafx/binding/ExpressionHelper.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/binding/ExpressionHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -381,9 +381,13 @@ public abstract class ExpressionHelper<T> extends ExpressionHelperBase {
                 if (curChangeSize > 0) {
                     final boolean changed = (currentValue == null)? (oldValue != null) : !currentValue.equals(oldValue);
                     if (changed) {
+                        // Capture currentValue, to pass down the same value to all listeners, given that
+                        // currentValue could be nullified if all the change listeners are removed. If that happens
+                        // during the notification loop, the pending listeners should still receive the correct value.
+                        final T newValue = currentValue;
                         for (int i = 0; i < curChangeSize; i++) {
                             try {
-                                curChangeList[i].changed(observable, oldValue, currentValue);
+                                curChangeList[i].changed(observable, oldValue, newValue);
                             } catch (Exception e) {
                                 Thread.currentThread().getUncaughtExceptionHandler().uncaughtException(Thread.currentThread(), e);
                             }

--- a/modules/javafx.base/src/test/java/test/com/sun/javafx/binding/ExpressionHelperTest.java
+++ b/modules/javafx.base/src/test/java/test/com/sun/javafx/binding/ExpressionHelperTest.java
@@ -812,7 +812,7 @@ public class ExpressionHelperTest {
             newValueRef.set(newValue);
         };
         final ChangeListener<Object> listenerA = (observable, oldValue, newValue) ->
-                ExpressionHelper.removeListener(helper, listenerB);
+                helper = ExpressionHelper.removeListener(helper, listenerB);
 
         helper = ExpressionHelper.addListener(helper, observable, listenerA);
         helper = ExpressionHelper.addListener(helper, observable, listenerB);
@@ -838,7 +838,7 @@ public class ExpressionHelperTest {
                 list.add(newValue);
 
         final ChangeListener<Object> listenerA = (observable, oldValue, newValue) ->
-                ExpressionHelper.removeListener(helper, listenerB);
+                helper = ExpressionHelper.removeListener(helper, listenerB);
 
         helper = ExpressionHelper.addListener(helper, observable, listenerA);
         helper = ExpressionHelper.addListener(helper, observable, listenerB);

--- a/modules/javafx.base/src/test/java/test/com/sun/javafx/binding/ExpressionHelperTest.java
+++ b/modules/javafx.base/src/test/java/test/com/sun/javafx/binding/ExpressionHelperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -795,5 +797,145 @@ public class ExpressionHelperTest {
 
             api.assertCollectable(collectable);
         });
+    }
+
+    @Test
+    public void shouldNotModifyExistingListenersWhenChangeListenerIsRemoved() {
+        helper = ExpressionHelper.addListener(helper, observable, invalidationListener[0]);
+        helper = ExpressionHelper.addListener(helper, observable, invalidationListener[1]);
+
+        final AtomicReference<Object> oldValueRef = new AtomicReference<>(UNDEFINED);
+        final AtomicReference<Object> newValueRef = new AtomicReference<>(UNDEFINED);
+        final ChangeListener<Object> listenerB = (observable, oldValue, newValue) -> {};
+        final ChangeListener<Object> listenerC = (observable, oldValue, newValue) -> {
+            oldValueRef.set(oldValue);
+            newValueRef.set(newValue);
+        };
+        final ChangeListener<Object> listenerA = (observable, oldValue, newValue) ->
+                ExpressionHelper.removeListener(helper, listenerB);
+
+        helper = ExpressionHelper.addListener(helper, observable, listenerA);
+        helper = ExpressionHelper.addListener(helper, observable, listenerB);
+        helper = ExpressionHelper.addListener(helper, observable, listenerC);
+
+        observable.set(DATA_2);
+        ExpressionHelper.fireValueChangedEvent(helper);
+
+        assertEquals(DATA_1, oldValueRef.get(), "ListenerC should observer the old value");
+        assertEquals(DATA_2, newValueRef.get(), "ListenerC should observer the new value");
+    }
+
+    @Test
+    public void shouldNotifyExistingListenersWhenChangeListenerIsRemoved() {
+        helper = ExpressionHelper.addListener(helper, observable, invalidationListener[0]);
+        helper = ExpressionHelper.addListener(helper, observable, invalidationListener[1]);
+
+        final List<Object> list = new ArrayList<>();
+        final ChangeListener<Object> listenerB = (observable, oldValue, newValue) -> {};
+        final ChangeListener<Object> listenerC = (observable, oldValue, newValue) ->
+                list.add(newValue);
+        final ChangeListener<Object> listenerD = (observable, oldValue, newValue) ->
+                list.add(newValue);
+
+        final ChangeListener<Object> listenerA = (observable, oldValue, newValue) ->
+                ExpressionHelper.removeListener(helper, listenerB);
+
+        helper = ExpressionHelper.addListener(helper, observable, listenerA);
+        helper = ExpressionHelper.addListener(helper, observable, listenerB);
+        helper = ExpressionHelper.addListener(helper, observable, listenerC);
+        helper = ExpressionHelper.addListener(helper, observable, listenerD);
+
+        observable.set(DATA_2);
+        ExpressionHelper.fireValueChangedEvent(helper);
+
+        assertEquals(List.of(DATA_2, DATA_2), list, "Listeners C and D should get notified once with the new value");
+
+        list.clear();
+        observable.set(DATA_1);
+        ExpressionHelper.fireValueChangedEvent(helper);
+
+        assertEquals(List.of(DATA_1, DATA_1), list, "Listeners C and D should still get notified once with the new value");
+    }
+
+    @Test
+    public void shouldNotModifyInvalidationListenersWhenChangeListenersAreRemoved() {
+        helper = ExpressionHelper.addListener(helper, observable, invalidationListener[0]);
+        helper = ExpressionHelper.addListener(helper, observable, invalidationListener[1]);
+
+        final ChangeListener<Object> listenerB = (observable, oldValue, newValue) -> {};
+        final ChangeListener<Object> listenerA = new ChangeListener<>() {
+            @Override
+            public void changed(ObservableValue<?> observable, Object oldValue, Object newValue) {
+                helper = ExpressionHelper.removeListener(helper, listenerB);
+                helper = ExpressionHelper.removeListener(helper, this);
+            }
+        };
+
+        helper = ExpressionHelper.addListener(helper, observable, listenerA);
+        helper = ExpressionHelper.addListener(helper, observable, listenerB);
+
+        observable.set(DATA_2);
+        ExpressionHelper.fireValueChangedEvent(helper);
+
+        invalidationListener[0].check(observable, 1);
+        invalidationListener[1].check(observable, 1);
+    }
+
+    @Test
+    public void shouldNotNotifyPendingListenersWithNullValueWhenSomeChangeListenersAreRemoved() {
+        helper = ExpressionHelper.addListener(helper, observable, invalidationListener[0]);
+        helper = ExpressionHelper.addListener(helper, observable, invalidationListener[1]);
+
+        final AtomicReference<Object> newValueRef = new AtomicReference<>(UNDEFINED);
+        final ChangeListener<Object> listenerB = (observable, oldValue, newValue) ->
+                newValueRef.set(newValue);
+        final ChangeListener<Object> listenerC = (observable, oldValue, newValue) -> {};
+        final ChangeListener<Object> listenerA = new ChangeListener<>() {
+            @Override
+            public void changed(ObservableValue<?> observable, Object oldValue, Object newValue) {
+                helper = ExpressionHelper.removeListener(helper, listenerB);
+                helper = ExpressionHelper.removeListener(helper, this);
+            }
+        };
+
+        helper = ExpressionHelper.addListener(helper, observable, listenerA);
+        helper = ExpressionHelper.addListener(helper, observable, listenerB);
+        helper = ExpressionHelper.addListener(helper, observable, listenerC);
+
+        observable.set(DATA_2);
+        ExpressionHelper.fireValueChangedEvent(helper);
+
+        assertEquals(DATA_2, newValueRef.get(), "listenerB should observe the new non-null value," +
+                " even if listenerA removed some change listeners during the notification");
+    }
+
+    @Test
+    public void shouldNotNotifyPendingListenersWithNullValueWhenAllChangeListenersAreRemoved() {
+        helper = ExpressionHelper.addListener(helper, observable, invalidationListener[0]);
+        helper = ExpressionHelper.addListener(helper, observable, invalidationListener[1]);
+
+        final AtomicReference<Object> newValueRef = new AtomicReference<>(UNDEFINED);
+        final ChangeListener<Object> listenerB = (observable, oldValue, newValue) ->
+                newValueRef.set(newValue);
+        final ChangeListener<Object> listenerC = (observable, oldValue, newValue) -> {};
+        final ChangeListener<Object> listenerA = new ChangeListener<>() {
+            @Override
+            public void changed(ObservableValue<?> observable, Object oldValue, Object newValue) {
+                helper = ExpressionHelper.removeListener(helper, listenerB);
+                helper = ExpressionHelper.removeListener(helper, listenerC);
+                helper = ExpressionHelper.removeListener(helper, this);
+            }
+        };
+
+        // Register A before the others
+        helper = ExpressionHelper.addListener(helper, observable, listenerA);
+        helper = ExpressionHelper.addListener(helper, observable, listenerB);
+        helper = ExpressionHelper.addListener(helper, observable, listenerC);
+
+        observable.set(DATA_2);
+        ExpressionHelper.fireValueChangedEvent(helper);
+
+        assertEquals(DATA_2, newValueRef.get(), "listenerB should observe the new non-null value," +
+                " even if listenerA removed all the change listeners during the notification");
     }
 }

--- a/modules/javafx.base/src/test/java/test/com/sun/javafx/binding/ExpressionHelperTest.java
+++ b/modules/javafx.base/src/test/java/test/com/sun/javafx/binding/ExpressionHelperTest.java
@@ -821,8 +821,8 @@ public class ExpressionHelperTest {
         observable.set(DATA_2);
         ExpressionHelper.fireValueChangedEvent(helper);
 
-        assertEquals(DATA_1, oldValueRef.get(), "ListenerC should observer the old value");
-        assertEquals(DATA_2, newValueRef.get(), "ListenerC should observer the new value");
+        assertEquals(DATA_1, oldValueRef.get(), "ListenerC should observe the old value");
+        assertEquals(DATA_2, newValueRef.get(), "ListenerC should observe the new value");
     }
 
     @Test


### PR DESCRIPTION
This PR captures the `currentValue` of the fired value change event in `ExpressionHelper$Generic::fireValueChangedEvent`,  before entering the notification loop, in order to pass it down to all the change listeners. 

This prevents a potential issue that could happen if all the change listeners are removed before the notification loop ends: the `currentValue` is nullified, and the pending listeners would unexpectedly receive null, instead of the value that was correctly sent to the previous listeners.

Some unit tests have been included, all of them but one pass before and after the proposed fix, and the last one fails before the fix and passes after it. 

The scenario that describes this failing test is: 
- A property has attached a few InvalidationListeners and a few ChangeListeners (so the Generic path is followed, and not the SingleChange). 
- At some point the property changes to a non-null `newValue`, and all the listeners get notified, one by one, in the same order as they were registered. 
- If, for any reason, and _while_ the different change listeners are being notified, all the change listeners are removed,  the pending listeners will, unexpectedly,  receive `null`, though the listeners that were notified before that happens received the expected `newValue`.

For simplicity, the test simulates that exact moment by removing all the change listeners when `listenerA` receives `newValue` from the `changed` notification. Then the `currentValue` gets nullified, and then the pending listeners in the notification list `curChangeList` (`listenerB` and `listenerC`, as they were registered after `listenerA`) get `null`. There could be other triggers, as long as they happen on the same thread, as part of the same call stack that started `fireValueChangedEvent`.

With the fix, by capturing the `currentValue` into `newValue` before entering the loop, then `B` and `C` will still receive `newValue`, regardless any possible change done to `currentValue` in the process.

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8387655](https://bugs.openjdk.org/browse/JDK-8387655): java.lang.NullPointerException: Cannot invoke "java.lang.Boolean.booleanValue()" because "newValue" is null (**Bug** - P4)


### Reviewers
 * [John Hendrikx](https://openjdk.org/census#jhendrikx) (@hjohn - **Reviewer**)
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2200/head:pull/2200` \
`$ git checkout pull/2200`

Update a local copy of the PR: \
`$ git checkout pull/2200` \
`$ git pull https://git.openjdk.org/jfx.git pull/2200/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2200`

View PR using the GUI difftool: \
`$ git pr show -t 2200`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2200.diff">https://git.openjdk.org/jfx/pull/2200.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2200#issuecomment-4876428595)
</details>
