### PR TITLE
8374836: Media: add missing jrt protocol to javadoc

### DIFF
--- a/modules/javafx.media/src/main/java/javafx/scene/media/Media.java
+++ b/modules/javafx.media/src/main/java/javafx/scene/media/Media.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -336,7 +336,7 @@ public final class Media {
     /**
      * Constructs a <code>Media</code> instance.  This is the only way to
      * specify the media source. The source must represent a valid <code>URI</code>
-     * and is immutable. Only HTTP, HTTPS, FILE, and JAR <code>URL</code>s are supported. If the
+     * and is immutable. Only HTTP, HTTPS, FILE, JAR, and JRT <code>URL</code>s are supported. If the
      * provided URL is invalid then an exception will be thrown.  If an
      * asynchronous error occurs, the {@link #errorProperty error} property will be set. Listen
      * to this property to be notified of any such errors.
@@ -353,12 +353,13 @@ public final class Media {
      * <ul>
      * <li>The supplied URI must conform to RFC-2396 as required by
      * <A href="https://docs.oracle.com/javase/8/docs/api/java/net/URI.html">java.net.URI</A>.</li>
-     * <li>Only HTTP, HTTPS, FILE, and JAR URIs are supported.</li>
+     * <li>Only HTTP, HTTPS, FILE, JAR, and JRT URIs are supported.</li>
      * </ul>
      *
      * <p>See <A href="https://docs.oracle.com/javase/8/docs/api/java/net/URI.html">java.net.URI</A>
      * for more information about URI formatting in general.
      * JAR URL syntax is specified in <a href="https://docs.oracle.com/javase/8/docs/api/java/net/JarURLConnection.html">java.net.JarURLConnection</A>.
+     * JRT URL syntax is specified in <a href="https://openjdk.org/jeps/220">JEP 220: Modular Run-Time Images</A>.
      *
      * @param source The URI of the source media.
      * @throws NullPointerException if the URI string is <code>null</code>.

--- a/modules/javafx.media/src/main/java/javafx/scene/media/package-info.java
+++ b/modules/javafx.media/src/main/java/javafx/scene/media/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -136,6 +136,11 @@
  *     <th scope="row">JAR</th>
  *     <td>Representation of media entries in files accessible via the FILE, HTTP or HTTPS protocols</td>
  *     <td><a href="https://docs.oracle.com/javase/8/docs/api/java/net/JarURLConnection.html">java.net.JarURLConnection</a></td>
+ * </tr>
+ * <tr>
+ *     <th scope="row">JRT</th>
+ *     <td>Representation of media resources in the Java run-time image</td>
+ *     <td><a href="https://openjdk.org/jeps/220">JEP 220: Modular Run-Time Images</a></td>
  * </tr>
  * <tr>
  *     <th scope="row">HTTP Live Streaming (HLS)</th>


### PR DESCRIPTION
- Added missing JRT protocol to javadocs.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8374836](https://bugs.openjdk.org/browse/JDK-8374836): Media: add missing jrt protocol to javadoc (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2248/head:pull/2248` \
`$ git checkout pull/2248`

Update a local copy of the PR: \
`$ git checkout pull/2248` \
`$ git pull https://git.openjdk.org/jfx.git pull/2248/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2248`

View PR using the GUI difftool: \
`$ git pr show -t 2248`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2248.diff">https://git.openjdk.org/jfx/pull/2248.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2248#issuecomment-5199104397)
</details>
