### PR TITLE
8388786: [macOS] NSImage leak in GlassPasteboard.m when using images for dnd or clipboard operations

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassPasteboard.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassPasteboard.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -273,6 +273,7 @@ static inline void SetNSPasteboardItemValueForUtf(JNIEnv *env, NSPasteboardItem 
                 NSData *data = [image TIFFRepresentation];
                 [item setData:data forType: [utf isEqualToString:RAW_IMAGE_MIME] ? NSPasteboardTypeTIFF : DRAG_IMAGE_MIME];
                 //NSLog(@"                setData: %p, ForUtf: %@", data, utf);
+                [image release];
             }
         }
         else if ([utf isEqualToString:DRAG_IMAGE_OFFSET] == YES)


### PR DESCRIPTION
This PR releases the NSImage that `SetNSPasteboardItemValueForUtf()` in GlassPasteboard.m obtains from `getImage()` in GlassPixels.m. Once the pixel data is used, such image is not longer needed and has to be released, preventing a memory leak.

Similar operations in GlassCursor.m and GlassMenu.m that use the same NSImage allocation mechanism, did already release the image in this very same way, so this PR just adds the missing release call to GlassPasteboard.m. 

There are no tests included, since this is a pure native objective-c memory leak (retained NSImages), and it can't be tracked down from the Java side, but I have tested manually with Instruments and the Leaks template, with this code snippet in MacPasteboardTest:

```
private void pushImage() {
        int size = 512; 
        ByteBuffer buffer = ByteBuffer.allocate(size * size * 4);
        Pixels pixels = Application.GetApplication().createPixels(size, size, buffer);
        macPasteboardShim.pushMacPasteboard(new HashMap<>(Map.of(Clipboard.RAW_IMAGE_TYPE, pixels)));
    }
```
calling it repeatedly for some time. 

Before the fix:

<img width="1236" height="168" alt="image" src="https://github.com/user-attachments/assets/62cf81a1-fd77-46a4-bce6-8575109d2dd2" />

as shown, the leaks are in `getImage` from libglass.dylib, that allocates a `NSImage`  with a `CGImage` (including same amount of internal data, providers, arrays, snapshots objects).

After the fix the leaks are gone:

<img width="1049" height="134" alt="image" src="https://github.com/user-attachments/assets/e9049674-3f4d-42ab-83ad-66601ea337a1" />

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388786](https://bugs.openjdk.org/browse/JDK-8388786): [macOS] NSImage leak in GlassPasteboard.m when using images for dnd or clipboard operations (**Bug** - P4)


### Reviewers
 * [Martin Fox](https://openjdk.org/census#mfox) (@beldenfox - Committer)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2222/head:pull/2222` \
`$ git checkout pull/2222`

Update a local copy of the PR: \
`$ git checkout pull/2222` \
`$ git pull https://git.openjdk.org/jfx.git pull/2222/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2222`

View PR using the GUI difftool: \
`$ git pr show -t 2222`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2222.diff">https://git.openjdk.org/jfx/pull/2222.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2222#issuecomment-5069562713)
</details>
