### PR TITLE
8294872: Document "resource" protocol

### DIFF
--- a/modules/javafx.media/src/main/java/com/sun/media/jfxmedia/locator/Locator.java
+++ b/modules/javafx.media/src/main/java/com/sun/media/jfxmedia/locator/Locator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -196,7 +196,7 @@ public class Locator {
      * manipulation in order to be used and this procedure fails to produce a
      * usable URI.
      * @throws IllegalArgumentException if the URI is a Jar URL as described in
-     * {@link JarURLConnection https://docs.oracle.com/javase/8/docs/api/java/net/JarURLConnection.html},
+     * {@link java.net.JarURLConnection},
      * and the scheme of the URL after removing the leading four characters is
      * <code>null</code>.
      * @throws UnsupportedOperationException if the URI's protocol is

--- a/modules/javafx.media/src/main/java/javafx/scene/media/AudioClip.java
+++ b/modules/javafx.media/src/main/java/javafx/scene/media/AudioClip.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -70,7 +70,8 @@ public final class AudioClip {
      * Create an <code>AudioClip</code> loaded from the supplied source URL.
      *
      * @param source URL string from which to load the audio clip. This can be an
-     * HTTP, HTTPS, FILE or JAR source.
+     * <code>http</code>, <code>https</code>, <code>file</code>, <code>jar</code>,
+     * <code>jrt</code>, and <code>resource</code> source.
      * @throws NullPointerException if the parameter is <code>null</code>.
      * @throws IllegalArgumentException if the parameter violates
      * <a href="http://www.ietf.org/rfc/rfc2396.txt">RFC 2396</a>.

--- a/modules/javafx.media/src/main/java/javafx/scene/media/AudioClip.java
+++ b/modules/javafx.media/src/main/java/javafx/scene/media/AudioClip.java
@@ -69,9 +69,9 @@ public final class AudioClip {
     /**
      * Create an <code>AudioClip</code> loaded from the supplied source URL.
      *
-     * @param source URL string from which to load the audio clip. This can be an
-     * <code>http</code>, <code>https</code>, <code>file</code>, <code>jar</code>,
-     * <code>jrt</code>, and <code>resource</code> source.
+     * @param source the URL from which to load the audio clip. Supported URL schemes
+     * are {@code http}, {@code https}, {@code file}, {@code jar}, {@code jrt}, and
+     * {@code resource}.
      * @throws NullPointerException if the parameter is <code>null</code>.
      * @throws IllegalArgumentException if the parameter violates
      * <a href="http://www.ietf.org/rfc/rfc2396.txt">RFC 2396</a>.

--- a/modules/javafx.media/src/main/java/javafx/scene/media/AudioClip.java
+++ b/modules/javafx.media/src/main/java/javafx/scene/media/AudioClip.java
@@ -71,7 +71,8 @@ public final class AudioClip {
      *
      * @param source the URL from which to load the audio clip. Supported URL schemes
      * are <code>http</code>, <code>https</code>, <code>file</code>, <code>jar</code>,
-     * <code>jrt</code>, and <code>resource</code>.
+     * <code>jrt</code>, and <code>resource</code>. <code>resource</code> URIs are
+     * supported only in statically linked applications.
      * @throws NullPointerException if the parameter is <code>null</code>.
      * @throws IllegalArgumentException if the parameter violates
      * <a href="http://www.ietf.org/rfc/rfc2396.txt">RFC 2396</a>.

--- a/modules/javafx.media/src/main/java/javafx/scene/media/AudioClip.java
+++ b/modules/javafx.media/src/main/java/javafx/scene/media/AudioClip.java
@@ -70,8 +70,8 @@ public final class AudioClip {
      * Create an <code>AudioClip</code> loaded from the supplied source URL.
      *
      * @param source the URL from which to load the audio clip. Supported URL schemes
-     * are {@code http}, {@code https}, {@code file}, {@code jar}, {@code jrt}, and
-     * {@code resource}.
+     * are <code>http</code>, <code>https</code>, <code>file</code>, <code>jar</code>,
+     * <code>jrt</code>, and <code>resource</code>.
      * @throws NullPointerException if the parameter is <code>null</code>.
      * @throws IllegalArgumentException if the parameter violates
      * <a href="http://www.ietf.org/rfc/rfc2396.txt">RFC 2396</a>.

--- a/modules/javafx.media/src/main/java/javafx/scene/media/Media.java
+++ b/modules/javafx.media/src/main/java/javafx/scene/media/Media.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -336,7 +336,7 @@ public final class Media {
     /**
      * Constructs a <code>Media</code> instance.  This is the only way to
      * specify the media source. The source must represent a valid <code>URI</code>
-     * and is immutable. Only HTTP, HTTPS, FILE, and JAR <code>URL</code>s are supported. If the
+     * and is immutable. Only HTTP, HTTPS, FILE, JAR, and RESOURCE <code>URL</code>s are supported. If the
      * provided URL is invalid then an exception will be thrown.  If an
      * asynchronous error occurs, the {@link #errorProperty error} property will be set. Listen
      * to this property to be notified of any such errors.
@@ -352,13 +352,15 @@ public final class Media {
      * <p>Constraints:
      * <ul>
      * <li>The supplied URI must conform to RFC-2396 as required by
-     * <A href="https://docs.oracle.com/javase/8/docs/api/java/net/URI.html">java.net.URI</A>.</li>
-     * <li>Only HTTP, HTTPS, FILE, and JAR URIs are supported.</li>
+     * <a href="https://docs.oracle.com/javase/8/docs/api/java/net/URI.html">java.net.URI</a>.</li>
+     * <li>Only HTTP, HTTPS, FILE, JAR, and RESOURCE URIs are supported.
+     * RESOURCE URIs are supported only in statically linked applications.</li>
      * </ul>
      *
-     * <p>See <A href="https://docs.oracle.com/javase/8/docs/api/java/net/URI.html">java.net.URI</A>
+     * <p>See <a href="https://docs.oracle.com/javase/8/docs/api/java/net/URI.html">java.net.URI</a>
      * for more information about URI formatting in general.
-     * JAR URL syntax is specified in <a href="https://docs.oracle.com/javase/8/docs/api/java/net/JarURLConnection.html">java.net.JarURLConnection</A>.
+     * JAR URL syntax is specified in <a href="https://docs.oracle.com/javase/8/docs/api/java/net/JarURLConnection.html">java.net.JarURLConnection</a>.
+     * RESOURCE URL syntax is specified in <a href="https://www.graalvm.org/latest/reference-manual/native-image/dynamic-features/URLProtocols/">URL Protocols in Native Image</a>.
      *
      * @param source The URI of the source media.
      * @throws NullPointerException if the URI string is <code>null</code>.

--- a/modules/javafx.media/src/main/java/javafx/scene/media/Media.java
+++ b/modules/javafx.media/src/main/java/javafx/scene/media/Media.java
@@ -336,31 +336,34 @@ public final class Media {
     /**
      * Constructs a <code>Media</code> instance.  This is the only way to
      * specify the media source. The source must represent a valid <code>URI</code>
-     * and is immutable. Only HTTP, HTTPS, FILE, JAR, and RESOURCE <code>URL</code>s are supported. If the
+     * and is immutable. Only <code>http</code>, <code>https</code>, <code>file</code>, <code>jar</code>,
+     * <code>jrt</code>, and <code>resource</code> <code>URL</code>s are supported. If the
      * provided URL is invalid then an exception will be thrown.  If an
      * asynchronous error occurs, the {@link #errorProperty error} property will be set. Listen
      * to this property to be notified of any such errors.
      *
-     * <p>If the source uses a non-blocking protocol such as FILE, then any
+     * <p>If the source uses a non-blocking protocol such as <code>file</code>, then any
      * problems which can be detected immediately will cause a <code>MediaException</code>
      * to be thrown. Such problems include the media being inaccessible or in an
      * unsupported format. If however a potentially blocking protocol such as
-     * HTTP is used, then the connection will be initialized asynchronously so
+     * <code>http</code> is used, then the connection will be initialized asynchronously so
      * that these sorts of errors will be signaled by setting the {@link #errorProperty error}
      * property.</p>
      *
      * <p>Constraints:
      * <ul>
      * <li>The supplied URI must conform to RFC-2396 as required by
-     * <a href="https://docs.oracle.com/javase/8/docs/api/java/net/URI.html">java.net.URI</a>.</li>
-     * <li>Only HTTP, HTTPS, FILE, JAR, and RESOURCE URIs are supported.
-     * RESOURCE URIs are supported only in statically linked applications.</li>
+     * {@link java.net.URI}.</li>
+     * <li>Only <code>http</code>, <code>https</code>, <code>file</code>, <code>jar</code>,
+     * <code>jrt</code>, and <code>resource</code> URIs are supported. <code>resource</code> URIs are supported only in
+     * statically linked applications.</li>
      * </ul>
      *
-     * <p>See <a href="https://docs.oracle.com/javase/8/docs/api/java/net/URI.html">java.net.URI</a>
+     * <p>See {@link java.net.URI}
      * for more information about URI formatting in general.
-     * JAR URL syntax is specified in <a href="https://docs.oracle.com/javase/8/docs/api/java/net/JarURLConnection.html">java.net.JarURLConnection</a>.
-     * RESOURCE URL syntax is specified in <a href="https://www.graalvm.org/latest/reference-manual/native-image/dynamic-features/URLProtocols/">URL Protocols in Native Image</a>.
+     * The <code>jar</code> URL syntax is specified in {@link java.net.JarURLConnection}.
+     * <code>jrt</code> URL syntax is specified in <a href="https://openjdk.org/jeps/220">JEP 220: Modular Run-Time Images</A>.
+     * The <code>resource</code> URL syntax is specified in <a href="https://www.graalvm.org/latest/reference-manual/native-image/dynamic-features/URLProtocols/">URL Protocols in Native Image</a>.
      *
      * @param source The URI of the source media.
      * @throws NullPointerException if the URI string is <code>null</code>.

--- a/modules/javafx.media/src/main/java/javafx/scene/media/Media.java
+++ b/modules/javafx.media/src/main/java/javafx/scene/media/Media.java
@@ -362,8 +362,8 @@ public final class Media {
      * <p>See {@link java.net.URI}
      * for more information about URI formatting in general.
      * The <code>jar</code> URL syntax is specified in {@link java.net.JarURLConnection}.
-     * <code>jrt</code> URL syntax is specified in <a href="https://openjdk.org/jeps/220">JEP 220: Modular Run-Time Images</A>.
-     * The <code>resource</code> URL syntax is specified in <a href="https://www.graalvm.org/latest/reference-manual/native-image/dynamic-features/URLProtocols/">URL Protocols in Native Image</a>.
+     * <code>jrt</code> URL syntax is described in <a href="https://openjdk.org/jeps/220">JEP 220: Modular Run-Time Images</a>.
+     * The <code>resource</code> URL syntax is described in <a href="https://www.graalvm.org/latest/reference-manual/native-image/dynamic-features/URLProtocols/">URL Protocols in Native Image</a>.
      *
      * @param source The URI of the source media.
      * @throws NullPointerException if the URI string is <code>null</code>.

--- a/modules/javafx.media/src/main/java/javafx/scene/media/package-info.java
+++ b/modules/javafx.media/src/main/java/javafx/scene/media/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -136,6 +136,11 @@
  *     <th scope="row">JAR</th>
  *     <td>Representation of media entries in files accessible via the FILE, HTTP or HTTPS protocols</td>
  *     <td><a href="https://docs.oracle.com/javase/8/docs/api/java/net/JarURLConnection.html">java.net.JarURLConnection</a></td>
+ * </tr>
+ * <tr>
+ *     <th scope="row">RESOURCE</th>
+ *     <td>Representation of media resources bundled in a statically linked application image</td>
+ *     <td><a href="https://www.graalvm.org/latest/reference-manual/native-image/dynamic-features/URLProtocols/">URL Protocols in Native Image</a></td>
  * </tr>
  * <tr>
  *     <th scope="row">HTTP Live Streaming (HLS)</th>

--- a/modules/javafx.media/src/main/java/javafx/scene/media/package-info.java
+++ b/modules/javafx.media/src/main/java/javafx/scene/media/package-info.java
@@ -34,7 +34,7 @@
  * <h2>Contents</h2>
  * <ol>
  * <li><a href="#SupportedMediaTypes">Supported Media Types</a></li>
- * <li><a href="#SupportedProtocols">Supported Protocols</a></li>
+ * <li><a href="#SupportedProtocols">Supported Schemes / Protocols</a></li>
  * <li><a href="#SupportedMetadataTags">Supported Metadata Tags</a></li>
  * <li><a href="#PlayingMediaInJavaFX">Playing Media in Java FX</a></li>
  * </ol>
@@ -112,46 +112,52 @@
  * aggregate similar attributes.
  *
  * <a id="SupportedProtocols"></a>
- * <h3>Supported Protocols</h3>
+ * <h3>Supported Schemes / Protocols</h3>
  *
  * <table border="1">
- * <caption>Supported Protocols Table</caption>
+ * <caption>Supported Schemes / Protocols Table</caption>
  * <tr><th scope="col">Protocol</th><th scope="col">Description</th><th scope="col">Reference</th></tr>
  * <tr>
- *     <th scope="row">FILE</th>
+ *     <th scope="row"><code>file</code></th>
  *     <td>Protocol for URI representation of local files</td>
- *     <td><a href="https://docs.oracle.com/javase/8/docs/api/java/net/URI.html">java.net.URI</a></td>
+ *     <td>{@link java.net.URI}</td>
  * </tr>
  * <tr>
- *     <th scope="row">HTTP</th>
+ *     <th scope="row"><code>http</code></th>
  *     <td>Hypertext transfer protocol for representation of remote files</td>
- *     <td><a href="https://docs.oracle.com/javase/8/docs/api/java/net/URI.html">java.net.URI</a></td>
+ *     <td>{@link java.net.URI}</td>
  * </tr>
  * <tr>
- *     <th scope="row">HTTPS</th>
+ *     <th scope="row"><code>https</code></th>
  *     <td>Hypertext transfer protocol secure for representation of remote files</td>
- *     <td><a href="https://docs.oracle.com/javase/8/docs/api/java/net/URI.html">java.net.URI</a></td>
+ *     <td>{@link java.net.URI}</td>
  * </tr>
  * <tr>
- *     <th scope="row">JAR</th>
- *     <td>Representation of media entries in files accessible via the FILE, HTTP or HTTPS protocols</td>
- *     <td><a href="https://docs.oracle.com/javase/8/docs/api/java/net/JarURLConnection.html">java.net.JarURLConnection</a></td>
+ *     <th scope="row"><code>jar</code></th>
+ *     <td>Representation of media resources packaged in JAR files accessible via the <code>file</code>,
+ *     <code>http</code>, or <code>https</code> protocols</td>
+ *     <td>{@link java.net.JarURLConnection}</td>
  * </tr>
  * <tr>
- *     <th scope="row">RESOURCE</th>
- *     <td>Representation of media resources bundled in a statically linked application image</td>
+ *     <th scope="row"><code>jrt</code></th>
+ *     <td>Representation of media resources in the Java run-time image</td>
+ *     <td><a href="https://openjdk.org/jeps/220">JEP 220: Modular Run-Time Images</a></td>
+ * </tr>
+ * <tr>
+ *     <th scope="row"><code>resource</code></th>
+ *     <td>Representation of media resources bundled in a GraalVM Native Image executable</td>
  *     <td><a href="https://www.graalvm.org/latest/reference-manual/native-image/dynamic-features/URLProtocols/">URL Protocols in Native Image</a></td>
  * </tr>
  * <tr>
  *     <th scope="row">HTTP Live Streaming (HLS)</th>
- *     <td>Playlist-based media streaming via HTTP or HTTPS</td>
+ *     <td>Playlist-based media streaming via <code>http</code> or <code>https</code></td>
  *     <td><a href="https://datatracker.ietf.org/doc/html/rfc8216">HTTP Live Streaming (RFC 8216)</a></td>
  * </tr>
  * </table>
  * <br>
- * <h4>MPEG-4 Playback via HTTP</h4>
+ * <h4>MPEG-4 Playback via <code>http</code> or <code>https</code></h4>
  * <p>
- * It is recommended that MPEG-4 media to be played over HTTP or HTTPS be formatted such that the
+ * It is recommended that MPEG-4 media to be played over <code>http</code> or <code>https</code> be formatted such that the
  * headers required to decode the stream appear at the beginning of the file. Otherwise,
  * playback might stall until the entire file is downloaded.
  * </p>

--- a/modules/javafx.media/src/main/java/javafx/scene/media/package-info.java
+++ b/modules/javafx.media/src/main/java/javafx/scene/media/package-info.java
@@ -115,7 +115,7 @@
  * <h3>Supported Schemes / Protocols</h3>
  *
  * <table border="1">
- * <caption>Supported Schemes / Protocols Table</caption>
+ * <caption>Supported URL Protocols</caption>
  * <tr><th scope="col">Protocol</th><th scope="col">Description</th><th scope="col">Reference</th></tr>
  * <tr>
  *     <th scope="row"><code>file</code></th>


### PR DESCRIPTION
- Added documentation for "resource" protocol.
- "resource" protocol was added with JDK-8238755 to support GraalVM native-image.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issues
 * [JDK-8294872](https://bugs.openjdk.org/browse/JDK-8294872): Document "resource" protocol (**Task** - P3)
 * [JDK-8374836](https://bugs.openjdk.org/browse/JDK-8374836): Media: add missing jrt protocol to javadoc (**Bug** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2251/head:pull/2251` \
`$ git checkout pull/2251`

Update a local copy of the PR: \
`$ git checkout pull/2251` \
`$ git pull https://git.openjdk.org/jfx.git pull/2251/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2251`

View PR using the GUI difftool: \
`$ git pr show -t 2251`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2251.diff">https://git.openjdk.org/jfx/pull/2251.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2251#issuecomment-5209580702)
</details>
