### PR TITLE
8389515: Memory leak in dshowwrapper - decoded buffers delivered by CSink are never unmapped

### DIFF
--- a/modules/javafx.media/src/main/native/gstreamer/plugins/dshowwrapper/Allocator.cpp
+++ b/modules/javafx.media/src/main/native/gstreamer/plugins/dshowwrapper/Allocator.cpp
@@ -55,20 +55,29 @@ HRESULT CAllocator::GetBuffer(IMediaSample **ppBuffer, REFERENCE_TIME *pStartTim
     if (FAILED(hr))
         return hr;
 
+    pSample = (CSample*)*ppBuffer;
+
     if (m_pBuffer == NULL)
     {
         if (GetGstBuffer != NULL)
             GetGstBuffer(&m_pBuffer, m_lSize, &m_UserData);
 
         if (m_pBuffer == NULL)
+        {
+            pSample->Release();
+            *ppBuffer = NULL;
             return E_FAIL;
+        }
     }
 
-    pSample = (CSample*)*ppBuffer;
     hr = pSample->SetGstBuffer(m_pBuffer);
     m_pBuffer = NULL;
     if (FAILED(hr))
+    {
+        pSample->Release();
+        *ppBuffer = NULL;
         return hr;
+    }
 
     return S_OK;
 }

--- a/modules/javafx.media/src/main/native/gstreamer/plugins/dshowwrapper/Allocator.cpp
+++ b/modules/javafx.media/src/main/native/gstreamer/plugins/dshowwrapper/Allocator.cpp
@@ -69,6 +69,7 @@ HRESULT CAllocator::GetBuffer(IMediaSample **ppBuffer, REFERENCE_TIME *pStartTim
         return hr;
 
     pSample->m_pGstBuffer = m_pBuffer;
+    pSample->m_pMappedGstBuffer = m_pBuffer;
     pSample->m_GstMapInfo = m_MapInfo;
 
     hr = pSample->SetPointer(m_MapInfo.data, m_MapInfo.size);
@@ -86,7 +87,11 @@ HRESULT CAllocator::ReleaseBuffer(IMediaSample *pBuffer)
     CSample *pSample = (CSample*)pBuffer;
     if (ReleaseSample != NULL)
     {
-        gst_buffer_unmap(pSample->m_pGstBuffer, &pSample->m_GstMapInfo);
+        if (pSample->m_pMappedGstBuffer != NULL)
+        {
+            gst_buffer_unmap(pSample->m_pMappedGstBuffer, &pSample->m_GstMapInfo);
+            pSample->m_pMappedGstBuffer = NULL;
+        }
         ReleaseSample(pSample->m_pGstBuffer, &m_UserData);
         pSample->m_pGstBuffer = NULL;
     }

--- a/modules/javafx.media/src/main/native/gstreamer/plugins/dshowwrapper/Allocator.cpp
+++ b/modules/javafx.media/src/main/native/gstreamer/plugins/dshowwrapper/Allocator.cpp
@@ -65,14 +65,7 @@ HRESULT CAllocator::GetBuffer(IMediaSample **ppBuffer, REFERENCE_TIME *pStartTim
     }
 
     pSample = (CSample*)*ppBuffer;
-    if (!gst_buffer_map(m_pBuffer, &m_MapInfo, GST_MAP_WRITE))
-        return hr;
-
-    pSample->m_pGstBuffer = m_pBuffer;
-    pSample->m_pMappedGstBuffer = m_pBuffer;
-    pSample->m_GstMapInfo = m_MapInfo;
-
-    hr = pSample->SetPointer(m_MapInfo.data, m_MapInfo.size);
+    hr = pSample->SetGstBuffer(m_pBuffer);
     m_pBuffer = NULL;
     if (FAILED(hr))
         return hr;
@@ -87,13 +80,11 @@ HRESULT CAllocator::ReleaseBuffer(IMediaSample *pBuffer)
     CSample *pSample = (CSample*)pBuffer;
     if (ReleaseSample != NULL)
     {
-        if (pSample->m_pMappedGstBuffer != NULL)
+        GstBuffer *pGstBuffer = pSample->TakeGstBuffer();
+        if (NULL != pGstBuffer)
         {
-            gst_buffer_unmap(pSample->m_pMappedGstBuffer, &pSample->m_GstMapInfo);
-            pSample->m_pMappedGstBuffer = NULL;
+            ReleaseSample(pGstBuffer, &m_UserData);
         }
-        ReleaseSample(pSample->m_pGstBuffer, &m_UserData);
-        pSample->m_pGstBuffer = NULL;
     }
 
     hr = CBaseAllocator::ReleaseBuffer(pBuffer);
@@ -186,4 +177,34 @@ STDMETHODIMP CAllocator::SetProperties(ALLOCATOR_PROPERTIES* pRequest, ALLOCATOR
     pActual->cbPrefix = m_lPrefix = pRequest->cbPrefix;
 
     return S_OK;
+}
+
+HRESULT CSample::SetGstBuffer(GstBuffer *pGstBuffer)
+{
+    if (NULL == pGstBuffer)
+    {
+        return E_FAIL;
+    }
+
+    m_pGstBuffer = pGstBuffer;
+
+    if (!gst_buffer_map(pGstBuffer, &m_GstMapInfo, GST_MAP_WRITE))
+    {
+        return E_FAIL;
+    }
+    m_bGstBufferMapped = true;
+
+    return SetPointer(m_GstMapInfo.data, m_GstMapInfo.size);
+}
+
+GstBuffer *CSample::TakeGstBuffer()
+{
+    GstBuffer *ret = m_pGstBuffer;
+    if (NULL != m_pGstBuffer && m_bGstBufferMapped)
+    {
+        gst_buffer_unmap(m_pGstBuffer, &m_GstMapInfo);
+    }
+    m_pGstBuffer = NULL;
+    m_bGstBufferMapped = false;
+    return ret;
 }

--- a/modules/javafx.media/src/main/native/gstreamer/plugins/dshowwrapper/Allocator.cpp
+++ b/modules/javafx.media/src/main/native/gstreamer/plugins/dshowwrapper/Allocator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.media/src/main/native/gstreamer/plugins/dshowwrapper/Allocator.h
+++ b/modules/javafx.media/src/main/native/gstreamer/plugins/dshowwrapper/Allocator.h
@@ -40,8 +40,14 @@ struct sUserData
 class CSample : public CMediaSample
 {
 public:
-    CSample(TCHAR *pName, CBaseAllocator *pAllocator, HRESULT *phr) : CMediaSample(pName, pAllocator, phr) { m_pGstBuffer = NULL; }
+    CSample(TCHAR *pName, CBaseAllocator *pAllocator, HRESULT *phr)
+        : CMediaSample(pName, pAllocator, phr)
+    {
+        m_pGstBuffer = NULL;
+        m_pMappedGstBuffer = NULL;
+    }
     GstBuffer *m_pGstBuffer;
+    GstBuffer *m_pMappedGstBuffer;
     GstMapInfo m_GstMapInfo;
 };
 

--- a/modules/javafx.media/src/main/native/gstreamer/plugins/dshowwrapper/Allocator.h
+++ b/modules/javafx.media/src/main/native/gstreamer/plugins/dshowwrapper/Allocator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.media/src/main/native/gstreamer/plugins/dshowwrapper/Allocator.h
+++ b/modules/javafx.media/src/main/native/gstreamer/plugins/dshowwrapper/Allocator.h
@@ -44,11 +44,16 @@ public:
         : CMediaSample(pName, pAllocator, phr)
     {
         m_pGstBuffer = NULL;
-        m_pMappedGstBuffer = NULL;
+        m_bGstBufferMapped = false;
     }
+
+    HRESULT SetGstBuffer(GstBuffer *pGstBuffer);
+    GstBuffer *TakeGstBuffer();
+
+private:
     GstBuffer *m_pGstBuffer;
-    GstBuffer *m_pMappedGstBuffer;
     GstMapInfo m_GstMapInfo;
+    bool m_bGstBufferMapped;
 };
 
 class CAllocator : public CBaseAllocator

--- a/modules/javafx.media/src/main/native/gstreamer/plugins/dshowwrapper/Allocator.h
+++ b/modules/javafx.media/src/main/native/gstreamer/plugins/dshowwrapper/Allocator.h
@@ -75,7 +75,6 @@ public:
 
 private:
     GstBuffer *m_pBuffer;
-    GstMapInfo m_MapInfo;
     sUserData m_UserData;
     void (*ReleaseSample)(GstBuffer *pBuffer, sUserData *pUserData);
     void (*GetGstBuffer)(GstBuffer **ppBuffer, long lSize, sUserData *pUserData); // This function will be called before GetBuffer() (before CBaseOutputPin::GetDeliveryBuffer()) if SetGstBuffer was not called

--- a/modules/javafx.media/src/main/native/gstreamer/plugins/dshowwrapper/Sink.cpp
+++ b/modules/javafx.media/src/main/native/gstreamer/plugins/dshowwrapper/Sink.cpp
@@ -389,8 +389,7 @@ HRESULT CSink::DoRenderSampleInternal(IMediaSample *pMediaSample)
     if (pSample == NULL)
         return S_FALSE;
 
-    pBuffer = pSample->m_pGstBuffer;
-    pSample->m_pGstBuffer = NULL;
+    pBuffer = pSample->TakeGstBuffer();
     if (pBuffer == NULL)
         return S_FALSE;
 

--- a/modules/javafx.media/src/main/native/gstreamer/plugins/dshowwrapper/Sink.cpp
+++ b/modules/javafx.media/src/main/native/gstreamer/plugins/dshowwrapper/Sink.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
This is the fix for "JDK-8389515: Memory leak in dshowwrapper - decoded buffers delivered by CSink are never unmapped"

To prevent leaks, the `CSample` class was refactored with new `SetGstBuffer` and `TakeGstBuffer` methods that automatically track and manage the mapping state of the underlying `GstBuffer`. The `Allocator` and `Sink` are updated to use these new methods, ensuring buffers are always properly unmapped and released when their ownership is transferred.

The reproducer (`NativeMemoryLeakReproducer.java`) log with the fix applied:
```
+ d:/work/jdk/jdk25/bin/java.exe @jfx/build/run.args NativeMemoryLeakReproducer.java demo.mp4
Java:   25 (OpenJDK 64-Bit Server VM)
JavaFX: 28-internal (runtime 28-internal+0-2026-08-04-080015)
451.6 MiB
459.3 MiB
452.4 MiB
463.1 MiB
465.6 MiB
469.9 MiB
474.9 MiB
494.9 MiB
498.5 MiB
496.0 MiB
509.4 MiB
```

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8389515](https://bugs.openjdk.org/browse/JDK-8389515): Memory leak in dshowwrapper - decoded buffers delivered by CSink are never unmapped (**Bug** - P3)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Alexander Matveev](https://openjdk.org/census#almatvee) (@sashamatveev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2234/head:pull/2234` \
`$ git checkout pull/2234`

Update a local copy of the PR: \
`$ git checkout pull/2234` \
`$ git pull https://git.openjdk.org/jfx.git pull/2234/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2234`

View PR using the GUI difftool: \
`$ git pr show -t 2234`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2234.diff">https://git.openjdk.org/jfx/pull/2234.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2234#issuecomment-5146394276)
</details>
