### PR TITLE
8376836: Fix mistakes in FX API docs

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ScrollPane.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ScrollPane.java
@@ -353,7 +353,7 @@ public class ScrollPane extends Control {
         return vmax;
     }
     /**
-     * If true and if the contained node is {@link Node#isResizable resizable}, then the node will be
+     * If true and if the contained node is {@linkplain Node#isResizable resizable}, then the node will be
      * kept resized to match the width of the ScrollPane's viewport. If the
      * contained node is not resizable, this value is ignored.
      */
@@ -390,7 +390,7 @@ public class ScrollPane extends Control {
         return fitToWidth;
     }
     /**
-     * If true and if the contained node is {@link Node#isResizable resizable}, then the node will be
+     * If true and if the contained node is {@linkplain Node#isResizable resizable}, then the node will be
      * kept resized to match the height of the ScrollPane's viewport. If the
      * contained node is not resizable, this value is ignored.
      */

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ScrollPane.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ScrollPane.java
@@ -353,9 +353,9 @@ public class ScrollPane extends Control {
         return vmax;
     }
     /**
-     * If true and if the contained node is a Resizable, then the node will be
+     * If true and if the contained node is {@link Node#isResizable resizable}, then the node will be
      * kept resized to match the width of the ScrollPane's viewport. If the
-     * contained node is not a Resizable, this value is ignored.
+     * contained node is not resizable, this value is ignored.
      */
     private BooleanProperty fitToWidth;
     public final void setFitToWidth(boolean value) {
@@ -390,9 +390,9 @@ public class ScrollPane extends Control {
         return fitToWidth;
     }
     /**
-     * If true and if the contained node is a Resizable, then the node will be
+     * If true and if the contained node is {@link Node#isResizable resizable}, then the node will be
      * kept resized to match the height of the ScrollPane's viewport. If the
-     * contained node is not a Resizable, this value is ignored.
+     * contained node is not resizable, this value is ignored.
      */
     private BooleanProperty fitToHeight;
     public final void setFitToHeight(boolean value) {

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeView.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeView.java
@@ -130,7 +130,7 @@ import java.util.Map;
  * description of how to write custom Cells.
  *
  * <h3>Warning: Nodes should not be inserted directly into the TreeView cells</h3>
- * {@code TreeView} allows for it's cells to contain elements of any type, including
+ * {@code TreeView} allows for its cells to contain elements of any type, including
  * {@code Node} instances. Putting nodes into
  * the TreeView cells is <strong>strongly discouraged</strong>, as it can
  * lead to unexpected results.

--- a/modules/javafx.fxml/src/main/java/javafx/fxml/JavaFXBuilderFactory.java
+++ b/modules/javafx.fxml/src/main/java/javafx/fxml/JavaFXBuilderFactory.java
@@ -107,7 +107,7 @@ public final class JavaFXBuilderFactory implements BuilderFactory {
 
     /**
      * Returns the builder for the specified type, or null if no builder is
-     * used. Most classes will note use a builder.
+     * used. Most classes will not use a builder.
      *
      * @param type the class being looked up
      *

--- a/modules/javafx.graphics/src/main/java/javafx/print/Collation.java
+++ b/modules/javafx.graphics/src/main/java/javafx/print/Collation.java
@@ -35,15 +35,15 @@ package javafx.print;
 public enum Collation {
 
     /**
-     * The same numbered pages are consecutive in the output,
-     * For example: 2 copies of a document with 2 pages is printed :
+     * The same numbered pages are consecutive in the output.
+     * For example, 2 copies of a document with 2 pages is printed:
      * Page 1, Page 1, Page 2, Page 2.
      */
     UNCOLLATED,
 
     /**
      * Each copy of a document is printed together.
-     * FOr example: 2 copies of a document with 2 pages is printed :
+     * For example, 2 copies of a document with 2 pages is printed:
      * Page 1, Page 2, Page 1, Page 2.
      */
     COLLATED

--- a/modules/javafx.graphics/src/main/java/javafx/print/Collation.java
+++ b/modules/javafx.graphics/src/main/java/javafx/print/Collation.java
@@ -36,14 +36,14 @@ public enum Collation {
 
     /**
      * The same numbered pages are consecutive in the output.
-     * For example, 2 copies of a document with 2 pages is printed:
+     * For example, 2 copies of a document with 2 pages are printed:
      * Page 1, Page 1, Page 2, Page 2.
      */
     UNCOLLATED,
 
     /**
      * Each copy of a document is printed together.
-     * For example, 2 copies of a document with 2 pages is printed:
+     * For example, 2 copies of a document with 2 pages are printed:
      * Page 1, Page 2, Page 1, Page 2.
      */
     COLLATED


### PR DESCRIPTION
Fixes the typos listed in the JBS issue.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8376836](https://bugs.openjdk.org/browse/JDK-8376836): Fix mistakes in FX API docs (**Bug** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2239/head:pull/2239` \
`$ git checkout pull/2239`

Update a local copy of the PR: \
`$ git checkout pull/2239` \
`$ git pull https://git.openjdk.org/jfx.git pull/2239/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2239`

View PR using the GUI difftool: \
`$ git pr show -t 2239`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2239.diff">https://git.openjdk.org/jfx/pull/2239.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2239#issuecomment-5286505909)
</details>
