### PR TITLE
8388174: Change JavaFX release version to 28

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -24,7 +24,7 @@
 [general]
 project=openjfx
 jbs=jdk
-version=jfx27
+version=jfx28
 
 [repository]
 tags=(jdk-){0,1}([1-9]([0-9]*)(\.(0|[1-9][0-9]*)){0,3})(\+(([0-9]+))|(-ga))|[1-9]((\.\d{1,3}){0,2})-((b\d{2,3})|(ga))|[1-9]u(\d{1,3})-((b\d{2,3})|(ga))

--- a/build.properties
+++ b/build.properties
@@ -44,7 +44,7 @@ jfx.release.suffix=-ea
 jfx.experimental.feature.name=
 
 # UPDATE THE FOLLOWING VALUES FOR A NEW RELEASE
-jfx.release.major.version=27
+jfx.release.major.version=28
 jfx.release.minor.version=0
 jfx.release.security.version=0
 jfx.release.patch.version=0

--- a/modules/javafx.base/src/test/java/test/com/sun/javafx/runtime/VersionInfoTest.java
+++ b/modules/javafx.base/src/test/java/test/com/sun/javafx/runtime/VersionInfoTest.java
@@ -38,7 +38,7 @@ import static org.junit.jupiter.api.Assertions.*;
 public class VersionInfoTest {
 
     // Increment this feature-release counter for every major release.
-    private static final String FEATURE = "27";
+    private static final String FEATURE = "28";
 
     // The working directory at runtime is 'modules/javafx.base'.
     private static final String PROPERTIES_FILE = "build/module-lib/javafx.properties";


### PR DESCRIPTION
Bump the version number of JavaFX to 28. I will integrate this to master as part of forking the jfx27 stabilization branch, which is scheduled for Thursday, July 16, 2026 at 16:00 UTC.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388174](https://bugs.openjdk.org/browse/JDK-8388174): Change JavaFX release version to 28 (**Task** - P2)


### Reviewers
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)
 * [Johan Vos](https://openjdk.org/census#jvos) (@johanvos - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2211/head:pull/2211` \
`$ git checkout pull/2211`

Update a local copy of the PR: \
`$ git checkout pull/2211` \
`$ git pull https://git.openjdk.org/jfx.git pull/2211/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2211`

View PR using the GUI difftool: \
`$ git pr show -t 2211`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2211.diff">https://git.openjdk.org/jfx/pull/2211.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2211#issuecomment-4963984272)
</details>
