### PR TITLE
8388526: [Windows] Crash in Platform.Preferences refresh on OS theme change when using FXCanvas

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/win/PlatformSupport.h
+++ b/modules/javafx.graphics/src/main/native-glass/win/PlatformSupport.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -70,7 +70,7 @@ public:
 
 private:
     JNIEnv* env;
-    jobject application;
+    JGlobalRef<jobject> application;
     bool initialized;
     Microsoft::WRL::ComPtr<ABI::Windows::UI::ViewManagement::IUISettings> settings;
     ABI::Windows::Networking::Connectivity::INetworkInformationStatics* networkInformation;


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [05a7b6d0](https://github.com/openjdk/jfx/commit/05a7b6d0db5e799395da27ab43a93d4337001e11) from the [openjdk/jfx](https://git.openjdk.org/jfx) repository.

The commit being backported was authored by Michael Strauß on 31 Jul 2026 and was reviewed by Kevin Rushforth and Lukasz Kostyra.

Thanks!

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8388526](https://bugs.openjdk.org/browse/JDK-8388526): [Windows] Crash in Platform.Preferences refresh on OS theme change when using FXCanvas (**Bug** - P3)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2235/head:pull/2235` \
`$ git checkout pull/2235`

Update a local copy of the PR: \
`$ git checkout pull/2235` \
`$ git pull https://git.openjdk.org/jfx.git pull/2235/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2235`

View PR using the GUI difftool: \
`$ git pr show -t 2235`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2235.diff">https://git.openjdk.org/jfx/pull/2235.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2235#issuecomment-5146612064)
</details>
