### PR TITLE
8388313: ContextMenu.show(node, side,x, y) evaluates CSS multiple times.

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ContextMenu.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ContextMenu.java
@@ -25,6 +25,8 @@
 
 package javafx.scene.control;
 
+import javafx.geometry.Bounds;
+import javafx.geometry.NodeOrientation;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.ObjectPropertyBase;
 import javafx.collections.ListChangeListener.Change;
@@ -44,6 +46,7 @@ import com.sun.javafx.beans.IDProperty;
 import com.sun.javafx.collections.TrackableObservableList;
 import com.sun.javafx.tk.Toolkit;
 import com.sun.javafx.util.Utils;
+import com.sun.javafx.stage.PopupWindowHelper;
 
 /**
  * <p>
@@ -249,10 +252,9 @@ public class ContextMenu extends PopupControl {
         if (anchor == null) return;
         if (getItems().size() == 0) return;
 
-        getScene().setNodeOrientation(anchor.getEffectiveNodeOrientation());
-        if (getScene().getStylesheets().isEmpty()) {
-            getScene().getStylesheets().setAll(anchor.getScene().getStylesheets());
-        }
+        PopupWindowHelper.ownerWindow(this).set(anchor.getScene().getWindow());
+        PopupWindowHelper.ownerNode(this).set(anchor);
+        PopupWindowHelper.applyStylesheetFromOwner(this, anchor.getScene().getWindow());
 
         HPos hpos = side == Side.LEFT ? HPos.LEFT : side == Side.RIGHT ? HPos.RIGHT : HPos.CENTER;
         VPos vpos = side == Side.TOP ? VPos.TOP : side == Side.BOTTOM ? VPos.BOTTOM : VPos.CENTER;

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ContextMenu.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ContextMenu.java
@@ -255,6 +255,7 @@ public class ContextMenu extends PopupControl {
         PopupWindowHelper.ownerWindow(this).set(anchor.getScene().getWindow());
         PopupWindowHelper.ownerNode(this).set(anchor);
         PopupWindowHelper.applyStylesheetFromOwner(this, anchor.getScene().getWindow());
+        getScene().setNodeOrientation(anchor.getEffectiveNodeOrientation());
 
         HPos hpos = side == Side.LEFT ? HPos.LEFT : side == Side.RIGHT ? HPos.RIGHT : HPos.CENTER;
         VPos vpos = side == Side.TOP ? VPos.TOP : side == Side.BOTTOM ? VPos.BOTTOM : VPos.CENTER;

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ContextMenuTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ContextMenuTest.java
@@ -36,6 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
 import javafx.css.PseudoClass;
 import javafx.event.ActionEvent;
 import javafx.event.EventHandler;
@@ -51,6 +52,7 @@ import javafx.scene.control.DialogPane;
 import javafx.scene.control.Label;
 import javafx.scene.control.Menu;
 import javafx.scene.control.MenuItem;
+import javafx.scene.control.skin.ButtonSkin;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.scene.input.KeyCode;
@@ -64,8 +66,7 @@ import com.sun.javafx.scene.control.ContextMenuContentShim;
 import test.com.sun.javafx.scene.control.infrastructure.KeyEventFirer;
 import test.com.sun.javafx.scene.control.infrastructure.MouseEventFirer;
 import test.com.sun.javafx.scene.control.infrastructure.StageLoader;
-import javafx.scene.control.skin.ButtonSkin;
-import java.util.concurrent.atomic.AtomicInteger;
+import test.javafx.scene.CssStyleHelperTest;
 
 public class ContextMenuTest {
 
@@ -697,16 +698,16 @@ public class ContextMenuTest {
         assertEquals(anchorBounds.getMinY(), cmBounds.getMinY(), 0.0);
     }
 
-    @Test public void test_css_skin_counter() {
-        anchorBtn.getScene().getStylesheets().add(
-                getClass().getResource("test_css_skin_counter.css").toExternalForm()
-        );
+    @Test public void testCssProcessedOnlyOnce() {
+        String css = """
+            .button { -fx-skin: "test.javafx.scene.control.ContextMenuTest$ButtonSkin1"; }
+            .anchor .button { -fx-skin: "st.javafx.scene.control.ContextMenuTest$ButtonSkin2"; }
+            """;
+        anchorBtn.getScene().getStylesheets().add(CssStyleHelperTest.toDataURL(css));
         anchorBtn.getStyleClass().add("anchor");
         AtomicInteger skinCounter = new AtomicInteger(0);
         Button button = new Button();
-        button.skinProperty().subscribe(skin -> {
-            System.out.println("new Skin: " + skin);
-            new Exception().printStackTrace();
+        button.skinProperty().subscribe((oldSkin, newSkin) -> {
             skinCounter.incrementAndGet();
         });
         menuItem.setGraphic(button);
@@ -719,10 +720,8 @@ public class ContextMenuTest {
 
         assertEquals(anchorBounds.getMinX(), cmBounds.getMinX(), 0.0);
         assertEquals(anchorBounds.getMinY(), cmBounds.getMaxY(), 0.0);
-
-        assertEquals(2, skinCounter.get());
+        assertEquals(1, skinCounter.get());
     }
-
 
     @Test public void test_position_withCSS() {
         anchorBtn.getScene().getStylesheets().add(

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ContextMenuTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ContextMenuTest.java
@@ -64,6 +64,8 @@ import com.sun.javafx.scene.control.ContextMenuContentShim;
 import test.com.sun.javafx.scene.control.infrastructure.KeyEventFirer;
 import test.com.sun.javafx.scene.control.infrastructure.MouseEventFirer;
 import test.com.sun.javafx.scene.control.infrastructure.StageLoader;
+import javafx.scene.control.skin.ButtonSkin;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class ContextMenuTest {
 
@@ -695,6 +697,32 @@ public class ContextMenuTest {
         assertEquals(anchorBounds.getMinY(), cmBounds.getMinY(), 0.0);
     }
 
+    @Test public void test_css_skin_counter() {
+        anchorBtn.getScene().getStylesheets().add(
+                getClass().getResource("test_css_skin_counter.css").toExternalForm()
+        );
+        anchorBtn.getStyleClass().add("anchor");
+        AtomicInteger skinCounter = new AtomicInteger(0);
+        Button button = new Button();
+        button.skinProperty().subscribe(skin -> {
+            System.out.println("new Skin: " + skin);
+            new Exception().printStackTrace();
+            skinCounter.incrementAndGet();
+        });
+        menuItem.setGraphic(button);
+        ContextMenu cm = createContextMenu(false);
+        cm.show(anchorBtn, Side.TOP, 0, 0);
+
+        Bounds anchorBounds = anchorBtn.localToScreen(anchorBtn.getLayoutBounds());
+        Node cmNode = cm.getScene().getRoot();
+        Bounds cmBounds = cm.getScene().getRoot().localToScreen(cmNode.getLayoutBounds());
+
+        assertEquals(anchorBounds.getMinX(), cmBounds.getMinX(), 0.0);
+        assertEquals(anchorBounds.getMinY(), cmBounds.getMaxY(), 0.0);
+
+        assertEquals(2, skinCounter.get());
+    }
+
 
     @Test public void test_position_withCSS() {
         anchorBtn.getScene().getStylesheets().add(
@@ -774,5 +802,12 @@ public class ContextMenuTest {
         assertEquals(0, padding.getBottom(), 0.0);
         assertEquals(0, padding.getLeft(), 0.0);
         anchorBtn.setGraphic(null);
+    }
+
+    public static class ButtonSkin1 extends ButtonSkin {
+        public ButtonSkin1(Button button) { super(button); }
+    }
+    public static class ButtonSkin2 extends ButtonSkin {
+        public ButtonSkin2(Button button) { super(button); }
     }
 }

--- a/modules/javafx.controls/src/test/resources/test/javafx/scene/control/test_css_skin_counter.css
+++ b/modules/javafx.controls/src/test/resources/test/javafx/scene/control/test_css_skin_counter.css
@@ -1,0 +1,2 @@
+.button { -fx-skin: "test.javafx.scene.control.ContextMenuTest$ButtonSkin1"; }
+.anchor .button { -fx-skin: "test.javafx.scene.control.ContextMenuTest$ButtonSkin2"; }

--- a/modules/javafx.controls/src/test/resources/test/javafx/scene/control/test_css_skin_counter.css
+++ b/modules/javafx.controls/src/test/resources/test/javafx/scene/control/test_css_skin_counter.css
@@ -1,2 +1,0 @@
-.button { -fx-skin: "test.javafx.scene.control.ContextMenuTest$ButtonSkin1"; }
-.anchor .button { -fx-skin: "test.javafx.scene.control.ContextMenuTest$ButtonSkin2"; }

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/stage/PopupWindowHelper.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/stage/PopupWindowHelper.java
@@ -27,6 +27,7 @@ package com.sun.javafx.stage;
 
 import com.sun.javafx.util.Utils;
 import javafx.collections.ObservableList;
+import javafx.beans.property.ReadOnlyObjectWrapper;
 import javafx.scene.Node;
 import javafx.stage.PopupWindow;
 import javafx.stage.Window;
@@ -67,6 +68,14 @@ public class PopupWindowHelper extends WindowHelper {
         popupWindowAccessor.applyStylesheetFromOwner(popupWindow, owner);
     }
 
+    public static ReadOnlyObjectWrapper<Window> ownerWindow(PopupWindow popupWindow) {
+        return popupWindowAccessor.ownerWindow(popupWindow);
+    }
+
+    public static ReadOnlyObjectWrapper<Node> ownerNode(PopupWindow popupWindow) {
+        return popupWindowAccessor.ownerNode(popupWindow);
+    }
+
     public static ObservableList<Node> getContent(PopupWindow popupWindow) {
         return popupWindowAccessor.getContent(popupWindow);
     }
@@ -84,5 +93,7 @@ public class PopupWindowHelper extends WindowHelper {
         void doVisibleChanging(Window window, boolean visible);
         void doVisibleChanged(Window window, boolean visible);
         void applyStylesheetFromOwner(PopupWindow popupWindow, Window owner);
+        ReadOnlyObjectWrapper<Window> ownerWindow(PopupWindow popupWindow);
+        ReadOnlyObjectWrapper<Node> ownerNode(PopupWindow popupWindow);
     }
 }

--- a/modules/javafx.graphics/src/main/java/javafx/stage/PopupWindow.java
+++ b/modules/javafx.graphics/src/main/java/javafx/stage/PopupWindow.java
@@ -121,6 +121,16 @@ public abstract class PopupWindow extends Window {
             public void applyStylesheetFromOwner(PopupWindow popupWindow, Window owner) {
                 popupWindow.applyStylesheetFromOwner(owner);
             }
+
+            @Override
+            public ReadOnlyObjectWrapper<Window> ownerWindow(PopupWindow popupWindow) {
+                return popupWindow.ownerWindow;
+            }
+
+            @Override
+            public ReadOnlyObjectWrapper<Node> ownerNode(PopupWindow popupWindow) {
+                return popupWindow.ownerNode;
+            }
         });
     }
 

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/CssStyleHelperTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/CssStyleHelperTest.java
@@ -965,7 +965,7 @@ public class CssStyleHelperTest {
         assertEquals(List.of(1.0, 2.0, 1.5, 1.0), trace);
     }
 
-    private static String toDataURL(String stylesheet) {
+    public static String toDataURL(String stylesheet) {
         return "data:text/plain;base64," + Base64.getEncoder().encodeToString(stylesheet.getBytes(StandardCharsets.UTF_8));
     }
 }


### PR DESCRIPTION
When ContextMenu.show(node, side, x, y) is executed, the CSS is evaluated multiple times.
Of these 3 times, 2 process a non-final CSS state.
This leads to temporary, unnecessary changes.

This is fixed by properly defining the stylesheets and the ownerWindow/ownerNode properties of the context menu
before applyCss is called. The previous solution was incomplete and resulted in unnecessary CSS calls.

Slightly related to my other PR: https://github.com/openjdk/jfx/pull/2213
But it is fixed in a way that works independently of it.

---------
- [ ] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Error
&nbsp;⚠️ Pull request body is missing required line: `- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).`

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8388313](https://bugs.openjdk.org/browse/JDK-8388313)

### Warning
&nbsp;⚠️ Found trailing period in issue title for `8388313: ContextMenu.show(node, side,x, y) evaluates CSS multiple times.`

### Issue
 * [JDK-8388313](https://bugs.openjdk.org/browse/JDK-8388313): ContextMenu.show(node, side,x, y) evaluates CSS multiple times (**Bug** - P4) ⚠️ Title mismatch between PR and JBS.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2215/head:pull/2215` \
`$ git checkout pull/2215`

Update a local copy of the PR: \
`$ git checkout pull/2215` \
`$ git pull https://git.openjdk.org/jfx.git pull/2215/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2215`

View PR using the GUI difftool: \
`$ git pr show -t 2215`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2215.diff">https://git.openjdk.org/jfx/pull/2215.diff</a>

</details>
