### PR TITLE
8364680: HelloWebView demo crashes when msn webpage is scrolled

### DIFF
--- a/modules/javafx.web/src/main/java/com/sun/webkit/network/NetworkContext.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/network/NetworkContext.java
@@ -37,6 +37,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import com.sun.javafx.logging.PlatformLogger;
 import com.sun.javafx.logging.PlatformLogger.Level;
+import com.sun.javafx.tk.Toolkit;
 import com.sun.webkit.WebPage;
 
 final class NetworkContext {
@@ -157,7 +158,7 @@ final class NetworkContext {
                     Util.formatHeaders(headers)));
         }
 
-        if (useHTTP2Loader) {
+        if (useHTTP2Loader && (asynchronous || Toolkit.getToolkit().canStartNestedEventLoop())) {
             final URLLoaderBase loader = HTTP2Loader.create(
                 webPage,
                 byteBufferPool,


### PR DESCRIPTION
Clean backport to jfx27, this fix ensure rendering of msn like web pages during web page scroll event.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8364680](https://bugs.openjdk.org/browse/JDK-8364680): HelloWebView demo crashes when msn webpage is scrolled (**Bug** - P2)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2255/head:pull/2255` \
`$ git checkout pull/2255`

Update a local copy of the PR: \
`$ git checkout pull/2255` \
`$ git pull https://git.openjdk.org/jfx.git pull/2255/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2255`

View PR using the GUI difftool: \
`$ git pr show -t 2255`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2255.diff">https://git.openjdk.org/jfx/pull/2255.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2255#issuecomment-5247938343)
</details>
