### PR TITLE
8388141: JavaFX.setOpenURIHandler() only receives event if application is already launched

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.h
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.h
@@ -53,6 +53,8 @@
     jboolean        jTaskBarApp;
     jlong           jshareContextPtr;
 
+    NSMutableArray<NSURL *> *bufferedURLs;
+
     // local and intra-app event monitoring
     //
     // id              localMonitor;

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.h
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.h
@@ -53,8 +53,6 @@
     jboolean        jTaskBarApp;
     jlong           jshareContextPtr;
 
-    NSMutableArray<NSURL *> *bufferedURLs;
-
     // local and intra-app event monitoring
     //
     // id              localMonitor;

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
@@ -77,18 +77,13 @@ static NSString* JavaRunLoopMode = @"AWTRunLoopMode";
 // don't deadlock.
 static NSArray<NSString*> *runLoopModes = nil;
 
-// Custom event that is emitted by AWT to let libraries like JavaFX
-// know that it is ready to receive embedded events. Until this event is
-// emitted libraries should buffer the already received events.
-static NSString* awtEmbeddedEventReady = @"AWTEmbeddedEventReady";
+// Specifies whether awt is initialized to receive embedded events.
+static bool awtInitialized = false;
 
 // Custom event that is provided by AWT to allow libraries like
 // JavaFX to forward native events to AWT even if AWT runs in
 // embedded mode.
 static NSString* awtEmbeddedEvent = @"AWTEmbeddedEvent";
-
-// Set to true once AWT has emitted the embedded ready event.
-static BOOL awtEmbeddedEventReadyReceived = false;
 
 #ifdef STATIC_BUILD
 jint JNICALL JNI_OnLoad_glass(JavaVM *vm, void *reserved)
@@ -197,13 +192,6 @@ static NSMutableArray<GlassRunnable*> *deferredRunnables = nil;
         {
             [GlassHelper SetGlassClassLoader:classLoader withEnv:env];
         }
-
-        self->bufferedURLs = [NSMutableArray array];
-
-        // register AWT embedded event ready listener
-        NSNotificationCenter *ctr = [NSNotificationCenter defaultCenter];
-        Class clz = [GlassApplication class];
-        [ctr addObserver:clz selector:@selector(_embeddedEventReady:) name:awtEmbeddedEventReady object:nil];
     }
     return self;
 }
@@ -217,19 +205,26 @@ static NSMutableArray<GlassRunnable*> *deferredRunnables = nil;
     [super dealloc];
 }
 
-+ (void)_embeddedEventReady:(NSNotification *)notification {
-    awtEmbeddedEventReadyReceived = true;
-    id delegate = [NSApp delegate];
-
-    if ([delegate isKindOfClass:[GlassApplication class]]) {
-        GlassApplication* glassApplication = (GlassApplication *)delegate;
-
-        [glassApplication application:NSApp openURLs:glassApplication->bufferedURLs];
-        [glassApplication->bufferedURLs removeAllObjects];
-    }
-}
-
 #pragma mark --- delegate methods
+
+- (void)_initAwt {
+    LOG("_initAwt");
+
+    if (awtInitialized) {
+        return;
+    }
+
+    JNIEnv *env = jEnv;
+    jclass awt = [GlassHelper ClassForName:"java.awt.Toolkit" withEnv:env];
+    jmethodID method = (*env)->GetMethodID(env, awt, "getDefaultToolkit", "()V");
+
+    if ((*env)->ExceptionCheck(env) == JNI_TRUE) {
+        return;
+    }
+
+    (*env)->CallVoidMethod(env, awt, method);
+    awtInitialized = true;
+}
 
 - (void)GlassApplicationDidChangeScreenParameters
 {
@@ -531,20 +526,18 @@ static NSMutableArray<GlassRunnable*> *deferredRunnables = nil;
 
 - (void)application:(NSApplication *)theApplication openURLs:(NSArray<NSURL *> *)urls
 {
-    for (NSURL* url in urls) {
-        if (awtEmbeddedEventReadyReceived) {
-                NSDictionary *userInfo = @{
-                    @"name": @"openURL",
-                    @"url": url.absoluteString
-                };
+    [self _initAwt];
 
-                [[NSNotificationCenter defaultCenter]
-                        postNotificationName:awtEmbeddedEvent
-                        object:nil
-                        userInfo:userInfo];
-        } else {
-            [self->bufferedURLs addObject:url];
-        }
+    for (NSURL* url in urls) {
+        NSDictionary *userInfo = @{
+            @"name": @"openURL",
+            @"url": url.absoluteString
+        };
+
+        [[NSNotificationCenter defaultCenter]
+                postNotificationName:awtEmbeddedEvent
+                object:nil
+                userInfo:userInfo];
     }
 }
 

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
@@ -77,10 +77,18 @@ static NSString* JavaRunLoopMode = @"AWTRunLoopMode";
 // don't deadlock.
 static NSArray<NSString*> *runLoopModes = nil;
 
+// Custom event that is emitted by AWT to let libraries like JavaFX 
+// know that it is ready to receive embedded events. Until this event is 
+// emitted libraries should buffer the already received events.
+static NSString* awtEmbeddedEventReady = @"AWTEmbeddedEventReady";
+
 // Custom event that is provided by AWT to allow libraries like
 // JavaFX to forward native events to AWT even if AWT runs in
 // embedded mode.
 static NSString* awtEmbeddedEvent = @"AWTEmbeddedEvent";
+
+// Set to true once AWT has emitted the embedded ready event.
+static BOOL awtEmbeddedEventReadyReceived = false;
 
 #ifdef STATIC_BUILD
 jint JNICALL JNI_OnLoad_glass(JavaVM *vm, void *reserved)
@@ -189,6 +197,13 @@ static NSMutableArray<GlassRunnable*> *deferredRunnables = nil;
         {
             [GlassHelper SetGlassClassLoader:classLoader withEnv:env];
         }
+
+        self->bufferedURLs = [NSMutableArray array];
+
+        // register AWT embedded event ready listener
+        NSNotificationCenter *ctr = [NSNotificationCenter defaultCenter];
+        Class clz = [GlassApplication class];
+        [ctr addObserver:clz selector:@selector(_embeddedEventReady:) name:awtEmbeddedEventReady object:nil];
     }
     return self;
 }
@@ -200,6 +215,19 @@ static NSMutableArray<GlassRunnable*> *deferredRunnables = nil;
     }
 
     [super dealloc];
+}
+
++ (void)_embeddedEventReady:(NSNotification *)notification {
+    awtEmbeddedEventReadyReceived = true;
+    id delegate = [NSApp delegate];
+
+    if ([delegate isKindOfClass:[GlassApplication class]]) 
+    {
+        GlassApplication* glassApplication = (GlassApplication *)delegate;
+
+        [glassApplication application:NSApp openURLs:glassApplication->bufferedURLs];
+        [glassApplication->bufferedURLs removeAllObjects];  
+    }
 }
 
 #pragma mark --- delegate methods
@@ -502,18 +530,23 @@ static NSMutableArray<GlassRunnable*> *deferredRunnables = nil;
     return YES;
 }
 
-- (void) application:(NSApplication *)theApplication openURLs:(NSArray<NSURL *> *)urls
+- (void)application:(NSApplication *)theApplication openURLs:(NSArray<NSURL *> *)urls
 {
     for (NSURL* url in urls) {
-         NSDictionary *userInfo = @{
-            @"name": @"openURL",
-            @"url": url.absoluteString
-        };
+        if (awtEmbeddedEventReadyReceived) 
+        {
+                NSDictionary *userInfo = @{
+                    @"name": @"openURL",
+                    @"url": url.absoluteString
+                };
 
-        [[NSNotificationCenter defaultCenter]
-                postNotificationName:awtEmbeddedEvent
-                object:nil
-                userInfo:userInfo];
+                [[NSNotificationCenter defaultCenter]
+                        postNotificationName:awtEmbeddedEvent
+                        object:nil
+                        userInfo:userInfo];
+        } else {
+            [self->bufferedURLs addObject:url];
+        }
     }
 }
 

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
@@ -77,8 +77,8 @@ static NSString* JavaRunLoopMode = @"AWTRunLoopMode";
 // don't deadlock.
 static NSArray<NSString*> *runLoopModes = nil;
 
-// Custom event that is emitted by AWT to let libraries like JavaFX 
-// know that it is ready to receive embedded events. Until this event is 
+// Custom event that is emitted by AWT to let libraries like JavaFX
+// know that it is ready to receive embedded events. Until this event is
 // emitted libraries should buffer the already received events.
 static NSString* awtEmbeddedEventReady = @"AWTEmbeddedEventReady";
 
@@ -221,12 +221,11 @@ static NSMutableArray<GlassRunnable*> *deferredRunnables = nil;
     awtEmbeddedEventReadyReceived = true;
     id delegate = [NSApp delegate];
 
-    if ([delegate isKindOfClass:[GlassApplication class]]) 
-    {
+    if ([delegate isKindOfClass:[GlassApplication class]]) {
         GlassApplication* glassApplication = (GlassApplication *)delegate;
 
         [glassApplication application:NSApp openURLs:glassApplication->bufferedURLs];
-        [glassApplication->bufferedURLs removeAllObjects];  
+        [glassApplication->bufferedURLs removeAllObjects];
     }
 }
 
@@ -533,8 +532,7 @@ static NSMutableArray<GlassRunnable*> *deferredRunnables = nil;
 - (void)application:(NSApplication *)theApplication openURLs:(NSArray<NSURL *> *)urls
 {
     for (NSURL* url in urls) {
-        if (awtEmbeddedEventReadyReceived) 
-        {
+        if (awtEmbeddedEventReadyReceived) {
                 NSDictionary *userInfo = @{
                     @"name": @"openURL",
                     @"url": url.absoluteString


### PR DESCRIPTION
# Problem description

When You create a JavaFX native application with *jpackage* for macOS You will run into an issue when trying to handle URIs. When Your application isn’t running and You have it registered for handling certain types of URIs it won’t receive the first URI. 

## Here is a simple example: 

If You have a JavaFX application that handles URIs for example of the form *openurifx://your-content* and You have it installed with *jpackage* for macOS and now You try to handle an URI by running the following command: 

``` open openurifx://hello-world ``` 

The application will open, but it won’t receive the above URI. If You call the same command after the application is already running, everything will work fine and the application will receive the URI.

# Problem cause

The cause of the problem is that when You build a JavaFX application and want to handle URIs You will have to combine JavaFX and AWT as AWT provides the URI handling capabilities. So the startup process is as follows:

1. JavaFX is initialized
2. JavaFX forwards the URI event to AWT
3. AWT is initialized 
4. AWT is ready to handle URI events from JavaFX

The issue is that the URI event is delivered before AWT can handle it and therefore is simple dropped. That’s why later URIs will be received and are handled properly. 

# Fix

The fix is that JavaFX will wait until it receives a ready event from AWT so JavaFX knows that AWT is able to handle events now. After that it will forward all buffered URIs and therefore everything will be handled correctly. This means that the fix involves both the JFX and JDK repositories and needs to be integrated in both. 

**Note**: In the case that a user has only a fix for the JFX part the URIs won’t be delivered at all, but there won’t be any error. This means that JavaFX applications won’t be able to handle any URIs so it might be an idea to add an environment variable to tell JavaFX to not wait for an AWT ready event. Then the first URI event would be lost, but at least all the following events would be handled properly.

# Tests

To test the error and the fix You can clone this repository: https://github.com/pabulaner/openurifx and checkout the branch *first-url*. There You will find a README.md with further instructions.

PR inside the JDK: https://github.com/openjdk/jdk/pull/31791

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change requires CSR request [JDK-8391252](https://bugs.openjdk.org/browse/JDK-8391252) to be approved
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issues
 * [JDK-8388141](https://bugs.openjdk.org/browse/JDK-8388141): JavaFX.setOpenURIHandler() only receives event if application is already launched (**Bug** - P4)
 * [JDK-8391252](https://bugs.openjdk.org/browse/JDK-8391252): JavaFX.setOpenURIHandler() only receives event if application is already launched (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2203/head:pull/2203` \
`$ git checkout pull/2203`

Update a local copy of the PR: \
`$ git checkout pull/2203` \
`$ git pull https://git.openjdk.org/jfx.git pull/2203/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2203`

View PR using the GUI difftool: \
`$ git pr show -t 2203`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2203.diff">https://git.openjdk.org/jfx/pull/2203.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2203#issuecomment-4894602155)
</details>
