### PR TITLE
8268657: Looked-up color fails for -fx-background-color in JavaFX CSS file

### DIFF
--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/css/ControlCssTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/css/ControlCssTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.javafx.scene.control.css;
+
+import com.sun.javafx.tk.Toolkit;
+import javafx.css.CssParser;
+import javafx.scene.Parent;
+import javafx.scene.Scene;
+import javafx.scene.control.Button;
+import javafx.scene.control.Label;
+import javafx.scene.control.Tab;
+import javafx.scene.control.TabPane;
+import javafx.scene.layout.Pane;
+import javafx.scene.layout.StackPane;
+import javafx.scene.layout.VBox;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import test.com.sun.javafx.scene.control.infrastructure.StageLoader;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ControlCssTest {
+
+    private StageLoader stageLoader;
+
+    @AfterEach
+    void tearDown() {
+        if (stageLoader != null) {
+            stageLoader.dispose();
+        }
+    }
+
+    /**
+     * When we swap the root of a scene, it should still correctly resolve the CSS.
+     */
+    @Test
+    void testLookupResolvesAfterSceneListenerRootSwap() {
+        var errors = CssParser.errorsProperty();
+        errors.clear();
+
+        TabPane tabPane = new TabPane();
+        Label label = new Label("Test");
+        tabPane.getTabs().add(new Tab("TestTab", label));
+
+        AtomicBoolean swapped = new AtomicBoolean(false);
+        label.sceneProperty().addListener((_, _, newScene) -> {
+            if (newScene != null && !swapped.getAndSet(true)) {
+                Parent oldRoot = newScene.getRoot();
+                StackPane newRoot = new StackPane();
+                newScene.setRoot(newRoot);
+                newRoot.getChildren().setAll(oldRoot);
+            }
+        });
+
+        Button btn = new Button("Add Child");
+        VBox root = new VBox(btn);
+        btn.setOnAction(_ -> root.getChildren().add(tabPane));
+
+        stageLoader = new StageLoader(new Scene(root));
+
+        btn.fire();
+        Toolkit.getToolkit().firePulse();
+
+        assertEquals(0, errors.size(), errors::toString);
+    }
+
+    /**
+     * When we swap a pane with a styleClass, the CSS for the children based of the Pane should correctly resolve.
+     */
+    @Test
+    void testPaneClassLookupResolvesAfterSceneListenerPaneSwap() {
+        var errors = CssParser.errorsProperty();
+        errors.clear();
+
+        String theme = toBase64("""
+                .my-pane {
+                    -color: #1B2631;
+                }
+                .my-pane .label {
+                    -fx-text-fill: -color;
+                }
+                """);
+
+        TabPane tabPane = new TabPane();
+        Label label = new Label("Test");
+        tabPane.getTabs().add(new Tab("TestTab", label));
+
+        StackPane myPane = new StackPane();
+        myPane.getStyleClass().add("my-pane");
+
+        AtomicBoolean swapped = new AtomicBoolean(false);
+        label.sceneProperty().addListener((_, _, newScene) -> {
+            if (newScene != null && !swapped.getAndSet(true)) {
+                StackPane newPaneRoot = new StackPane();
+                Pane paneRoot = (Pane) myPane.getParent();
+
+                paneRoot.getChildren().remove(myPane);
+                paneRoot.getChildren().add(newPaneRoot);
+
+                myPane.getStyleClass().remove("my-pane");
+                newPaneRoot.getStyleClass().add("my-pane");
+
+                newPaneRoot.getChildren().setAll(myPane);
+            }
+        });
+
+        Button btn = new Button("Add Child");
+        VBox root = new VBox(btn, myPane);
+        btn.setOnAction(_ -> myPane.getChildren().add(tabPane));
+
+        Scene scene = new Scene(root);
+        scene.getStylesheets().add(theme);
+        stageLoader = new StageLoader(scene);
+
+        btn.fire();
+        Toolkit.getToolkit().firePulse();
+
+        assertEquals(0, errors.size(), errors::toString);
+    }
+
+    private static String toBase64(String css) {
+        return "data:text/css;base64," + Base64.getEncoder().encodeToString(css.getBytes(StandardCharsets.UTF_8));
+    }
+
+}

--- a/modules/javafx.graphics/src/main/java/javafx/scene/CssStyleHelper.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/CssStyleHelper.java
@@ -87,15 +87,23 @@ final class CssStyleHelper {
      * Creates a new StyleHelper.
      */
     static CssStyleHelper createStyleHelper(final Node node) {
-
         // need to know how far we are to root in order to init arrays.
         // TODO: should we hang onto depth to avoid this nonsense later?
         // TODO: is there some other way of knowing how far from the root a node is?
+        Node styleableAncestor = null;
         Styleable parent = node;
         int depth = 0;
-        while(parent != null) {
+        while (parent != null) {
             depth++;
             parent = parent.getStyleableParent();
+
+            if (styleableAncestor == null && parent instanceof Node parentNode && isStyleableAncestor(parentNode)) {
+                styleableAncestor = parentNode;
+            }
+        }
+
+        if (node.styleHelper != null) {
+            setFirstStyleableAncestor(node.styleHelper, styleableAncestor);
         }
 
         // The List<CacheEntry> should only contain entries for those
@@ -116,7 +124,6 @@ final class CssStyleHelper {
         // reuse the existing styleHelper if possible.
         //
         if ( canReuseStyleHelper(node, styleMap) ) {
-
             //
             // JDK-8123731
             //
@@ -138,7 +145,6 @@ final class CssStyleHelper {
 
             updateParentTriggerStates(node, depth, triggerStates);
             return node.styleHelper;
-
         }
 
         if (styleMap == null || styleMap.isEmpty()) {
@@ -174,6 +180,7 @@ final class CssStyleHelper {
         }
 
         final CssStyleHelper helper = new CssStyleHelper();
+        setFirstStyleableAncestor(helper, styleableAncestor);
 
         if (triggerStates[0] != null) {
             helper.triggerStates.addAll(triggerStates[0]);
@@ -182,8 +189,6 @@ final class CssStyleHelper {
         updateParentTriggerStates(node, depth, triggerStates);
 
         helper.cacheContainer = new CacheContainer(node, styleMap, depth);
-
-        helper.firstStyleableAncestor = new WeakReference<>(findFirstStyleableAncestor(node));
 
         // If this node had a style helper, we need to reset all properties that will be unset with the
         // new style map to their initial values. Properties that remain set with the new style map carry
@@ -205,32 +210,29 @@ final class CssStyleHelper {
         for(int n=1; n<depth; n++) {
 
             // TODO: this means that a style like .menu-item:hover won't work. Need to separate CssStyleHelper tree from scene-graph tree
-            if (parent instanceof Node == false) {
-                parent=parent.getStyleableParent();
+            if (!(parent instanceof Node parentNode)) {
+                parent = parent.getStyleableParent();
                 continue;
             }
-            Node parentNode = (Node)parent;
 
             final PseudoClassState triggerState = triggerStates[n];
 
             // if there is nothing in triggerState, then continue since there
             // isn't any pseudo-class state that might trigger a state change
-            if (triggerState != null && triggerState.size() > 0) {
-
+            if (triggerState != null && !triggerState.isEmpty()) {
                 // Create a StyleHelper for the parent, if necessary.
-                // TODO : check why calling createStyleHelper(parentNode) does not work here?
                 if (parentNode.styleHelper == null) {
+                    // The createStyleHelper(..) is not used, because it can return null.
+                    // But we do need a helper to hold the triggerStates.
                     parentNode.styleHelper = new CssStyleHelper();
-                    parentNode.styleHelper.firstStyleableAncestor = new WeakReference(findFirstStyleableAncestor(parentNode)) ;
                 }
                 parentNode.styleHelper.triggerStates.addAll(triggerState);
-
             }
 
-            parent=parent.getStyleableParent();
+            parent = parent.getStyleableParent();
         }
-
     }
+
     //
     // return true if the fontStyleableProperty's origin is USER
     //
@@ -244,8 +246,8 @@ final class CssStyleHelper {
             if (fontStyleableProperty != null && fontStyleableProperty.getStyleOrigin() == StyleOrigin.USER) return true;
         }
 
-        Styleable styleableParent = firstStyleableAncestor.get();
-        CssStyleHelper parentStyleHelper = getStyleHelper(firstStyleableAncestor.get());
+        Node styleableParent = getCachedStyleableAncestor(node);
+        CssStyleHelper parentStyleHelper = getStyleHelper(styleableParent);
 
         if (parentStyleHelper != null) {
             return parentStyleHelper.isUserSetFont(styleableParent);
@@ -258,20 +260,56 @@ final class CssStyleHelper {
         return (n != null)? n.styleHelper : null;
     }
 
-    private static Node findFirstStyleableAncestor(Styleable st) {
-        Node ancestor = null;
-        Styleable parent = st.getStyleableParent();
+    private static Node findFirstStyleableAncestor(Styleable styleable) {
+        Node ancestor = getCachedStyleableAncestor(styleable);
+        if (ancestor != null) {
+            return ancestor;
+        }
+
+        ancestor = findFirstStyleableAncestorInParent(styleable);
+        if (styleable instanceof Node node) {
+            setFirstStyleableAncestor(node.styleHelper, ancestor);
+        }
+        return ancestor;
+    }
+
+    private static void setFirstStyleableAncestor(CssStyleHelper helper, Node ancestor) {
+        if (ancestor == null) {
+            helper.firstStyleableAncestor = null;
+            return;
+        }
+        helper.firstStyleableAncestor = new WeakReference<>(ancestor);
+    }
+
+    private static Node getCachedStyleableAncestor(Styleable styleable) {
+        if (styleable instanceof Node node) {
+            WeakReference<Node> ancestorRef = node.styleHelper.firstStyleableAncestor;
+            if (ancestorRef != null) {
+                return ancestorRef.get();
+            }
+        }
+        return null;
+    }
+
+    private static Node findFirstStyleableAncestorInParent(Styleable styleable) {
+        Styleable parent = styleable.getStyleableParent();
         while (parent != null) {
-            if (parent instanceof Node) {
-                if (((Node) parent).styleHelper != null) {
-                    ancestor = (Node) parent;
-                    break;
+            if (parent instanceof Node parentNode) {
+                if (isStyleableAncestor(parentNode)) {
+                    return parentNode;
                 }
             }
             parent = parent.getStyleableParent();
         }
+        return null;
+    }
 
-        return ancestor;
+    private static boolean isStyleableAncestor(Node parentNode) {
+        if (parentNode.styleHelper == null) {
+            parentNode.styleHelper = createStyleHelper(parentNode);
+        }
+
+        return parentNode.styleHelper != null;
     }
 
     //
@@ -311,9 +349,6 @@ final class CssStyleHelper {
             return false;
         }
 
-        //update ancestor since this node may have changed positions in the scene graph (JDK-8237469)
-        node.styleHelper.firstStyleableAncestor = new WeakReference<>(findFirstStyleableAncestor(node));
-
         // If the style maps are the same instance, we can re-use the current styleHelper if the cacheContainer is null.
         // Under this condition, there are no styles for this node _and_ no styles inherit.
         if (node.styleHelper.cacheContainer == null) {
@@ -334,7 +369,7 @@ final class CssStyleHelper {
             return true;
         }
 
-        CssStyleHelper parentHelper = getStyleHelper(node.styleHelper.firstStyleableAncestor.get());
+        CssStyleHelper parentHelper = getStyleHelper(getCachedStyleableAncestor(node));
 
         if (parentHelper != null && parentHelper.cacheContainer != null) {
 
@@ -361,11 +396,13 @@ final class CssStyleHelper {
         return false;
     }
 
-    private static final WeakReference<Node> EMPTY_NODE = new WeakReference<>(null);
 
-    /* This is the first Styleable parent (of Node this StyleHelper belongs to)
-     * having a valid StyleHelper */
-    private WeakReference<Node> firstStyleableAncestor = EMPTY_NODE;
+    /**
+     * This is the first valid styleable ancestor of this helper.
+     * The first styleable ancestor is a styleable parent of the node (this helper belongs to) that has a styleHelper
+     * and therefore might be important for styling this node.
+     */
+    private WeakReference<Node> firstStyleableAncestor = null;
 
     private CacheContainer cacheContainer;
 
@@ -1326,21 +1363,21 @@ final class CssStyleHelper {
             final Styleable styleable,
             final String property) {
 
-        Styleable parent = ((Node)styleable).styleHelper.firstStyleableAncestor.get();
-        CssStyleHelper parentStyleHelper = getStyleHelper((Node) parent);
+        Node ancestor = findFirstStyleableAncestor(styleable);
+        CssStyleHelper parentStyleHelper = getStyleHelper(ancestor);
 
-        if (parent != null && parentStyleHelper != null) {
+        if (ancestor != null && parentStyleHelper != null) {
 
-            StyleMap parentStyleMap = parentStyleHelper.getStyleMap(parent);
-            Set<PseudoClass> transitionStates = ((Node)parent).pseudoClassStates;
-            CascadingStyle cascadingStyle = parentStyleHelper.getStyle(parent, property, parentStyleMap, transitionStates);
+            StyleMap parentStyleMap = parentStyleHelper.getStyleMap(ancestor);
+            Set<PseudoClass> transitionStates = ancestor.pseudoClassStates;
+            CascadingStyle cascadingStyle = parentStyleHelper.getStyle(ancestor, property, parentStyleMap, transitionStates);
 
             if (cascadingStyle != null) {
 
                 final ParsedValue cssValue = cascadingStyle.getParsedValue();
 
                 if ("inherit".equals(cssValue.getValue())) {
-                    return getInheritedStyle(parent, property);
+                    return getInheritedStyle(ancestor, property);
                 }
                 return cascadingStyle;
             }
@@ -1371,20 +1408,17 @@ final class CssStyleHelper {
             } else {
                 // TODO: This block was copied from inherit. Both should use same code somehow.
 
-                Styleable styleableParent = ((Node)styleable).styleHelper.firstStyleableAncestor.get();
-                CssStyleHelper parentStyleHelper = getStyleHelper((Node) styleableParent);
+                Node ancestor = findFirstStyleableAncestor(styleable);
+                CssStyleHelper parentStyleHelper = getStyleHelper(ancestor);
 
-                if (styleableParent == null || parentStyleHelper == null) {
+                if (ancestor == null || parentStyleHelper == null) {
                     return null;
                 }
 
-                StyleMap parentStyleMap = parentStyleHelper.getStyleMap(styleableParent);
-                Set<PseudoClass> styleableParentPseudoClassStates =
-                    styleableParent instanceof Node
-                        ? ((Node)styleableParent).pseudoClassStates
-                        : styleable.getPseudoClassStates();
+                StyleMap parentStyleMap = parentStyleHelper.getStyleMap(ancestor);
+                Set<PseudoClass> styleableParentPseudoClassStates = ancestor.pseudoClassStates;
 
-                return parentStyleHelper.resolveRef(styleableParent, property,
+                return parentStyleHelper.resolveRef(ancestor, property,
                         parentStyleMap, styleableParentPseudoClassStates);
             }
         }

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/CssStyleHelperTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/CssStyleHelperTest.java
@@ -972,7 +972,7 @@ public class CssStyleHelperTest {
      */
     @Test
     void testLookupResolvesWithPseudoClassAndIntermediatePane() {
-        var errors = StyleManager.errorsProperty();
+        var errors = CssParser.errorsProperty();
         errors.clear();
 
         String theme = toDataURL("""
@@ -1006,7 +1006,7 @@ public class CssStyleHelperTest {
      */
     @Test
     void testColorLookupClassCastExceptionWhenStylesheetNotOnRoot() {
-        var errors = StyleManager.errorsProperty();
+        var errors = CssParser.errorsProperty();
         errors.clear();
 
         String themeA = toDataURL("""
@@ -1038,7 +1038,7 @@ public class CssStyleHelperTest {
      */
     @Test
     void testColorLookupClassCastExceptionAfterNewRootSwap() {
-        var errors = StyleManager.errorsProperty();
+        var errors = CssParser.errorsProperty();
         errors.clear();
 
         String themeA = toDataURL("""
@@ -1072,7 +1072,7 @@ public class CssStyleHelperTest {
      */
     @Test
     void testLookupResolvesAfterRootTransitionToStateRootSwap() {
-        var errors = StyleManager.errorsProperty();
+        var errors = CssParser.errorsProperty();
         errors.clear();
 
         String theme = toDataURL("""
@@ -1115,7 +1115,7 @@ public class CssStyleHelperTest {
      */
     @Test
     void testLookupResolvesAfterChildTransitionToStateRootSwap() {
-        var errors = StyleManager.errorsProperty();
+        var errors = CssParser.errorsProperty();
         errors.clear();
 
         String theme = toDataURL("""

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/CssStyleHelperTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/CssStyleHelperTest.java
@@ -29,6 +29,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.sun.javafx.css.StyleManager;
 import com.sun.javafx.tk.Toolkit;
@@ -50,6 +51,7 @@ import javafx.stage.Stage;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -963,6 +965,196 @@ public class CssStyleHelperTest {
         toolkit.handleAnimation();
         assertEquals(1,  p.getScaleX());
         assertEquals(List.of(1.0, 2.0, 1.5, 1.0), trace);
+    }
+
+    /**
+     * PseudoClass should correctly pass down even if there are intermediate unstyled panes inbetween.
+     */
+    @Test
+    void testLookupResolvesWithPseudoClassAndIntermediatePane() {
+        var errors = StyleManager.errorsProperty();
+        errors.clear();
+
+        String theme = toDataURL("""
+                .root { -my-color: #0000FF; }
+                .pseudo:ps1 .leaf { -fx-background-color: -my-color; }
+                """);
+
+        StackPane leaf = new StackPane();
+        leaf.getStyleClass().add("leaf");
+        StackPane intermediate = new StackPane(leaf);
+
+        StackPane pseudo = new StackPane(intermediate);
+        pseudo.getStyleClass().add("pseudo");
+        pseudo.pseudoClassStateChanged(PseudoClass.getPseudoClass("ps1"), true);
+
+        StackPane root = new StackPane(pseudo);
+
+        Scene scene = new Scene(root);
+        scene.getStylesheets().add(theme);
+
+        scene.getRoot().applyCss();
+
+        assertEquals(0, errors.size(), errors::toString);
+        assertEquals(Color.BLUE, leaf.getBackground().getFills().getFirst().getFill());
+    }
+
+    /**
+     * The stylesheet uses '.root' styleClass but is not on the root node results in the following css error:
+     * {@code Caught 'java.lang.ClassCastException: class java.lang.String cannot be cast to class javafx.scene.paint.Paint
+     * while converting value for '-fx-background-color'.}
+     */
+    @Test
+    void testColorLookupClassCastExceptionWhenStylesheetNotOnRoot() {
+        var errors = StyleManager.errorsProperty();
+        errors.clear();
+
+        String themeA = toDataURL("""
+                .root { -theme-button: #0000FF; }
+                .leaf { -fx-background-color: -theme-button; }
+                """);
+
+        StackPane sub = new StackPane();
+        sub.getStylesheets().add(themeA);
+
+        Pane leaf = new Pane();
+        leaf.getStyleClass().add("leaf");
+        sub.getChildren().add(leaf);
+
+        StackPane root = new StackPane(sub);
+        Scene _ = new Scene(root);
+        root.applyCss();
+
+        assertEquals(1, errors.size(), errors::toString);
+
+        assertNull(leaf.getBackground());
+    }
+
+    /**
+     * The stylesheet was correctly on the root node with the styleClass '.root' but will be reparented
+     * to a new root node results in the following css error:
+     * {@code Caught 'java.lang.ClassCastException: class java.lang.String cannot be cast to class javafx.scene.paint.Paint
+     * while converting value for '-fx-background-color'.}
+     */
+    @Test
+    void testColorLookupClassCastExceptionAfterNewRootSwap() {
+        var errors = StyleManager.errorsProperty();
+        errors.clear();
+
+        String themeA = toDataURL("""
+                .root { -theme-button: #0000FF; }
+                .leaf { -fx-background-color: -theme-button; }
+                """);
+
+        StackPane root = new StackPane();
+        root.getStylesheets().add(themeA);
+
+        Pane leaf = new Pane();
+        leaf.getStyleClass().add("leaf");
+        root.getChildren().add(leaf);
+
+        Scene scene = new Scene(root);
+        root.applyCss();
+
+        assertEquals(Color.BLUE, leaf.getBackground().getFills().getFirst().getFill());
+
+        root = new StackPane(root);
+        scene.setRoot(root);
+        root.applyCss();
+
+        assertEquals(1, errors.size(), errors::toString);
+
+        assertNull(leaf.getBackground());
+    }
+
+    /**
+     * No errors when we switch the root node in a listener of the root node (which is triggered by a CSS pulse).
+     */
+    @Test
+    void testLookupResolvesAfterRootTransitionToStateRootSwap() {
+        var errors = StyleManager.errorsProperty();
+        errors.clear();
+
+        String theme = toDataURL("""
+                .root {
+                    -jr-fg: #0000FF;
+                    -fx-background-color: -jr-fg;
+                }
+                .leaf {
+                    -fx-background-color: -jr-fg;
+                }
+                """);
+
+        StackPane oldRoot = new StackPane();
+
+        StackPane leaf = new StackPane();
+        leaf.getStyleClass().add("leaf");
+        oldRoot.getChildren().add(leaf);
+
+        Scene scene = new Scene(oldRoot);
+        scene.getStylesheets().add(theme);
+
+        // When CSS applies -fx-background-color to oldRoot, we are in the transitionToState phase (mid-pulse).
+        AtomicBoolean swapped = new AtomicBoolean(false);
+        oldRoot.backgroundProperty().addListener((_, _, _) -> {
+            if (!swapped.getAndSet(true)) {
+                StackPane newRoot = new StackPane(oldRoot);
+                scene.setRoot(newRoot);
+            }
+        });
+
+        scene.getRoot().applyCss();
+
+        assertEquals(0, errors.size(), errors::toString);
+
+        assertEquals(Color.BLUE, leaf.getBackground().getFills().getFirst().getFill());
+    }
+
+    /**
+     * No errors when we switch the root node in a listener of a child node (which is triggered by a CSS pulse).
+     */
+    @Test
+    void testLookupResolvesAfterChildTransitionToStateRootSwap() {
+        var errors = StyleManager.errorsProperty();
+        errors.clear();
+
+        String theme = toDataURL("""
+                .root {
+                    -jr-fg: #0000FF;
+                }
+                .leaf {
+                    -fx-background-color: -jr-fg;
+                }
+                .leaf-leaf {
+                    -fx-background-color: -jr-fg;
+                }
+                """);
+
+        StackPane oldRoot = new StackPane();
+
+        StackPane leafLeaf = new StackPane();
+        leafLeaf.getStyleClass().add("leaf-leaf");
+        StackPane leaf = new StackPane(leafLeaf);
+        leaf.getStyleClass().add("leaf");
+        oldRoot.getChildren().add(leaf);
+
+        Scene scene = new Scene(oldRoot);
+        scene.getStylesheets().add(theme);
+
+        // When CSS applies -fx-background-color to leaf, we are in the transitionToState phase (mid-pulse).
+        AtomicBoolean swapped = new AtomicBoolean(false);
+        leaf.backgroundProperty().addListener((_, _, _) -> {
+            if (!swapped.getAndSet(true)) {
+                StackPane newRoot = new StackPane(oldRoot);
+                scene.setRoot(newRoot);
+            }
+        });
+
+        scene.getRoot().applyCss();
+
+        assertEquals(0, errors.size(), errors::toString);
+
+        assertEquals(Color.BLUE, leaf.getBackground().getFills().getFirst().getFill());
     }
 
     private static String toDataURL(String stylesheet) {


### PR DESCRIPTION
This one took me several days to fix. Below I will try to explain every information I found out while debugging and fixing this.

Originally I found this weird CSS issue already years ago, hence my comment in the issue.
It happened because `ControlsFX` secretly changes your `Scene` root to its `DecorationPane` (and attaches your old root under it). This seems to trigger CSS errors sometimes that do not make sense and the UI seems to be fine as well.

I tried to write several tests and scenarios that should work or not work. So some tests succeed without the fix and also after.
The fix is only in `CssStyleHelper` and consists of two changes. Both for the `firstStyleableAncestor`, which has some issues.

The `firstStyleableAncestor` was introcuded in https://bugs.openjdk.org/browse/JDK-8090462, so this is technically somewhat a regression from there.

### The fix

A child can change the scene structure (e.g. change the root) as a result from processing its CSS. I wrote multiple tests to show that. Because of this scenario, we need to change how the `firstStyleableAncestor` is found.

1.  The `firstStyleableAncestor` is now found by eagerly creating its `styleHelper` (before, we just checked if it has one). If this worked (-> that node is styleable), we have our ancestor.
  - 1.1 In `createStyleHelper`, we already traverse the parents to get the `depth`, so we can optimize our `firstStyleableAncestor` search by hanging into the loop and check if this is our styleable ancestor

2. In very rare cases `firstStyleableAncestor` can be null for a non-root `Node`. This, again can happen if something changes while we are processing the CSS. Normally CSS processing is top-down. But when a child changes a parent (or root), the structure changes and in this case we could no longer have a `firstStyleableAncestor`. So both CSS processing methods `resolveRef` and `getInheritedStyle` will search for a styleable ancestor if there is none set.
  - 2.1. This usually never happens and for `Scene` roots this will be a noop.

#### Performance

Performance wise, I could not see any problem or regression. We still cache our `firstStyleableAncestor` (and even reuse a preexisting loop). 
We might create a parent `styleHelper` more early in rare scenarios, but those will be created anyway the next pulse and usually are reused then.

I also avoid to create any null `WeakReference` objects, as `resolveRef` could be hot path if the user hovers e.g. over table entries. So no objects are created in this case.

There is https://bugs.openjdk.org/browse/JDK-8187955 which has an idea how to get rid of a recursion which I think is a good step if we want to optimize this further. But the ticket has not much information, so it is hard to completely get what the author meant.

##### What I tried before

At first, I thought this problem is only related to the `Scene` root node. So I first implemented a fix on the `rootProperty`, always prcoessing css for the new root (immediately, so we create a new `styleHelper` now and not the next pulse) or nulling the `styleHelper` on the old root.

But then I checked if this issue can be reproduced with non-root `Node`s as well, so I wrote tests for it that proves that this is a generic problem not related to the root `Node` (it just so happens that `modena.css` and usually all other stylesheets usually set the colors on `.root { ... }` and not on a child node).

With that information, the problem must be inside `CssStyleHelper` and not in `Scene#rootProperty` or `Node#setScenes`.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8268657](https://bugs.openjdk.org/browse/JDK-8268657): Looked-up color fails for -fx-background-color in JavaFX CSS file (**Bug** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [John Hendrikx](https://openjdk.org/census#jhendrikx) (@hjohn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2201/head:pull/2201` \
`$ git checkout pull/2201`

Update a local copy of the PR: \
`$ git checkout pull/2201` \
`$ git pull https://git.openjdk.org/jfx.git pull/2201/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2201`

View PR using the GUI difftool: \
`$ git pr show -t 2201`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2201.diff">https://git.openjdk.org/jfx/pull/2201.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2201#issuecomment-4878140002)
</details>
