### PR TITLE
8388304: Scene.setNodeOrientation triggers instant CSS but also doesn't update properly

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
@@ -5876,7 +5876,7 @@ public class Scene implements EventTarget {
                 @Override
                 protected void invalidated() {
                     sceneEffectiveOrientationInvalidated();
-                    getRoot().applyCss();
+                    getRoot().reapplyCSS();
                 }
 
                 @Override

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/Node_effectiveOrientation_Css_Test.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/Node_effectiveOrientation_Css_Test.java
@@ -44,7 +44,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 /**
  * Test :dir functional pseudo-class
  */
-@Disabled("JDK-8234152")
 public class Node_effectiveOrientation_Css_Test {
 
     private Group root;
@@ -119,6 +118,7 @@ public class Node_effectiveOrientation_Css_Test {
         assertEquals(Color.web("#ff0000"), rect.getFill());
     }
 
+    @Disabled("JDK-8234152")
     @Test
     public void test_CompounSelector_dir_pseudoClass_on_parent_with_scene_effective_orientation_ltr() {
         Stylesheet stylesheet = new CssParser().parse(
@@ -139,6 +139,8 @@ public class Node_effectiveOrientation_Css_Test {
         assertEquals(Color.web("#00ff00"), rect.getFill());
     }
 
+
+    @Disabled("JDK-8234152")
     @Test
     public void test_CompoundSelector_dir_pseudoClass_on_parent_with_scene_effective_orientation_rtl() {
         Stylesheet stylesheet = new CssParser().parse(
@@ -160,6 +162,7 @@ public class Node_effectiveOrientation_Css_Test {
         assertEquals(Color.web("#ff0000"), rect.getFill());
     }
 
+    @Disabled("JDK-8234152")
     @Test
     public void test_CompounSelector_dir_pseudoClass_on_child_with_scene_effective_orientation_ltr() {
         Stylesheet stylesheet = new CssParser().parse(
@@ -180,6 +183,7 @@ public class Node_effectiveOrientation_Css_Test {
         assertEquals(Color.web("#00ff00"), rect.getFill());
     }
 
+    @Disabled("JDK-8234152")
     @Test
     public void test_CompoundSelector_dir_pseudoClass_on_child_with_scene_effective_orientation_rtl() {
         Stylesheet stylesheet = new CssParser().parse(
@@ -234,6 +238,37 @@ public class Node_effectiveOrientation_Css_Test {
         // :dir() pseudo-class functions on scene effective orientation, not node
         assertEquals(Color.web("#ff0000"), rect.getFill());
 
+    }
+
+    @Test
+    public void testCssUpdates() {
+        Group root = new Group();
+        Scene scene = new Scene(root);
+        Stage stage = new Stage();
+        stage.setScene(scene);
+        stage.show();
+
+        Stylesheet stylesheet = new CssParser().parse(
+                ".rect:dir(rtl) { -fx-fill: #ff0000; }" +
+                ".rect:dir(ltr) { -fx-fill: #00ff00; }" +
+                ".rect { -fx-fill: #0000ff; }"
+        );
+        StyleManager.getInstance().setDefaultUserAgentStylesheet(stylesheet);
+
+        Rectangle rect = new Rectangle();
+        rect.getStyleClass().add("rect");
+        root.getChildren().add(rect);
+
+        root.applyCss();
+        assertEquals(Color.web("#00ff00"), rect.getFill());
+
+        scene.setNodeOrientation(RIGHT_TO_LEFT);
+        root.applyCss();
+        assertEquals(Color.web("#ff0000"), rect.getFill());
+
+        scene.setNodeOrientation(LEFT_TO_RIGHT);
+        root.applyCss();
+        assertEquals(Color.web("#00ff00"), rect.getFill());
     }
 
 }

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/Node_effectiveOrientation_Css_Test.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/Node_effectiveOrientation_Css_Test.java
@@ -120,7 +120,7 @@ public class Node_effectiveOrientation_Css_Test {
 
     @Disabled("JDK-8234152")
     @Test
-    public void test_CompounSelector_dir_pseudoClass_on_parent_with_scene_effective_orientation_ltr() {
+    public void test_CompoundSelector_dir_pseudoClass_on_parent_with_scene_effective_orientation_ltr() {
         Stylesheet stylesheet = new CssParser().parse(
                 ".root:dir(rtl) .rect { -fx-fill: #ff0000; }" +
                 ".root:dir(ltr) .rect { -fx-fill: #00ff00; }" +
@@ -164,7 +164,7 @@ public class Node_effectiveOrientation_Css_Test {
 
     @Disabled("JDK-8234152")
     @Test
-    public void test_CompounSelector_dir_pseudoClass_on_child_with_scene_effective_orientation_ltr() {
+    public void test_CompoundSelector_dir_pseudoClass_on_child_with_scene_effective_orientation_ltr() {
         Stylesheet stylesheet = new CssParser().parse(
                 ".root .rect:dir(rtl) { -fx-fill: #ff0000; }" +
                 ".root .rect:dir(ltr) { -fx-fill: #00ff00; }" +
@@ -241,7 +241,7 @@ public class Node_effectiveOrientation_Css_Test {
     }
 
     @Test
-    public void testCssUpdates() {
+    public void testChangeNodeOrientationWillReapplyCss() {
         Group root = new Group();
         Scene scene = new Scene(root);
         Stage stage = new Stage();


### PR DESCRIPTION
### Fix
The PR replaces applyCss() with reapplyCSS in the nodeOrientation code of Scene.
applyCss() reapplied styles eagerly - and didn't rebuild the "style maps" resulting in wrong css.
reapplyCSS() rematches correctly - and also defers it to the next pulse.

I've added a unit test to: Node_effectiveOrientation_Css_Test.

### Test improvements
Because the whole test class was disabled, I've also investigated which tests are working - and reenabled the working tests.
This PR also fixes 2 of the previously failing tests in Node_effectiveOrientation_Css_Test - which are now enabled.

Which are the following tests:
```
Node_effectiveOrientation_Css_Test.test_dir_pseudoClass_functions_on_scene_effective_orientation_not_node
Node_effectiveOrientation_Css_Test.test_SimpleSelector_dir_pseudoClass_with_scene_effective_orientation_rtl
```





---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388304](https://bugs.openjdk.org/browse/JDK-8388304): Scene.setNodeOrientation triggers instant CSS but also doesn't update properly (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2213/head:pull/2213` \
`$ git checkout pull/2213`

Update a local copy of the PR: \
`$ git checkout pull/2213` \
`$ git pull https://git.openjdk.org/jfx.git pull/2213/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2213`

View PR using the GUI difftool: \
`$ git pr show -t 2213`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2213.diff">https://git.openjdk.org/jfx/pull/2213.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2213#issuecomment-5682938440)
</details>
