### PR TITLE
8387301: ListView, ComboBox, TableView, TreeTableView fail when item type is a value class

### DIFF
--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/SelectedItemsReadOnlyObservableList.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/SelectedItemsReadOnlyObservableList.java
@@ -28,7 +28,6 @@ import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
 import javafx.collections.ObservableListBase;
 
-import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Supplier;
@@ -38,7 +37,7 @@ public abstract class SelectedItemsReadOnlyObservableList<E> extends ObservableL
     // This is the actual observable list of selected indices used in the selection model
     private final ObservableList<Integer> selectedIndices;
     private final Supplier<Integer> modelSizeSupplier;
-    private final List<WeakReference<E>> itemsRefList;
+    private final List<WeakReferenceWrapper<E>> itemsRefList;
 
     public SelectedItemsReadOnlyObservableList(ObservableList<Integer> selectedIndices, Supplier<Integer> modelSizeSupplier) {
         this.modelSizeSupplier = modelSizeSupplier;
@@ -85,7 +84,7 @@ public abstract class SelectedItemsReadOnlyObservableList<E> extends ObservableL
             // FIXME we could make this more efficient by only making the reported changes to the list
             itemsRefList.clear();
             for (int selectedIndex : selectedIndices) {
-                itemsRefList.add(new WeakReference<>(getModelItem(selectedIndex)));
+                itemsRefList.add(new WeakReferenceWrapper<>(getModelItem(selectedIndex)));
             }
 
             endChange();

--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/SelectedItemsReadOnlyObservableList.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/SelectedItemsReadOnlyObservableList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/WeakReferenceWrapper.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/WeakReferenceWrapper.java
@@ -38,6 +38,22 @@ import java.util.Objects;
  * In the case of a value object, the referent is never collected, so it is only
  * suitable for uses that do not rely on the object being placed onto a reference
  * queue.
+ * This class might not be suitable for large trees of value objects or for
+ * value objects that wrap an identity object (for example, {@code Optional<Object>}.
+ * Using it for such cases can lead to memory being held longer than expected
+ * (as long as the {@code WeakReferenceWrapper} itself is held).
+ * <p>
+ * NOTE: we might be able to modify or eliminate this class in the future based
+ * on one the following:
+ *
+ * <ol>
+ * <li>A future version of the value objects preview (a follow-on to JEP 401) might
+ * relax the restriction on weak references of value objects. Depending on how
+ * this is done, we might change this wrapper to take advantage of that.</li>
+ * <li>A future improvement to list-based UI controls might eliminate the need
+ * for some or all of the weak references to application-proved items. If all are
+ * eliminated, then we can eliminate this wrapper class.</li>
+ * </ol>
  *
  * @param <T> the type of the referent
  */

--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/WeakReferenceWrapper.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/WeakReferenceWrapper.java
@@ -33,7 +33,7 @@ import java.util.Objects;
 /**
  * Wrapper class that holds a reference to an object with or without identity.
  * If the object is non-null and has identity, a weak reference is created and
- * stored; otherwise it holds a reference to the object itself,
+ * stored; otherwise it holds a reference to the object itself.
  * <p>
  * In the case of a value object, the referent is never collected, so it is only
  * suitable for uses that do not rely on the object being placed onto a reference
@@ -50,7 +50,7 @@ public class WeakReferenceWrapper<T> {
     static {
         Method meth;
         try {
-            meth = Objects.class.getDeclaredMethod("hasIdentity", Object.class);
+            meth = Objects.class.getMethod("hasIdentity", Object.class);
         } catch (NoSuchMethodException ex) {
             meth = null;
         }
@@ -59,12 +59,13 @@ public class WeakReferenceWrapper<T> {
     }
 
     /**
-     * Helper function that calls Object.hasIdentity via reflection.
-     * If `obj` is null, treat is as having no identity (matching JDK 28's
-     * behavior with or without --enable-preview) and return false.
-     * If `obj` is not null, check whether Objects.hasIdentity exists: if the
-     * method doesn't exist or cannot be invoked, return true; otherwise, call
-     * Objects.hasIdentity(obj) reflectively and return its value.
+     * Helper method that reflectively calls Objects.hasIdentity to determine
+     * whether we should create and hold a weak reference to the given object.
+     * If {@code obj} is null, treat it as having no identity (matching JDK 28's
+     * behavior with or without {@code --enable-preview}) and return false.
+     * If {@code obj} is not null, check whether {@code Objects.hasIdentity} exists:
+     * if the method doesn't exist or cannot be invoked, return true; otherwise,
+     * call {@code Objects.hasIdentity(obj)} reflectively and return its value.
      */
     private static boolean useWeakRef(Object obj) {
         if (obj == null) {
@@ -86,7 +87,9 @@ public class WeakReferenceWrapper<T> {
     /**
      * Creates a new reference that refers to the given object.
      * If the object is non-null and has identity, a weak reference is created and
-     * stored; otherwise it holds a reference to the object itself,
+     * stored; otherwise it holds a reference to the object itself.
+     *
+     * @param obj the object this reference will refer to
      */
     public WeakReferenceWrapper(T obj) {
         if (useWeakRef(obj)) {

--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/WeakReferenceWrapper.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/WeakReferenceWrapper.java
@@ -70,7 +70,7 @@ public class WeakReferenceWrapper<T> {
             return true;
         } else {
             try {
-                System.err.println("[3] Calling Ojbects.hasIdentityMethod(obj)");
+                System.err.println("[3] Calling Objects.hasIdentityMethod(obj)");
                 return (Boolean)hasIdentityMethod.invoke(null, obj);
             } catch (Exception ex) {
                 return true;

--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/WeakReferenceWrapper.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/WeakReferenceWrapper.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.sun.javafx.scene.control;
+
+import java.lang.ref.WeakReference;
+import java.lang.reflect.Method;
+import java.util.Objects;
+
+/**
+ * Wrapper class for weak references.
+ * TODO: describe the purpose of this class.
+ *
+ * NOTE: In the case of value objects, the referent is never going to be
+ * collected!
+ */
+public class WeakReferenceWrapper<T> {
+
+    private static final Method hasIdentityMethod;
+    private final T obj;
+    private final WeakReference<T> ref;
+
+    static {
+        Method meth;
+        try {
+            meth = Objects.class.getDeclaredMethod("hasIdentity", Object.class);
+        } catch (NoSuchMethodException ex) {
+            meth = null;
+        }
+        hasIdentityMethod = meth;
+        System.err.println("hasIdentityMethod = " + hasIdentityMethod);
+    }
+
+    /**
+     * Helper function that calls Object.hasIdentity via reflection.
+     * If `obj` is null, treat is as having no identity (matching JDK 28's
+     * behavior with or without --enable-preview) and return false.
+     * If `obj` is not null, check whether Objects.hasIdentity exists: if the
+     * method doesn't exist or cannot be invoked, return true; otherwise, call
+     * Objects.hasIdentity(obj) reflectively and return its value
+     */
+    private static boolean hasIdentity(Object obj) {
+        if (obj == null) {
+            System.err.println("[1] null");
+            return false;
+        } else if (hasIdentityMethod == null) {
+            System.err.println("[2] hasIdentityMethod == null");
+            return true;
+        } else {
+            try {
+                System.err.println("[3] Calling Ojbects.hasIdentityMethod(obj)");
+                return (Boolean)hasIdentityMethod.invoke(null, obj);
+            } catch (Exception ex) {
+                return true;
+            }
+        }
+    }
+
+    public WeakReferenceWrapper(T obj) {
+        if (hasIdentity(obj)) {
+            System.err.println("obj has identity : " + obj);
+            this.obj = null;
+            this.ref = new WeakReference<>(obj);
+        } else {
+            System.err.println("obj is a value object : " + obj);
+            this.obj = obj;
+            this.ref = null;
+        }
+
+        System.err.println("WeakReferenceWrapper: this.obj = " + this.obj + ", this.ref = " + this.ref);
+    }
+
+    public T get() {
+        return ref != null ? ref.get() : obj;
+    }
+}

--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/WeakReferenceWrapper.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/WeakReferenceWrapper.java
@@ -55,7 +55,6 @@ public class WeakReferenceWrapper<T> {
             meth = null;
         }
         hasIdentityMethod = meth;
-        System.err.println("hasIdentityMethod = " + hasIdentityMethod);
     }
 
     /**
@@ -69,14 +68,11 @@ public class WeakReferenceWrapper<T> {
      */
     private static boolean useWeakRef(Object obj) {
         if (obj == null) {
-            System.err.println("[1] null");
             return false;
         } else if (hasIdentityMethod == null) {
-            System.err.println("[2] hasIdentityMethod == null");
             return true;
         } else {
             try {
-                System.err.println("[3] Calling Objects.hasIdentityMethod(obj)");
                 return (Boolean)hasIdentityMethod.invoke(null, obj);
             } catch (IllegalAccessException | InvocationTargetException ex) {
                 return true;
@@ -93,16 +89,12 @@ public class WeakReferenceWrapper<T> {
      */
     public WeakReferenceWrapper(T obj) {
         if (useWeakRef(obj)) {
-            System.err.println("obj has identity : " + obj);
             this.obj = null;
             this.ref = new WeakReference<>(obj);
         } else {
-            System.err.println("obj is a value object : " + obj);
             this.obj = obj;
             this.ref = null;
         }
-
-        System.err.println("WeakReferenceWrapper: this.obj = " + this.obj + ", this.ref = " + this.ref);
     }
 
     /**

--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/WeakReferenceWrapper.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/WeakReferenceWrapper.java
@@ -26,15 +26,20 @@
 package com.sun.javafx.scene.control;
 
 import java.lang.ref.WeakReference;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Objects;
 
 /**
- * Wrapper class for weak references.
- * TODO: describe the purpose of this class.
+ * Wrapper class that holds a reference to an object with or without identity.
+ * If the object is non-null and has identity, a weak reference is created and
+ * stored; otherwise it holds a reference to the object itself,
+ * <p>
+ * In the case of a value object, the referent is never collected, so it is only
+ * suitable for uses that do not rely on the object being placed onto a reference
+ * queue.
  *
- * NOTE: In the case of value objects, the referent is never going to be
- * collected!
+ * @param <T> the type of the referent
  */
 public class WeakReferenceWrapper<T> {
 
@@ -59,9 +64,9 @@ public class WeakReferenceWrapper<T> {
      * behavior with or without --enable-preview) and return false.
      * If `obj` is not null, check whether Objects.hasIdentity exists: if the
      * method doesn't exist or cannot be invoked, return true; otherwise, call
-     * Objects.hasIdentity(obj) reflectively and return its value
+     * Objects.hasIdentity(obj) reflectively and return its value.
      */
-    private static boolean hasIdentity(Object obj) {
+    private static boolean useWeakRef(Object obj) {
         if (obj == null) {
             System.err.println("[1] null");
             return false;
@@ -72,14 +77,19 @@ public class WeakReferenceWrapper<T> {
             try {
                 System.err.println("[3] Calling Objects.hasIdentityMethod(obj)");
                 return (Boolean)hasIdentityMethod.invoke(null, obj);
-            } catch (Exception ex) {
+            } catch (IllegalAccessException | InvocationTargetException ex) {
                 return true;
             }
         }
     }
 
+    /**
+     * Creates a new reference that refers to the given object.
+     * If the object is non-null and has identity, a weak reference is created and
+     * stored; otherwise it holds a reference to the object itself,
+     */
     public WeakReferenceWrapper(T obj) {
-        if (hasIdentity(obj)) {
+        if (useWeakRef(obj)) {
             System.err.println("obj has identity : " + obj);
             this.obj = null;
             this.ref = new WeakReference<>(obj);
@@ -92,6 +102,13 @@ public class WeakReferenceWrapper<T> {
         System.err.println("WeakReferenceWrapper: this.obj = " + this.obj + ", this.ref = " + this.ref);
     }
 
+    /**
+     * Returns this reference object's referent. If the referent is held in a weak reference,
+     * and this reference object has been cleared by the garbage collector, then this method
+     * returns null.
+     *
+     * @return the object to which this reference refers, or null if this reference object has been cleared
+     */
     public T get() {
         return ref != null ? ref.get() : obj;
     }

--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/WeakReferenceWrapper.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/WeakReferenceWrapper.java
@@ -39,19 +39,19 @@ import java.util.Objects;
  * suitable for uses that do not rely on the object being placed onto a reference
  * queue.
  * This class might not be suitable for large trees of value objects or for
- * value objects that wrap an identity object (for example, {@code Optional<Object>}.
+ * value objects that wrap an identity object (for example, {@code Optional<Object>}).
  * Using it for such cases can lead to memory being held longer than expected
  * (as long as the {@code WeakReferenceWrapper} itself is held).
  * <p>
  * NOTE: we might be able to modify or eliminate this class in the future based
- * on one the following:
+ * on one of the following:
  *
  * <ol>
  * <li>A future version of the value objects preview (a follow-on to JEP 401) might
  * relax the restriction on weak references of value objects. Depending on how
  * this is done, we might change this wrapper to take advantage of that.</li>
  * <li>A future improvement to list-based UI controls might eliminate the need
- * for some or all of the weak references to application-proved items. If all are
+ * for some or all of the weak references to application-provided items. If all are
  * eliminated, then we can eliminate this wrapper class.</li>
  * </ol>
  *

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TableCell.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TableCell.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TableCell.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TableCell.java
@@ -25,6 +25,7 @@
 
 package javafx.scene.control;
 
+import com.sun.javafx.scene.control.WeakReferenceWrapper;
 import javafx.css.PseudoClass;
 import javafx.beans.InvalidationListener;
 import javafx.beans.WeakInvalidationListener;
@@ -631,7 +632,7 @@ public class TableCell<S,T> extends IndexedCell<T> {
 
     private boolean isFirstRun = true;
 
-    private WeakReference<S> oldRowItemRef;
+    private WeakReferenceWrapper<S> oldRowItemRef;
 
     /*
      * This is called when we think that the data within this TableCell may have
@@ -704,7 +705,7 @@ public class TableCell<S,T> extends IndexedCell<T> {
             updateItem(newValue, false);
         }
 
-        oldRowItemRef = new WeakReference<>(rowItem);
+        oldRowItemRef = new WeakReferenceWrapper<>(rowItem);
 
         if (currentObservableValue == null) {
             return;

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TablePosition.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TablePosition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TablePosition.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TablePosition.java
@@ -25,9 +25,7 @@
 
 package javafx.scene.control;
 
-import com.sun.javafx.scene.control.WeakReferenceWrapper;
 import java.lang.ref.WeakReference;
-import java.util.List;
 
 import javafx.beans.NamedArg;
 
@@ -71,10 +69,6 @@ public class TablePosition<S,T> extends TablePositionBase<TableColumn<S,T>> {
         super(row, tableColumn);
         this.controlRef = new WeakReference<>(tableView);
 
-        List<S> items = tableView != null ? tableView.getItems() : null;
-        this.itemRef = new WeakReferenceWrapper<>(
-                items != null && row >= 0 && row < items.size() ? items.get(row) : null);
-
         nonFixedColumnIndex = tableView == null || tableColumn == null ? -1 : tableView.getVisibleLeafIndex(tableColumn);
     }
 
@@ -87,7 +81,6 @@ public class TablePosition<S,T> extends TablePositionBase<TableColumn<S,T>> {
      **************************************************************************/
 
     private final WeakReference<TableView<S>> controlRef;
-    private final WeakReferenceWrapper<S> itemRef;
     int fixedColumnIndex = -1;
     private final int nonFixedColumnIndex;
 
@@ -122,14 +115,6 @@ public class TablePosition<S,T> extends TablePositionBase<TableColumn<S,T>> {
     @Override public final TableColumn<S,T> getTableColumn() {
         // Forcing the return type to be TableColumn<S,T>, not TableColumnBase<S,T>
         return super.getTableColumn();
-    }
-
-    /**
-     * Returns the item that backs the {@link #getRow()} row}, at the point
-     * in time when this TablePosition was created.
-     */
-    final S getItem() {
-        return itemRef == null ? null : itemRef.get();
     }
 
     /**

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TablePosition.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TablePosition.java
@@ -25,6 +25,7 @@
 
 package javafx.scene.control;
 
+import com.sun.javafx.scene.control.WeakReferenceWrapper;
 import java.lang.ref.WeakReference;
 import java.util.List;
 
@@ -71,7 +72,7 @@ public class TablePosition<S,T> extends TablePositionBase<TableColumn<S,T>> {
         this.controlRef = new WeakReference<>(tableView);
 
         List<S> items = tableView != null ? tableView.getItems() : null;
-        this.itemRef = new WeakReference<>(
+        this.itemRef = new WeakReferenceWrapper<>(
                 items != null && row >= 0 && row < items.size() ? items.get(row) : null);
 
         nonFixedColumnIndex = tableView == null || tableColumn == null ? -1 : tableView.getVisibleLeafIndex(tableColumn);
@@ -86,7 +87,7 @@ public class TablePosition<S,T> extends TablePositionBase<TableColumn<S,T>> {
      **************************************************************************/
 
     private final WeakReference<TableView<S>> controlRef;
-    private final WeakReference<S> itemRef;
+    private final WeakReferenceWrapper<S> itemRef;
     int fixedColumnIndex = -1;
     private final int nonFixedColumnIndex;
 

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableCell.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableCell.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableCell.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableCell.java
@@ -25,6 +25,7 @@
 
 package javafx.scene.control;
 
+import com.sun.javafx.scene.control.WeakReferenceWrapper;
 import javafx.css.PseudoClass;
 import javafx.scene.control.skin.TreeTableCellSkin;
 import javafx.beans.InvalidationListener;
@@ -626,7 +627,7 @@ public class TreeTableCell<S,T> extends IndexedCell<T> {
 
     private boolean isFirstRun = true;
 
-    private WeakReference<S> oldRowItemRef;
+    private WeakReferenceWrapper<S> oldRowItemRef;
 
     /*
      * This is called when we think that the data within this TreeTableCell may have
@@ -700,7 +701,7 @@ public class TreeTableCell<S,T> extends IndexedCell<T> {
             updateItem(newValue, false);
         }
 
-        oldRowItemRef = new WeakReference<>(rowItem);
+        oldRowItemRef = new WeakReferenceWrapper<>(rowItem);
 
         if (currentObservableValue == null) {
             return;

--- a/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/WeakReferenceWrapperTest.java
+++ b/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/WeakReferenceWrapperTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package test.com.sun.javafx.scene.control;
+
+import com.sun.javafx.scene.control.WeakReferenceWrapper;
+import java.lang.ref.WeakReference;
+import org.junit.jupiter.api.Test;
+import test.util.memory.JMemoryBuddy;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/*
+ * Test WeakReferenceWrapper utility.
+ */
+public class WeakReferenceWrapperTest {
+
+    // POJO with identity
+    static class POJO {
+        final int i;
+
+        @Override
+        public int hashCode() {
+            return i;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (other instanceof POJO otherPOJO) {
+                return i == otherPOJO.i;
+            } else {
+                return false;
+            }
+        }
+
+        POJO(int i) {
+            this.i = i;
+        }
+    }
+
+    // Test WeakReferenceWrapper with null, Integer (could be a value object),
+    // String (always an identity object), and a POJO (identity object).
+    @Test
+    public void testWeakReferenceWrapper() {
+        var nullRef = new WeakReferenceWrapper<Object>(null);
+        assertNull(nullRef.get());
+
+        Integer i = 123;
+        var intRef = new WeakReferenceWrapper<Integer>(i);
+        assertEquals(i, intRef.get());
+
+        String str = "abc";
+        var strRef = new WeakReferenceWrapper<String>(str);
+        assertEquals(str, strRef.get());
+
+        POJO pojo = new POJO(456);
+        var pojoRef = new WeakReferenceWrapper<POJO>(pojo);
+        assertEquals(pojo, pojoRef.get());
+    }
+
+    // Test that a WeakReferenceWrapper of an identity object holds the object
+    // weakly and does not prevent the object from being collected.
+    @Test
+    public void testWeakReferenceToIdentityObjIsCollectable() {
+        var pojo = new POJO(789);
+        var pojoWeakRef = new WeakReference<POJO>(pojo);
+        var pojoRef = new WeakReferenceWrapper<POJO>(pojo);
+
+        JMemoryBuddy.assertNotCollectable(pojoWeakRef);
+        assertNotNull(pojoRef.get());
+        assertSame(pojo, pojoRef.get());
+
+        pojo = null;
+        JMemoryBuddy.assertCollectable(pojoWeakRef);
+        assertNull(pojoRef.get());
+    }
+}


### PR DESCRIPTION
This PR creates a WeakReferenceWrapper object to replace direct uses of WeakReference in controls where the referent is a user-supplied object of an unknown type.

As noted in JEP 401, which is now integrated into JDK 28, "The garbage collection APIs in java.lang.ref ... do not allow developers to manually manage value objects in the heap. Attempts to create Reference objects for value objects throw IdentityException at run time."

Several core JDK classes such as all of the primitive wrappers (e.g., `Integer`, `Character`), `Optional`, `LocalDateTime`, and a few others are now value types if JDK 28 is run with the `--enable-preview` option.

The `ListView`, `ComboBox`, `TableView`, and `TreeTableView` controls take a parameterized item type and hold items of that type. The following places in the implementation create weak references to an item. If that item type is a value class -- meaning that it does not have identity -- creating the `WeakReference` fails.

As noted in the JBS issue, there are 3 cases to consider.

1. `SelectedItemsReadOnlyObservableList<E>` -- `E` is the item type (created by `MultipleSelectionModelBase<T>`) : `ListView`, `TableView`, `ComboBox` (due to its skin creating a `ListView<T>`) -- replace with `WeakReferenceWrapper`

2. `TablePosition<S,T>` -- `S` is the item type : `TableView` -- the reference is unused, so I removed it

3. `TableCell<S,T>` and `TreeTableCell<S,T>` -- `S` is the item type : `TableView`, `TreeTableView` -- replace with `WeakReferenceWrapper`

The new `WeakReferenceWrapper` class takes a referent of any type and either creates a WeakReference (if it has identity) or directly stores the reference (if it is null or does not have identity). I added a test for the wrapper.

All of the controls tests pass with this fix. I did three test runs as follows:

1. JDK 25
2. JDK 28 without `--enable-preview`
3. JDK 28 with `--enable-preview`

Without the fix, 31 controls tests fails on the 3rd run.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8387301](https://bugs.openjdk.org/browse/JDK-8387301): ListView, ComboBox, TableView, TreeTableView fail when item type is a value class (**Bug** - P3)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Marius Hanl](https://openjdk.org/census#mhanl) (@Maran23 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2250/head:pull/2250` \
`$ git checkout pull/2250`

Update a local copy of the PR: \
`$ git checkout pull/2250` \
`$ git pull https://git.openjdk.org/jfx.git pull/2250/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2250`

View PR using the GUI difftool: \
`$ git pr show -t 2250`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2250.diff">https://git.openjdk.org/jfx/pull/2250.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2250#issuecomment-5297444667)
</details>
