### PR TITLE
8389970: StringIndexOutOfBoundsException when a text containing a mnemonic is removed

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/LabeledSkinBase.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/LabeledSkinBase.java
@@ -548,11 +548,12 @@ public abstract class LabeledSkinBase<C extends Labeled> extends SkinBase<C> {
             graphicHeight = graphic.getLayoutBounds().getHeight();
         }
 
+        updateDisplayedText(w, h);
+
         if (ignoreText) {
             textWidth  = textHeight = 0;
             text.setText("");
         } else {
-            updateDisplayedText(w, h); // Have to do this just in case it needs to be recomputed
             textWidth  = snapSizeX(Math.min(text.getLayoutBounds().getWidth(),  wrapWidth));
             textHeight = snapSizeY(Math.min(text.getLayoutBounds().getHeight(), wrapHeight));
         }
@@ -599,14 +600,19 @@ public abstract class LabeledSkinBase<C extends Labeled> extends SkinBase<C> {
         Point2D mnemonicPos = null;
         double mnemonicWidth = 0.0;
         double mnemonicHeight = 0.0;
-        int mnemonicIndex = mnemonicInfo != null ? mnemonicInfo.getMnemonicIndex() : -1;
-        if (containsMnemonic && mnemonicIndex >= 0) {
-            final Font font = text.getFont();
-            String preSt = mnemonicInfo.getText();
-            boolean isRTL = (labeledNode.getEffectiveNodeOrientation() == NodeOrientation.RIGHT_TO_LEFT);
-            mnemonicPos = Utils.computeMnemonicPosition(font, preSt, mnemonicIndex, this.wrapWidth, labeled.getLineSpacing(), isRTL);
-            mnemonicWidth = Utils.computeTextWidth(font, preSt.substring(mnemonicIndex, mnemonicIndex + 1), 0);
-            mnemonicHeight = Utils.computeTextHeight(font, "_", 0, text.getBoundsType());
+        if (containsMnemonic && mnemonicInfo != null) {
+            int mnemonicIndex = mnemonicInfo.getMnemonicIndex();
+            String cleanText = mnemonicInfo.getText();
+            // The mnemonic KeyCode can also be defined in the following form: Exit_(q)
+            // In this case, no mnemonic character is available and the mnemonicIndex value is equal to the text.length().
+            // This means we cannot substring the character from the text.
+            if (mnemonicIndex >= 0 && mnemonicInfo.getExtendedMnemonicText() == null) {
+                final Font font = text.getFont();
+                boolean isRTL = (labeledNode.getEffectiveNodeOrientation() == NodeOrientation.RIGHT_TO_LEFT);
+                mnemonicPos = Utils.computeMnemonicPosition(font, cleanText, mnemonicIndex, this.wrapWidth, labeled.getLineSpacing(), isRTL);
+                mnemonicWidth = Utils.computeTextWidth(font, cleanText.substring(mnemonicIndex, mnemonicIndex + 1), 0);
+                mnemonicHeight = Utils.computeTextHeight(font, "_", 0, text.getBoundsType());
+            }
         }
 
 
@@ -969,7 +975,9 @@ public abstract class LabeledSkinBase<C extends Labeled> extends SkinBase<C> {
             if (cleanText != null && cleanText.length() > 0
                     && mnemonicInfo != null
                     && !com.sun.javafx.PlatformUtil.isMac()
-                    && getSkinnable().isMnemonicParsing()) {
+                    && getSkinnable().isMnemonicParsing()
+                    // Consider the mnemonic as not present if the text is not visible at all
+                    && labeled.getContentDisplay() != ContentDisplay.GRAPHIC_ONLY) {
                 /*
                 ** the Labeled has a MnemonicParsing property,
                 ** if set true, then auto-parsing will check for

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/LabeledSkinBase.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/LabeledSkinBase.java
@@ -548,11 +548,15 @@ public abstract class LabeledSkinBase<C extends Labeled> extends SkinBase<C> {
             graphicHeight = graphic.getLayoutBounds().getHeight();
         }
 
+        // Have to do this just in case it needs to be recomputed
+        // This is especially important because it also recomputes the 'containsMnemonic' value,
+        // which is used by this method later on.
+        updateDisplayedText(w, h);
+
         if (ignoreText) {
             textWidth  = textHeight = 0;
             text.setText("");
         } else {
-            updateDisplayedText(w, h); // Have to do this just in case it needs to be recomputed
             textWidth  = snapSizeX(Math.min(text.getLayoutBounds().getWidth(),  wrapWidth));
             textHeight = snapSizeY(Math.min(text.getLayoutBounds().getHeight(), wrapHeight));
         }

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/LabeledSkinBase.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/LabeledSkinBase.java
@@ -1104,7 +1104,7 @@ public abstract class LabeledSkinBase<C extends Labeled> extends SkinBase<C> {
         Labeled labeled = getSkinnable();
         String sourceText = labeled.getText();
 
-        if (labeled.isMnemonicParsing()) {
+        if (labeled.isMnemonicParsing() && !com.sun.javafx.PlatformUtil.isMac()) {
             if (mnemonicInfo == null) {
                 mnemonicInfo = new MnemonicInfo(sourceText);
             } else {

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/LabeledSkinBase.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/LabeledSkinBase.java
@@ -551,12 +551,12 @@ public abstract class LabeledSkinBase<C extends Labeled> extends SkinBase<C> {
         // Have to do this just in case it needs to be recomputed
         // This is especially important because it also recomputes the 'containsMnemonic' value,
         // which is used by this method later on.
-        updateDisplayedText(w, h);
 
         if (ignoreText) {
             textWidth  = textHeight = 0;
             text.setText("");
         } else {
+            updateDisplayedText(w, h);
             textWidth  = snapSizeX(Math.min(text.getLayoutBounds().getWidth(),  wrapWidth));
             textHeight = snapSizeY(Math.min(text.getLayoutBounds().getHeight(), wrapHeight));
         }
@@ -603,12 +603,13 @@ public abstract class LabeledSkinBase<C extends Labeled> extends SkinBase<C> {
         Point2D mnemonicPos = null;
         double mnemonicWidth = 0.0;
         double mnemonicHeight = 0.0;
-        if (containsMnemonic) {
+        int mnemonicIndex = mnemonicInfo != null ? mnemonicInfo.getMnemonicIndex() : -1;
+        if (containsMnemonic && mnemonicIndex >= 0) {
             final Font font = text.getFont();
             String preSt = mnemonicInfo.getText();
             boolean isRTL = (labeledNode.getEffectiveNodeOrientation() == NodeOrientation.RIGHT_TO_LEFT);
-            mnemonicPos = Utils.computeMnemonicPosition(font, preSt, mnemonicInfo.getMnemonicIndex(), this.wrapWidth, labeled.getLineSpacing(), isRTL);
-            mnemonicWidth = Utils.computeTextWidth(font, preSt.substring(mnemonicInfo.getMnemonicIndex(), mnemonicInfo.getMnemonicIndex() + 1), 0);
+            mnemonicPos = Utils.computeMnemonicPosition(font, preSt, mnemonicIndex, this.wrapWidth, labeled.getLineSpacing(), isRTL);
+            mnemonicWidth = Utils.computeTextWidth(font, preSt.substring(mnemonicIndex, mnemonicIndex + 1), 0);
             mnemonicHeight = Utils.computeTextHeight(font, "_", 0, text.getBoundsType());
         }
 

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/LabeledSkinBase.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/LabeledSkinBase.java
@@ -975,9 +975,7 @@ public abstract class LabeledSkinBase<C extends Labeled> extends SkinBase<C> {
             if (cleanText != null && cleanText.length() > 0
                     && mnemonicInfo != null
                     && !com.sun.javafx.PlatformUtil.isMac()
-                    && getSkinnable().isMnemonicParsing()
-                    // Consider the mnemonic as not present if the text is not visible at all
-                    && labeled.getContentDisplay() != ContentDisplay.GRAPHIC_ONLY) {
+                    && getSkinnable().isMnemonicParsing()) {
                 /*
                 ** the Labeled has a MnemonicParsing property,
                 ** if set true, then auto-parsing will check for
@@ -1030,16 +1028,19 @@ public abstract class LabeledSkinBase<C extends Labeled> extends SkinBase<C> {
             }
 
             if (containsMnemonic) {
-                if (mnemonic_underscore == null) {
-                    mnemonic_underscore = new Line();
-                    mnemonic_underscore.setStartX(0.0f);
-                    mnemonic_underscore.setStartY(0.0f);
-                    mnemonic_underscore.setEndY(0.0f);
-                    mnemonic_underscore.getStyleClass().clear();
-                    mnemonic_underscore.getStyleClass().setAll("mnemonic-underline");
-                }
-                if (!getChildren().contains(mnemonic_underscore)) {
-                    getChildren().add(mnemonic_underscore);
+                // If only the graphic is visible, we do not need mnemonic_underscore node
+                if (labeled.getContentDisplay() != ContentDisplay.GRAPHIC_ONLY) {
+                    if (mnemonic_underscore == null) {
+                        mnemonic_underscore = new Line();
+                        mnemonic_underscore.setStartX(0.0f);
+                        mnemonic_underscore.setStartY(0.0f);
+                        mnemonic_underscore.setEndY(0.0f);
+                        mnemonic_underscore.getStyleClass().clear();
+                        mnemonic_underscore.getStyleClass().setAll("mnemonic-underline");
+                    }
+                    if (!getChildren().contains(mnemonic_underscore)) {
+                        getChildren().add(mnemonic_underscore);
+                    }
                 }
             } else if (mnemonic_underscore != null && getChildren().contains(mnemonic_underscore)) {
                 Platform.runLater(() -> {

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/LabeledSkinBase.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/LabeledSkinBase.java
@@ -946,24 +946,26 @@ public abstract class LabeledSkinBase<C extends Labeled> extends SkinBase<C> {
             final Labeled labeled = getSkinnable();
             String cleanText = getCleanText();
 
-            if (mnemonicInfo != null && mnemonicInfo.getMnemonicIndex() >= 0) {
-                // If only the graphic is visible, we do not need mnemonic_underscore node
-                if (labeled.getContentDisplay() != ContentDisplay.GRAPHIC_ONLY) {
-                    if (mnemonic_underscore == null) {
-                        mnemonic_underscore = new Line();
-                        mnemonic_underscore.setStartX(0.0f);
-                        mnemonic_underscore.setStartY(0.0f);
-                        mnemonic_underscore.setEndY(0.0f);
-                        mnemonic_underscore.getStyleClass().clear();
-                        mnemonic_underscore.getStyleClass().setAll("mnemonic-underline");
+            if (!com.sun.javafx.PlatformUtil.isMac()) {
+                if (mnemonicInfo != null && mnemonicInfo.getMnemonicIndex() >= 0) {
+                    // If only the graphic is visible, we do not need mnemonic_underscore node
+                    if (labeled.getContentDisplay() != ContentDisplay.GRAPHIC_ONLY) {
+                        if (mnemonic_underscore == null) {
+                            mnemonic_underscore = new Line();
+                            mnemonic_underscore.setStartX(0.0f);
+                            mnemonic_underscore.setStartY(0.0f);
+                            mnemonic_underscore.setEndY(0.0f);
+                            mnemonic_underscore.getStyleClass().clear();
+                            mnemonic_underscore.getStyleClass().setAll("mnemonic-underline");
+                        }
+                        if (!getChildren().contains(mnemonic_underscore)) {
+                            getChildren().add(mnemonic_underscore);
+                        }
                     }
-                    if (!getChildren().contains(mnemonic_underscore)) {
-                        getChildren().add(mnemonic_underscore);
-                    }
+                } else if (mnemonic_underscore != null && getChildren().contains(mnemonic_underscore)) {
+                    getChildren().remove(mnemonic_underscore);
+                    mnemonic_underscore = null;
                 }
-            } else if (mnemonic_underscore != null && getChildren().contains(mnemonic_underscore)) {
-                getChildren().remove(mnemonic_underscore);
-                mnemonic_underscore = null;
             }
 
             int len = cleanText != null ? cleanText.length() : 0;
@@ -1104,7 +1106,7 @@ public abstract class LabeledSkinBase<C extends Labeled> extends SkinBase<C> {
         Labeled labeled = getSkinnable();
         String sourceText = labeled.getText();
 
-        if (labeled.isMnemonicParsing() && !com.sun.javafx.PlatformUtil.isMac()) {
+        if (labeled.isMnemonicParsing()) {
             if (mnemonicInfo == null) {
                 mnemonicInfo = new MnemonicInfo(sourceText);
             } else {
@@ -1119,10 +1121,13 @@ public abstract class LabeledSkinBase<C extends Labeled> extends SkinBase<C> {
     }
 
     private void updateMnemonicRegistration() {
+        if (com.sun.javafx.PlatformUtil.isMac()) {
+            return;
+        }
         Control skinnable = getSkinnable();
         Scene skinnableScene = skinnable.getScene();
         Node mnemonicNode = skinnable;
-        if(skinnable instanceof Label l && l.getLabelFor() != null) {
+        if (skinnable instanceof Label l && l.getLabelFor() != null) {
             mnemonicNode =  l.getLabelFor();
         }
 

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/LabeledSkinBase.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/LabeledSkinBase.java
@@ -548,15 +548,11 @@ public abstract class LabeledSkinBase<C extends Labeled> extends SkinBase<C> {
             graphicHeight = graphic.getLayoutBounds().getHeight();
         }
 
-        // Have to do this just in case it needs to be recomputed
-        // This is especially important because it also recomputes the 'containsMnemonic' value,
-        // which is used by this method later on.
-
         if (ignoreText) {
             textWidth  = textHeight = 0;
             text.setText("");
         } else {
-            updateDisplayedText(w, h);
+            updateDisplayedText(w, h); // Have to do this just in case it needs to be recomputed
             textWidth  = snapSizeX(Math.min(text.getLayoutBounds().getWidth(),  wrapWidth));
             textHeight = snapSizeY(Math.min(text.getLayoutBounds().getHeight(), wrapHeight));
         }

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/LabeledSkinBase.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/LabeledSkinBase.java
@@ -129,11 +129,10 @@ public abstract class LabeledSkinBase<C extends Labeled> extends SkinBase<C> {
     private MnemonicInfo mnemonicInfo;
     private Line mnemonic_underscore;
 
-    private boolean containsMnemonic = false;
-    private Scene mnemonicScene = null;
-    private KeyCombination mnemonicCode;
-    // needs to be an object, as MenuItem isn't a node
-    private Node labeledNode = null;
+    // Mnemonic and the scene where it was added.
+    private Mnemonic mnemonic;
+    private Scene mnemonicRegistrationScene;
+
     private final AtomicBoolean textTruncated = new AtomicBoolean();
 
 
@@ -215,7 +214,6 @@ public abstract class LabeledSkinBase<C extends Labeled> extends SkinBase<C> {
             getSkinnable().requestLayout();
         });
         registerChangeListener(labeled.mnemonicParsingProperty(), o -> {
-            containsMnemonic = false;
             textMetricsChanged();
         });
         registerChangeListener(labeled.textProperty(), o -> {
@@ -600,7 +598,7 @@ public abstract class LabeledSkinBase<C extends Labeled> extends SkinBase<C> {
         Point2D mnemonicPos = null;
         double mnemonicWidth = 0.0;
         double mnemonicHeight = 0.0;
-        if (containsMnemonic && mnemonicInfo != null) {
+        if (mnemonicInfo != null) {
             int mnemonicIndex = mnemonicInfo.getMnemonicIndex();
             String cleanText = mnemonicInfo.getText();
             // The mnemonic KeyCode can also be defined in the following form: Exit_(q)
@@ -608,7 +606,7 @@ public abstract class LabeledSkinBase<C extends Labeled> extends SkinBase<C> {
             // This means we cannot substring the character from the text.
             if (mnemonicIndex >= 0 && mnemonicInfo.getExtendedMnemonicText() == null) {
                 final Font font = text.getFont();
-                boolean isRTL = (labeledNode.getEffectiveNodeOrientation() == NodeOrientation.RIGHT_TO_LEFT);
+                boolean isRTL = (labeled.getEffectiveNodeOrientation() == NodeOrientation.RIGHT_TO_LEFT);
                 mnemonicPos = Utils.computeMnemonicPosition(font, cleanText, mnemonicIndex, this.wrapWidth, labeled.getLineSpacing(), isRTL);
                 mnemonicWidth = Utils.computeTextWidth(font, cleanText.substring(mnemonicIndex, mnemonicIndex + 1), 0);
                 mnemonicHeight = Utils.computeTextHeight(font, "_", 0, text.getBoundsType());
@@ -643,7 +641,7 @@ public abstract class LabeledSkinBase<C extends Labeled> extends SkinBase<C> {
             // adjust the text based on the text's minX/minY so no need to
             // worry about that here
             text.relocate(snapPositionX(contentX), snapPositionY(contentY));
-            if (containsMnemonic && (mnemonicPos != null)) {
+            if (mnemonic_underscore != null && mnemonicPos != null) {
                 mnemonic_underscore.setEndX(mnemonicWidth-2.0);
                 mnemonic_underscore.relocate(snapPositionX(contentX + mnemonicPos.getX()),
                                              snapPositionY(contentY + mnemonicPos.getY()));
@@ -655,7 +653,7 @@ public abstract class LabeledSkinBase<C extends Labeled> extends SkinBase<C> {
             // there is a graphic, the text isn't even in the scene)
             text.relocate(snapPositionX(contentX), snapPositionY(contentY));
             graphic.relocate(snapPositionX(contentX), snapPositionY(contentY));
-            if (containsMnemonic && (mnemonicPos != null)) {
+            if (mnemonic_underscore != null && mnemonicPos != null) {
                 mnemonic_underscore.setEndX(mnemonicWidth);
                 mnemonic_underscore.setStrokeWidth(mnemonicHeight/10.0);
                 mnemonic_underscore.relocate(snapPositionX(contentX + mnemonicPos.getX()),
@@ -702,7 +700,7 @@ public abstract class LabeledSkinBase<C extends Labeled> extends SkinBase<C> {
                 textY = contentY + ((contentHeight - textHeight) / 2.0);
             }
             text.relocate(snapPositionX(textX), snapPositionY(textY));
-            if (containsMnemonic && (mnemonicPos != null)) {
+            if (mnemonic_underscore != null && mnemonicPos != null) {
                 mnemonic_underscore.setEndX(mnemonicWidth);
                 mnemonic_underscore.setStrokeWidth(mnemonicHeight/10.0);
                 mnemonic_underscore.relocate(snapPositionX(textX + mnemonicPos.getX()),
@@ -917,34 +915,11 @@ public abstract class LabeledSkinBase<C extends Labeled> extends SkinBase<C> {
     ** swap them over, and tidy up.
     */
     void mnemonicTargetChanged() {
-        if (containsMnemonic) {
-            /*
-            ** was there previously a labelFor
-            */
-            removeMnemonic();
-
-            /*
-            ** is there a new labelFor
-            */
-            Control control = getSkinnable();
-            if (control instanceof Label) {
-                labeledNode = ((Label)control).getLabelFor();
-                addMnemonic();
-            }
-            else {
-                labeledNode = null;
-            }
-        }
+        updateMnemonicRegistration();
     }
 
     private void sceneChanged() {
-        final Labeled labeled = getSkinnable();
-        Scene scene = labeled.getScene();
-
-        if (scene != null && containsMnemonic) {
-            addMnemonic();
-        }
-
+        updateMnemonicRegistration();
     }
 
     /**
@@ -970,64 +945,8 @@ public abstract class LabeledSkinBase<C extends Labeled> extends SkinBase<C> {
         if (invalidText) {
             final Labeled labeled = getSkinnable();
             String cleanText = getCleanText();
-            int mnemonicIndex = -1;
 
-            if (cleanText != null && cleanText.length() > 0
-                    && mnemonicInfo != null
-                    && !com.sun.javafx.PlatformUtil.isMac()
-                    && getSkinnable().isMnemonicParsing()) {
-                /*
-                ** the Labeled has a MnemonicParsing property,
-                ** if set true, then auto-parsing will check for
-                ** a mnemonic
-                */
-                if (labeled instanceof Label) {
-                    // buttons etc
-                    labeledNode = ((Label)labeled).getLabelFor();
-                } else {
-                    labeledNode = labeled;
-                }
-
-                if (labeledNode == null) {
-                    labeledNode = labeled;
-                }
-                mnemonicIndex = mnemonicInfo.getMnemonicIndex() ;
-            }
-
-            /*
-            ** we were previously a mnemonic
-            */
-            if (containsMnemonic) {
-                /*
-                ** are we no longer a mnemonic, or have we changed code?
-                */
-                if (mnemonicScene != null) {
-                    if (mnemonicIndex == -1 ||
-                            (mnemonicInfo != null && !mnemonicInfo.getMnemonicKeyCombination().equals(mnemonicCode))) {
-                        removeMnemonic();
-                        containsMnemonic = false;
-                    }
-                }
-            }
-            else {
-                /*
-                ** this can happen if mnemonic parsing is
-                ** disabled on a previously valid mnemonic
-                */
-                removeMnemonic();
-            }
-
-            /*
-            ** check we have a labeled
-            */
-            if (cleanText != null && cleanText.length() > 0
-                    && mnemonicIndex >= 0 && !containsMnemonic) {
-                containsMnemonic = true;
-                mnemonicCode = mnemonicInfo.getMnemonicKeyCombination();
-                addMnemonic();
-            }
-
-            if (containsMnemonic) {
+            if (mnemonicInfo != null && mnemonicInfo.getMnemonicIndex() >= 0) {
                 // If only the graphic is visible, we do not need mnemonic_underscore node
                 if (labeled.getContentDisplay() != ContentDisplay.GRAPHIC_ONLY) {
                     if (mnemonic_underscore == null) {
@@ -1043,10 +962,8 @@ public abstract class LabeledSkinBase<C extends Labeled> extends SkinBase<C> {
                     }
                 }
             } else if (mnemonic_underscore != null && getChildren().contains(mnemonic_underscore)) {
-                Platform.runLater(() -> {
-                      getChildren().remove(mnemonic_underscore);
-                      mnemonic_underscore = null;
-                });
+                getChildren().remove(mnemonic_underscore);
+                mnemonic_underscore = null;
             }
 
             int len = cleanText != null ? cleanText.length() : 0;
@@ -1175,6 +1092,7 @@ public abstract class LabeledSkinBase<C extends Labeled> extends SkinBase<C> {
             text.setText(result);
             updateWrappingWidth();
             LabeledHelper.setTextTruncated(getSkinnable(), textTruncated.get());
+            updateMnemonicRegistration();
             invalidText = false;
         }
     }
@@ -1186,33 +1104,52 @@ public abstract class LabeledSkinBase<C extends Labeled> extends SkinBase<C> {
         Labeled labeled = getSkinnable();
         String sourceText = labeled.getText();
 
-        if (sourceText != null && labeled.isMnemonicParsing()) {
+        if (labeled.isMnemonicParsing()) {
             if (mnemonicInfo == null) {
                 mnemonicInfo = new MnemonicInfo(sourceText);
             } else {
                 mnemonicInfo.update(sourceText);
             }
-
             return mnemonicInfo.getText();
+        } else {
+            mnemonicInfo = null;
         }
 
         return sourceText;
     }
 
-    private void addMnemonic() {
-        if (labeledNode != null) {
-            mnemonicScene = labeledNode.getScene();
-            if (mnemonicScene != null) {
-                mnemonicScene.addMnemonic(new Mnemonic(labeledNode, mnemonicCode));
+    private void updateMnemonicRegistration() {
+        Control skinnable = getSkinnable();
+        Scene skinnableScene = skinnable.getScene();
+        Node mnemonicNode = skinnable;
+        if(skinnable instanceof Label l && l.getLabelFor() != null) {
+            mnemonicNode =  l.getLabelFor();
+        }
+
+        if (mnemonic != null) {
+            // Mnemonic registration implies the following information:
+            // - Is it defined at all?
+            // - Scene where the mnemonic is registered
+            // - Node that receives the event
+            // - KeyCombination that triggers the event
+            // If any of this changes we must remove the previous mnemonic registration.
+            if (mnemonicInfo == null
+                    || mnemonicRegistrationScene != skinnableScene
+                    || mnemonic.getNode() != mnemonicNode
+                    || !mnemonic.getKeyCombination().equals(mnemonicInfo.getMnemonicKeyCombination())) {
+                mnemonicRegistrationScene.removeMnemonic(mnemonic);
+                mnemonicRegistrationScene = null;
+                mnemonic = null;
             }
         }
-    }
 
-
-    private void removeMnemonic() {
-        if (mnemonicScene != null && labeledNode != null) {
-            mnemonicScene.removeMnemonic(new Mnemonic(labeledNode, mnemonicCode));
-            mnemonicScene = null;
+        if (mnemonicInfo != null && mnemonic == null) {
+            KeyCombination mnemonicKeyCombination = mnemonicInfo.getMnemonicKeyCombination();
+            if (skinnableScene != null && mnemonicKeyCombination != null) {
+                mnemonic = new Mnemonic(mnemonicNode, mnemonicKeyCombination);
+                skinnableScene.addMnemonic(mnemonic);
+                mnemonicRegistrationScene = skinnableScene;
+            }
         }
     }
 

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/LabelSkinTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/LabelSkinTest.java
@@ -30,9 +30,11 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.sun.javafx.PlatformUtil;
 import com.sun.javafx.scene.control.behavior.MnemonicInfo;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.stream.Stream;
 import javafx.beans.value.ObservableValue;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
@@ -53,6 +55,7 @@ import javafx.scene.effect.BlendMode;
 import javafx.scene.input.KeyCombination;
 import javafx.scene.input.Mnemonic;
 import javafx.scene.layout.HBox;
+import javafx.scene.layout.StackPane;
 import javafx.scene.paint.Color;
 import javafx.scene.shape.Line;
 import javafx.scene.shape.Rectangle;
@@ -61,10 +64,14 @@ import javafx.scene.text.Text;
 import javafx.scene.text.TextAlignment;
 import javafx.stage.Stage;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import com.sun.javafx.scene.control.skin.Utils;
 import com.sun.javafx.tk.Toolkit;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import test.com.sun.javafx.scene.control.infrastructure.StageLoader;
 
 /**
@@ -2142,17 +2149,126 @@ public class LabelSkinTest {
         checkMnemonics();
     }
 
+    @Test
+    public void withGraphic() {
+        Assumptions.assumeFalse(PlatformUtil.isMac());
+        label.setText("_test");
+        label.setMnemonicParsing(true);
+        label.setGraphic(new Label());
+        label.setContentDisplay(ContentDisplay.GRAPHIC_ONLY);
+        stageLoader = new StageLoader(label);
+        Toolkit.getToolkit().firePulse(); // No NPE
+    }
+
+    @ParameterizedTest
+    @MethodSource("provide_testMnemonics_parameters")
+    void testMnemonics_with_new_Labeled_and_Scene_each_time(boolean mnemonicParsing, ContentDisplay contentDisplay, String text, Node graphic, Node labelFor) {
+        label.setMnemonicParsing(mnemonicParsing);
+        label.setContentDisplay(contentDisplay);
+        label.setText(text);
+        label.setGraphic(graphic);
+        label.setLabelFor(labelFor);
+
+        StackPane root = new StackPane(label);
+        if (labelFor != null) {
+            root.getChildren().add(labelFor);
+        }
+        stageLoader = new StageLoader(root);
+
+        checkMnemonics();
+    }
+
+    @Test
+    void testMnemonics_with_same_Labeled_and_Scene() {
+        StackPane root = new StackPane();
+        root.getChildren().add(label);
+        stageLoader = new StageLoader(root);
+
+        StringBuilder sb = new StringBuilder();
+
+        provide_testMnemonics_parameters().forEach(a -> {
+            boolean mnemonicParsing = (boolean) a.get()[0];
+            ContentDisplay contentDisplay = (ContentDisplay) a.get()[1];
+            String text = (String) a.get()[2];
+            Node graphic = (Node) a.get()[3];
+            Node labelFor = (Node) a.get()[4];
+
+            if (labelFor != null) {
+                if (!root.getChildren().contains(labelFor)) {
+                    root.getChildren().add(labelFor);
+                }
+            } else {
+                root.getChildren().removeIf(o -> o != label);
+            }
+
+            label.setMnemonicParsing(mnemonicParsing);
+            label.setContentDisplay(contentDisplay);
+            label.setText(text);
+            label.setGraphic(graphic);
+            label.setLabelFor(labelFor);
+
+            sb.append(mnemonicParsing + ", " + contentDisplay + ", " + text + ", " + graphic + ", " + labelFor).append("\n");
+            try {
+                checkMnemonics();
+            } catch (Throwable e) {
+                // This makes it easier to identify the failed step
+                System.out.println(sb.toString());
+                throw e;
+            }
+        });
+    }
+
+    private static Stream<Arguments> provide_testMnemonics_parameters() {
+        Label graphicNode = new Label() {
+            @Override
+            public String toString() {
+                return "graphic";
+            }
+        };
+        Label labelForNode = new Label() {
+            @Override
+            public String toString() {
+                return "labelFor";
+            }
+        };
+
+        List<Arguments> arguments = new ArrayList<>();
+
+        for (Boolean mnemonicParsing : listOf(true, false)) {
+            for (ContentDisplay contentDisplay : listOf(ContentDisplay.LEFT, ContentDisplay.TEXT_ONLY, ContentDisplay.GRAPHIC_ONLY)) {
+                for (String text : listOf(null, "", "xxx", "foo_bar", "test_(t)")) {
+                    for (Label graphic : listOf(null, graphicNode)) {
+                        for (Label labelFor : listOf(null, labelForNode)) {
+                            arguments.add(Arguments.of(listOf(mnemonicParsing, contentDisplay, text, graphic, labelFor).toArray()));
+                        }
+                    }
+                }
+            }
+        }
+
+        return arguments.stream();
+    }
+
+    private static <T> List<T> listOf(T... a) {
+        List<T> result = new ArrayList<>();
+        for (T o : a) {
+            result.add(o);
+        }
+        return result;
+    }
+
     private void checkMnemonics() {
         Toolkit tk = Toolkit.getToolkit();
-        StageLoader sl = createStageLoader(label);
+        if (stageLoader == null) {
+            stageLoader = new StageLoader(label);
+        }
         tk.firePulse();
 
-        ObservableMap<KeyCombination, ObservableList<Mnemonic>> mnemonics = sl.getStage().getScene().getMnemonics();
-
         Function<String, Boolean> mnemonicRegistrationChecker = character ->
-                mnemonics.getOrDefault(
-                        new MnemonicInfo.MnemonicKeyCombination(character), FXCollections.emptyObservableList())
-                .stream().filter(m -> m.getNode() == label).toList().size() == 1;
+                label.getScene().getMnemonics()
+                        .getOrDefault(new MnemonicInfo.MnemonicKeyCombination(character), FXCollections.emptyObservableList())
+                        .stream().filter(m -> m.getNode() == (label.getLabelFor() != null ? label.getLabelFor() : label))
+                        .toList().size() == 1;
 
         Supplier<Boolean> mnemonicNodePresenceChecker = () -> label.getChildrenUnmodifiable().stream().anyMatch(p -> p instanceof Line);
 
@@ -2160,7 +2276,7 @@ public class LabelSkinTest {
                 (expected
                         ? "Mnemonic registration expected but not found: "
                         : "No mnemonic expected but was: ")
-                        + mnemonics;
+                        + label.getScene().getMnemonics();
 
         // Mac does not support mnemonics
         boolean expectedMnemonics = PlatformUtil.isMac() ? false : label.isMnemonicParsing();
@@ -2171,7 +2287,7 @@ public class LabelSkinTest {
         // no text
         label.setText(null);
         tk.firePulse();
-        assertTrue(mnemonics.values().stream().allMatch(List::isEmpty), mnemonicErrorMessageSupplier.apply(false));
+        assertTrue(label.getScene().getMnemonics().values().stream().allMatch(List::isEmpty), mnemonicErrorMessageSupplier.apply(false));
         assertFalse(mnemonicNodePresenceChecker.get());
 
         // initial mnemonic
@@ -2256,14 +2372,6 @@ public class LabelSkinTest {
         assertEquals(label1.getBaselineOffset(), (label2.getBaselineOffset() - (r.getHeight()-label2Height)/2), 0);
         sl.dispose();
     }
-
-    private StageLoader createStageLoader(Node node) {
-        if (stageLoader == null) {
-            stageLoader = new StageLoader(node);
-        }
-        return stageLoader;
-    }
-
 
     /********************************************************************************
      *                                                                              *

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/LabelSkinTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/LabelSkinTest.java
@@ -28,6 +28,7 @@ package test.javafx.scene.control.skin;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.function.Supplier;
 import javafx.beans.value.ObservableValue;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/LabelSkinTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/LabelSkinTest.java
@@ -28,11 +28,19 @@ package test.javafx.scene.control.skin;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import com.sun.javafx.PlatformUtil;
+import com.sun.javafx.scene.control.behavior.MnemonicInfo;
+import java.util.List;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import javafx.beans.value.ObservableValue;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.collections.ObservableMap;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
 import javafx.scene.Group;
+import javafx.scene.Node;
 import javafx.scene.Scene;
 import javafx.scene.control.ContentDisplay;
 import javafx.scene.control.Label;
@@ -42,6 +50,8 @@ import javafx.scene.control.skin.LabelSkin;
 import javafx.scene.control.skin.LabelSkinBaseShim;
 import javafx.scene.control.skin.LabeledSkinBaseShim;
 import javafx.scene.effect.BlendMode;
+import javafx.scene.input.KeyCombination;
+import javafx.scene.input.Mnemonic;
 import javafx.scene.layout.HBox;
 import javafx.scene.paint.Color;
 import javafx.scene.shape.Line;
@@ -50,12 +60,12 @@ import javafx.scene.text.Font;
 import javafx.scene.text.Text;
 import javafx.scene.text.TextAlignment;
 import javafx.stage.Stage;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import com.sun.javafx.scene.control.skin.Utils;
 import com.sun.javafx.tk.Toolkit;
 import test.com.sun.javafx.scene.control.infrastructure.StageLoader;
-
 
 /**
  * Need to test:
@@ -66,6 +76,7 @@ public class LabelSkinTest {
     private Label label;
     private LabelSkinMock skin;
     private Text text;
+    private StageLoader stageLoader;
 
     @BeforeEach
     public void setup() {
@@ -78,6 +89,13 @@ public class LabelSkinTest {
         // It so happens that a brand new LabelSkin on a plain Label
         // will have as its only child the Text node
         text = (Text) SkinBaseShim.getChildren(skin).get(0);
+    }
+
+    @AfterEach
+    public void teardown() {
+        if (stageLoader != null) {
+            stageLoader.dispose();
+        }
     }
 
     /****************************************************************************
@@ -2096,94 +2114,112 @@ public class LabelSkinTest {
     }
 
     @Test
-    public void testMnemonics_noExceptionIsThrown() {
+    public void testMnemonics_setMnemonicParsing() {
         label.setMnemonicParsing(true);
-        checkMnemonics();
+        checkMnemonics(true);
 
         label.setMnemonicParsing(false);
-        checkMnemonics();
+        checkMnemonics(false);
+
+        label.setMnemonicParsing(true);
+        checkMnemonics(true);
     }
 
     @Test
-    public void testMnemonics_whenContentDisplay_GRAPHIC_ONLY_noExceptionIsThrown() {
+    public void testMnemonics_setContentDisplay() {
         label.setMnemonicParsing(true);
-        label.setContentDisplay(ContentDisplay.GRAPHIC_ONLY);
 
-        checkMnemonics();
-    }
-
-    @Test
-    public void testMnemonics_whenContentDisplay_GRAPHIC_ONLY_noAdditionalChildren() {
-        Toolkit tk = Toolkit.getToolkit();
-        StageLoader sl = new StageLoader(label);
-        tk.firePulse();
-
-        label.setMnemonicParsing(true);
-        Supplier<Boolean> containsMnemonicNode = () -> label.getChildrenUnmodifiable().stream().anyMatch(p -> p instanceof Line);
-
-        label.setText("foo_bar");
-        tk.firePulse();
-        // Mac does not implement or add mnemonics, skip this test on a Mac
-        if (!com.sun.javafx.PlatformUtil.isMac()) {
-            assertTrue(containsMnemonicNode.get());
-        }
+        ContentDisplay originalContentDisplay = label.getContentDisplay();
+        checkMnemonics(true);
 
         label.setContentDisplay(ContentDisplay.GRAPHIC_ONLY);
-        tk.firePulse();
-        assertFalse(containsMnemonicNode.get());
+        checkMnemonics(false);
 
-        label.setText("xxx");
-        tk.firePulse();
-        assertFalse(containsMnemonicNode.get());
-
-        label.setText("foo_bar");
-        tk.firePulse();
-        assertFalse(containsMnemonicNode.get());
-
-        sl.dispose();
-    }
-
-    @Test
-    public void testMnemonics_whenContentDisplay_TEXT_ONLY_noExceptionIsThrown() {
-        label.setMnemonicParsing(true);
         label.setContentDisplay(ContentDisplay.TEXT_ONLY);
+        checkMnemonics(true);
 
-        checkMnemonics();
+        label.setContentDisplay(originalContentDisplay);
+        checkMnemonics(true);
     }
 
-    private void checkMnemonics() {
+    private void checkMnemonics(boolean expectedMnemonics) {
         Toolkit tk = Toolkit.getToolkit();
-        StageLoader sl = new StageLoader(label);
+        StageLoader sl = createStageLoader(label);
         tk.firePulse();
 
+        ObservableMap<KeyCombination, ObservableList<Mnemonic>> mnemonics = sl.getStage().getScene().getMnemonics();
+
+        Function<String, Boolean> mnemonicRegistrationChecker = character ->
+                mnemonics.getOrDefault(
+                        new MnemonicInfo.MnemonicKeyCombination(character), FXCollections.emptyObservableList())
+                .stream().filter(m -> m.getNode() == label).toList().size() == 1;
+
+        Supplier<Boolean> mnemonicNodePresenceChecker = () -> label.getChildrenUnmodifiable().stream().anyMatch(p -> p instanceof Line);
+
+        Function<Boolean, String> mnemonicErrorMessageSupplier = expected ->
+                (expected
+                        ? "Mnemonic registration expected but not found: "
+                        : "No mnemonic expected but was: ")
+                        + mnemonics;
+
+        // Mac does not support mnemonics
+        expectedMnemonics = PlatformUtil.isMac() ? false : expectedMnemonics;
+
+        // --------------------------------------------------------------------
+
+        // no text
+        label.setText(null);
+        tk.firePulse();
+        assertTrue(mnemonics.values().stream().allMatch(List::isEmpty), mnemonicErrorMessageSupplier.apply(false));
+        assertFalse(mnemonicNodePresenceChecker.get());
+
+        // initial mnemonic
         label.setText("foo_bar");
         tk.firePulse();
+        assertEquals(expectedMnemonics, mnemonicRegistrationChecker.apply("b"), mnemonicErrorMessageSupplier.apply(expectedMnemonics));
+        assertEquals(expectedMnemonics, mnemonicNodePresenceChecker.get());
 
         // mnemonic -> text
         label.setText("xxx");
         tk.firePulse();
+        assertFalse(mnemonicRegistrationChecker.apply("b"), mnemonicErrorMessageSupplier.apply(false));
+        assertFalse(mnemonicNodePresenceChecker.get());
 
         // text -> mnemonic
         label.setText("foo_bar");
         tk.firePulse();
+        assertEquals(expectedMnemonics, mnemonicRegistrationChecker.apply("b"), mnemonicErrorMessageSupplier.apply(expectedMnemonics));
+        assertEquals(expectedMnemonics, mnemonicNodePresenceChecker.get());
 
         // mnemonic -> empty
         label.setText("");
         tk.firePulse();
+        assertFalse(mnemonicRegistrationChecker.apply("b"), mnemonicErrorMessageSupplier.apply(false));
+        assertFalse(mnemonicNodePresenceChecker.get());
 
         // empty -> mnemonic
         label.setText("foo_bar");
         tk.firePulse();
+        assertEquals(expectedMnemonics, mnemonicRegistrationChecker.apply("b"), mnemonicErrorMessageSupplier.apply(expectedMnemonics));
+        assertEquals(expectedMnemonics, mnemonicNodePresenceChecker.get());
 
         // mnemonic -> null
         label.setText(null);
         tk.firePulse();
+        assertFalse(mnemonicRegistrationChecker.apply("b"), mnemonicErrorMessageSupplier.apply(false));
+        assertFalse(mnemonicNodePresenceChecker.get());
 
         // null -> mnemonic
         label.setText("foo_bar");
         tk.firePulse();
+        assertEquals(expectedMnemonics, mnemonicRegistrationChecker.apply("b"), mnemonicErrorMessageSupplier.apply(expectedMnemonics));
+        assertEquals(expectedMnemonics, mnemonicNodePresenceChecker.get());
 
-        sl.dispose();
+        // extended mnemonic
+        label.setText("test_(t)");
+        tk.firePulse();
+        assertEquals(expectedMnemonics, mnemonicRegistrationChecker.apply("t"), mnemonicErrorMessageSupplier.apply(expectedMnemonics));
+        assertEquals(expectedMnemonics, mnemonicNodePresenceChecker.get());
     }
 
     /*********************************************************************
@@ -2218,6 +2254,13 @@ public class LabelSkinTest {
         tk.firePulse();
         assertEquals(label1.getBaselineOffset(), (label2.getBaselineOffset() - (r.getHeight()-label2Height)/2), 0);
         sl.dispose();
+    }
+
+    private StageLoader createStageLoader(Node node) {
+        if (stageLoader == null) {
+            stageLoader = new StageLoader(node);
+        }
+        return stageLoader;
     }
 
 

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/LabelSkinTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/LabelSkinTest.java
@@ -2116,13 +2116,13 @@ public class LabelSkinTest {
     @Test
     public void testMnemonics_setMnemonicParsing() {
         label.setMnemonicParsing(true);
-        checkMnemonics(true);
+        checkMnemonics();
 
         label.setMnemonicParsing(false);
-        checkMnemonics(false);
+        checkMnemonics();
 
         label.setMnemonicParsing(true);
-        checkMnemonics(true);
+        checkMnemonics();
     }
 
     @Test
@@ -2130,19 +2130,19 @@ public class LabelSkinTest {
         label.setMnemonicParsing(true);
 
         ContentDisplay originalContentDisplay = label.getContentDisplay();
-        checkMnemonics(true);
+        checkMnemonics();
 
         label.setContentDisplay(ContentDisplay.GRAPHIC_ONLY);
-        checkMnemonics(false);
+        checkMnemonics();
 
         label.setContentDisplay(ContentDisplay.TEXT_ONLY);
-        checkMnemonics(true);
+        checkMnemonics();
 
         label.setContentDisplay(originalContentDisplay);
-        checkMnemonics(true);
+        checkMnemonics();
     }
 
-    private void checkMnemonics(boolean expectedMnemonics) {
+    private void checkMnemonics() {
         Toolkit tk = Toolkit.getToolkit();
         StageLoader sl = createStageLoader(label);
         tk.firePulse();
@@ -2163,7 +2163,8 @@ public class LabelSkinTest {
                         + mnemonics;
 
         // Mac does not support mnemonics
-        expectedMnemonics = PlatformUtil.isMac() ? false : expectedMnemonics;
+        boolean expectedMnemonics = PlatformUtil.isMac() ? false : label.isMnemonicParsing();
+        boolean expectedMnemonicsNode = expectedMnemonics && label.getContentDisplay() != ContentDisplay.GRAPHIC_ONLY;
 
         // --------------------------------------------------------------------
 
@@ -2177,7 +2178,7 @@ public class LabelSkinTest {
         label.setText("foo_bar");
         tk.firePulse();
         assertEquals(expectedMnemonics, mnemonicRegistrationChecker.apply("b"), mnemonicErrorMessageSupplier.apply(expectedMnemonics));
-        assertEquals(expectedMnemonics, mnemonicNodePresenceChecker.get());
+        assertEquals(expectedMnemonicsNode, mnemonicNodePresenceChecker.get());
 
         // mnemonic -> text
         label.setText("xxx");
@@ -2189,7 +2190,7 @@ public class LabelSkinTest {
         label.setText("foo_bar");
         tk.firePulse();
         assertEquals(expectedMnemonics, mnemonicRegistrationChecker.apply("b"), mnemonicErrorMessageSupplier.apply(expectedMnemonics));
-        assertEquals(expectedMnemonics, mnemonicNodePresenceChecker.get());
+        assertEquals(expectedMnemonicsNode, mnemonicNodePresenceChecker.get());
 
         // mnemonic -> empty
         label.setText("");
@@ -2201,7 +2202,7 @@ public class LabelSkinTest {
         label.setText("foo_bar");
         tk.firePulse();
         assertEquals(expectedMnemonics, mnemonicRegistrationChecker.apply("b"), mnemonicErrorMessageSupplier.apply(expectedMnemonics));
-        assertEquals(expectedMnemonics, mnemonicNodePresenceChecker.get());
+        assertEquals(expectedMnemonicsNode, mnemonicNodePresenceChecker.get());
 
         // mnemonic -> null
         label.setText(null);
@@ -2213,13 +2214,13 @@ public class LabelSkinTest {
         label.setText("foo_bar");
         tk.firePulse();
         assertEquals(expectedMnemonics, mnemonicRegistrationChecker.apply("b"), mnemonicErrorMessageSupplier.apply(expectedMnemonics));
-        assertEquals(expectedMnemonics, mnemonicNodePresenceChecker.get());
+        assertEquals(expectedMnemonicsNode, mnemonicNodePresenceChecker.get());
 
         // extended mnemonic
         label.setText("test_(t)");
         tk.firePulse();
         assertEquals(expectedMnemonics, mnemonicRegistrationChecker.apply("t"), mnemonicErrorMessageSupplier.apply(expectedMnemonics));
-        assertEquals(expectedMnemonics, mnemonicNodePresenceChecker.get());
+        assertEquals(expectedMnemonicsNode, mnemonicNodePresenceChecker.get());
     }
 
     /*********************************************************************

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/LabelSkinTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/LabelSkinTest.java
@@ -43,6 +43,7 @@ import javafx.scene.control.skin.LabeledSkinBaseShim;
 import javafx.scene.effect.BlendMode;
 import javafx.scene.layout.HBox;
 import javafx.scene.paint.Color;
+import javafx.scene.shape.Line;
 import javafx.scene.shape.Rectangle;
 import javafx.scene.text.Font;
 import javafx.scene.text.Text;
@@ -53,6 +54,7 @@ import org.junit.jupiter.api.Test;
 import com.sun.javafx.scene.control.skin.Utils;
 import com.sun.javafx.tk.Toolkit;
 import test.com.sun.javafx.scene.control.infrastructure.StageLoader;
+
 
 /**
  * Need to test:
@@ -2107,6 +2109,34 @@ public class LabelSkinTest {
         label.setContentDisplay(ContentDisplay.GRAPHIC_ONLY);
 
         checkMnemonics();
+    }
+
+    @Test
+    public void testMnemonics_whenContentDisplay_GRAPHIC_ONLY_noAdditionalChildren() {
+        Toolkit tk = Toolkit.getToolkit();
+        StageLoader sl = new StageLoader(label);
+        tk.firePulse();
+
+        label.setMnemonicParsing(true);
+        Supplier<Boolean> containsMnemonicNode = () -> label.getChildrenUnmodifiable().stream().anyMatch(p -> p instanceof Line);
+
+        label.setText("foo_bar");
+        tk.firePulse();
+        assertTrue(containsMnemonicNode.get());
+
+        label.setContentDisplay(ContentDisplay.GRAPHIC_ONLY);
+        tk.firePulse();
+        assertFalse(containsMnemonicNode.get());
+
+        label.setText("xxx");
+        tk.firePulse();
+        assertFalse(containsMnemonicNode.get());
+
+        label.setText("foo_bar");
+        tk.firePulse();
+        assertFalse(containsMnemonicNode.get());
+
+        sl.dispose();
     }
 
     @Test

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/LabelSkinTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/LabelSkinTest.java
@@ -2092,6 +2092,60 @@ public class LabelSkinTest {
         assertEquals("foo __bar", LabelSkinBaseShim.getText(label).getText());
     }
 
+    @Test
+    public void testMnemonics_whenTextNotEmpty_noExceptionIsThrown() {
+        Toolkit tk = Toolkit.getToolkit();
+        StageLoader sl = new StageLoader(label);
+        tk.firePulse();
+
+        label.setMnemonicParsing(true);
+
+        label.setText("foo_bar");
+        tk.firePulse();
+        label.setText("xxx");
+        tk.firePulse();
+        label.setText("foo_bar");
+        tk.firePulse();
+
+        sl.dispose();
+    }
+
+    @Test
+    public void testMnemonics_whenTextIsEmpty_noExceptionIsThrown() {
+        Toolkit tk = Toolkit.getToolkit();
+        StageLoader sl = new StageLoader(label);
+        tk.firePulse();
+
+        label.setMnemonicParsing(true);
+
+        label.setText("foo_bar");
+        tk.firePulse();
+        label.setText("");
+        tk.firePulse();
+        label.setText("foo_bar");
+        tk.firePulse();
+
+        sl.dispose();
+    }
+
+    @Test
+    public void testMnemonics_whenTextIsNull_noExceptionIsThrown() {
+        Toolkit tk = Toolkit.getToolkit();
+        StageLoader sl = new StageLoader(label);
+        tk.firePulse();
+
+        label.setMnemonicParsing(true);
+
+        label.setText("foo_bar");
+        tk.firePulse();
+        label.setText(null);
+        tk.firePulse();
+        label.setText("foo_bar");
+        tk.firePulse();
+
+        sl.dispose();
+    }
+
     /*********************************************************************
      *
      * Tests for bug reports                                             *

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/LabelSkinTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/LabelSkinTest.java
@@ -2123,7 +2123,10 @@ public class LabelSkinTest {
 
         label.setText("foo_bar");
         tk.firePulse();
-        assertTrue(containsMnemonicNode.get());
+        // Mac does not implement or add mnemonics, skip this test on a Mac
+        if (!com.sun.javafx.PlatformUtil.isMac()) {
+            assertTrue(containsMnemonicNode.get());
+        }
 
         label.setContentDisplay(ContentDisplay.GRAPHIC_ONLY);
         tk.firePulse();

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/LabelSkinTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/LabelSkinTest.java
@@ -2093,53 +2093,59 @@ public class LabelSkinTest {
     }
 
     @Test
-    public void testMnemonics_whenTextNotEmpty_noExceptionIsThrown() {
+    public void testMnemonics_noExceptionIsThrown() {
+        label.setMnemonicParsing(true);
+        checkMnemonics();
+
+        label.setMnemonicParsing(false);
+        checkMnemonics();
+    }
+
+    @Test
+    public void testMnemonics_whenContentDisplay_GRAPHIC_ONLY_noExceptionIsThrown() {
+        label.setMnemonicParsing(true);
+        label.setContentDisplay(ContentDisplay.GRAPHIC_ONLY);
+
+        checkMnemonics();
+    }
+
+    @Test
+    public void testMnemonics_whenContentDisplay_TEXT_ONLY_noExceptionIsThrown() {
+        label.setMnemonicParsing(true);
+        label.setContentDisplay(ContentDisplay.TEXT_ONLY);
+
+        checkMnemonics();
+    }
+
+    private void checkMnemonics() {
         Toolkit tk = Toolkit.getToolkit();
         StageLoader sl = new StageLoader(label);
         tk.firePulse();
 
-        label.setMnemonicParsing(true);
-
         label.setText("foo_bar");
         tk.firePulse();
+
+        // mnemonic -> text
         label.setText("xxx");
         tk.firePulse();
+
+        // text -> mnemonic
         label.setText("foo_bar");
         tk.firePulse();
 
-        sl.dispose();
-    }
-
-    @Test
-    public void testMnemonics_whenTextIsEmpty_noExceptionIsThrown() {
-        Toolkit tk = Toolkit.getToolkit();
-        StageLoader sl = new StageLoader(label);
-        tk.firePulse();
-
-        label.setMnemonicParsing(true);
-
-        label.setText("foo_bar");
-        tk.firePulse();
+        // mnemonic -> empty
         label.setText("");
         tk.firePulse();
+
+        // empty -> mnemonic
         label.setText("foo_bar");
         tk.firePulse();
 
-        sl.dispose();
-    }
-
-    @Test
-    public void testMnemonics_whenTextIsNull_noExceptionIsThrown() {
-        Toolkit tk = Toolkit.getToolkit();
-        StageLoader sl = new StageLoader(label);
-        tk.firePulse();
-
-        label.setMnemonicParsing(true);
-
-        label.setText("foo_bar");
-        tk.firePulse();
+        // mnemonic -> null
         label.setText(null);
         tk.firePulse();
+
+        // null -> mnemonic
         label.setText("foo_bar");
         tk.firePulse();
 


### PR DESCRIPTION
This PR fixes the StringIndexOutOfBoundsException, that occurs when an empty text is set to a Labeled, that previously contained a mnemonic.

The reason for the error is that the ``updateDisplayedText(double, double)``, which also updates ``containsMnemonic`` flag, was not invoked if the text was empty. The value of this flag was still ``true`` but the index of the mnemonic character inside ``MnemonicInfo`` had already been updated to -1. This led to the StringIndexOutOfBoundsException in the line 611.

I fixed it by moving the call to ``updateDisplayedText(double, double)`` outside the if-clause, so that it is always called when the text is being laid out. This should not affect performance because the method already checks whether recalculation is required. If not, it exits quickly.

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8389970](https://bugs.openjdk.org/browse/JDK-8389970): StringIndexOutOfBoundsException when a text containing a mnemonic is removed (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2253/head:pull/2253` \
`$ git checkout pull/2253`

Update a local copy of the PR: \
`$ git checkout pull/2253` \
`$ git pull https://git.openjdk.org/jfx.git pull/2253/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2253`

View PR using the GUI difftool: \
`$ git pr show -t 2253`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2253.diff">https://git.openjdk.org/jfx/pull/2253.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2253#issuecomment-5219876511)
</details>
