### PR TITLE
8389881: Allow Gradle to not rerun up-to-date tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2188,7 +2188,7 @@ allprojects {
     test {
         useJUnitPlatform();
 
-        // Tests are forced to rerun when they are *not* marked as up-to-date 
+        // Tests are forced to rerun when they are *not* marked as up-to-date
         outputs.upToDateWhen { !IS_FORCE_TESTS }
 
         executable = JAVA;

--- a/build.gradle
+++ b/build.gradle
@@ -485,7 +485,8 @@ ext.SWT_FILE_NAME =
 defineProperty("FULL_TEST", "false")
 ext.IS_FULL_TEST = Boolean.parseBoolean(FULL_TEST);
 
-defineProperty("FORCE_TESTS", "false")
+// Specifies whether tests should be forced to rerun even when up-to-date
+defineProperty("FORCE_TESTS", "true")
 ext.IS_FORCE_TESTS = Boolean.parseBoolean(FORCE_TESTS);
 
 // Specifies whether to run robot-based visual tests (only used when FULL_TEST is also enabled)
@@ -2187,8 +2188,8 @@ allprojects {
     test {
         useJUnitPlatform();
 
-        // Always run tests
-        outputs.upToDateWhen { false }
+        // Tests are forced to rerun when they are *not* marked as up-to-date 
+        outputs.upToDateWhen { !IS_FORCE_TESTS }
 
         executable = JAVA;
         enableAssertions = true;


### PR DESCRIPTION
Wires the leftover `FORCE_TESTS` property to the `test` task. For example, running twice

`gradlew :controls:test -PFORCE_TESTS=false`

will not rerun the tests again. The default is `true` to always rerun tests.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8389881](https://bugs.openjdk.org/browse/JDK-8389881): Allow Gradle to not rerun up-to-date tests (**Enhancement** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2249/head:pull/2249` \
`$ git checkout pull/2249`

Update a local copy of the PR: \
`$ git checkout pull/2249` \
`$ git pull https://git.openjdk.org/jfx.git pull/2249/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2249`

View PR using the GUI difftool: \
`$ git pr show -t 2249`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2249.diff">https://git.openjdk.org/jfx/pull/2249.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2249#issuecomment-5204828484)
</details>
