### PR TITLE
8389092: PopupWindow.show() unconditionally overwrites user-set scene stylesheets with the owner's stylesheets

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/stage/PopupWindow.java
+++ b/modules/javafx.graphics/src/main/java/javafx/stage/PopupWindow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -458,31 +458,34 @@ public abstract class PopupWindow extends Window {
     }
 
     private void showImpl(final Window owner) {
+        Window rootWindow = getRootWindow(owner);
+        if (rootWindow == null) {
+            return;
+        }
+
         // Update the owner field
         this.ownerWindow.set(owner);
         if (owner instanceof PopupWindow) {
             ((PopupWindow)owner).children.add(this);
         }
+
         // PopupWindow should disappear when owner node is not visible
-        if (owner != null) {
-            owner.showingProperty().addListener(weakOwnerNodeListener);
-        }
+        owner.showingProperty().addListener(weakOwnerNodeListener);
 
         final Scene sceneValue = getScene();
         SceneHelper.parentEffectiveOrientationInvalidated(sceneValue);
 
-        // JDK-8116444
-        applyStylesheetFromOwner(owner);
-
-        final Scene ownerScene = getRootWindow(owner).getScene();
+        final Scene ownerScene = rootWindow.getScene();
         if (ownerScene != null) {
+            copyStylesheetFromOwnerScene(ownerScene);
+
             if (sceneValue.getCursor() == null) {
                 sceneValue.setCursor(ownerScene.getCursor());
             }
         }
 
         // It is required that the root window exist and be visible to show the popup.
-        if (getRootWindow(owner).isShowing()) {
+        if (rootWindow.isShowing()) {
             // We do show() first so that the width and height of the
             // popup window are initialized. This way the x,y location of the
             // popup calculated below uses the right width and height values for
@@ -498,14 +501,34 @@ public abstract class PopupWindow extends Window {
      * @param owner the owner {@link Window}
      */
     void applyStylesheetFromOwner(Window owner) {
-        Scene scene = getScene();
-        final Scene ownerScene = getRootWindow(owner).getScene();
-        if (ownerScene != null) {
-            if (ownerScene.getUserAgentStylesheet() != null) {
-                scene.setUserAgentStylesheet(ownerScene.getUserAgentStylesheet());
-            }
-            scene.getStylesheets().setAll(ownerScene.getStylesheets());
+        // JDK-8116444
+        Window rootWindow = getRootWindow(owner);
+        if (rootWindow == null) {
+            return;
         }
+
+        final Scene ownerScene = rootWindow.getScene();
+        if (ownerScene == null) {
+            return;
+        }
+
+        copyStylesheetFromOwnerScene(ownerScene);
+    }
+
+    private void copyStylesheetFromOwnerScene(Scene ownerScene) {
+        Scene scene = getScene();
+        if (scene.getUserAgentStylesheet() == null && ownerScene.getUserAgentStylesheet() != null) {
+            scene.setUserAgentStylesheet(ownerScene.getUserAgentStylesheet());
+        }
+
+        List<String> newStylesheets = new ArrayList<>();
+        for (String stylesheet : ownerScene.getStylesheets()) {
+            if (!scene.getStylesheets().contains(stylesheet)) {
+                newStylesheets.add(stylesheet);
+            }
+        }
+
+        scene.getStylesheets().addAll(newStylesheets);
     }
 
     /**

--- a/modules/javafx.graphics/src/test/java/test/javafx/stage/PopupTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/stage/PopupTest.java
@@ -870,6 +870,34 @@ public class PopupTest {
         assertEquals(List.of(popupStylesheet, ownerStylesheet), popup.getScene().getStylesheets());
     }
 
+    @Test
+    public void testShowTwiceAddsStylesheetOfOwnerOnlyOnce() {
+        final String ownerStylesheet = toBase64(".owner { -fx-fill: green; }");
+        scene.getStylesheets().add(ownerStylesheet);
+
+        final Popup popup = new Popup();
+
+        popup.show(stage);
+        popup.hide();
+        popup.show(stage);
+
+        assertEquals(List.of(ownerStylesheet), popup.getScene().getStylesheets());
+    }
+
+    @Test
+    public void testShowDoesNotAddStylesheetTwiceWhenPopupAndOwnerShareIt() {
+        final String sharedStylesheet = toBase64(".owner { -fx-fill: green; }");
+
+        scene.getStylesheets().addAll(sharedStylesheet);
+
+        final Popup popup = new Popup();
+        popup.getScene().getStylesheets().add(sharedStylesheet);
+
+        popup.show(stage);
+
+        assertEquals(List.of(sharedStylesheet), popup.getScene().getStylesheets());
+    }
+
     private String toBase64(String stylesheet) {
         return "data:base64," + Base64.getEncoder().encodeToString(stylesheet.getBytes(StandardCharsets.UTF_8));
     }

--- a/modules/javafx.graphics/src/test/java/test/javafx/stage/PopupTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/stage/PopupTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,6 +48,9 @@ import javafx.scene.input.KeyEvent;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.shape.Rectangle;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javafx.scene.Node;
 import javafx.scene.ParentShim;
@@ -63,6 +66,7 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import test.com.sun.javafx.stage.PopupRootHelper;
@@ -108,10 +112,8 @@ public class PopupTest {
         assertFalse(p2.isShowing());
 
         // test showing popup without parent
-        // TODO should result in an exception
-//        Popup p3 = new Popup();
-//        p3.show(null);
-//        assertFalse(p3.isVisible());
+        Popup p3 = new Popup();
+        assertThrows(NullPointerException.class, () -> p3.show(null));
     }
 
     @Test
@@ -498,7 +500,7 @@ public class PopupTest {
     }
 
     @Test
-    public void testDefautValueOfAutofix() {
+    public void testDefaultValueOfAutofix() {
         Popup p = new Popup();
         assertTrue(p.isAutoFix());
         assertTrue(p.autoFixProperty().get());
@@ -800,6 +802,76 @@ public class PopupTest {
         popup.show(stage);
         assertEquals(Cursor.CLOSED_HAND, popup.getScene().getCursor());
 
+    }
+
+    @Test
+    public void testShowWithOwnerWithoutRootWindow() {
+        final Popup ownerPopup = new Popup();
+        final Popup popup = new Popup();
+
+        popup.show(ownerPopup);
+
+        assertFalse(popup.isShowing());
+    }
+
+    @Test
+    public void testShowWithOwnerWithoutScene() {
+        final Stage ownerWithoutScene = new Stage();
+
+        final Popup popup = new Popup();
+
+        popup.show(ownerWithoutScene);
+
+        assertFalse(popup.isShowing());
+    }
+
+    @Test
+    public void testShowKeepsCursorOfPopup() {
+        stage.getScene().setCursor(Cursor.CLOSED_HAND);
+
+        final Popup popup = new Popup();
+        popup.getScene().setCursor(Cursor.TEXT);
+
+        popup.show(stage);
+
+        assertEquals(Cursor.TEXT, popup.getScene().getCursor());
+    }
+
+    @Test
+    public void testShowAppliesUserAgentStylesheetOfOwnerWhenPopupHasNone() {
+        final String ownerUserAgentStylesheet = toBase64(".owner-ua { -fx-fill: red; }");
+        scene.setUserAgentStylesheet(ownerUserAgentStylesheet);
+
+        final Popup popup = new Popup();
+        assertNull(popup.getScene().getUserAgentStylesheet());
+
+        popup.show(stage);
+
+        assertEquals(ownerUserAgentStylesheet, popup.getScene().getUserAgentStylesheet());
+    }
+
+    @Test
+    public void testShowKeepsStylesheetsOfPopupAndAddsStylesheetsOfOwner() {
+        final String ownerUserAgentStylesheet = toBase64(".owner-ua { -fx-fill: red; }");
+        final String ownerStylesheet = toBase64(".owner { -fx-fill: green; }");
+        final String popupUserAgentStylesheet = toBase64(".popup-ua { -fx-fill: blue; }");
+        final String popupStylesheet = toBase64(".popup { -fx-fill: yellow; }");
+
+        scene.setUserAgentStylesheet(ownerUserAgentStylesheet);
+        scene.getStylesheets().add(ownerStylesheet);
+
+        final Popup popup = new Popup();
+        popup.getScene().setUserAgentStylesheet(popupUserAgentStylesheet);
+        popup.getScene().getStylesheets().add(popupStylesheet);
+
+        popup.show(stage);
+
+        assertEquals(popupUserAgentStylesheet, popup.getScene().getUserAgentStylesheet());
+        assertEquals(List.of(popupStylesheet, ownerStylesheet), popup.getScene().getStylesheets());
+    }
+
+    private String toBase64(String stylesheet) {
+        return "data:base64," + Base64.getEncoder().encodeToString(stylesheet.getBytes(StandardCharsets.UTF_8));
     }
 
     private static final class EventCounter implements EventHandler<Event> {


### PR DESCRIPTION
`PopupWindow` will always overwrite its `Scene` (user agent) stylesheets when an owner was set and `show` is called.
Code like this:

```java
        final Popup popup = new Popup();
        popup.getScene().setUserAgentStylesheet(popupUserAgentStylesheet);
        popup.getScene().getStylesheets().add(popupStylesheet);
```

will do nothing, because your added stylesheets will be later overwritten when `show` is called. 
Andy and I were already wondering about this behavior two years ago: https://github.com/openjdk/jfx/pull/1394#discussion_r1617620949

---

I can't see any reason why we should do that. Instead, this PR will only add the stylesheets of the owner if they do not exist already. 
Additionally, we will not overwrite the user agent stylesheet if it was already set.

Added tests for all combinations I can think of. This PR also fixes NPEs that can happen when the owner window has no 'root window'.

There is already a test for the `Cursor` behavior, but there was none that verifies that the `Cursor` is not overwritten, so added one as well.

https://github.com/openjdk/jfx/blob/05a7b6d0db5e799395da27ab43a93d4337001e11/modules/javafx.graphics/src/main/java/javafx/stage/PopupWindow.java#L479-L481

Now, we will never overwrite anything that the developer set (before `show`ing). And as we can see above, this was already done this way with the `Cursor`.


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8389092](https://bugs.openjdk.org/browse/JDK-8389092): PopupWindow.show() unconditionally overwrites user-set scene stylesheets with the owner's stylesheets (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2236/head:pull/2236` \
`$ git checkout pull/2236`

Update a local copy of the PR: \
`$ git checkout pull/2236` \
`$ git pull https://git.openjdk.org/jfx.git pull/2236/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2236`

View PR using the GUI difftool: \
`$ git pr show -t 2236`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2236.diff">https://git.openjdk.org/jfx/pull/2236.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2236#issuecomment-5147015356)
</details>
