### PR TITLE
8388450: ImageIO.write(SwingFXUtils.fromFXImage()) creates 0 length JPEG for some images

### DIFF
--- a/modules/javafx.swing/src/main/java/javafx/embed/swing/SwingFXUtils.java
+++ b/modules/javafx.swing/src/main/java/javafx/embed/swing/SwingFXUtils.java
@@ -205,8 +205,7 @@ public class SwingFXUtils {
 
     private static boolean checkFXImageOpaque(PixelReader pr, int iw, int ih) {
         int[] pixels = new int[iw];
-        WritablePixelFormat<IntBuffer> format =
-                PixelFormat.getIntArgbPreInstance();
+        WritablePixelFormat<IntBuffer> format = PixelFormat.getIntArgbPreInstance();
         for (int y = 0; y < ih; y++) {
             pr.getPixels(0, y, iw, 1, format, pixels, 0, iw);
             for (int pixel : pixels) {
@@ -256,14 +255,15 @@ public class SwingFXUtils {
         int ih = (int) img.getHeight();
         PixelFormat<?> fxFormat = pr.getPixelFormat();
         boolean srcPixelsAreOpaque = false;
-        boolean opacityMatters = bimg == null ||
-                bimg.getType() == BufferedImage.TYPE_INT_BGR ||
-                bimg.getType() == BufferedImage.TYPE_INT_RGB;
         switch (fxFormat.getType()) {
             case INT_ARGB_PRE:
             case INT_ARGB:
             case BYTE_BGRA_PRE:
+            case BYTE_BGRA:
             case BYTE_INDEXED:
+                boolean opacityMatters = bimg == null ||
+                        bimg.getType() == BufferedImage.TYPE_INT_BGR ||
+                        bimg.getType() == BufferedImage.TYPE_INT_RGB;
                 if (opacityMatters) {
                     srcPixelsAreOpaque = checkFXImageOpaque(pr, iw, ih);
                 }

--- a/modules/javafx.swing/src/main/java/javafx/embed/swing/SwingFXUtils.java
+++ b/modules/javafx.swing/src/main/java/javafx/embed/swing/SwingFXUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -156,6 +156,9 @@ public class SwingFXUtils {
                 return bimgType;
             }
         }
+        if (isOpaque) {
+            return BufferedImage.TYPE_INT_RGB;
+        }
         switch (fxFormat.getType()) {
             default:
             case BYTE_BGRA_PRE:
@@ -201,10 +204,13 @@ public class SwingFXUtils {
     }
 
     private static boolean checkFXImageOpaque(PixelReader pr, int iw, int ih) {
-        for (int x = 0; x < iw; x++) {
-            for (int y = 0; y < ih; y++) {
-                Color color = pr.getColor(x,y);
-                if (color.getOpacity() != 1.0) {
+        int[] pixels = new int[iw];
+        WritablePixelFormat<IntBuffer> format =
+                PixelFormat.getIntArgbPreInstance();
+        for (int y = 0; y < ih; y++) {
+            pr.getPixels(0, y, iw, 1, format, pixels, 0, iw);
+            for (int pixel : pixels) {
+                if ((pixel >>> 24) != 0xff) {
                     return false;
                 }
             }
@@ -250,16 +256,15 @@ public class SwingFXUtils {
         int ih = (int) img.getHeight();
         PixelFormat<?> fxFormat = pr.getPixelFormat();
         boolean srcPixelsAreOpaque = false;
+        boolean opacityMatters = bimg == null ||
+                bimg.getType() == BufferedImage.TYPE_INT_BGR ||
+                bimg.getType() == BufferedImage.TYPE_INT_RGB;
         switch (fxFormat.getType()) {
             case INT_ARGB_PRE:
             case INT_ARGB:
             case BYTE_BGRA_PRE:
-            case BYTE_BGRA:
-                // Check fx image opacity only if
-                // supplied BufferedImage is without alpha channel
-                if (bimg != null &&
-                        (bimg.getType() == BufferedImage.TYPE_INT_BGR ||
-                         bimg.getType() == BufferedImage.TYPE_INT_RGB)) {
+            case BYTE_INDEXED:
+                if (opacityMatters) {
                     srcPixelsAreOpaque = checkFXImageOpaque(pr, iw, ih);
                 }
                 break;

--- a/tests/system/src/test/java/test/javafx/embed/swing/SwingFXUtilsTest.java
+++ b/tests/system/src/test/java/test/javafx/embed/swing/SwingFXUtilsTest.java
@@ -28,7 +28,9 @@ package test.javafx.embed.swing;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.io.ByteArrayOutputStream;
 import java.awt.image.BufferedImage;
+import javax.imageio.ImageIO;
 import java.util.concurrent.CountDownLatch;
 import javafx.application.Application;
 import javafx.application.Platform;
@@ -36,6 +38,7 @@ import javafx.embed.swing.SwingFXUtils;
 import javafx.scene.image.Image;
 import javafx.scene.image.PixelFormat;
 import javafx.scene.image.PixelReader;
+import javafx.scene.image.WritableImage;
 import javafx.stage.Stage;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -79,6 +82,19 @@ public class SwingFXUtilsTest {
         testFromFXImg("opaque.jpg");
         testFromFXImg("opaque.png");
         testFromFXImg("trans.gif");
+    }
+
+    @Test
+    public void testOpaqueArgbImageCanBeWrittenAsJpeg() throws Exception {
+        WritableImage image = new WritableImage(2, 1);
+        image.getPixelWriter().setArgb(0, 0, 0xff112233);
+        image.getPixelWriter().setArgb(1, 0, 0xff445566);
+
+        BufferedImage bimg = SwingFXUtils.fromFXImage(image, null);
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ImageIO.write(bimg, "jpg", out);
+        assertTrue(out.size() > 0, "0-length JPEG image created");
     }
 
     static void testFromFXImg(String imgfilename) {


### PR DESCRIPTION
If an image has RGBA encoding and all pixels are opaque, then `SwingFXUtils.fromFXImage(image, null)` selects TYPE_INT_ARGB_PRE pixel format but the JPEG ImageIO writer cannot encode this alpha-bearing image pixel format since it has no support for it and returns false; so an empty byte array is created.

Issue is when `bimg` (used to store the returned pixel data from `fromFXImage`) is null`,  fromFXImage` uses the JavaFX PixelReader’s storage format, not the alpha values of individual pixels. 
For an RGBA PNG, JavaFX commonly decodes the pixels into premultiplied ARGB/BGRA, so `fxFormat.getType()` is one of INT_ARGB_PRE/BYTE_BGRA_PRE so `getBestBufferedImageType` returns `BufferedImage.TYPE_INT_ARGB_PRE` because the pixel format has an alpha component. It does not inspect whether every alpha value happens to be 255.

The existing `fromFXImage` code only calls `checkFXImageOpaque()` when the caller supplies a non-null `bImg` BufferedImage. 
If `bImg `is null, all-opaque RGBA PNG produces an alpha-capable BufferedImage i.e., BufferedImage.TYPE_INT_ARGB_PRE
```
if (bimg == null) {
    bimg = new BufferedImage(iw, ih, prefBimgType);
}
```
and since JPEG has no standard alpha channel so it cannot store transparency, so when `ImageIO.write(image, "jpg", out)` runs, ImageIO looks for a registered JPEG writer which can encode that pre-multiplied-alpha image type,
 but the JPEG writer rejects an alpha-bearing BufferedImage, so `ImageIO.write` finds no suitable writer and returns false 
so OutputStream is not written into and have 0 bytes 
[Basically the JPEG writer does not check whether the alpha values are all 255; it only sees that the input image has an alpha channel and declines to write it]

The proposed JavaFX change avoids the rejection for an RGBA-formatted but fully opaque image by returning TYPE_INT_RGB, which JPEG can encode. 
ie., for a JavaFX image with an alpha-capable format but only opaque pixels, `fromFXImage(image, null)` is made to choose RGB format rather than ARGB.
Additionally, checkFXImageOpaque is improved to scan one row at a time instead of costly full-image scan so that unnecessary Color object for each pixels is not created just to inspect alpha.

A regression subtest is added to existing testcase

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8388450](https://bugs.openjdk.org/browse/JDK-8388450): ImageIO.write(SwingFXUtils.fromFXImage()) creates 0 length JPEG for some images (**Bug** - P3)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2254/head:pull/2254` \
`$ git checkout pull/2254`

Update a local copy of the PR: \
`$ git checkout pull/2254` \
`$ git pull https://git.openjdk.org/jfx.git pull/2254/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2254`

View PR using the GUI difftool: \
`$ git pr show -t 2254`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2254.diff">https://git.openjdk.org/jfx/pull/2254.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2254#issuecomment-5238075648)
</details>
