### PR TITLE
8390433: Add pixel-snapping documentation

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/scene/Parent.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Parent.java
@@ -1146,7 +1146,6 @@ public abstract non-sealed class Parent extends Node {
         }
     }
 
-    // PENDING_DOC_REVIEW
     /**
      * Computes the preferred width for the specified height.
      * <p>
@@ -1176,7 +1175,6 @@ public abstract non-sealed class Parent extends Node {
         return maxX - minX;
     }
 
-    // PENDING_DOC_REVIEW
     /**
      * Computes the preferred height for the specified width.
      * <p>
@@ -1223,7 +1221,6 @@ public abstract non-sealed class Parent extends Node {
         return prefWidth(height);
     }
 
-    // PENDING_DOC_REVIEW
     /**
      * Computes the minimum height for the specified width.
      * <p>

--- a/modules/javafx.graphics/src/main/java/javafx/scene/Parent.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Parent.java
@@ -1148,14 +1148,19 @@ public abstract non-sealed class Parent extends Node {
 
     // PENDING_DOC_REVIEW
     /**
-     * Calculates the preferred width of this {@code Parent}. The default
-     * implementation calculates this width as the width of the area occupied
-     * by its managed children when they are positioned at their
-     * current positions at their preferred widths.
+     * Computes the preferred width for the specified height.
+     * <p>
+     * An overriding implementation should be consistent with the layout policy implemented by
+     * {@link #layoutChildren()}. If pixel snapping is used, corresponding measurement and layout
+     * calculations must use the same snapped values.
      *
-     * @param height the height that should be used if preferred width depends
-     *      on it
-     * @return the calculated preferred width
+     * @implNote The default implementation computes the horizontal span containing the parent's origin
+     *           and all managed children. It uses each child's current layout position and preferred width,
+     *           constrained by the child's minimum and maximum widths.
+     *           The {@code height} parameter is ignored.
+     * @param height the height on which to base the preferred width, or {@code -1} if no height is specified
+     * @return the computed preferred width
+     * @see <a href="layout/package-summary.html#pixel-snapping">Pixel Snapping</a>
      */
     protected double computePrefWidth(double height) {
         double minX = 0;
@@ -1173,14 +1178,19 @@ public abstract non-sealed class Parent extends Node {
 
     // PENDING_DOC_REVIEW
     /**
-     * Calculates the preferred height of this {@code Parent}. The default
-     * implementation calculates this height as the height of the area occupied
-     * by its managed children when they are positioned at their current
-     * positions at their preferred heights.
+     * Computes the preferred height for the specified width.
+     * <p>
+     * An overriding implementation should be consistent with the layout policy implemented by
+     * {@link #layoutChildren()}. If pixel snapping is used, corresponding measurement and layout
+     * calculations must use the same snapped values.
      *
-     * @param width the width that should be used if preferred height depends
-     *      on it
-     * @return the calculated preferred height
+     * @implNote The default implementation computes the vertical span containing the parent's origin
+     *           and all managed children. It uses each child's current layout position and preferred height,
+     *           constrained by the child's minimum and maximum heights.
+     *           The {@code width} parameter is ignored.
+     * @param width the width on which to base the preferred height, or {@code -1} if no width is specified
+     * @return the computed preferred height
+     * @see <a href="layout/package-summary.html#pixel-snapping">Pixel Snapping</a>
      */
     protected double computePrefHeight(double width) {
         double minY = 0;
@@ -1197,12 +1207,16 @@ public abstract non-sealed class Parent extends Node {
     }
 
     /**
-     * Calculates the minimum width of this {@code Parent}. The default
-     * implementation simply returns the pref width.
+     * Computes the minimum width for the specified height.
+     * <p>
+     * An overriding implementation should be consistent with the layout policy implemented by
+     * {@link #layoutChildren()}. If pixel snapping is used, corresponding measurement and layout
+     * calculations must use the same snapped values.
      *
-     * @param height the height that should be used if min width depends
-     *      on it
-     * @return the calculated min width
+     * @implNote The default implementation returns {@link #prefWidth(double) prefWidth(height)}.
+     * @param height the height on which to base the minimum width, or {@code -1} if no height is specified
+     * @return the computed minimum width
+     * @see <a href="layout/package-summary.html#pixel-snapping">Pixel Snapping</a>
      * @since JavaFX 2.1
      */
     protected double computeMinWidth(double height) {
@@ -1211,12 +1225,16 @@ public abstract non-sealed class Parent extends Node {
 
     // PENDING_DOC_REVIEW
     /**
-     * Calculates the min height of this {@code Parent}. The default
-     * implementation simply returns the pref height;
+     * Computes the minimum height for the specified width.
+     * <p>
+     * An overriding implementation should be consistent with the layout policy implemented by
+     * {@link #layoutChildren()}. If pixel snapping is used, corresponding measurement and layout
+     * calculations must use the same snapped values.
      *
-     * @param width the width that should be used if min height depends
-     *      on it
-     * @return the calculated min height
+     * @implNote The default implementation returns {@link #prefHeight(double) prefHeight(width)}.
+     * @param width the width on which to base the minimum height, or {@code -1} if no width is specified
+     * @return the computed minimum height
+     * @see <a href="layout/package-summary.html#pixel-snapping">Pixel Snapping</a>
      * @since JavaFX 2.1
      */
     protected double computeMinHeight(double width) {
@@ -1299,12 +1317,16 @@ public abstract non-sealed class Parent extends Node {
     }
 
     /**
-     * Invoked during the layout pass to layout the children in this
-     * {@code Parent}. By default it will only set the size of managed,
-     * resizable content to their preferred sizes and does not do any node
-     * positioning.
+     * Invoked by {@link #layout()} during a layout pass to position and resize the managed children.
      * <p>
-     * Subclasses should override this function to layout content as needed.
+     * Subclasses should override this method to implement their layout policy. When pixel snapping is used,
+     * this parent owns the snapping policy for the positions and sizes it allocates to its children.
+     * The snapped allocations made here must be consistent with the corresponding minimum-size and
+     * preferred-size calculations.
+     *
+     * @implSpec The default implementation invokes {@link Node#autosize()} on each managed,
+     *           resizable child and leaves all child positions unchanged.
+     * @see <a href="layout/package-summary.html#pixel-snapping">Pixel Snapping</a>
      */
     protected void layoutChildren() {
         for (int i=0, max=children.size(); i<max; i++) {

--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/Region.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/Region.java
@@ -1591,41 +1591,61 @@ public class Region extends Parent {
     }
 
     /**
-     * Computes the minimum width of this region.
-     * Returns the sum of the left and right insets by default.
-     * region subclasses should override this method to return an appropriate
-     * value based on their content and layout strategy.  If the subclass
-     * doesn't have a VERTICAL content bias, then the height parameter can be
-     * ignored.
+     * Computes the minimum width of this region for the specified height.
+     * <p>
+     * This method supplies the value used by {@link #minWidth(double)} when the {@link #minWidth}
+     * property is set to {@link #USE_COMPUTED_SIZE}.
+     * <p>
+     * Subclasses should override this method when their content or layout policy requires a different
+     * minimum width. If {@link #getContentBias()} is {@link Orientation#VERTICAL}, the computation should
+     * use {@code height}; otherwise {@code height} can be ignored. An overriding implementation should be
+     * consistent with its {@link #layoutChildren()} implementation, including its pixel-snapping decisions.
      *
-     * @return the computed minimum width of this region
+     * @implNote The default implementation returns the sum of the left and right {@linkplain #getInsets() insets}.
+     * @param height the height on which to base the minimum width, or {@code -1} if no height is specified
+     * @return the computed minimum width
+     * @see <a href="package-summary.html#pixel-snapping">Pixel Snapping</a>
      */
     @Override protected double computeMinWidth(double height) {
         return getInsets().getLeft() + getInsets().getRight();
     }
 
     /**
-     * Computes the minimum height of this region.
-     * Returns the sum of the top and bottom insets by default.
-     * Region subclasses should override this method to return an appropriate
-     * value based on their content and layout strategy.  If the subclass
-     * doesn't have a HORIZONTAL content bias, then the width parameter can be
-     * ignored.
+     * Computes the minimum height of this region for the specified width.
+     * <p>
+     * This method supplies the value used by {@link #minHeight(double)} when the {@link #minHeight}
+     * property is set to {@link #USE_COMPUTED_SIZE}.
+     * <p>
+     * Subclasses should override this method when their content or layout policy requires a different
+     * minimum height. If {@link #getContentBias()} is {@link Orientation#HORIZONTAL}, the computation should
+     * use {@code width}; otherwise {@code width} can be ignored. An overriding implementation should be
+     * consistent with its {@link #layoutChildren()} implementation, including its pixel-snapping decisions.
      *
-     * @return the computed minimum height for this region
+     * @implNote The default implementation returns the sum of the top and bottom {@linkplain #getInsets() insets}.
+     * @param width the width on which to base the minimum height, or {@code -1} if no width is specified
+     * @return the computed minimum height
+     * @see <a href="package-summary.html#pixel-snapping">Pixel Snapping</a>
      */
     @Override protected double computeMinHeight(double width) {
         return getInsets().getTop() + getInsets().getBottom();
     }
 
     /**
-     * Computes the preferred width of this region for the given height.
-     * Region subclasses should override this method to return an appropriate
-     * value based on their content and layout strategy.  If the subclass
-     * doesn't have a VERTICAL content bias, then the height parameter can be
-     * ignored.
+     * Computes the preferred width of this region for the specified height.
+     * <p>
+     * This method supplies the value used by {@link #prefWidth(double)} when the {@link #prefWidth}
+     * property is set to {@link #USE_COMPUTED_SIZE}.
+     * <p>
+     * Subclasses that implement a custom layout policy should override this method to compute the width
+     * needed by that policy. If {@link #getContentBias()} is {@link Orientation#VERTICAL}, the computation
+     * should use {@code height}; otherwise {@code height} can be ignored. An overriding implementation should
+     * be consistent with its {@link #layoutChildren()} implementation, including its pixel-snapping decisions.
      *
-     * @return the computed preferred width for this region
+     * @implNote The default implementation adds the left and right {@linkplain #getInsets() insets} to the preferred
+     *           width computed by the {@link Parent#computePrefWidth(double) superclass implementation}.
+     * @param height the height on which to base the preferred width, or {@code -1} if no height is specified
+     * @return the computed preferred width
+     * @see <a href="package-summary.html#pixel-snapping">Pixel Snapping</a>
      */
     @Override protected double computePrefWidth(double height) {
         final double w = super.computePrefWidth(height);
@@ -1633,13 +1653,21 @@ public class Region extends Parent {
     }
 
     /**
-     * Computes the preferred height of this region for the given width;
-     * Region subclasses should override this method to return an appropriate
-     * value based on their content and layout strategy.  If the subclass
-     * doesn't have a HORIZONTAL content bias, then the width parameter can be
-     * ignored.
+     * Computes the preferred height of this region for the specified width.
+     * <p>
+     * This method supplies the value used by {@link #prefHeight(double)} when the {@link #prefHeight}
+     * property is set to {@link #USE_COMPUTED_SIZE}.
+     * <p>
+     * Subclasses that implement a custom layout policy should override this method to compute the height
+     * needed by that policy. If {@link #getContentBias()} is {@link Orientation#HORIZONTAL}, the computation
+     * should use {@code width}; otherwise {@code width} can be ignored. An overriding implementation should
+     * be consistent with its {@link #layoutChildren()} implementation, including its pixel-snapping decisions.
      *
-     * @return the computed preferred height for this region
+     * @implNote The default implementation adds the top and bottom {@linkplain #getInsets() insets} to the preferred
+     *           height computed by the {@link Parent#computePrefHeight(double) superclass implementation}.
+     * @param width the width on which to base the preferred height, or {@code -1} if no width is specified
+     * @return the computed preferred height
+     * @see <a href="package-summary.html#pixel-snapping">Pixel Snapping</a>
      */
     @Override protected double computePrefHeight(double width) {
         final double h = super.computePrefHeight(width);
@@ -1647,32 +1675,42 @@ public class Region extends Parent {
     }
 
     /**
-     * Computes the maximum width for this region.
-     * Returns Double.MAX_VALUE by default.
-     * Region subclasses may override this method to return an different
-     * value based on their content and layout strategy.  If the subclass
-     * doesn't have a VERTICAL content bias, then the height parameter can be
-     * ignored.
+     * Computes the maximum width of this region for the specified height.
+     * <p>
+     * This method supplies the value used by {@link #maxWidth(double)} when the {@link #maxWidth}
+     * property is set to {@link #USE_COMPUTED_SIZE}.
+     * <p>
+     * Subclasses may override this method to impose an upper bound based on their content or layout policy.
+     * If {@link #getContentBias()} is {@link Orientation#VERTICAL}, the computation should use {@code height};
+     * otherwise {@code height} can be ignored. A finite maximum derived from layout geometry should be consistent
+     * with the calculations and pixel-snapping decisions used by {@link #layoutChildren()}.
      *
-     * @param height The height of the Region, in case this value might dictate
-     * the maximum width
-     * @return the computed maximum width for this region
+     * @implNote The default implementation returns {@link Double#MAX_VALUE}, indicating that
+     *           the region has no finite maximum width.
+     * @param height the height on which to base the maximum width, or {@code -1} if no height is specified
+     * @return the computed maximum width; {@link Double#MAX_VALUE} indicates no finite maximum
+     * @see <a href="package-summary.html#pixel-snapping">Pixel Snapping</a>
      */
     protected double computeMaxWidth(double height) {
         return Double.MAX_VALUE;
     }
 
     /**
-     * Computes the maximum height of this region.
-     * Returns Double.MAX_VALUE by default.
-     * Region subclasses may override this method to return a different
-     * value based on their content and layout strategy.  If the subclass
-     * doesn't have a HORIZONTAL content bias, then the width parameter can be
-     * ignored.
+     * Computes the maximum height of this region for the specified width.
+     * <p>
+     * This method supplies the value used by {@link #maxHeight(double)} when the {@link #maxHeight}
+     * property is set to {@link #USE_COMPUTED_SIZE}.
+     * <p>
+     * Subclasses may override this method to impose an upper bound based on their content or layout policy.
+     * If {@link #getContentBias()} is {@link Orientation#HORIZONTAL}, the computation should use {@code width};
+     * otherwise {@code width} can be ignored. A finite maximum derived from layout geometry should be consistent
+     * with the calculations and pixel-snapping decisions used by {@link #layoutChildren()}.
      *
-     * @param width The width of the Region, in case this value might dictate
-     * the maximum height
-     * @return the computed maximum height for this region
+     * @implNote The default implementation returns {@link Double#MAX_VALUE}, indicating that
+     *           the region has no finite maximum height.
+     * @param width the width on which to base the maximum height, or {@code -1} if no width is specified
+     * @return the computed maximum height; {@link Double#MAX_VALUE} indicates no finite maximum
+     * @see <a href="package-summary.html#pixel-snapping">Pixel Snapping</a>
      */
     protected double computeMaxHeight(double width) {
         return Double.MAX_VALUE;

--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/package-info.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/package-info.java
@@ -303,7 +303,6 @@
  *     <li>A position is rounded to the nearest pixel so that an edge stays close to its requested coordinate.
  *     <li>Sizes use ceiling so that snapping itself does not reduce the measured content allocation.
  *     <li>Empty space can usually become slightly smaller without losing content.
- *     <li>{@code snapSpaceX/Y} can also be used to remove floating-point drift from the result of a computation.
  * </ul>
  *
  * The {@linkplain javafx.scene.layout.Region#snappedTopInset() snapped inset} methods return the combined border
@@ -344,8 +343,8 @@
  * combined sum of such elements, each semantic role can require a different decision:
  * <ul>
  *     <li>Snapping too early can lose precision, while snapping too late can introduce errors.
- *     <li>Snapping several children independently can avoid clipping, but at the same time risk exceeding
- *         the content size defined by the region.
+ *     <li>Snapping several children independently can avoid clipping, but the region's measurement and layout
+ *         methods must use consistent calculations so that the computed content size includes those allocations.
  * </ul>
  *
  * Additionally, adding or subtracting already-snapped values can introduce floating-point drift that may cause a
@@ -391,29 +390,52 @@
  *         // Incorrect: a 0.1-unit gap becomes a full pixel
  *         double gap = snapSizeX(0.1);
  *         }
+ *     <li><b>Re-snap after calculations, using the meaning of the result.</b><br>
+ *         Addition and subtraction of already-snapped values can leave the result a few floating-point units away
+ *         from a pixel boundary. After calculating a final value from snapped terms, re-snap a coordinate with
+ *         {@code snapPositionX/Y}, and re-snap a gap or other empty space with {@code snapSpaceX/Y}. Also use
+ *         {@code snapSpaceX/Y} to re-snap a final allocated span composed of independently snapped sizes and spaces:
+ *         {@snippet :
+ *         double firstWidth = snapSizeX(firstChildWidth);
+ *         double gapWidth = snapSpaceX(getGap());
+ *         double secondWidth = snapSizeX(secondChildWidth);
+ *
+ *         // Correct: re-snap the final allocated span with snapSpaceX after arithmetic
+ *         double allocatedWidth = snapSpaceX(firstWidth + gapWidth + secondWidth);
+ *
+ *         // Correct: coordinate calculated from snapped values is re-snapped as a position
+ *         double childX = snapPositionX(snappedLeftInset() + allocatedWidth);
+ *
+ *         // Incorrect: snapSizeX can turn floating-point noise into an extra pixel
+ *         double allocatedWidth = snapSizeX(firstWidth + gapWidth + secondWidth);
+ *
+ *         // Incorrect: the sum of snapped values can add floating-point drift
+ *         double allocatedWidth = firstWidth + gapWidth + secondWidth;
+ *         }
+ *         Using {@code snapSpaceX/Y} for the allocated span does not mean that the span is empty space, it merely
+ *         selects nearest-pixel rounding for the final arithmetic result.
  *     <li><b>Snap independent allocations independently.</b><br>
  *         If two independent pieces of content each need their own pixels, snapping only their sum can under-allocate
  *         layout space. At scale {@code 1.0}, two content widths of {@code 0.4} <em>each</em> require one pixel, while
- *         their combined raw width of {@code 0.8} would be ceiled to only one pixel:
+ *         their combined raw width of {@code 0.8} would be rounded to only one pixel:
  *         {@snippet :
  *         // Correct: each content item receives an independent allocation
  *         double total = snapSpaceX(snapSizeX(firstWidth) + snapSizeX(secondWidth)); // 2.0
  *
- *         // Incorrect: 0.4 + 0.4 is treated as one content allocation
- *         double total = snapSizeX(firstWidth + secondWidth); // 1.0
+ *         // Incorrect: the raw sum is treated as one allocation
+ *         double total = snapSpaceX(firstWidth + secondWidth); // 1.0
  *         }
- *         In the correct example, {@code snapSizeX} is used to create each child's size allocation independently.
- *         Then, both size allocations are added and {@code snapSpaceX} removes floating-point drift.
- *         The same rule applies to distinct margins and gaps: snap each one with {@code snapSpaceX/Y}, then re-snap
- *         the final sum with {@code snapSpaceX/Y} again. For more information, refer to <em>Re-snap after
- *         calculations, using the meaning of the result</em>.
+ *         Only the correct example gives each child its own snapped allocation before adding them; the outer
+ *         {@code snapSpaceX} follows the preceding re-snapping rule. This independent allocation rule also
+ *         applies to distinct margins and gaps.
  *         <p>
  *         Note that this only applies to <em>independent</em> allocations. If several children must fit within a
  *         fixed allocated space, the algorithm must consider all children together and coordinate rounding children
  *         up or down so that their sum does not exceed the allocated space.
- *     <li><b>Do not repeatedly ceil the same semantic size.</b><br>
- *         Preserve precision while refining a measurement and call {@code snapSizeX/Y} only after the refinement.
- *         For example, if an adjustment is part of the same content measurement:
+ *     <li><b>Do not repeatedly snap the same semantic value.</b><br>
+ *         Preserve precision while refining a value and call the appropriate snapping method only after the
+ *         refinement. Repeated snapping is especially dangerous for content sizes because {@code snapSizeX/Y}
+ *         uses ceiling. For example, if an adjustment is part of the same content measurement:
  *         {@snippet :
  *         // Correct: compute all terms first, then allocate the width once
  *         double width = snapSizeX(measuredWidth + measurementAdjustment);
@@ -425,42 +447,6 @@
  *         (incorrect) form returns {@code 2.0}. This rule does not conflict with the preceding rule: two independent
  *         pieces of content are two allocations, while two intermediate terms describing one piece of content are
  *         one allocation.
- *     <li><b>Re-snap after calculations, using the meaning of the result.</b><br>
- *         Addition and subtraction of snapped values can leave the result a few floating-point units away from a
- *         pixel boundary. Re-snap a final coordinate as a <em>position</em> and the allocated span as a <em>space</em>:
- *         {@snippet :
- *         // Correct:
- *         double firstWidth = snapSizeX(firstChildWidth);
- *         double gapWidth = snapSpaceX(getGap());
- *         double secondWidth = snapSizeX(secondChildWidth);
- *         double allocatedWidth = snapSpaceX(firstWidth + gapWidth + secondWidth);
- *
- *         // Incorrect: arithmetic can add floating-point noise to snapped values
- *         double allocatedWidth = firstWidth + gapWidth + secondWidth;
- *
- *         // Incorrect: snapSizeX can turn floating-point noise into an extra pixel
- *         double allocatedWidth = snapSizeX(firstWidth + gapWidth + secondWidth);
- *         }
- *         In this example, {@code firstWidth} and {@code secondWidth} are content sizes, so they use {@code snapSizeX}.
- *         On the other hand, {@code gap} is empty space, so it uses {@code snapSpaceX}. Since all terms are snapped,
- *         the addition of these terms produces the final allocated width, but it can introduce floating-point error.
- *         The final {@code snapSpaceX} does not mean that the allocated width is empty space, it merely uses
- *         the snapping method to remove a tiny amount of floating-point drift.
- *         <p>
- *         The same principle applies to coordinates: after calculating a final coordinate from snapped values, use
- *         {@code snapPositionX/Y} to remove potential floating-point drift.
- *     <li><b>Deliberately apply the snapping policy to values determined by the parent.</b><br>
- *         Since a region's position and allocated size are determined by its parent (and the {@code isSnapToPixel}
- *         policy of its parent), it must not reposition or resize itself. If the allocated width or height is not
- *         aligned, the region cannot both preserve the exact allocation and make its complete bounds pixel-aligned.
- *         Apply the snapping policy of the region deliberately:
- *         {@snippet :
- *         double rawAvailableWidth = getWidth();
- *         double rawAvailableHeight = getHeight();
- *
- *         // Depending on this region's fitting and overflow policy, snap this region's
- *         // raw position and raw allocated size to lay out its children.
- *         }
  *     <li><b>Use the same snapped dependent dimension for measurement and layout.</b><br>
  *         Content-biased nodes have an order dependency between width and height. For example, for a
  *         horizontally-biased child, height depends on width. Establish the snapped width first and pass
@@ -476,23 +462,44 @@
  *             child.minWidth(-1),
  *             child.maxWidth(-1));
  *
- *         // Snap the width the child will actually receive
+ *         // Correct:
+ *         // 1. Snap the width the child will actually receive
  *         double snappedChildWidth = snapSizeX(rawChildWidth);
  *
- *         // Use the snapped width for every dependent height measurement
+ *         // 2. Use the snapped width for every dependent height measurement
  *         double rawChildHeight = boundedSize(
  *             child.prefHeight(snappedChildWidth),
  *             child.minHeight(snappedChildWidth),
  *             child.maxHeight(snappedChildWidth));
  *
- *         // Snap the height the child will receive
+ *         // 3. Snap the height the child will receive
  *         double snappedChildHeight = snapSizeY(rawChildHeight);
  *
- *         // Incorrect: height is measured for rawChildWidth
- *         double snappedChildHeight = snapSizeY(boundedSize(
+ *         // Incorrect:
+ *         // 1. The dependent height is measured for rawChildWidth
+ *         double rawChildHeight = boundedSize(
  *             child.prefHeight(rawChildWidth),
  *             child.minHeight(rawChildWidth),
- *             child.maxHeight(rawChildWidth)));
+ *             child.maxHeight(rawChildWidth));
+ *
+ *          // 2. rawChildHeight was measured for a width that the child might not
+ *          //    actually receive, which makes the snapped value potentially wrong
+ *          double snappedChildHeight = snapSizeY(rawChildHeight);
+ *         }
+ *     <li><b>Deliberately apply the snapping policy to values determined by the parent.</b><br>
+ *         Since a region's position and allocated size are determined by its parent (and the {@code isSnapToPixel}
+ *         policy of its parent), it must not reposition or resize itself. If the allocated width or height is not
+ *         pixel-aligned, the region cannot both preserve the exact allocation and make its complete bounds
+ *         pixel-aligned. The region must choose how to lay out its children according to its fitting and overflow
+ *         policy. For example, a fill policy that accepts a slight underflow or overflow can round the available
+ *         span to the nearest pixel before laying out a resizable child:
+ *         {@snippet :
+ *         // Snap own width and height to determine the content rectangle for children
+ *         double availableWidth = snapSpaceX(getWidth());
+ *         double availableHeight = snapSpaceY(getHeight());
+ *
+ *         // Assumes a completely unconstrained, resizable child
+ *         child.resizeRelocate(0, 0, availableWidth, availableHeight);
  *         }
  *     <li><b>Property values should not be snapped when set, only when they are consumed.</b><br>
  *         The setter of a geometric property should not snap the value, and the getter should return the

--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/package-info.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/package-info.java
@@ -217,5 +217,303 @@
  * mode, a mirroring transform is automatically applied to nodes, flipping the visual flow in the horizontal
  * direction. If this behavior is not desired, nodes can override {@link javafx.scene.Node#usesMirroring()}
  * and return {@code false}.
+ *
+ * <h2>Pixel Snapping</h2>
+ *
+ * In JavaFX, layout coordinates use {@code double} values, which means that a position or size can be fractional.
+ * Mapping fractional coordinates onto a physical screen can introduce blurriness if the edge of a node falls
+ * somewhere between physical pixels. JavaFX uses <em>snapping</em> to fix this problem; it ensures that the bounds
+ * of scene graph nodes do not fall between physical pixels on the screen.
+ * <p>
+ * This section provides guidance for authors of custom {@link javafx.scene.layout.Region} or
+ * {@link javafx.scene.control.SkinBase} implementations that override measurement and layout methods such as
+ * {@link javafx.scene.Parent#layoutChildren()}, {@link javafx.scene.layout.Region#computeMinWidth(double)},
+ * {@link javafx.scene.layout.Region#computeMinHeight(double)}, {@link javafx.scene.layout.Region#computePrefWidth(double)},
+ * {@link javafx.scene.layout.Region#computePrefHeight(double)}, as well as the corresponding {@code SkinBase} methods.
+ *
+ * <h3>Logical vs. pixel coordinates</h3>
+ *
+ * Layout is expressed in logical coordinates, and the {@linkplain javafx.stage.Window#getRenderScaleX() horizontal}
+ * and {@linkplain javafx.stage.Window#getRenderScaleY() vertical} render scales of a window convert logical units
+ * to pixels in the window's rendering buffer:
+ *
+ * <pre>{@code
+ *     physical pixels = logical units * render scale
+ * }</pre>
+ *
+ * At a render scale of {@code 1.0}, one logical unit is one pixel. At a render scale of {@code 1.5}, one pixel is
+ * {@code 1 / 1.5} ≈ {@code 0.6667}, logical units. A correctly snapped value is therefore not necessarily an integer,
+ * and simply rounding coordinates to integers is wrong. Conceptually, snapping applies a rounding operation in pixels
+ * and converts the result back to logical units:
+ *
+ * <pre>{@code
+ *     snappedValue = round(logicalValue * renderScale) / renderScale
+ * }</pre>
+ *
+ * The render scales in the two axes can be different, and they can change when a window moves between screens.
+ * A {@link javafx.scene.layout.Region Region} that is not attached to a window uses a render scale of {@code 1.0}.
+ * Applications should use the snapping methods on {@code Region} instead of implementing the formula above or
+ * caching its result. The built-in methods use the appropriate current render scale and account for floating-point
+ * error near pixel boundaries.
+ *
+ * <h3>Choosing the snapping operation</h3>
+ *
+ * {@code Region} provides three pairs of axis-specific snapping methods. Their names describe the semantic role of
+ * the value being snapped, which influences the snapping direction:
+ *
+ * <table border="1">
+ *     <caption>Snapping operations</caption>
+ *     <thead>
+ *         <tr>
+ *             <th scope="col">Meaning</th>
+ *             <th scope="col">Method</th>
+ *             <th scope="col">Rounding</th>
+ *             <th scope="col">Example</th>
+ *         </tr>
+ *     </thead>
+ *     <tbody>
+ *         <tr>
+ *             <td>Position of a child</td>
+ *             <td>{@link javafx.scene.layout.Region#snapPositionX(double) snapPositionX} or
+ *                 {@link javafx.scene.layout.Region#snapPositionY(double) snapPositionY}</td>
+ *             <td>Nearest pixel</td>
+ *             <td>The final {@code x} or {@code y} passed to
+ *                 {@link javafx.scene.Node#relocate(double, double) relocate}</td>
+ *         </tr>
+ *         <tr>
+ *             <td>Size of a child</td>
+ *             <td>{@link javafx.scene.layout.Region#snapSizeX(double) snapSizeX} or
+ *                 {@link javafx.scene.layout.Region#snapSizeY(double) snapSizeY}</td>
+ *             <td>Up to the next pixel</td>
+ *             <td>The final {@code width} or {@code height} passed to
+ *                 {@link javafx.scene.Node#resize(double, double) resize}</td>
+ *         </tr>
+ *         <tr>
+ *             <td>Empty space</td>
+ *             <td>{@link javafx.scene.layout.Region#snapSpaceX(double) snapSpaceX} or
+ *                 {@link javafx.scene.layout.Region#snapSpaceY(double) snapSpaceY}</td>
+ *             <td>Nearest pixel</td>
+ *             <td>An inset, a padding, or a gap between adjacent children</td>
+ *         </tr>
+ *     </tbody>
+ * </table>
+ *
+ * The reason for the different snapping methods is semantic:
+ * <ul>
+ *     <li>A position is rounded to the nearest pixel so that an edge stays close to its requested coordinate.
+ *     <li>Sizes use ceiling so that snapping itself does not reduce the measured content allocation.
+ *     <li>Empty space can usually become slightly smaller without losing content.
+ *     <li>{@code snapSpaceX/Y} can also be used to remove floating-point drift from the result of a computation.
+ * </ul>
+ *
+ * The {@linkplain javafx.scene.layout.Region#snappedTopInset() snapped inset} methods return the combined border
+ * inset and padding; custom controls should normally use these methods instead of snapping
+ * {@linkplain javafx.scene.layout.Region#getInsets() raw insets} manually.
+ *
+ * <h3>Who controls snapping?</h3>
+ *
+ * The {@link javafx.scene.layout.Region#snapToPixelProperty() snapToPixel} property controls layout calculations
+ * <em>performed by that region only</em>; it is not inherited from the parent and does not affect whether children
+ * snap their contents. A region owns the position and size it allocates to a child; the child owns the layout of
+ * its own descendants.
+ * <p>
+ * For example, setting only the child's property does not repair a fractional position assigned by its parent:
+ * {@snippet :
+ * parent.setSnapToPixel(false);
+ * child.setSnapToPixel(true);
+ *
+ * // At scale 1.0, the parent places the child between pixels
+ * child.relocate(10.5, 20.5);
+ * }
+ *
+ * In this case, even if the child snaps its descendants in its local coordinates, the entire child subtree remains
+ * shifted by half a pixel. Conversely, a parent can allocate a child pixel-aligned outer bounds even when that child
+ * has disabled snapping for its own layout.
+ * <p>
+ * Transforms are applied after the layout has been computed. For example, at render scale {@code 1.0},
+ * the following translation undoes the alignment established during layout:
+ * {@snippet :
+ * child.relocate(snapPositionX(10), snapPositionY(20));
+ * child.setTranslateX(0.5); // The rendered X coordinate is now between pixels
+ * }
+ *
+ * <h3>Why snapping is difficult</h3>
+ *
+ * There is no <em>single</em> correct direction in which to round a value, and no <em>single</em> place in a layout
+ * algorithm where snapping must occur. Since a value can represent a position, content size, empty space, or a
+ * combined sum of such elements, each semantic role can require a different decision:
+ * <ul>
+ *     <li>Snapping too early can lose precision, while snapping too late can introduce errors.
+ *     <li>Snapping several children independently can avoid clipping, but at the same time risk exceeding
+ *         the content size defined by the region.
+ * </ul>
+ *
+ * Additionally, adding or subtracting already-snapped values can introduce floating-point drift that may cause a
+ * later snapping operation to incorrectly add or remove a pixel. Calling a snapping method somewhere in a layout
+ * algorithm is not, by itself, evidence that the resulting value is correctly snapped. Implementing correct snapping
+ * therefore requires a great deal of caution to get it right.
+ *
+ * <h3>Checklist for correct snapping</h3>
+ *
+ * <ol>
+ *     <li><b>Use the axis-specific snapping method.</b><br>
+ *         A horizontal value uses the X scale and a vertical value uses the Y scale.
+ *         This matters when those scales differ:
+ *         {@snippet :
+ *         double left = snapSpaceX(margin.getLeft()); // Correct
+ *         double top = snapSpaceY(margin.getTop());   // Correct
+ *
+ *         double top = snapSpaceX(margin.getTop());   // Incorrect axis
+ *         double gap = snapSpace(rawGap);             // Deprecated and ambiguous
+ *         }
+ *     <li><b>Identify the owner of the snapping policy.</b><br>
+ *         The region arranging a child owns the child's position and its allocated size; use that region's
+ *         {@code isSnapToPixel} policy. For example, write:
+ *         {@snippet :
+ *         // Correct: this region owns the child's position
+ *         double x = snapPositionX(computeChildX());
+ *         double y = snapPositionY(computeChildY());
+ *         child.relocate(x, y);
+ *
+ *         // Incorrect: the child's snapping policy does not control placement by its parent
+ *         double x = child.snapPositionX(computeChildX());
+ *         double y = child.snapPositionY(computeChildY());
+ *         child.relocate(x, y);
+ *         }
+ *     <li><b>Classify each value before choosing a snapping method.</b><br>
+ *         Positions and spaces use nearest-pixel rounding; content sizes use ceiling.
+ *         This distinction prevents gaps from growing unnecessarily and content from being clipped:
+ *         {@snippet :
+ *         double x = snapPositionX(rawX);       // coordinate
+ *         double gap = snapSpaceX(rawGap);      // empty space
+ *         double width = snapSizeX(rawWidth);   // content size
+ *
+ *         // Incorrect: a 0.1-unit gap becomes a full pixel
+ *         double gap = snapSizeX(0.1);
+ *         }
+ *     <li><b>Snap independent allocations independently.</b><br>
+ *         If two independent pieces of content each need their own pixels, snapping only their sum can under-allocate
+ *         layout space. At scale {@code 1.0}, two content widths of {@code 0.4} <em>each</em> require one pixel, while
+ *         their combined raw width of {@code 0.8} would be ceiled to only one pixel:
+ *         {@snippet :
+ *         // Correct: each content item receives an independent allocation
+ *         double total = snapSpaceX(snapSizeX(firstWidth) + snapSizeX(secondWidth)); // 2.0
+ *
+ *         // Incorrect: 0.4 + 0.4 is treated as one content allocation
+ *         double total = snapSizeX(firstWidth + secondWidth); // 1.0
+ *         }
+ *         In the correct example, {@code snapSizeX} is used to create each child's size allocation independently.
+ *         Then, both size allocations are added and {@code snapSpaceX} removes floating-point drift.
+ *         The same rule applies to distinct margins and gaps: snap each one with {@code snapSpaceX/Y}, then re-snap
+ *         the final sum with {@code snapSpaceX/Y} again. For more information, refer to <em>Re-snap after
+ *         calculations, using the meaning of the result</em>.
+ *         <p>
+ *         Note that this only applies to <em>independent</em> allocations. If several children must fit within a
+ *         fixed allocated space, the algorithm must consider all children together and coordinate rounding children
+ *         up or down so that their sum does not exceed the allocated space.
+ *     <li><b>Do not repeatedly ceil the same semantic size.</b><br>
+ *         Preserve precision while refining a measurement and call {@code snapSizeX/Y} only after the refinement.
+ *         For example, if an adjustment is part of the same content measurement:
+ *         {@snippet :
+ *         // Correct: compute all terms first, then allocate the width once
+ *         double width = snapSizeX(measuredWidth + measurementAdjustment);
+ *
+ *         // Incorrect: snapping early throws away information and the second snapSizeX can add another pixel
+ *         double width = snapSizeX(snapSizeX(measuredWidth) + measurementAdjustment);
+ *         }
+ *         At scale {@code 1.0}, if both values are {@code 0.2}, the first form returns {@code 1.0}, while the second
+ *         (incorrect) form returns {@code 2.0}. This rule does not conflict with the preceding rule: two independent
+ *         pieces of content are two allocations, while two intermediate terms describing one piece of content are
+ *         one allocation.
+ *     <li><b>Re-snap after calculations, using the meaning of the result.</b><br>
+ *         Addition and subtraction of snapped values can leave the result a few floating-point units away from a
+ *         pixel boundary. Re-snap a final coordinate as a <em>position</em> and the allocated span as a <em>space</em>:
+ *         {@snippet :
+ *         // Correct:
+ *         double firstWidth = snapSizeX(firstChildWidth);
+ *         double gapWidth = snapSpaceX(getGap());
+ *         double secondWidth = snapSizeX(secondChildWidth);
+ *         double allocatedWidth = snapSpaceX(firstWidth + gapWidth + secondWidth);
+ *
+ *         // Incorrect: arithmetic can add floating-point noise to snapped values
+ *         double allocatedWidth = firstWidth + gapWidth + secondWidth;
+ *
+ *         // Incorrect: snapSizeX can turn floating-point noise into an extra pixel
+ *         double allocatedWidth = snapSizeX(firstWidth + gapWidth + secondWidth);
+ *         }
+ *         In this example, {@code firstWidth} and {@code secondWidth} are content sizes, so they use {@code snapSizeX}.
+ *         On the other hand, {@code gap} is empty space, so it uses {@code snapSpaceX}. Since all terms are snapped,
+ *         the addition of these terms produces the final allocated width, but it can introduce floating-point error.
+ *         The final {@code snapSpaceX} does not mean that the allocated width is empty space, it merely uses
+ *         the snapping method to remove a tiny amount of floating-point drift.
+ *         <p>
+ *         The same principle applies to coordinates: after calculating a final coordinate from snapped values, use
+ *         {@code snapPositionX/Y} to remove potential floating-point drift.
+ *     <li><b>Deliberately apply the snapping policy to values determined by the parent.</b><br>
+ *         Since a region's position and allocated size are determined by its parent (and the {@code isSnapToPixel}
+ *         policy of its parent), it must not reposition or resize itself. If the allocated width or height is not
+ *         aligned, the region cannot both preserve the exact allocation and make its complete bounds pixel-aligned.
+ *         Apply the snapping policy of the region deliberately:
+ *         {@snippet :
+ *         double rawAvailableWidth = getWidth();
+ *         double rawAvailableHeight = getHeight();
+ *
+ *         // Depending on this region's fitting and overflow policy, snap this region's
+ *         // raw position and raw allocated size to lay out its children.
+ *         }
+ *     <li><b>Use the same snapped dependent dimension for measurement and layout.</b><br>
+ *         Content-biased nodes have an order dependency between width and height. For example, for a
+ *         horizontally-biased child, height depends on width. Establish the snapped width first and pass
+ *         that exact width to the height calculation:
+ *         {@snippet :
+ *         static double boundedSize(double value, double min, double max) {
+ *             return Math.min(Math.max(value, min), Math.max(min, max));
+ *         }
+ *
+ *         // This assumes the child should fill the available width
+ *         double rawChildWidth = boundedSize(
+ *             availableWidth,
+ *             child.minWidth(-1),
+ *             child.maxWidth(-1));
+ *
+ *         // Snap the width the child will actually receive
+ *         double snappedChildWidth = snapSizeX(rawChildWidth);
+ *
+ *         // Use the snapped width for every dependent height measurement
+ *         double rawChildHeight = boundedSize(
+ *             child.prefHeight(snappedChildWidth),
+ *             child.minHeight(snappedChildWidth),
+ *             child.maxHeight(snappedChildWidth));
+ *
+ *         // Snap the height the child will receive
+ *         double snappedChildHeight = snapSizeY(rawChildHeight);
+ *
+ *         // Incorrect: height is measured for rawChildWidth
+ *         double snappedChildHeight = snapSizeY(boundedSize(
+ *             child.prefHeight(rawChildWidth),
+ *             child.minHeight(rawChildWidth),
+ *             child.maxHeight(rawChildWidth)));
+ *         }
+ *     <li><b>Property values should not be snapped when set, only when they are consumed.</b><br>
+ *         The setter of a geometric property should not snap the value, and the getter should return the
+ *         exact value set by the application:
+ *         {@snippet :
+ *         // Correct
+ *         public void setGap(double value) {
+ *             gap.set(value);
+ *         }
+ *
+ *         protected void layoutChildren() {
+ *             double snappedGap = snapSpaceX(getGap());
+ *             // use snappedGap for this horizontal allocation
+ *         }
+ *
+ *         // Incorrect: this loses the requested value and uses whichever scale is
+ *         //            current when the setter happens to be called
+ *         public void setGap(double value) {
+ *             gap.set(snapSpaceX(value));
+ *         }
+ *         }
+ * </ol>
  */
 package javafx.scene.layout;

--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/package-info.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/package-info.java
@@ -218,7 +218,7 @@
  * direction. If this behavior is not desired, nodes can override {@link javafx.scene.Node#usesMirroring()}
  * and return {@code false}.
  *
- * <h2>Pixel Snapping</h2>
+ * <h2 id="pixel-snapping">Pixel Snapping</h2>
  *
  * In JavaFX, layout coordinates use {@code double} values, which means that a position or size can be fractional.
  * Mapping fractional coordinates onto a physical screen can introduce blurriness if the edge of a node falls
@@ -394,11 +394,20 @@
  *         // Incorrect: a 0.1-unit gap becomes a full pixel
  *         double gap = snapSizeX(0.1);
  *         }
- *     <li><b>Re-snap after calculations, using the meaning of the result.</b><br>
- *         Addition and subtraction of already-snapped values can leave the result a few floating-point units away
- *         from a pixel boundary. After calculating a final value from snapped terms, re-snap a coordinate with
- *         {@code snapPositionX/Y}, and re-snap a gap or other empty space with {@code snapSpaceX/Y}. Also use
- *         {@code snapSpaceX/Y} to re-snap a final allocated span composed of independently snapped sizes and spaces:
+ *     <li><b>Re-snap calculations whose exact result is known to be pixel-aligned.</b><br>
+ *         If every operand of an addition or subtraction has already been snapped, the <em>idealized</em>
+ *         mathematical result is also pixel-aligned. However, floating-point arithmetic can cause that result
+ *         to be slightly off the pixel grid. In this situation, the fractional remainder is <em>known</em> to
+ *         be arithmetic drift rather than an intentional offset, so re-snap the final result using nearest-pixel
+ *         rounding before returning it or using it in another layout calculation:
+ *         <p>
+ *         <ul>
+ *             <li>Re-snap a coordinate with {@code snapPositionX/Y}.
+ *             <li>Re-snap empty space (gaps, margins, padding) or an allocated content span with {@code snapSpaceX/Y}.
+ *             <li>Do not use {@code snapSizeX/Y} to snap such a result, because ceiling can turn positive
+ *                 floating-point drift into an extra pixel.
+ *         </ul>
+ *         For example, write:
  *         {@snippet :
  *         double firstWidth = snapSizeX(firstChildWidth);
  *         double gapWidth = snapSpaceX(getGap());
@@ -416,8 +425,6 @@
  *         // Incorrect: the sum of snapped values can add floating-point drift
  *         double allocatedWidth = firstWidth + gapWidth + secondWidth;
  *         }
- *         Using {@code snapSpaceX/Y} for the allocated span does not mean that the span is empty space, it merely
- *         selects nearest-pixel rounding for the final arithmetic result.
  *     <li><b>Snap independent allocations independently.</b><br>
  *         If two independent pieces of content each need their own pixels, snapping only their sum can under-allocate
  *         layout space. At scale {@code 1.0}, two content widths of {@code 0.4} <em>each</em> require one pixel, while

--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/package-info.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/package-info.java
@@ -309,12 +309,13 @@
  * inset and padding; custom controls should normally use these methods instead of snapping
  * {@linkplain javafx.scene.layout.Region#getInsets() raw insets} manually.
  *
- * <h3>Who controls snapping?</h3>
+ * <h3>Why snapped content can still look blurry</h3>
  *
- * The {@link javafx.scene.layout.Region#snapToPixelProperty() snapToPixel} property controls layout calculations
- * <em>performed by that region only</em>; it is not inherited from the parent and does not affect whether children
- * snap their contents. A region owns the position and size it allocates to a child; the child owns the layout of
- * its own descendants.
+ * Enabling pixel snapping on a region does not guarantee that the region or its descendants will be rendered on
+ * pixel boundaries. The {@link javafx.scene.layout.Region#snapToPixelProperty() snapToPixel} property controls
+ * layout calculations <em>performed by that region only</em>; it is not inherited from the parent and does not
+ * affect whether children snap their contents. A region owns the position and size it allocates to a child;
+ * the child owns the layout of its own descendants.
  * <p>
  * For example, setting only the child's property does not repair a fractional position assigned by its parent:
  * {@snippet :
@@ -335,6 +336,9 @@
  * child.relocate(snapPositionX(10), snapPositionY(20));
  * child.setTranslateX(0.5); // The rendered X coordinate is now between pixels
  * }
+ * <p>
+ * Therefore, if content appears blurry despite pixel snapping being enabled, check both how its ancestors position
+ * and size it and whether transforms affect its final rendered position.
  *
  * <h3>Why snapping is difficult</h3>
  *

--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/package-info.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/package-info.java
@@ -400,7 +400,6 @@
  *         to be slightly off the pixel grid. In this situation, the fractional remainder is <em>known</em> to
  *         be arithmetic drift rather than an intentional offset, so re-snap the final result using nearest-pixel
  *         rounding before returning it or using it in another layout calculation:
- *         <p>
  *         <ul>
  *             <li>Re-snap a coordinate with {@code snapPositionX/Y}.
  *             <li>Re-snap empty space (gaps, margins, padding) or an allocated content span with {@code snapSpaceX/Y}.

--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/package-info.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/package-info.java
@@ -242,7 +242,7 @@
  * }</pre>
  *
  * At a render scale of {@code 1.0}, one logical unit is one pixel. At a render scale of {@code 1.5}, one pixel is
- * {@code 1 / 1.5} ≈ {@code 0.6667}, logical units. A correctly snapped value is therefore not necessarily an integer,
+ * {@code 1 / 1.5} ≈ {@code 0.6667} logical units. A correctly snapped value is therefore not necessarily an integer,
  * and simply rounding coordinates to integers is wrong. Conceptually, snapping applies a rounding operation in pixels
  * and converts the result back to logical units:
  *


### PR DESCRIPTION
Pixel snapping is really hard to get right (in fact, it's so hard that even JavaFX itself gets it wrong in so many places).
I've compiled a list of things that I've learned, because there isn't really any good documentation as of yet.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390433](https://bugs.openjdk.org/browse/JDK-8390433): Add pixel-snapping documentation (**Enhancement** - P4)


### Reviewers
 * [John Hendrikx](https://openjdk.org/census#jhendrikx) (@hjohn - **Reviewer**)
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Marius Hanl](https://openjdk.org/census#mhanl) (@Maran23 - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2260/head:pull/2260` \
`$ git checkout pull/2260`

Update a local copy of the PR: \
`$ git checkout pull/2260` \
`$ git pull https://git.openjdk.org/jfx.git pull/2260/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2260`

View PR using the GUI difftool: \
`$ git pr show -t 2260`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2260.diff">https://git.openjdk.org/jfx/pull/2260.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2260#issuecomment-5303675933)
</details>
