### PR TITLE
8388140: Significant CSS performance regression after JDK-8268657

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/scene/CssStyleHelper.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/CssStyleHelper.java
@@ -87,9 +87,15 @@ final class CssStyleHelper {
      * Creates a new StyleHelper.
      */
     static CssStyleHelper createStyleHelper(final Node node) {
-        // need to know how far we are to root in order to init arrays.
-        // TODO: should we hang onto depth to avoid this nonsense later?
-        // TODO: is there some other way of knowing how far from the root a node is?
+        boolean userSetFont;
+        if (node.styleHelper == null) {
+            // Node styleHelper can not be reused later, because it does not exist.
+            // We can therefore safely set this true and ignore the property for the rest of this method.
+            userSetFont = true;
+        } else {
+            userSetFont = isUserSetFont(node);
+        }
+
         Node styleableAncestor = null;
         Styleable parent = node;
         int depth = 0;
@@ -97,13 +103,14 @@ final class CssStyleHelper {
             depth++;
             parent = parent.getStyleableParent();
 
-            if (styleableAncestor == null && parent instanceof Node parentNode && isStyleableAncestor(parentNode)) {
-                styleableAncestor = parentNode;
+            if (parent instanceof Node parentNode) {
+                if (styleableAncestor == null && parentNode.styleHelper != null) {
+                    styleableAncestor = parentNode;
+                }
+                if (!userSetFont) {
+                    userSetFont = isUserSetFont(parentNode);
+                }
             }
-        }
-
-        if (node.styleHelper != null) {
-            setFirstStyleableAncestor(node.styleHelper, styleableAncestor);
         }
 
         // The List<CacheEntry> should only contain entries for those
@@ -123,7 +130,7 @@ final class CssStyleHelper {
         //
         // reuse the existing styleHelper if possible.
         //
-        if ( canReuseStyleHelper(node, styleMap) ) {
+        if ( canReuseStyleHelper(node, styleMap, styleableAncestor) ) {
             //
             // JDK-8123731
             //
@@ -134,7 +141,7 @@ final class CssStyleHelper {
             // trigger a REAPPLY. If the REAPPLY comes because of a change in font, then the fontSizeCache
             // needs to be invalidated (cleared) so that new values will be looked up for all transition states.
             //
-            if (node.styleHelper.cacheContainer != null && node.styleHelper.isUserSetFont(node)) {
+            if (userSetFont) {
                 node.styleHelper.cacheContainer.fontSizeCache.clear();
             }
             node.styleHelper.cacheContainer.forceSlowpath = true;
@@ -143,6 +150,7 @@ final class CssStyleHelper {
                 node.styleHelper.triggerStates.addAll(triggerStates[0]);
             }
 
+            setFirstStyleableAncestor(node.styleHelper, null);
             updateParentTriggerStates(node, depth, triggerStates);
             return node.styleHelper;
         }
@@ -180,7 +188,6 @@ final class CssStyleHelper {
         }
 
         final CssStyleHelper helper = new CssStyleHelper();
-        setFirstStyleableAncestor(helper, styleableAncestor);
 
         if (triggerStates[0] != null) {
             helper.triggerStates.addAll(triggerStates[0]);
@@ -233,39 +240,40 @@ final class CssStyleHelper {
         }
     }
 
-    //
-    // return true if the fontStyleableProperty's origin is USER
-    //
-    private boolean isUserSetFont(Styleable node) {
-
-        if (node == null) return false; // should never happen, but just to be safe...
-
-        CssMetaData<Styleable, Font> fontCssMetaData = cacheContainer != null ? cacheContainer.fontProp : null;
-        if (fontCssMetaData != null) {
-            StyleableProperty<Font> fontStyleableProperty = fontCssMetaData != null ? fontCssMetaData.getStyleableProperty(node) : null;
-            if (fontStyleableProperty != null && fontStyleableProperty.getStyleOrigin() == StyleOrigin.USER) return true;
-        }
-
-        Node styleableParent = getCachedStyleableAncestor(node);
-        CssStyleHelper parentStyleHelper = getStyleHelper(styleableParent);
-
-        if (parentStyleHelper != null) {
-            return parentStyleHelper.isUserSetFont(styleableParent);
-        } else {
+    private static boolean isUserSetFont(Node node) {
+        if (node.styleHelper == null || node.styleHelper.cacheContainer == null) {
             return false;
         }
+        CssMetaData<Styleable, Font> fontMetadata = node.styleHelper.cacheContainer.fontProp;
+        if (fontMetadata != null) {
+            StyleableProperty<Font> fontStyleableProperty = fontMetadata.getStyleableProperty(node);
+            if (fontStyleableProperty != null && fontStyleableProperty.getStyleOrigin() == StyleOrigin.USER) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static CssStyleHelper getStyleHelper(Node n) {
         return (n != null)? n.styleHelper : null;
     }
 
+    /**
+     * Finds the first styleable ancestor of this styleable.
+     * Will first check if we have a cached ancestor, otherwise walk up and find one.
+     */
     private static Node findFirstStyleableAncestor(Styleable styleable) {
+        // Root node.
+        if (styleable.getStyleableParent() == null) {
+            return null;
+        }
+
         Node ancestor = getCachedStyleableAncestor(styleable);
         if (ancestor != null) {
             return ancestor;
         }
 
+        // This path is only called for the first time if we have no cached ancestor yet.
         ancestor = findFirstStyleableAncestorInParent(styleable);
         if (styleable instanceof Node node) {
             setFirstStyleableAncestor(node.styleHelper, ancestor);
@@ -329,7 +337,7 @@ final class CssStyleHelper {
     //
     // return true if the Node's current styleHelper can be reused.
     //
-    private static boolean canReuseStyleHelper(final Node node, final StyleMap styleMap) {
+    private static boolean canReuseStyleHelper(final Node node, final StyleMap styleMap, Node styleableAncestor) {
 
         // Obviously, we cannot reuse the node's style helper if it doesn't have one.
         if (node == null || node.styleHelper == null) {
@@ -369,8 +377,7 @@ final class CssStyleHelper {
             return true;
         }
 
-        CssStyleHelper parentHelper = getStyleHelper(getCachedStyleableAncestor(node));
-
+        CssStyleHelper parentHelper = getStyleHelper(styleableAncestor);
         if (parentHelper != null && parentHelper.cacheContainer != null) {
 
             int[] parentIds = parentHelper.cacheContainer.styleCacheKey.getStyleMapIds();


### PR DESCRIPTION
Since the last [PR](https://github.com/openjdk/jfx/pull/2201) made the parent `styleHelper` creation more eager, creating and adding many nodes will be slower (initially).

The fix is actually something I already had in mind when I did the previous PR: Find the ancestor lazily.
Now, when we create a `CssStyleHelper` we will not yet set the `firstStyleableAncestor`. 
This will improve the performance to the level before while all tests still pass.

This makes sense because `CssStyleHelper` is created (top-down) but not immediately used. It can also be (re)created when a `Node` changes its `Parent` (or deferred from there).

Later, `transitionToState` is called (top-down) which will then need the `firstStyleableAncestor` (and this is also where we will compute it now). Since in the meantime the scene structure could change, it makes sense to do that as late as possible.

The days before I also investigated [JDK-8187955](https://bugs.openjdk.org/browse/JDK-8187955) and found a good improvement as well (no recursion needed, we can again use the preexisting loop). Since we now create the `firstStyleableAncestor` lazy, it makes sense to combine it, as otherwise the `isUserSetFont` need to be changed which I think is more risky.

Also did some digging about `isUserSetFont`, and was added/changed in this tickets:
- `isUserSetFont` code added: https://bugs.openjdk.org/browse/JDK-8123731
- `isUserSetFont` code changed: https://bugs.openjdk.org/browse/JDK-8093577

/issue add JDK-8187955

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8388140](https://bugs.openjdk.org/browse/JDK-8388140)

### Issues
 * [JDK-8388140](https://bugs.openjdk.org/browse/JDK-8388140): [BACKOUT] Looked-up color fails for -fx-background-color in JavaFX CSS file (**Bug** - P2) ⚠️ Title mismatch between PR and JBS.
 * [JDK-8187955](https://bugs.openjdk.org/browse/JDK-8187955): CssStyleHelper : recursion in isUserSetFont() can be avoided (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2210/head:pull/2210` \
`$ git checkout pull/2210`

Update a local copy of the PR: \
`$ git checkout pull/2210` \
`$ git pull https://git.openjdk.org/jfx.git pull/2210/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2210`

View PR using the GUI difftool: \
`$ git pr show -t 2210`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2210.diff">https://git.openjdk.org/jfx/pull/2210.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2210#issuecomment-4962442978)
</details>
