### PR TITLE
8389921: Changes in hlsl files do not dirty build sources

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2490,20 +2490,21 @@ project(":graphics") {
 
     if (IS_WINDOWS) {
         addNative(project, "prismD3D")
-        // TODO need to hook this up to be executed only if PassThroughVS.h is missing or PassThroughVS.hlsl is changed
+        def prismD3DSource = "src/main/native-prism-d3d"
         task generateD3DHeaders(group: "Build") {
             enabled = IS_WINDOWS
-            inputs.file "src/main/native-prism-d3d/hlsl/Mtl1PS.hlsl"
-            inputs.file "src/main/native-prism-d3d/hlsl/Mtl1VS.hlsl"
-            inputs.file "src/main/native-prism-d3d/PassThroughVS.hlsl"
+            inputs.files(fileTree("$prismD3DSource/hlsl") {
+                      include "*.hlsl"
+                      include "*.h"
+                  }).withPropertyName("hlslSources")
+            inputs.file("$prismD3DSource/PassThroughVS.hlsl").withPropertyName("PassThroughVsSources")
             outputs.dir "$buildDir/headers/PrismD3D/"
-            outputs.dir "$buildDir/headers/PrismD3D/hlsl/"
             description = "Generate headers by compiling hlsl files"
             doLast {
                 mkdir file("$buildDir/headers/PrismD3D/hlsl")
-                def PS_3D_SRC = file("src/main/native-prism-d3d/hlsl/Mtl1PS.hlsl")
-                def VS_3D_SRC = file("src/main/native-prism-d3d/hlsl/Mtl1VS.hlsl")
-                def PASSTHROUGH_VS_SRC = file("src/main/native-prism-d3d/PassThroughVS.hlsl")
+                def PS_3D_SRC = file("$prismD3DSource/hlsl/Mtl1PS.hlsl")
+                def VS_3D_SRC = file("$prismD3DSource/hlsl/Mtl1VS.hlsl")
+                def PASSTHROUGH_VS_SRC = file("$prismD3DSource/PassThroughVS.hlsl")
                 def jobs = [
                         ["$FXC", "/nologo", "/T", "vs_3_0", "/Fh", "$buildDir/headers/PrismD3D/PassThroughVS.h", "/E", "passThrough", "$PASSTHROUGH_VS_SRC"],
                         ["$FXC", "/nologo", "/T", "ps_3_0", "/Fh", "$buildDir/headers/PrismD3D/hlsl/Mtl1PS.h", "/DSpec=0", "/DSType=0", "$PS_3D_SRC"],

--- a/build.gradle
+++ b/build.gradle
@@ -2496,8 +2496,8 @@ project(":graphics") {
             inputs.files(fileTree("$prismD3DSource/hlsl") {
                       include "*.hlsl"
                       include "*.h"
-                  }).withPropertyName("hlslSources")
-            inputs.file("$prismD3DSource/PassThroughVS.hlsl").withPropertyName("PassThroughVsSources")
+                  })
+            inputs.file("$prismD3DSource/PassThroughVS.hlsl")
             outputs.dir "$buildDir/headers/PrismD3D/"
             description = "Generate headers by compiling hlsl files"
             doLast {

--- a/build.gradle
+++ b/build.gradle
@@ -2188,7 +2188,7 @@ allprojects {
     test {
         useJUnitPlatform();
 
-        // Tests are forced to rerun when they are *not* marked as up-to-date 
+        // Tests are forced to rerun when they are *not* marked as up-to-date
         outputs.upToDateWhen { !IS_FORCE_TESTS }
 
         executable = JAVA;

--- a/build.gradle
+++ b/build.gradle
@@ -485,7 +485,8 @@ ext.SWT_FILE_NAME =
 defineProperty("FULL_TEST", "false")
 ext.IS_FULL_TEST = Boolean.parseBoolean(FULL_TEST);
 
-defineProperty("FORCE_TESTS", "false")
+// Specifies whether tests should be forced to rerun even when up-to-date
+defineProperty("FORCE_TESTS", "true")
 ext.IS_FORCE_TESTS = Boolean.parseBoolean(FORCE_TESTS);
 
 // Specifies whether to run robot-based visual tests (only used when FULL_TEST is also enabled)
@@ -2187,8 +2188,8 @@ allprojects {
     test {
         useJUnitPlatform();
 
-        // Always run tests
-        outputs.upToDateWhen { false }
+        // Tests are forced to rerun when they are *not* marked as up-to-date 
+        outputs.upToDateWhen { !IS_FORCE_TESTS }
 
         executable = JAVA;
         enableAssertions = true;


### PR DESCRIPTION
* Adds the missing .h files as inputs.
* ~~Names the input properties for `-i` debug info.~~
* Removes a redundant nested output dir.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8389921](https://bugs.openjdk.org/browse/JDK-8389921): Changes in hlsl files do not dirty build sources (**Bug** - P3)


### Reviewers
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)
 * [Lukasz Kostyra](https://openjdk.org/census#lkostyra) (@lukostyra - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2252/head:pull/2252` \
`$ git checkout pull/2252`

Update a local copy of the PR: \
`$ git checkout pull/2252` \
`$ git pull https://git.openjdk.org/jfx.git pull/2252/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2252`

View PR using the GUI difftool: \
`$ git pr show -t 2252`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2252.diff">https://git.openjdk.org/jfx/pull/2252.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2252#issuecomment-5296021856)
</details>
