### PR TITLE
8389371: cssref: explain font properties

### DIFF
--- a/modules/javafx.graphics/src/main/docs/javafx/scene/doc-files/cssref.html
+++ b/modules/javafx.graphics/src/main/docs/javafx/scene/doc-files/cssref.html
@@ -1423,14 +1423,18 @@
       <span class="grammar">[[ &lt;font-style&gt; || &lt;font-weight&gt; ]?
         &lt;font-size&gt; &lt;font-family&gt; ]</span></p>
     <h4><a id="fontprops">Font Properties</a></h4>
-    <p>Most classes that use text will support the following font properties. In
-      some cases a similar set of properties will be supported but with a
-      different prefix instead of "-fx-font".</p>
+    <p>Most classes that use text will support the following font properties.</p>
+    <p>
+        Additionally, this treatment is extended to any font property whose suffix matches an entry in the table below.
+        <br>
+        Example: "-fx-tick-label-font" or "custom-font-weight".
+    </p>
     <table class="csspropertytable">
     <caption>Available CSS Properties</caption>
       <thead>
         <tr>
         <th class="propertyname" scope="col">CSS Property</th>
+        <th class="propertyname" scope="col">Suffix</th>
         <th class="value" scope="col">Values</th>
         <th scope="col">Default</th>
         <th scope="col">Comments</th>
@@ -1439,6 +1443,7 @@
       <tbody>
         <tr>
         <th class="propertyname" scope="row">-fx-font</th>
+          <td>font</td>
           <td class="value"><a href="#typefont" class="typelink">&lt;font&gt;</a></td>
           <td>inherit</td>
           <td>shorthand property for font-size, font-family, font-weight and
@@ -1446,24 +1451,28 @@
         </tr>
         <tr>
         <th class="propertyname" scope="row">-fx-font-family</th>
+          <td>font-family</td>
           <td class="value"><a href="#typefont" class="typelink">&lt;font-family&gt;</a></td>
           <td>inherit</td>
           <td>&nbsp;</td>
         </tr>
         <tr>
         <th class="propertyname" scope="row">-fx-font-size</th>
+          <td>font-size</td>
           <td class="value"><a href="#typefont" class="typelink">&lt;font-size&gt;</a></td>
           <td>inherit</td>
           <td>&nbsp;</td>
         </tr>
         <tr>
         <th class="propertyname" scope="row">-fx-font-style</th>
+          <td>font-style</td>
           <td class="value"><a href="#typefont" class="typelink">&lt;font-style&gt;</a></td>
           <td>inherit</td>
           <td>&nbsp;</td>
         </tr>
         <tr>
         <th class="propertyname" scope="row">-fx-font-weight</th>
+          <td>font-weight</td>
           <td class="value"><a href="#typefont" class="typelink">&lt;font-weight&gt;</a></td>
           <td>inherit</td>
           <td>&nbsp;</td>


### PR DESCRIPTION
This pull request contains a backport of commit [038d790c](https://urldefense.com/v3/__https://github.com/openjdk/jfx/commit/038d790c38f9c2b9dd09950ccb6629213f184bab__;!!ACWV5N9M2RV99hQ!ISh2-88X-vFxmFQJf4x2SskIQoAvCk2kH6KNGiftDycDTpyNGhqb6a--xNF-_805zl6YrvpJcajSi_O5b5A8_2zVVFNIYA$) from the [openjdk/jfx](https://git.openjdk.org/jfx) repository.

The commit being backported was authored by Andy Goryachev on 31 Jul 2026 and was reviewed by Marius Hanl, John Hendrikx and Kevin Rushforth.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8389371](https://bugs.openjdk.org/browse/JDK-8389371): cssref: explain font properties (**Enhancement** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2233/head:pull/2233` \
`$ git checkout pull/2233`

Update a local copy of the PR: \
`$ git checkout pull/2233` \
`$ git pull https://git.openjdk.org/jfx.git pull/2233/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2233`

View PR using the GUI difftool: \
`$ git pr show -t 2233`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2233.diff">https://git.openjdk.org/jfx/pull/2233.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2233#issuecomment-5144713130)
</details>
