### PR TITLE
8389127: Native memory leak in macOS Metal 3D mesh rendering

### DIFF
--- a/modules/javafx.graphics/src/main/native-prism-mtl/MetalContext.h
+++ b/modules/javafx.graphics/src/main/native-prism-mtl/MetalContext.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,6 @@
 @class MetalShader;
 @class MetalMeshView;
 
-#define BUFFER_SIZE 1
 #define ARGS_BUFFER_SIZE (8  * 1024 * 1024)
 #define DATA_BUFFER_SIZE (20 * 1024 * 1024)
 
@@ -101,7 +100,6 @@ typedef enum VertexInputIndex {
     MTLRenderPassDescriptor* phongRPD;
     vector_float4 cPos;
     bool depthEnabled;
-    NSUInteger currentBufferIndex;
 
     int compositeMode;
     int cullMode;
@@ -128,7 +126,6 @@ typedef enum VertexInputIndex {
 - (void) endCurrentRenderEncoder;
 
 - (id<MTLRenderPipelineState>) getPhongPipelineStateWithNumLights:(int)numLights;
-- (NSUInteger) getCurrentBufferIndex;
 
 - (void) updateDepthDetails:(bool)depthTest;
 - (void) verifyDepthTexture;

--- a/modules/javafx.graphics/src/main/native-prism-mtl/MetalContext.m
+++ b/modules/javafx.graphics/src/main/native-prism-mtl/MetalContext.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -68,7 +68,6 @@
         nonLinearSamplerDict = [[NSMutableDictionary alloc] init];
         compositeMode = com_sun_prism_mtl_MTLContext_MTL_COMPMODE_SRCOVER; //default
 
-        currentBufferIndex = 0;
         commandQueue = [device newCommandQueue];
         commandQueue.label = @"The only MTLCommandQueue";
         pipelineManager = [MetalPipelineManager alloc];
@@ -358,11 +357,6 @@
         [currentRenderEncoder release];
         currentRenderEncoder = nil;
     }
-}
-
-- (NSUInteger) getCurrentBufferIndex
-{
-    return currentBufferIndex;
 }
 
 - (id<MTLRenderPipelineState>) getPhongPipelineStateWithNumLights:(int)numLights

--- a/modules/javafx.graphics/src/main/native-prism-mtl/MetalMesh.h
+++ b/modules/javafx.graphics/src/main/native-prism-mtl/MetalMesh.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,8 +34,8 @@
 @interface MetalMesh : NSObject
 {
     MetalContext *context;
-    id<MTLBuffer> indexBuffer[3];
-    id<MTLBuffer> vertexBuffer[3];
+    id<MTLBuffer> indexBuffer;
+    id<MTLBuffer> vertexBuffer;
     NSUInteger numVertices;
     NSUInteger numIndices;
     NSUInteger indexType;

--- a/modules/javafx.graphics/src/main/native-prism-mtl/MetalMesh.m
+++ b/modules/javafx.graphics/src/main/native-prism-mtl/MetalMesh.m
@@ -133,6 +133,7 @@ typedef struct
 - (void) releaseVertexBuffer
 {
     for (int i = 0; i < BUFFER_SIZE; i++) {
+        [vertexBuffer[i] release];
         vertexBuffer[i] = nil;
     }
     numVertices = 0;
@@ -150,6 +151,7 @@ typedef struct
 - (void) releaseIndexBuffer
 {
     for (int i = 0; i < BUFFER_SIZE; i++) {
+        [indexBuffer[i] release];
         indexBuffer[i] = nil;
     }
     numIndices = 0;

--- a/modules/javafx.graphics/src/main/native-prism-mtl/MetalMesh.m
+++ b/modules/javafx.graphics/src/main/native-prism-mtl/MetalMesh.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,9 +60,8 @@ typedef struct
         numVertices = vbCount;
     }
 
-    NSUInteger currentIndex = [context getCurrentBufferIndex];
-    if (vertexBuffer[currentIndex] != nil) {
-        memcpy(vertexBuffer[currentIndex].contents, vb, size);
+    if (vertexBuffer != nil) {
+        memcpy(vertexBuffer.contents, vb, size);
     }
 
     size = ibSize * sizeof (unsigned short);
@@ -72,8 +71,8 @@ typedef struct
         numIndices = ibSize;
     }
 
-    if (indexBuffer[currentIndex] != nil) {
-        memcpy(indexBuffer[currentIndex].contents, ib, size);
+    if (indexBuffer != nil) {
+        memcpy(indexBuffer.contents, ib, size);
     }
     indexType = MTLIndexTypeUInt16;
     return true;
@@ -94,9 +93,8 @@ typedef struct
         numVertices = vbCount;
     }
 
-    NSUInteger currentIndex = [context getCurrentBufferIndex];
-    if (vertexBuffer[currentIndex] != nil) {
-        memcpy(vertexBuffer[currentIndex].contents, vb, size);
+    if (vertexBuffer != nil) {
+        memcpy(vertexBuffer.contents, vb, size);
     }
 
     size = ibSize * sizeof (unsigned int);
@@ -106,8 +104,8 @@ typedef struct
         numIndices = ibSize;
     }
 
-    if (indexBuffer[currentIndex] != nil) {
-        memcpy(indexBuffer[currentIndex].contents, ib, size);
+    if (indexBuffer != nil) {
+        memcpy(indexBuffer.contents, ib, size);
     }
 
     indexType = MTLIndexTypeUInt32;
@@ -124,47 +122,39 @@ typedef struct
 - (void) createVertexBuffer:(unsigned int)size;
 {
     id<MTLDevice> device = [context getDevice];
-    for (int i = 0; i < BUFFER_SIZE; i++) {
-        vertexBuffer[i] = [device newBufferWithLength:size
-            options:MTLResourceStorageModeShared];
-    }
+    vertexBuffer = [device newBufferWithLength:size
+        options:MTLResourceStorageModeShared];
 }
 
 - (void) releaseVertexBuffer
 {
-    for (int i = 0; i < BUFFER_SIZE; i++) {
-        [vertexBuffer[i] release];
-        vertexBuffer[i] = nil;
-    }
+    [vertexBuffer release];
+    vertexBuffer = nil;
     numVertices = 0;
 }
 
 - (void) createIndexBuffer:(unsigned int)size;
 {
     id<MTLDevice> device = [context getDevice];
-    for (int i = 0; i < BUFFER_SIZE; i++) {
-        indexBuffer[i] = [device newBufferWithLength:size
-            options:MTLResourceStorageModeShared];
-    }
+    indexBuffer = [device newBufferWithLength:size
+        options:MTLResourceStorageModeShared];
 }
 
 - (void) releaseIndexBuffer
 {
-    for (int i = 0; i < BUFFER_SIZE; i++) {
-        [indexBuffer[i] release];
-        indexBuffer[i] = nil;
-    }
+    [indexBuffer release];
+    indexBuffer = nil;
     numIndices = 0;
 }
 
 - (id<MTLBuffer>) getVertexBuffer
 {
-    return vertexBuffer[[context getCurrentBufferIndex]];
+    return vertexBuffer;
 }
 
 - (id<MTLBuffer>) getIndexBuffer
 {
-    return indexBuffer[[context getCurrentBufferIndex]];
+    return indexBuffer;
 }
 
 - (NSUInteger) getNumVertices


### PR DESCRIPTION
If a 3D Mesh is updated with different Vertices/Indices, Metal pipeline is creating a new Vertex/Index MTLBuffer without releasing the old Buffer. Running the sample program in JBS reveals that memory footprint increases to ~300MB from the initial ~120MB after running for 30 minutes. Releasing the MTLBuffer resolves this memory leak issue.

Functional and Performance testing is green with this change. Refer to JBS comments for in depth details of testing. We can't reliably measure the increase/decrease in memory footprint for this leak, so there is no regression test.

I have also cleared the unused multi buffer logic for these Vertex/Index data.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8389127](https://bugs.openjdk.org/browse/JDK-8389127): Native memory leak in macOS Metal 3D mesh rendering (**Bug** - P3)


### Reviewers
 * [Ajit Ghaisas](https://openjdk.org/census#aghaisas) (@aghaisas - **Reviewer**)
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2243/head:pull/2243` \
`$ git checkout pull/2243`

Update a local copy of the PR: \
`$ git checkout pull/2243` \
`$ git pull https://git.openjdk.org/jfx.git pull/2243/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2243`

View PR using the GUI difftool: \
`$ git pr show -t 2243`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2243.diff">https://git.openjdk.org/jfx/pull/2243.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2243#issuecomment-5190383682)
</details>
