### PR TITLE
Instruction to publish OpenJFX artifacts to local Maven repository

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -257,5 +257,19 @@ bash ./gradlew -PFULL_TEST=true -PUSE_ROBOT=true all test
 
 If you don't build WebKit (using the `-PCOMPILE_WEBKIT=true` option), you are likely to get test failures when running the web tests. See the [Web Testing](WEBKIT-MEDIA-STUBS.md) page for information on how to address this.
 
+#### Build and publish to your local Maven repository
+
+With Gradle, you can build and publish the OpenJFX artifacts to your local Maven repository (`/.m2`) with:
+
+```sh
+bash ./gradlew -PMAVEN_PUBLISH=true -PMAVEN_VERSION=<version> publishToMavenLocal
+```
+
+Make sure to set a version in `-PMAVEN_VERSION` (e.g. `999`).
+
+The version number can be changed in your existing applications to locally test the previously build and published OpenJFX artifacts.
+
+---
+
 Even more documentation on OpenJFX projects and its build system can be found on the
 [OpenJFX Wiki](https://wiki.openjdk.org/display/OpenJFX/).


### PR DESCRIPTION
Idea for instructions so that developers can easily publish the JavaFX artifacts to their local Maven repository.
Makes testing existing applications very easy because you usually just need to change the Maven or Gradle JavaFX version number.

<img width="663" height="373" alt="image" src="https://github.com/user-attachments/assets/06d39fbd-592e-4288-aa9d-6aecf0da5e3a" />

---

## The worflow for testing a Branch (or your local changes) is:

1. Run `./gradlew -PMAVEN_PUBLISH=true -PMAVEN_VERSION=<version> publishToMavenLocal`
2. Change in your Maven project `pom.xml`

<img width="497" height="235" alt="image" src="https://github.com/user-attachments/assets/82a9bf93-65db-43d3-a15f-01a4ba65294a" />

**OR**

2. Change in your Gradle project `build.gradle`

<img width="503" height="130" alt="image" src="https://github.com/user-attachments/assets/59f0944c-635b-4153-ba8d-023d1e21ecda" />

3. Run application, changes can be tested right away

Feedback welcome.


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[ \] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2208/head:pull/2208` \
`$ git checkout pull/2208`

Update a local copy of the PR: \
`$ git checkout pull/2208` \
`$ git pull https://git.openjdk.org/jfx.git pull/2208/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2208`

View PR using the GUI difftool: \
`$ git pr show -t 2208`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2208.diff">https://git.openjdk.org/jfx/pull/2208.diff</a>

</details>
