### PR TITLE
8389093: Typos in the JavaFX CSS Reference Guide

### DIFF
--- a/modules/javafx.graphics/src/main/docs/javafx/scene/doc-files/cssref.html
+++ b/modules/javafx.graphics/src/main/docs/javafx/scene/doc-files/cssref.html
@@ -485,7 +485,7 @@
     </p>
     <p>
       The structure of this document is as follows. First, there is a
-      description of all value types for JavaFX CSS properties.Where
+      description of all value types for JavaFX CSS properties. Where
       appropriate, this includes a grammar for the syntax of values of that
       type. Then, for each scene&#8209;graph node that supports CSS styles, a table is
       given that lists the properties that are supported, along with type and
@@ -596,7 +596,7 @@
         Beginning with JavaFX 2.1, the Parent class has a
         <a href="../../../javafx/scene/Parent.html#getStylesheets--">getStylesheets</a> property,
         allowing style sheets to be set on a container. This allows for one branch
-        of of the scene&#8209;graph to have a distinct set of styles. Any instance of
+        of the scene&#8209;graph to have a distinct set of styles. Any instance of
         Parent can have style sheets. A child will take its styles from its own
         inline styles, the style sheets of all its ancestors, and any style sheets
         from the Scene.
@@ -1260,7 +1260,7 @@
     <p>If the <span class="grammar">&lt;address&gt;</span> does not have a [scheme:] component, the <span class="grammar">&lt;address&gt;</span>
         is considered to be the [path] component only.
         A leading '/' character indicates that the [path] is relative to the
-        root of the classpath. If the the style appears in a stylesheet and
+        root of the classpath. If the style appears in a stylesheet and
         has no leading '/' character, the path is relative to the base URI of
         the stylesheet. If the style appears in an inline style, the path is
         relative to the root of the classpath (regardless of whether or not
@@ -1762,7 +1762,7 @@
       feature, as it allows a generic palette of colors to be specified on the
       scene then used throughout the application. If you want to change one of
       those palette colors you can do so at any level in the scene tree and it
-      will affect that node and all its decendents. Looked-up colors are not
+      will affect that node and all its descendants. Looked-up colors are not
       looked up until they are applied, so they are live and react to any style
       changes that might occur, such as replacing a palette color at runtime
       with the "style" property on a node.</p>
@@ -1912,7 +1912,7 @@
     <p class="grammar">linear | &lt;linear-easing-function&gt; | &lt;cubic-bezier-easing-function&gt; | &lt;step-easing-function&gt; | &lt;fx-easing-function&gt;</p>
     <p><strong>Linear</strong> <span class="grammar" style="font-size: smaller;">linear</span><br>
        The linear easing keyword is a simple linear mapping from the input progress value to the output progress value.<br>
-       It it equivalent to <span class="grammar">linear(0, 1)</span></p>
+       It is equivalent to <span class="grammar">linear(0, 1)</span></p>
     <figure style="display: inline-block">
         <img src="easing-linear.svg" width="200" alt="Linear easing function">
     </figure>
@@ -1966,7 +1966,7 @@
     <p>A cubic Bézier function is defined by four control points, where P0 is fixed at (0,0) and P3 is fixed at (1,1).
        P1 and P2 are restricted to the interval [0,1] on the input progress axis:</p>
     <figure style="display: inline-block">
-        <img src="easing-cubicbezier.svg" width="200" alt="Cubic Bèzier easing function">
+        <img src="easing-cubicbezier.svg" width="200" alt="Cubic Bézier easing function">
     </figure>
     <p><strong>Step Easing Functions</strong> <span class="grammar" style="font-size: smaller;">&lt;step-easing-function&gt;</span></p>
     <p class="grammar">step-start | step-end | steps(<a href="#typenumber" class="typelink">&lt;integer&gt;</a>[,&lt;step-position&gt;]?)</p>
@@ -2046,7 +2046,7 @@
         </tr>
         <tr>
             <td style="width: 120px; vertical-align: top"><span class="grammar">-fx-ease-both</span></td>
-            <td>SMIL 3.0 ease-in/out function with an acceleration and decelaration factor of 0.2</td>
+            <td>SMIL 3.0 ease-in/out function with an acceleration and deceleration factor of 0.2</td>
         </tr>
     </table>
     <p>These functions are provided for compatibility with <code>javafx.animation.Interpolator</code>
@@ -5272,7 +5272,7 @@
         </tr>
         <tr>
         <th class="propertyname" scope="row">right</th>
-          <td>applies if the side is rght</td>
+          <td>applies if the side is right</td>
         </tr>
         <tr>
         <th class="propertyname" scope="row">bottom</th>


### PR DESCRIPTION
Fixed:

- typos
- repeating words (of of, the the, ...)
- missing whitespace
- accented Bézier in the headings (but not in the text, keeping "bezier")

This can probably be backported to jfx27.


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8389093](https://bugs.openjdk.org/browse/JDK-8389093): Typos in the JavaFX CSS Reference Guide (**Bug** - P4)(⚠️ The fixVersion in this issue is [jfx27] but the fixVersion in .jcheck/conf is jfx28, a new backport will be created when this pr is integrated.)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2228/head:pull/2228` \
`$ git checkout pull/2228`

Update a local copy of the PR: \
`$ git checkout pull/2228` \
`$ git pull https://git.openjdk.org/jfx.git pull/2228/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2228`

View PR using the GUI difftool: \
`$ git pr show -t 2228`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2228.diff">https://git.openjdk.org/jfx/pull/2228.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2228#issuecomment-5122185151)
</details>
