### PR TITLE
8388526: [Windows] Crash in Platform.Preferences refresh on OS theme change when using FXCanvas

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/win/PlatformSupport.h
+++ b/modules/javafx.graphics/src/main/native-glass/win/PlatformSupport.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -70,7 +70,7 @@ public:
 
 private:
     JNIEnv* env;
-    jobject application;
+    JGlobalRef<jobject> application;
     bool initialized;
     Microsoft::WRL::ComPtr<ABI::Windows::UI::ViewManagement::IUISettings> settings;
     ABI::Windows::Networking::Connectivity::INetworkInformationStatics* networkInformation;


### PR DESCRIPTION
On Windows, changing a system preference such as the light/dark color mode can crash an application that embeds JavaFX in SWT using `FXCanvas`.

`GlassApplication` receives the Java `WinApplication` instance as the local JNI reference `jrefThis`. It passes this reference to `PlatformSupport` and separately creates a global reference for `m_grefThis`:
```cpp
GlassApplication::GlassApplication(jobject jrefThis) : BaseWnd(), m_platformSupport(GetEnv(), jrefThis)
{
    m_grefThis = GetEnv()->NewGlobalRef(jrefThis);
    ...
}
```

Creating `m_grefThis` does not promote the original reference. `NewGlobalRef` returns a new handle, while the copy retained by `PlatformSupport` remains a local JNI reference. That local reference becomes invalid when the native method invocation returns.

Using an invalid JNI reference is undefined behavior. Depending on the state of the reused local-reference slot, the result can be a `NullPointerException` without Java frames or an access violation inside the JVM.

This change stores the application reference as a `JGlobalRef<jobject>`, which creates an independent global JNI reference while the input local reference is still valid.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388526](https://bugs.openjdk.org/browse/JDK-8388526): [Windows] Crash in Platform.Preferences refresh on OS theme change when using FXCanvas (**Bug** - P3)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Lukasz Kostyra](https://openjdk.org/census#lkostyra) (@lukostyra - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2226/head:pull/2226` \
`$ git checkout pull/2226`

Update a local copy of the PR: \
`$ git checkout pull/2226` \
`$ git pull https://git.openjdk.org/jfx.git pull/2226/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2226`

View PR using the GUI difftool: \
`$ git pr show -t 2226`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2226.diff">https://git.openjdk.org/jfx/pull/2226.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2226#issuecomment-5109893730)
</details>
