### PR TITLE
8389735: [macos] Closing owner of FileChooser breaks other windows

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassDialogs.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassDialogs.m
@@ -93,8 +93,21 @@
     dd->eventLoop = (*env)->NewGlobalRef(env, jobj);
 
     if (owner) {
+        // AppKit does not call the completionHandler when the owner window
+        // is closed, which would lead the nested event loop stuck.
+        // Therefore we close the dialog when the owner is closed.
+        id closeObserver = [[NSNotificationCenter defaultCenter]
+            addObserverForName:NSWindowWillCloseNotification
+                        object:owner
+                         queue:nil
+                    usingBlock:^(NSNotification *note)
+        {
+            [self->owner endSheet:self->panel returnCode:NSModalResponseCancel];
+        }];
+
         [panel beginSheetModalForWindow: owner completionHandler:^(NSInteger result)
         {
+            [[NSNotificationCenter defaultCenter] removeObserver:closeObserver];
             [dd exitModalWithEnv:env result:result];
         }
         ];

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow.m
@@ -819,6 +819,7 @@ JNIEXPORT void JNICALL Java_com_sun_glass_ui_mac_MacWindow__1setEnabled
     GLASS_POOL_ENTER;
     {
         GlassWindow *window = getGlassWindow(env, jPtr);
+        BOOL wasEnabled = window->isEnabled;
         window->isEnabled = (BOOL)isEnabled;
         NSButton *zoomButton = [window->nsWindow standardWindowButton:NSWindowZoomButton];
         if ((window->isEnabled) && (window->isResizable)){
@@ -837,6 +838,12 @@ JNIEXPORT void JNICALL Java_com_sun_glass_ui_mac_MacWindow__1setEnabled
             [window->nsWindow setStyleMask:
                 (window->enabledStyleMask & ~(NSUInteger)(NSWindowStyleMaskMiniaturizable | NSWindowStyleMaskResizable))];
             [zoomButton setEnabled:NO];
+        }
+        if (!wasEnabled && window->isEnabled && [window->nsWindow isKeyWindow]) {
+            // the window became focused/key while it was disabled.
+            // So we have to resend the suppressed focus event.
+            [window windowDidBecomeKey:[NSNotification notificationWithName:NSWindowDidBecomeKeyNotification
+                                                                    object:window->nsWindow]];
         }
     }
     GLASS_POOL_EXIT;

--- a/tests/system/src/test/java/test/javafx/stage/FileChooserOwnerCloseTest.java
+++ b/tests/system/src/test/java/test/javafx/stage/FileChooserOwnerCloseTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package test.javafx.stage;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import javafx.application.Application;
+import javafx.application.Platform;
+import javafx.scene.Scene;
+import javafx.scene.control.Label;
+import javafx.scene.control.TextField;
+import javafx.scene.layout.VBox;
+import javafx.stage.FileChooser;
+import javafx.stage.Stage;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import test.util.Util;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * This class tests, whether closing the owner actually also closes the FileChooser.
+ */
+@EnabledOnOs(OS.MAC)
+class FileChooserOwnerCloseTest {
+
+    Stage mainStage = null;
+    Stage subStage = null;
+
+    private static final CountDownLatch startupLatch = new CountDownLatch(1);
+
+    @BeforeAll
+    static void initFX() throws Exception {
+        Util.launch(startupLatch, TestApp.class);
+    }
+
+    @AfterAll
+    static void teardown() {
+        Util.shutdown();
+    }
+
+    @Test
+    public void closingOwnerClosesFilechooser() throws Exception {
+
+        Util.runAndWait(() -> {
+            mainStage = new Stage();
+            mainStage.setScene(new Scene(new VBox(new Label("Main Stage"), new TextField())));
+            mainStage.show();
+        });
+        waitForStageFocus(mainStage);
+
+        Util.runAndWait(() -> {
+            subStage = new Stage();
+            subStage.initOwner(mainStage);
+            subStage.setScene(new Scene(new Label("Sub Stage")));
+            subStage.show();
+        });
+        waitForStageFocus(subStage);
+
+        CountDownLatch dialogReturned = new CountDownLatch(1);
+        Platform.runLater(() -> {
+            new FileChooser().showOpenDialog(subStage);
+            dialogReturned.countDown();
+        });
+
+        // let the dialog open, then close its owner window
+        Thread.sleep(2000);
+        Platform.runLater(subStage::hide);
+
+        assertTrue(dialogReturned.await(10, TimeUnit.SECONDS),
+                "FileChooser.showOpenDialog did not return after its owner window was closed");
+
+        // If this doesn't happen - we land in a state
+        // where the main-stage can no longer be focused at all.
+        // Refocusing on OS then only results in a beep sounds without receiving focus.
+        waitForStageFocus(mainStage);
+
+        Util.runAndWait(mainStage::hide);
+    }
+
+    public static void waitForStageFocus(Stage stage) throws Exception {
+        CountDownLatch latch = new CountDownLatch(1);
+        Platform.runLater(() -> {
+            stage.focusedProperty().subscribe(focused -> {
+                if(focused) {
+                    latch.countDown();
+                }
+            });
+        });
+        assertTrue(latch.await(10, TimeUnit.SECONDS),
+                "Stage never became focuse");
+    }
+
+    public static class TestApp extends Application {
+        @Override
+        public void start(Stage primaryStage) {
+            Platform.setImplicitExit(false);
+            startupLatch.countDown();
+        }
+    }
+}


### PR DESCRIPTION
### Description

The setup is the following:
Window1
Window2 owner Window1
FileChooser owner Window2

When Window2 is closed,
then Window2 and the FileChooser are closed,
but the nested event loop from the dialog never returns.
Even worse, Window1 is in a broken state: it can't ever get focus again.

### The Fix
The fix has two parts.

### Close FileChooser when owner is closed (GlassDialogs.m)
AppKit does not call the completionHandler of the dialog when the owner window is closed, so the nested event loop is never left.
We add a listener to the owner of the FileChooser, ensuring the FileChooser gets closed when the owner is closed.
showOpenDialog then returns null, as if the user had cancelled.

### Refocus when disabled window becomes key/focused (GlassWindow.m)
When a window becomes focused while it is disabled, the focus isn't processed.
Therefore we resend the focus event when it gets re-enabled.

### System test
A system test is included which tests both changes at once.

### A note on platform differences
On Windows/Linux, closing the owner of a FileChooser currently doesn't close
the FileChooser at all. For that reason, the test only works on macOS.
But this difference is not introduced by the PR.
It probably would be possible to change that behavior and it would be a good
additional improvement, because in all other cases, closing the owner also closes the child windows.

From the Stage JavaDoc (class doc, showAndWait doc):
 > When a parent window is closed or iconified, then all owned windows will be affected as well
 > A Stage is hidden (closed) by one of the following means: ... this stage has a non-null owner window, and its owner is closed

### Close API
A possible follow-up would be to provide an API to close the FileChooser programmatically.
This would also make it easier to write tests.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8389735](https://bugs.openjdk.org/browse/JDK-8389735): [macos] Closing owner of FileChooser breaks other windows (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2242/head:pull/2242` \
`$ git checkout pull/2242`

Update a local copy of the PR: \
`$ git checkout pull/2242` \
`$ git pull https://git.openjdk.org/jfx.git pull/2242/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2242`

View PR using the GUI difftool: \
`$ git pr show -t 2242`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2242.diff">https://git.openjdk.org/jfx/pull/2242.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2242#issuecomment-5714385781)
</details>
