### PR TITLE
8339270: GHA: build on Linux / aarch64

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -155,9 +155,9 @@ jobs:
     env:
       # FIXME: read this information from a property file
       # BOOT_JDK_VERSION: "${{ fromJson(needs.prerequisites.outputs.dependencies).BOOT_JDK_VERSION }}"
-      # BOOT_JDK_FILENAME: "${{ fromJson(needs.prerequisites.outputs.dependencies).LINUX_X64_BOOT_JDK_FILENAME }}"
-      # BOOT_JDK_URL: "${{ fromJson(needs.prerequisites.outputs.dependencies).LINUX_X64_BOOT_JDK_URL }}"
-      # BOOT_JDK_SHA256: "${{ fromJson(needs.prerequisites.outputs.dependencies).LINUX_X64_BOOT_JDK_SHA256 }}"
+      # BOOT_JDK_FILENAME: "${{ fromJson(needs.prerequisites.outputs.dependencies).LINUX_AARCH64_BOOT_JDK_FILENAME }}"
+      # BOOT_JDK_URL: "${{ fromJson(needs.prerequisites.outputs.dependencies).LINUX_AARCH64_BOOT_JDK_URL }}"
+      # BOOT_JDK_SHA256: "${{ fromJson(needs.prerequisites.outputs.dependencies).LINUX_AARCH64_BOOT_JDK_SHA256 }}"
       BOOT_JDK_VERSION: "25.0.1"
       BOOT_JDK_FILENAME: "jdk-25.0.1_linux-aarch64_bin.tar.gz"
       BOOT_JDK_URL: "https://download.oracle.com/java/25/archive/jdk-25.0.1_linux-aarch64_bin.tar.gz"

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -147,6 +147,90 @@ jobs:
           bash gradlew --info --continue -PTEST_ONLY=true test -x :web:test
 
 
+  linux_aarch64_build:
+    name: Linux aarch64
+    needs: validation
+    runs-on: "ubuntu-24.04-arm"
+
+    env:
+      # FIXME: read this information from a property file
+      # BOOT_JDK_VERSION: "${{ fromJson(needs.prerequisites.outputs.dependencies).BOOT_JDK_VERSION }}"
+      # BOOT_JDK_FILENAME: "${{ fromJson(needs.prerequisites.outputs.dependencies).LINUX_X64_BOOT_JDK_FILENAME }}"
+      # BOOT_JDK_URL: "${{ fromJson(needs.prerequisites.outputs.dependencies).LINUX_X64_BOOT_JDK_URL }}"
+      # BOOT_JDK_SHA256: "${{ fromJson(needs.prerequisites.outputs.dependencies).LINUX_X64_BOOT_JDK_SHA256 }}"
+      BOOT_JDK_VERSION: "25.0.1"
+      BOOT_JDK_FILENAME: "jdk-25.0.1_linux-aarch64_bin.tar.gz"
+      BOOT_JDK_URL: "https://download.oracle.com/java/25/archive/jdk-25.0.1_linux-aarch64_bin.tar.gz"
+      # ANT_DIR: "apache-ant-1.10.5"
+      # ANT_FILENAME: "apache-ant-1.10.5.tar.gz"
+      # ANT_URL: "https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.5-bin.tar.gz"
+
+    steps:
+      - name: Checkout the source
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          path: jfx
+
+      - name: Install dependencies
+        run: |
+          set -x
+          sudo apt-get update
+          sudo apt-get install ant libgl1-mesa-dev libx11-dev libxxf86vm-dev libxt-dev pkg-config libgtk2.0-dev libgtk-3-dev libxtst-dev gcc-14 g++-14
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 100 --slave /usr/bin/g++ g++ /usr/bin/g++-14
+          mkdir -p "${HOME}/build-tools"
+          # wget -O "${HOME}/build-tools/${ANT_FILENAME}" "${ANT_URL}"
+          # tar -zxf "${HOME}/build-tools/${ANT_FILENAME}" -C "${HOME}/build-tools"
+
+# FIXME: enable cache for boot JDK
+#      - name: Restore boot JDK from cache
+#        id: bootjdk
+#        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+#        with:
+#          path: ~/bootjdk/${{ env.BOOT_JDK_VERSION }}
+#          key: bootjdk-${{ runner.os }}-${{ env.BOOT_JDK_VERSION }}-${{ env.BOOT_JDK_SHA256 }}-v1
+
+      - name: Download boot JDK
+        run: |
+          set -x
+          mkdir -p "${HOME}/bootjdk"
+          wget -O "${HOME}/bootjdk/${BOOT_JDK_FILENAME}" "${BOOT_JDK_URL}"
+          # FIXME: sha256sum
+          tar -xf "${HOME}/bootjdk/${BOOT_JDK_FILENAME}" -C "${HOME}/bootjdk"
+          # FIXME: enable cache for boot JDK
+
+      - name: Setup environment
+        run: |
+          set -x
+          export JAVA_HOME="${HOME}/bootjdk/jdk-${BOOT_JDK_VERSION}"
+          echo "JAVA_HOME=${JAVA_HOME}" >> "${GITHUB_ENV}"
+          # export ANT_HOME="${HOME}/build-tools/${ANT_DIR}"
+          # echo "ANT_HOME=${ANT_HOME}" >> "${GITHUB_ENV}"
+          # export PATH="$JAVA_HOME/bin:$ANT_HOME/bin:$PATH"
+          export PATH="$JAVA_HOME/bin:$PATH"
+          env | sort
+          which java
+          java -version
+          which ant
+          ant -version
+          gcc -v
+
+      - name: Build JavaFX artifacts
+        working-directory: jfx
+        run: |
+          set -x
+          # export PATH="$JAVA_HOME/bin:$ANT_HOME/bin:$PATH"
+          export PATH="$JAVA_HOME/bin:$PATH"
+          bash gradlew -version
+          bash gradlew --info all
+
+      - name: Run JavaFX headless tests
+        working-directory: jfx
+        run: |
+          set -x
+          # export PATH="$JAVA_HOME/bin:$ANT_HOME/bin:$PATH"
+          export PATH="$JAVA_HOME/bin:$PATH"
+          bash gradlew --info --continue -PTEST_ONLY=true test -x :web:test
+
   macos_x64_build:
     name: macOS x64
     needs: validation


### PR DESCRIPTION
Adding Linux aarch64 in GHA build. The required change is very minor.
Similar to difference between macOS x64 and aarch64, the linux x64 and aarch64 differ in,
- name
- runs-on platform name
- BOOT_JDK_FILENAME
- BOOT_JDK_URL

Verification:
- The GHA build completed successfully on Linux aarch64 platform
- The build log is as expected, with a few differences in the timestamp, hashes, gradle thread names, etc.


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8339270](https://bugs.openjdk.org/browse/JDK-8339270): GHA: build on Linux / aarch64 (**Enhancement** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2214/head:pull/2214` \
`$ git checkout pull/2214`

Update a local copy of the PR: \
`$ git checkout pull/2214` \
`$ git pull https://git.openjdk.org/jfx.git pull/2214/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2214`

View PR using the GUI difftool: \
`$ git pr show -t 2214`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2214.diff">https://git.openjdk.org/jfx/pull/2214.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2214#issuecomment-4980100666)
</details>
