### PR TITLE
8389371: cssref: explain font properties

### DIFF
--- a/modules/javafx.graphics/src/main/docs/javafx/scene/doc-files/cssref.html
+++ b/modules/javafx.graphics/src/main/docs/javafx/scene/doc-files/cssref.html
@@ -1423,14 +1423,16 @@
       <span class="grammar">[[ &lt;font-style&gt; || &lt;font-weight&gt; ]?
         &lt;font-size&gt; &lt;font-family&gt; ]</span></p>
     <h4><a id="fontprops">Font Properties</a></h4>
-    <p>Most classes that use text will support the following font properties. In
-      some cases a similar set of properties will be supported but with a
-      different prefix instead of "-fx-font".</p>
+    <p>Most classes that use text will support the following font properties.</p>
+    <p>Additionally, any property whose suffix matches an entry in the table below will be treated
+        as the corresponding font property.<br>Example: "-fx-tick-label-font" or "custom-font-weight".
+    </p>
     <table class="csspropertytable">
     <caption>Available CSS Properties</caption>
       <thead>
         <tr>
         <th class="propertyname" scope="col">CSS Property</th>
+        <th class="propertyname" scope="col">Suffix</th>
         <th class="value" scope="col">Values</th>
         <th scope="col">Default</th>
         <th scope="col">Comments</th>
@@ -1439,6 +1441,7 @@
       <tbody>
         <tr>
         <th class="propertyname" scope="row">-fx-font</th>
+          <td>font</td>
           <td class="value"><a href="#typefont" class="typelink">&lt;font&gt;</a></td>
           <td>inherit</td>
           <td>shorthand property for font-size, font-family, font-weight and
@@ -1446,24 +1449,28 @@
         </tr>
         <tr>
         <th class="propertyname" scope="row">-fx-font-family</th>
+          <td>font-family</td>
           <td class="value"><a href="#typefont" class="typelink">&lt;font-family&gt;</a></td>
           <td>inherit</td>
           <td>&nbsp;</td>
         </tr>
         <tr>
         <th class="propertyname" scope="row">-fx-font-size</th>
+          <td>font-size</td>
           <td class="value"><a href="#typefont" class="typelink">&lt;font-size&gt;</a></td>
           <td>inherit</td>
           <td>&nbsp;</td>
         </tr>
         <tr>
         <th class="propertyname" scope="row">-fx-font-style</th>
+          <td>font-style</td>
           <td class="value"><a href="#typefont" class="typelink">&lt;font-style&gt;</a></td>
           <td>inherit</td>
           <td>&nbsp;</td>
         </tr>
         <tr>
         <th class="propertyname" scope="row">-fx-font-weight</th>
+          <td>font-weight</td>
           <td class="value"><a href="#typefont" class="typelink">&lt;font-weight&gt;</a></td>
           <td>inherit</td>
           <td>&nbsp;</td>

--- a/modules/javafx.graphics/src/main/docs/javafx/scene/doc-files/cssref.html
+++ b/modules/javafx.graphics/src/main/docs/javafx/scene/doc-files/cssref.html
@@ -1424,8 +1424,10 @@
         &lt;font-size&gt; &lt;font-family&gt; ]</span></p>
     <h4><a id="fontprops">Font Properties</a></h4>
     <p>Most classes that use text will support the following font properties.</p>
-    <p>Additionally, any property whose suffix matches an entry in the table below will be treated
-        as the corresponding font property.<br>Example: "-fx-tick-label-font" or "custom-font-weight".
+    <p>
+        Additionally, this treatment is extended to any font property whose suffix matches an entry in the table below.
+        <br>
+        Example: "-fx-tick-label-font" or "custom-font-weight".
     </p>
     <table class="csspropertytable">
     <caption>Available CSS Properties</caption>


### PR DESCRIPTION
Explains the logic applied to font properties.

<img width="796" height="254" alt="suggestion 2026-07-29 at 15 26 19" src="https://github.com/user-attachments/assets/542d46d1-1e24-495f-81c5-b07fdc0c05cd" />


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8389371](https://bugs.openjdk.org/browse/JDK-8389371): cssref: explain font properties (**Enhancement** - P4)(⚠️ The fixVersion in this issue is [jfx27] but the fixVersion in .jcheck/conf is jfx28, a new backport will be created when this pr is integrated.)


### Reviewers
 * [Marius Hanl](https://openjdk.org/census#mhanl) (@Maran23 - **Reviewer**)
 * [John Hendrikx](https://openjdk.org/census#jhendrikx) (@hjohn - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2230/head:pull/2230` \
`$ git checkout pull/2230`

Update a local copy of the PR: \
`$ git checkout pull/2230` \
`$ git pull https://git.openjdk.org/jfx.git pull/2230/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2230`

View PR using the GUI difftool: \
`$ git pr show -t 2230`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2230.diff">https://git.openjdk.org/jfx/pull/2230.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2230#issuecomment-5124147254)
</details>
