### PR TITLE
8360587: Gradle Configuration message: Cannot infer source root(s) for source

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2444,9 +2444,9 @@ project(":graphics") {
 
         classpath = configurations.compileClasspath
 
-        source = project.sourceSets.main.java.srcDirs
-        source += "$buildDir/gensrc/java"
-        source += project.sourceSets.shaders.output
+        source project.sourceSets.main.java.srcDirs
+        source "$buildDir/gensrc/java"
+        source project.sourceSets.shaders.output
 
         destinationDirectory = project.sourceSets.main.java.destinationDirectory
         options.compilerArgs.addAll([


### PR DESCRIPTION
This is a very simple change for avoiding a warning repeated for 1570 times.

When JavaFX is built with `--info` gradle option, (`gradle --info` .... ).
1570 warnings are printed, like the one below here:
```
Cannot infer source root(s) for source `file '/Users/runner/work/jfx/jfx/jfx/modules/javafx.graphics/src/main/java/javafx/css/Size.java'`. Supported types are `File` (directories only), `DirectoryTree` and `SourceDirectorySet`.
```

**Fix**: is to change how the source directories are specified for graphics module.

**Verification**: 
0 warnings of above type.
The build artifacts are exact same as before, and sanity testing is all good.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8360587](https://bugs.openjdk.org/browse/JDK-8360587): Gradle Configuration message: Cannot infer source root(s) for source (**Bug** - P4)


### Reviewers
 * [Marius Hanl](https://openjdk.org/census#mhanl) (@Maran23 - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2216/head:pull/2216` \
`$ git checkout pull/2216`

Update a local copy of the PR: \
`$ git checkout pull/2216` \
`$ git pull https://git.openjdk.org/jfx.git pull/2216/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2216`

View PR using the GUI difftool: \
`$ git pr show -t 2216`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2216.diff">https://git.openjdk.org/jfx/pull/2216.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2216#issuecomment-4987916590)
</details>
