### PR TITLE
8389582: JavaFX MenuItem accelerator for NumPad keys is displayed incorrectly

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/scene/input/KeyCharacterCombination.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/input/KeyCharacterCombination.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,7 +48,7 @@ import javafx.beans.NamedArg;
  */
 public final class KeyCharacterCombination extends KeyCombination {
     /** The key character associated with this key combination. */
-    private String character = "";
+    private final String character;
 
     /**
      * Gets the key character associated with this key combination.

--- a/modules/javafx.graphics/src/main/java/javafx/scene/input/KeyCodeCombination.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/input/KeyCodeCombination.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,7 @@ import javafx.beans.NamedArg;
  */
 public final class KeyCodeCombination extends KeyCombination {
     /** The key code associated with this key combination. */
-    private KeyCode code;
+    private final KeyCode code;
 
     /**
      * Gets the key code associated with this key combination.
@@ -145,8 +145,8 @@ public final class KeyCodeCombination extends KeyCombination {
         sb.append(super.getDisplayText());
         final int initialLength = sb.length();
 
-        char c = getSingleChar(code);
-        if (c != 0) {
+        String c = getSingleChar(code);
+        if (c != null) {
             sb.append(c);
             return sb.toString();
         }
@@ -218,59 +218,67 @@ public final class KeyCodeCombination extends KeyCombination {
         }
     }
 
-    /** Compute a single suitable char summarizing the code, if any, and 0 otherwise. */
-    private static char getSingleChar(KeyCode code) {
+    // Returns a suitable string representation of the key code or null
+    private static String getSingleChar(KeyCode code) {
         switch (code) {
-            case ENTER: return '\u21B5';
-            case LEFT: return '\u2190';
-            case UP: return '\u2191';
-            case RIGHT: return '\u2192';
-            case DOWN: return '\u2193';
-            case COMMA: return ',';
-            case MINUS: return '-';
-            case PERIOD: return '.';
-            case SLASH: return '/';
-            case SEMICOLON: return ';';
-            case EQUALS: return '=';
-            case OPEN_BRACKET: return '[';
-            case BACK_SLASH: return '\\';
-            case CLOSE_BRACKET: return ']';
-            case MULTIPLY: return '*';
-            case ADD: return '+';
-            case SUBTRACT: return '-';
-            case DECIMAL: return '.';
-            case DIVIDE: return '/';
-            case BACK_QUOTE: return '`';
-            case QUOTE: return '"';
-            case AMPERSAND: return '&';
-            case ASTERISK: return '*';
-            case LESS: return '<';
-            case GREATER: return '>';
-            case BRACELEFT: return '{';
-            case BRACERIGHT: return '}';
-            case AT: return '@';
-            case COLON: return ':';
-            case CIRCUMFLEX: return '^';
-            case DOLLAR: return '$';
-            case EURO_SIGN: return '\u20AC';
-            case EXCLAMATION_MARK: return '!';
-            case LEFT_PARENTHESIS: return '(';
-            case NUMBER_SIGN: return '#';
-            case PLUS: return '+';
-            case RIGHT_PARENTHESIS: return ')';
-            case UNDERSCORE: return '_';
-            case DIGIT0: return '0';
-            case DIGIT1: return '1';
-            case DIGIT2: return '2';
-            case DIGIT3: return '3';
-            case DIGIT4: return '4';
-            case DIGIT5: return '5';
-            case DIGIT6: return '6';
-            case DIGIT7: return '7';
-            case DIGIT8: return '8';
-            case DIGIT9: return '9';
-            default:
-                break;
+            case ENTER: return "\u21B5";
+            case LEFT: return "\u2190";
+            case UP: return "\u2191";
+            case RIGHT: return "\u2192";
+            case DOWN: return "\u2193";
+            case COMMA: return ",";
+            case MINUS: return "-";
+            case PERIOD: return ".";
+            case SLASH: return "/";
+            case SEMICOLON: return ";";
+            case EQUALS: return "=";
+            case OPEN_BRACKET: return "[";
+            case BACK_SLASH: return "\\";
+            case CLOSE_BRACKET: return "]";
+            case MULTIPLY: return "NumPad *";
+            case ADD: return "NumPad +";
+            case SUBTRACT: return "NumPad -";
+            case DECIMAL: return "NumPad .";
+            case DIVIDE: return "NumPad /";
+            case BACK_QUOTE: return "`";
+            case QUOTE: return "\"";
+            case AMPERSAND: return "&";
+            case ASTERISK: return "*";
+            case LESS: return "<";
+            case GREATER: return ">";
+            case BRACELEFT: return "{";
+            case BRACERIGHT: return "}";
+            case AT: return "@";
+            case COLON: return ":";
+            case CIRCUMFLEX: return "^";
+            case DOLLAR: return "$";
+            case EURO_SIGN: return "\u20AC";
+            case EXCLAMATION_MARK: return "!";
+            case LEFT_PARENTHESIS: return "(";
+            case NUMBER_SIGN: return "#";
+            case PLUS: return "+";
+            case RIGHT_PARENTHESIS: return ")";
+            case UNDERSCORE: return "_";
+            case DIGIT0: return "0";
+            case DIGIT1: return "1";
+            case DIGIT2: return "2";
+            case DIGIT3: return "3";
+            case DIGIT4: return "4";
+            case DIGIT5: return "5";
+            case DIGIT6: return "6";
+            case DIGIT7: return "7";
+            case DIGIT8: return "8";
+            case DIGIT9: return "9";
+            case NUMPAD0: return "NumPad 0";
+            case NUMPAD1: return "NumPad 1";
+            case NUMPAD2: return "NumPad 2";
+            case NUMPAD3: return "NumPad 3";
+            case NUMPAD4: return "NumPad 4";
+            case NUMPAD5: return "NumPad 5";
+            case NUMPAD6: return "NumPad 6";
+            case NUMPAD7: return "NumPad 7";
+            case NUMPAD8: return "NumPad 8";
+            case NUMPAD9: return "NumPad 9";
         }
 
         /*
@@ -279,13 +287,11 @@ public final class KeyCodeCombination extends KeyCombination {
         */
         if (com.sun.javafx.PlatformUtil.isMac()) {
             switch (code) {
-                case BACK_SPACE: return '\u232B';
-                case ESCAPE: return '\u238B';
-                case DELETE: return '\u2326';
-                default:
-                    break;
+                case BACK_SPACE: return "\u232B";
+                case ESCAPE: return "\u238B";
+                case DELETE: return "\u2326";
             }
         }
-        return 0;
+        return null;
     }
 }

--- a/modules/javafx.graphics/src/main/java/javafx/scene/input/KeyCodeCombination.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/input/KeyCodeCombination.java
@@ -220,6 +220,16 @@ public final class KeyCodeCombination extends KeyCombination {
 
     // Returns a suitable string representation of the key code or null
     private static String getSingleChar(KeyCode code) {
+        // On Mac we display these unicode symbols,
+        // otherwise we default to the Text version of the char.
+        if (com.sun.javafx.PlatformUtil.isMac()) {
+            switch (code) {
+                case BACK_SPACE: return "\u232B";
+                case ESCAPE: return "\u238B";
+                case DELETE: return "\u2326";
+            }
+        }
+
         switch (code) {
             case ENTER: return "\u21B5";
             case LEFT: return "\u2190";
@@ -279,19 +289,12 @@ public final class KeyCodeCombination extends KeyCombination {
             case NUMPAD7: return "NumPad 7";
             case NUMPAD8: return "NumPad 8";
             case NUMPAD9: return "NumPad 9";
+            case BACK_SPACE: return "Backspace";
+            case ESCAPE: return "Esc";
+            case PAGE_DOWN: return "PgDn";
+            case PAGE_UP: return "PgUp";
         }
 
-        /*
-        ** On Mac we display these unicode symbols,
-        ** otherwise we default to the Text version of the char.
-        */
-        if (com.sun.javafx.PlatformUtil.isMac()) {
-            switch (code) {
-                case BACK_SPACE: return "\u232B";
-                case ESCAPE: return "\u238B";
-                case DELETE: return "\u2326";
-            }
-        }
         return null;
     }
 }

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/input/KeyCombinationTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/input/KeyCombinationTest.java
@@ -34,7 +34,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 import javafx.event.Event;
@@ -607,9 +609,9 @@ public class KeyCombinationTest {
 
     private static Stream platformSpecificCombinations() {
         return Stream.of(
-            Arguments.of("Back Space", "\u232B", KeyCode.BACK_SPACE), // Back Space?? it's Backspace on my keyboard
+            Arguments.of("Backspace", "\u232B", KeyCode.BACK_SPACE),
             Arguments.of("Delete", "\u2326", KeyCode.DELETE),
-            Arguments.of("Escape", "\u238B", KeyCode.ESCAPE)
+            Arguments.of("Esc", "\u238B", KeyCode.ESCAPE)
         );
     }
 
@@ -623,31 +625,54 @@ public class KeyCombinationTest {
         assertPlatformEquals(win, mac, k.getDisplayText());
     }
 
-    private static Stream numPadCombinations() {
-        return Stream.of(
-            Arguments.of("NumPad 0", KeyCode.NUMPAD0),
-            Arguments.of("NumPad 1", KeyCode.NUMPAD1),
-            Arguments.of("NumPad 2", KeyCode.NUMPAD2),
-            Arguments.of("NumPad 3", KeyCode.NUMPAD3),
-            Arguments.of("NumPad 4", KeyCode.NUMPAD4),
-            Arguments.of("NumPad 5", KeyCode.NUMPAD5),
-            Arguments.of("NumPad 6", KeyCode.NUMPAD6),
-            Arguments.of("NumPad 7", KeyCode.NUMPAD7),
-            Arguments.of("NumPad 8", KeyCode.NUMPAD8),
-            Arguments.of("NumPad 9", KeyCode.NUMPAD9),
-            Arguments.of("NumPad *", KeyCode.MULTIPLY),
-            Arguments.of("NumPad +", KeyCode.ADD),
-            Arguments.of("NumPad -", KeyCode.SUBTRACT),
-            Arguments.of("NumPad .", KeyCode.DECIMAL),
-            Arguments.of("NumPad /", KeyCode.DIVIDE)
+    private static List<Arguments> commonCombinations() {
+        return toArgumentsList(
+            2,
+            "NumPad 0", KeyCode.NUMPAD0,
+            "NumPad 1", KeyCode.NUMPAD1,
+            "NumPad 2", KeyCode.NUMPAD2,
+            "NumPad 3", KeyCode.NUMPAD3,
+            "NumPad 4", KeyCode.NUMPAD4,
+            "NumPad 5", KeyCode.NUMPAD5,
+            "NumPad 6", KeyCode.NUMPAD6,
+            "NumPad 7", KeyCode.NUMPAD7,
+            "NumPad 8", KeyCode.NUMPAD8,
+            "NumPad 9", KeyCode.NUMPAD9,
+            "NumPad *", KeyCode.MULTIPLY,
+            "NumPad +", KeyCode.ADD,
+            "NumPad -", KeyCode.SUBTRACT,
+            "NumPad .", KeyCode.DECIMAL,
+            "NumPad /", KeyCode.DIVIDE,
+            "PgDn", KeyCode.PAGE_DOWN,
+            "PgUp", KeyCode.PAGE_UP
         );
+    }
+
+    // converts an array into a Stream<Arguments> with the specified arity (number of arguments)
+    // this should be a standard function in junit5
+    private static List<Arguments> toArgumentsList(int arity, Object... items) {
+        if (arity <= 0) {
+            throw new IllegalArgumentException("arity must be > 0");
+        }
+        if ((items.length % arity) != 0) {
+            throw new IllegalArgumentException("wrong number of items for arity=" + arity);
+        }
+        ArrayList<Arguments> a = new ArrayList<>();
+        for (int i = 0; i < items.length;) {
+            Object[] v = new Object[arity];
+            for (int j = 0; j < arity; ) {
+                v[j++] = items[i++];
+            }
+            a.add(Arguments.of(v));
+        }
+        return a;
     }
 
     /**
      * Checks numeric pad keys
      */
     @ParameterizedTest
-    @MethodSource("numPadCombinations")
+    @MethodSource("commonCombinations")
     public void numPadSymbols(String expected, KeyCode code) {
         KeyCodeCombination k = new KeyCodeCombination(code);
         assertEquals(expected, k.getDisplayText());

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/input/KeyCombinationTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/input/KeyCombinationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,29 +30,29 @@ import static javafx.scene.input.KeyCombination.CONTROL_ANY;
 import static javafx.scene.input.KeyCombination.CONTROL_DOWN;
 import static javafx.scene.input.KeyCombination.SHIFT_ANY;
 import static javafx.scene.input.KeyCombination.SHIFT_DOWN;
-
-import java.util.HashMap;
-import java.util.Map;
-
-import javafx.event.Event;
-import javafx.scene.input.KeyCombination.ModifierValue;
-
-import test.com.sun.javafx.pgstub.StubToolkit;
-import com.sun.javafx.scene.input.KeyCodeMap;
-import com.sun.javafx.tk.Toolkit;
-import javafx.scene.input.KeyCharacterCombination;
-import javafx.scene.input.KeyCode;
-import javafx.scene.input.KeyCodeCombination;
-import javafx.scene.input.KeyCombination;
-import javafx.scene.input.KeyEvent;
-
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+import javafx.event.Event;
+import javafx.scene.input.KeyCharacterCombination;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyCodeCombination;
+import javafx.scene.input.KeyCombination;
+import javafx.scene.input.KeyCombination.ModifierValue;
+import javafx.scene.input.KeyEvent;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import com.sun.javafx.scene.input.KeyCodeMap;
+import com.sun.javafx.tk.Toolkit;
+import test.com.sun.javafx.pgstub.StubToolkit;
 
 
 public class KeyCombinationTest {
@@ -605,12 +605,51 @@ public class KeyCombinationTest {
         assertEquals("[", acceleratorKeyCombo.getDisplayText());
     }
 
-    /*
-     * check that the KeyCodeCombination for KeyCode.DELETE produces something printable.
-     * We only display the unicode DELETE char on mac, otherwise we use "Delete".
+    private static Stream platformSpecificCombinations() {
+        return Stream.of(
+            Arguments.of("Back Space", "\u232B", KeyCode.BACK_SPACE), // Back Space?? it's Backspace on my keyboard
+            Arguments.of("Delete", "\u2326", KeyCode.DELETE),
+            Arguments.of("Escape", "\u238B", KeyCode.ESCAPE)
+        );
+    }
+
+    /**
+     * Checks keys that show different text between Windows/Linux and macOS.
      */
-    @Test public void validStringForDELETE() {
-        KeyCodeCombination keyComboDELETE = new KeyCodeCombination(KeyCode.DELETE);
-        assertPlatformEquals("Delete", "\u2326", keyComboDELETE.getDisplayText());
+    @ParameterizedTest
+    @MethodSource("platformSpecificCombinations")
+    public void platformSpecific(String win, String mac, KeyCode code) {
+        KeyCodeCombination k = new KeyCodeCombination(code);
+        assertPlatformEquals(win, mac, k.getDisplayText());
+    }
+
+    private static Stream numPadCombinations() {
+        return Stream.of(
+            Arguments.of("NumPad 0", KeyCode.NUMPAD0),
+            Arguments.of("NumPad 1", KeyCode.NUMPAD1),
+            Arguments.of("NumPad 2", KeyCode.NUMPAD2),
+            Arguments.of("NumPad 3", KeyCode.NUMPAD3),
+            Arguments.of("NumPad 4", KeyCode.NUMPAD4),
+            Arguments.of("NumPad 5", KeyCode.NUMPAD5),
+            Arguments.of("NumPad 6", KeyCode.NUMPAD6),
+            Arguments.of("NumPad 7", KeyCode.NUMPAD7),
+            Arguments.of("NumPad 8", KeyCode.NUMPAD8),
+            Arguments.of("NumPad 9", KeyCode.NUMPAD9),
+            Arguments.of("NumPad *", KeyCode.MULTIPLY),
+            Arguments.of("NumPad +", KeyCode.ADD),
+            Arguments.of("NumPad -", KeyCode.SUBTRACT),
+            Arguments.of("NumPad .", KeyCode.DECIMAL),
+            Arguments.of("NumPad /", KeyCode.DIVIDE)
+        );
+    }
+
+    /**
+     * Checks numeric pad keys
+     */
+    @ParameterizedTest
+    @MethodSource("numPadCombinations")
+    public void numPadSymbols(String expected, KeyCode code) {
+        KeyCodeCombination k = new KeyCodeCombination(code);
+        assertEquals(expected, k.getDisplayText());
     }
 }


### PR DESCRIPTION
Updated `KeyCodeCombination.getDisplayText()` to return "NumPad *" text for all numpad keys:

```
            Arguments.of("NumPad 0", KeyCode.NUMPAD0),
            Arguments.of("NumPad 1", KeyCode.NUMPAD1),
            Arguments.of("NumPad 2", KeyCode.NUMPAD2),
            Arguments.of("NumPad 3", KeyCode.NUMPAD3),
            Arguments.of("NumPad 4", KeyCode.NUMPAD4),
            Arguments.of("NumPad 5", KeyCode.NUMPAD5),
            Arguments.of("NumPad 6", KeyCode.NUMPAD6),
            Arguments.of("NumPad 7", KeyCode.NUMPAD7),
            Arguments.of("NumPad 8", KeyCode.NUMPAD8),
            Arguments.of("NumPad 9", KeyCode.NUMPAD9),
            Arguments.of("NumPad *", KeyCode.MULTIPLY),
            Arguments.of("NumPad +", KeyCode.ADD),
            Arguments.of("NumPad -", KeyCode.SUBTRACT),
            Arguments.of("NumPad .", KeyCode.DECIMAL),
            Arguments.of("NumPad /", KeyCode.DIVIDE)
```

Added test for numpad and also modified the test case where we have platform-specific differences (Backspace, Delete, ...)

NOTE: noticed the auto-generated text shows weird names - "Back Space" instead of "Backspace".  We might want to double check and fix these as well.

some names are weird, perhaps these should also be fixed:

KeyCode.BACK_SPACE: Back Space
KeyCode.QUOTEDBL: Quotedbl
KeyCode.EJECT_TOGGLE: Eject Toggle
KeyCode.KP_DOWN: Kp Down
KeyCode.KP_LEFT: Kp Left
KeyCode.KP_RIGHT: Kp Right
KeyCode.KP_UP: Kp Up

Also, there is difference in naming certain keys between macOS keyboards and the rest of the world:

esc - Esc
backspace == delete
return - Enter
caps lock - Caps Lock
shift - Shift

The use of symbols for macOS is questionable in my opinion, maybe the keyboard have changed since then:

KeyCode.BACK_SPACE: ⌫
KeyCode.DELETE: ⌦
KeyCode.ESCAPE: ⎋

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8389582](https://bugs.openjdk.org/browse/JDK-8389582): JavaFX MenuItem accelerator for NumPad keys is displayed incorrectly (**Bug** - P4)


### Reviewers
 * [Martin Fox](https://openjdk.org/census#mfox) (@beldenfox - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2257/head:pull/2257` \
`$ git checkout pull/2257`

Update a local copy of the PR: \
`$ git checkout pull/2257` \
`$ git pull https://git.openjdk.org/jfx.git pull/2257/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2257`

View PR using the GUI difftool: \
`$ git pr show -t 2257`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2257.diff">https://git.openjdk.org/jfx/pull/2257.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2257#issuecomment-5285496067)
</details>
