### PR TITLE
8390440: Region.layoutInArea measures content-biased children against an unsnapped value

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/BorderPane.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/BorderPane.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -508,6 +508,9 @@ public class BorderPane extends Pane {
             width = width < minWidth ? minWidth : width;
         }
 
+        final boolean snapToPixel = isSnapToPixel();
+        final double snapScaleX = getSnapScaleX(this);
+        final double snapScaleY = getSnapScaleY(this);
         final double insideX = insets.getLeft();
         final double insideY = insets.getTop();
         final double insideWidth = width - insideX - insets.getRight();
@@ -523,19 +526,17 @@ public class BorderPane extends Pane {
             Insets topMargin = getNodeMargin(t);
             double adjustedWidth = adjustWidthByMargin(insideWidth, topMargin);
             double adjustedHeight = adjustHeightByMargin(insideHeight, topMargin);
-            topHeight = snapSizeY(t.prefHeight(adjustedWidth));
-            topHeight = Math.min(topHeight, adjustedHeight);
             Vec2d result = boundedNodeSizeWithBias(t, adjustedWidth,
-                   topHeight, true, true, TEMP_VEC2D);
-            topHeight = snapSizeY(result.y);
-            t.resize(snapSizeX(result.x), topHeight);
+                    adjustedHeight, true, false, snapToPixel, snapScaleX, snapScaleY, TEMP_VEC2D);
+            topHeight = result.y;
+            t.resize(result.x, topHeight);
 
             topHeight = snapSpaceY(topMargin.getBottom()) + topHeight + snapSpaceY(topMargin.getTop());
             Pos alignment = getAlignment(t);
             positionInArea(t, insideX, insideY, insideWidth, topHeight, 0/*ignore baseline*/,
                     topMargin,
                     alignment != null? alignment.getHpos() : HPos.LEFT,
-                    alignment != null? alignment.getVpos() : VPos.TOP, isSnapToPixel());
+                    alignment != null? alignment.getVpos() : VPos.TOP, snapToPixel);
         }
 
         double bottomHeight = 0;
@@ -543,12 +544,10 @@ public class BorderPane extends Pane {
             Insets bottomMargin = getNodeMargin(b);
             double adjustedWidth = adjustWidthByMargin(insideWidth, bottomMargin);
             double adjustedHeight = adjustHeightByMargin(insideHeight - topHeight, bottomMargin);
-            bottomHeight = snapSizeY(b.prefHeight(adjustedWidth));
-            bottomHeight = Math.min(bottomHeight, adjustedHeight);
             Vec2d result = boundedNodeSizeWithBias(b, adjustedWidth,
-                    bottomHeight, true, true, TEMP_VEC2D);
-            bottomHeight = snapSizeY(result.y);
-            b.resize(snapSizeX(result.x), bottomHeight);
+                    adjustedHeight, true, false, snapToPixel, snapScaleX, snapScaleY, TEMP_VEC2D);
+            bottomHeight = result.y;
+            b.resize(result.x, bottomHeight);
 
             bottomHeight = snapSpaceY(bottomMargin.getBottom()) + bottomHeight + snapSpaceY(bottomMargin.getTop());
             Pos alignment = getAlignment(b);
@@ -556,7 +555,7 @@ public class BorderPane extends Pane {
                     insideWidth, bottomHeight, 0/*ignore baseline*/,
                     bottomMargin,
                     alignment != null? alignment.getHpos() : HPos.LEFT,
-                    alignment != null? alignment.getVpos() : VPos.BOTTOM, isSnapToPixel());
+                    alignment != null? alignment.getVpos() : VPos.BOTTOM, snapToPixel);
         }
 
         double leftWidth = 0;
@@ -564,12 +563,10 @@ public class BorderPane extends Pane {
             Insets leftMargin = getNodeMargin(l);
             double adjustedWidth = adjustWidthByMargin(insideWidth, leftMargin);
             double adjustedHeight = adjustHeightByMargin(insideHeight - topHeight - bottomHeight, leftMargin); // ????
-            leftWidth = snapSizeX(l.prefWidth(adjustedHeight));
-            leftWidth = Math.min(leftWidth, adjustedWidth);
-            Vec2d result = boundedNodeSizeWithBias(l, leftWidth, adjustedHeight,
-                    true, true, TEMP_VEC2D);
-            leftWidth = snapSizeX(result.x);
-            l.resize(leftWidth, snapSizeY(result.y));
+            Vec2d result = boundedNodeSizeWithBias(l, adjustedWidth, adjustedHeight,
+                    false, true, snapToPixel, snapScaleX, snapScaleY, TEMP_VEC2D);
+            leftWidth = result.x;
+            l.resize(leftWidth, result.y);
 
             leftWidth = snapSpaceX(leftMargin.getLeft()) + leftWidth + snapSpaceX(leftMargin.getRight());
             Pos alignment = getAlignment(l);
@@ -577,7 +574,7 @@ public class BorderPane extends Pane {
                     leftWidth, insideHeight - topHeight - bottomHeight, 0/*ignore baseline*/,
                     leftMargin,
                     alignment != null? alignment.getHpos() : HPos.LEFT,
-                    alignment != null? alignment.getVpos() : VPos.TOP, isSnapToPixel());
+                    alignment != null? alignment.getVpos() : VPos.TOP, snapToPixel);
         }
 
         double rightWidth = 0;
@@ -586,12 +583,10 @@ public class BorderPane extends Pane {
             double adjustedWidth = adjustWidthByMargin(insideWidth - leftWidth, rightMargin);
             double adjustedHeight = adjustHeightByMargin(insideHeight - topHeight - bottomHeight, rightMargin);
 
-            rightWidth = snapSizeX(r.prefWidth(adjustedHeight));
-            rightWidth = Math.min(rightWidth, adjustedWidth);
-            Vec2d result = boundedNodeSizeWithBias(r, rightWidth, adjustedHeight,
-                    true, true, TEMP_VEC2D);
-            rightWidth = snapSizeX(result.x);
-            r.resize(rightWidth, snapSizeY(result.y));
+            Vec2d result = boundedNodeSizeWithBias(r, adjustedWidth, adjustedHeight,
+                    false, true, snapToPixel, snapScaleX, snapScaleY, TEMP_VEC2D);
+            rightWidth = result.x;
+            r.resize(rightWidth, result.y);
 
             rightWidth = snapSpaceX(rightMargin.getLeft()) + rightWidth + snapSpaceX(rightMargin.getRight());
             Pos alignment = getAlignment(r);
@@ -599,7 +594,7 @@ public class BorderPane extends Pane {
                     rightWidth, insideHeight - topHeight - bottomHeight, 0/*ignore baseline*/,
                     rightMargin,
                     alignment != null? alignment.getHpos() : HPos.RIGHT,
-                    alignment != null? alignment.getVpos() : VPos.TOP, isSnapToPixel());
+                    alignment != null? alignment.getVpos() : VPos.TOP, snapToPixel);
         }
 
         if (c != null && c.isManaged()) {

--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/HeaderBar.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/HeaderBar.java
@@ -919,10 +919,9 @@ public class HeaderBar extends Region {
 
     private double resizeChild(Node child, double adjustedWidth, boolean fillWidth, double insideHeight, Insets margin) {
         double adjustedHeight = adjustHeightByMargin(insideHeight, margin);
-        double childWidth = fillWidth ? adjustedWidth : Math.min(snapSizeX(child.prefWidth(adjustedHeight)), adjustedWidth);
-        Vec2d size = boundedNodeSizeWithBias(child, childWidth, adjustedHeight, true, true, TEMP_VEC2D);
-        size.x = snapSizeX(size.x);
-        size.y = snapSizeX(size.y);
+        Vec2d size = boundedNodeSizeWithBias(
+            child, adjustedWidth, adjustedHeight, fillWidth, true, isSnapToPixel(),
+            getSnapScaleX(this), getSnapScaleY(this), TEMP_VEC2D);
         child.resize(size.x, size.y);
         return size.x;
     }

--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/Region.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/Region.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -2168,11 +2168,15 @@ public class Region extends Parent {
      * @param areaHeight the height of the bounding area where the node is going to be placed
      * @param fillWidth if Node should try to fill the area width
      * @param fillHeight if Node should try to fill the area height
+     * @param isSnapToPixel whether to snap size to pixels
+     * @param snapScaleX the horizontal scale to use when snapping
+     * @param snapScaleY the vertical scale to use when snapping
      * @param result Vec2d object for the result or null if new one should be created
      * @return Vec2d object with width(x parameter) and height (y parameter)
      */
     static Vec2d boundedNodeSizeWithBias(Node node, double areaWidth, double areaHeight,
-            boolean fillWidth, boolean fillHeight, Vec2d result) {
+            boolean fillWidth, boolean fillHeight, boolean isSnapToPixel,
+            double snapScaleX, double snapScaleY, Vec2d result) {
         if (result == null) {
             result = new Vec2d();
         }
@@ -2183,34 +2187,34 @@ public class Region extends Parent {
         double childHeight = 0;
 
         if (bias == null) {
-            childWidth = boundedSize(
+            childWidth = snapSize(boundedSize(
                     node.minWidth(-1), fillWidth ? areaWidth
                     : Math.min(areaWidth, node.prefWidth(-1)),
-                    node.maxWidth(-1));
-            childHeight = boundedSize(
+                    node.maxWidth(-1)), isSnapToPixel, snapScaleX);
+            childHeight = snapSize(boundedSize(
                     node.minHeight(-1), fillHeight ? areaHeight
                     : Math.min(areaHeight, node.prefHeight(-1)),
-                    node.maxHeight(-1));
+                    node.maxHeight(-1)), isSnapToPixel, snapScaleY);
 
         } else if (bias == Orientation.HORIZONTAL) {
-            childWidth = boundedSize(
+            childWidth = snapSize(boundedSize(
                     node.minWidth(-1), fillWidth ? areaWidth
                     : Math.min(areaWidth, node.prefWidth(-1)),
-                    node.maxWidth(-1));
-            childHeight = boundedSize(
+                    node.maxWidth(-1)), isSnapToPixel, snapScaleX);
+            childHeight = snapSize(boundedSize(
                     node.minHeight(childWidth), fillHeight ? areaHeight
                     : Math.min(areaHeight, node.prefHeight(childWidth)),
-                    node.maxHeight(childWidth));
+                    node.maxHeight(childWidth)), isSnapToPixel, snapScaleY);
 
         } else { // bias == VERTICAL
-            childHeight = boundedSize(
+            childHeight = snapSize(boundedSize(
                     node.minHeight(-1), fillHeight ? areaHeight
                     : Math.min(areaHeight, node.prefHeight(-1)),
-                    node.maxHeight(-1));
-            childWidth = boundedSize(
+                    node.maxHeight(-1)), isSnapToPixel, snapScaleY);
+            childWidth = snapSize(boundedSize(
                     node.minWidth(childHeight), fillWidth ? areaWidth
                     : Math.min(areaWidth, node.prefWidth(childHeight)),
-                    node.maxWidth(childHeight));
+                    node.maxWidth(childHeight)), isSnapToPixel, snapScaleX);
         }
 
         result.set(childWidth, childHeight);
@@ -2602,9 +2606,8 @@ public class Region extends Parent {
 
         if (child.isResizable()) {
             Vec2d size = boundedNodeSizeWithBias(child, areaWidth - left - right, areaHeight - top - bottom,
-                    fillWidth, fillHeight, TEMP_VEC2D);
-            child.resize(snapSize(size.x, isSnapToPixel, snapScaleX),
-                         snapSize(size.y, isSnapToPixel, snapScaleY));
+                    fillWidth, fillHeight, isSnapToPixel, snapScaleX, snapScaleY, TEMP_VEC2D);
+            child.resize(size.x, size.y);
         }
         position(child, areaX, areaY, areaWidth, areaHeight, areaBaselineOffset,
                 top, right, bottom, left, halignment, valignment, isSnapToPixel);

--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/Region.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/Region.java
@@ -2172,7 +2172,8 @@ public class Region extends Parent {
      * @param snapScaleX the horizontal scale to use when snapping
      * @param snapScaleY the vertical scale to use when snapping
      * @param result Vec2d object for the result or null if new one should be created
-     * @return Vec2d object with width(x parameter) and height (y parameter)
+     * @return Vec2d object with width(x parameter) and height (y parameter), both snapped if
+     *               {@code isSnapToPixel} is {@code true}
      */
     static Vec2d boundedNodeSizeWithBias(Node node, double areaWidth, double areaHeight,
             boolean fillWidth, boolean fillHeight, boolean isSnapToPixel,

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/BorderPaneTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/BorderPaneTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1065,4 +1065,32 @@ public class BorderPaneTest {
         assertEquals(30, center.getHeight(), 1e-100);
     }
 
+    @Test
+    public void testSnappedPrimarySizeForBiasedEdgeChildren() {
+        var top = new MockBiased(Orientation.HORIZONTAL, 100, 200);
+        var bottom = new MockBiased(Orientation.HORIZONTAL, 100, 200);
+        var horizontalPane = new BorderPane();
+        horizontalPane.setTop(top);
+        horizontalPane.setBottom(bottom);
+        horizontalPane.resize(99.2, 1000);
+        horizontalPane.layout();
+
+        assertEquals(100, top.getWidth());
+        assertEquals(200, top.getHeight());
+        assertEquals(100, bottom.getWidth());
+        assertEquals(200, bottom.getHeight());
+
+        var left = new MockBiased(Orientation.VERTICAL, 200, 100);
+        var right = new MockBiased(Orientation.VERTICAL, 200, 100);
+        var verticalPane = new BorderPane();
+        verticalPane.setLeft(left);
+        verticalPane.setRight(right);
+        verticalPane.resize(1000, 99.2);
+        verticalPane.layout();
+
+        assertEquals(200, left.getWidth());
+        assertEquals(100, left.getHeight());
+        assertEquals(200, right.getWidth());
+        assertEquals(100, right.getHeight());
+    }
 }

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/HeaderBarTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/HeaderBarTest.java
@@ -39,6 +39,7 @@ import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.ObjectProperty;
 import javafx.geometry.Dimension2D;
 import javafx.geometry.Insets;
+import javafx.geometry.Orientation;
 import javafx.geometry.Pos;
 import javafx.scene.Node;
 import javafx.scene.Scene;
@@ -277,6 +278,31 @@ public class HeaderBarTest {
 
     @Nested
     class LayoutTest {
+        @Test
+        void verticallyBiasedChildUsesSnappedHeightForWidth() {
+            var content = new MockBiased(Orientation.VERTICAL, 200, 100);
+            headerBar.setLeft(content);
+            headerBar.resize(1000, 99.2);
+            headerBar.layout();
+
+            assertEquals(200, content.getWidth());
+            assertEquals(100, content.getHeight());
+        }
+
+        @Test
+        void childHeightUsesVerticalRenderScale() {
+            stage.setRenderScaleX(1.25);
+            stage.setRenderScaleY(1.5);
+
+            var content = new MockResizable(0, 0, 10, 10, Double.MAX_VALUE, Double.MAX_VALUE);
+            headerBar.setLeft(content);
+            headerBar.resize(100, 10.2);
+            headerBar.layout();
+
+            assertEquals(10.4, content.getWidth());
+            assertEquals(10.666666666666666, content.getHeight());
+        }
+
         @ParameterizedTest
         @CsvSource({
             "TOP_LEFT, 10, 10, 100, 80",

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/RegionTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/RegionTest.java
@@ -39,8 +39,11 @@ import javafx.scene.shape.LineTo;
 import javafx.scene.shape.MoveTo;
 import javafx.scene.shape.Path;
 import javafx.stage.Stage;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.DoubleUnaryOperator;
 import com.sun.javafx.scene.DirtyBits;
 import com.sun.javafx.scene.NodeHelper;
 import com.sun.javafx.sg.prism.NGRegion;
@@ -2118,6 +2121,145 @@ public class RegionTest {
                 double snapOfSnappedValue = RegionShim.snapPortionY(region, snappedValue);
                 assertEquals(snappedValue, snapOfSnappedValue, 0.0, failMessage);
             }
+        }
+    }
+
+    @Test
+    public void layoutInAreaUsesSnappedWidthForHorizontalBias() {
+        var child = new RecordingBiasedRegion(Orientation.HORIZONTAL, 10.2, value -> value < 11 ? 40 : 20);
+        Region.layoutInArea(child, 0, 0, 10.2, 100, -1, Insets.EMPTY, true, false, HPos.LEFT, VPos.TOP, true);
+
+        assertEquals(11, child.getWidth());
+        assertEquals(20, child.getHeight());
+        assertDependentArguments(child, 11);
+    }
+
+    @Test
+    public void layoutInAreaUsesSnappedHeightForVerticalBias() {
+        var child = new RecordingBiasedRegion(Orientation.VERTICAL, 10.2, value -> value < 11 ? 40 : 20);
+        Region.layoutInArea(child, 0, 0, 100, 10.2, -1, Insets.EMPTY, false, true, HPos.LEFT, VPos.TOP, true);
+
+        assertEquals(20, child.getWidth());
+        assertEquals(11, child.getHeight());
+        assertDependentArguments(child, 11);
+    }
+
+    @Test
+    public void layoutInAreaSnapsPreferredPrimarySizeWhenNotFilling() {
+        var child = new RecordingBiasedRegion(Orientation.HORIZONTAL, 10.2, _ -> 20);
+        Region.layoutInArea(child, 0, 0, 100, 100, -1, Insets.EMPTY, false, false, HPos.LEFT, VPos.TOP, true);
+
+        assertEquals(11, child.getWidth());
+        assertEquals(20, child.getHeight());
+        assertDependentArguments(child, 11);
+    }
+
+    @Test
+    public void layoutInAreaPreservesRawPrimarySizeWhenSnappingIsDisabled() {
+        var child = new RecordingBiasedRegion(Orientation.HORIZONTAL, 10.2, _ -> 20.3);
+        Region.layoutInArea(child, 0, 0, 10.2, 100, -1, Insets.EMPTY, true, false, HPos.LEFT, VPos.TOP, false);
+
+        assertEquals(10.2, child.getWidth());
+        assertEquals(20.3, child.getHeight());
+        assertDependentArguments(child, 10.2);
+    }
+
+    @Test
+    public void layoutInAreaUsesAxisSpecificFractionalRenderScales() {
+        Stage stage = new Stage();
+        Pane root = new Pane();
+        stage.setScene(new Scene(root));
+        stage.setRenderScaleX(1.25);
+        stage.setRenderScaleY(1.5);
+
+        try {
+            var horizontal = new RecordingBiasedRegion(Orientation.HORIZONTAL, 10.2, _ -> 10.2);
+            root.getChildren().setAll(horizontal);
+            Region.layoutInArea(horizontal, 0, 0, 10.2, 100, -1, Insets.EMPTY, true, false, HPos.LEFT, VPos.TOP, true);
+
+            assertEquals(10.4, horizontal.getWidth());
+            assertEquals(10.666666666666666, horizontal.getHeight());
+            assertDependentArguments(horizontal, 10.4);
+
+            var vertical = new RecordingBiasedRegion(Orientation.VERTICAL, 10.2, _ -> 10.2);
+            root.getChildren().setAll(vertical);
+            Region.layoutInArea(vertical, 0, 0, 100, 10.2, -1, Insets.EMPTY, false, true, HPos.LEFT, VPos.TOP, true);
+
+            assertEquals(10.4, vertical.getWidth());
+            assertEquals(10.666666666666666, vertical.getHeight());
+            assertDependentArguments(vertical, 10.666666666666666);
+        } finally {
+            stage.close();
+        }
+    }
+
+    @Test
+    public void layoutInAreaHonorsContinuousConstraintsAtSnappedPrimarySize() {
+        var child = new MockBiased(Orientation.HORIZONTAL, 100, 200);
+        Region.layoutInArea(child, 0, 0, 99.2, 1000, -1, Insets.EMPTY, true, false, HPos.LEFT, VPos.TOP, true);
+
+        assertEquals(100, child.getWidth());
+        assertEquals(200, child.getHeight());
+        assertEquals(child.minHeight(child.getWidth()), child.getHeight());
+        assertEquals(child.maxHeight(child.getWidth()), child.getHeight());
+    }
+
+    private static void assertDependentArguments(RecordingBiasedRegion child, double expected) {
+        assertEquals(List.of(expected, expected, expected), child.dependentArguments);
+    }
+
+    private static final class RecordingBiasedRegion extends Region {
+        private final Orientation bias;
+        private final double preferredPrimarySize;
+        private final DoubleUnaryOperator dependentSize;
+        private final List<Double> dependentArguments = new ArrayList<>();
+
+        private RecordingBiasedRegion(Orientation bias,
+                                      double preferredPrimarySize,
+                                      DoubleUnaryOperator dependentSize) {
+            this.bias = bias;
+            this.preferredPrimarySize = preferredPrimarySize;
+            this.dependentSize = dependentSize;
+        }
+
+        @Override
+        public Orientation getContentBias() {
+            return bias;
+        }
+
+        @Override
+        protected double computeMinWidth(double height) {
+            return bias == Orientation.VERTICAL ? computeDependentSize(height) : 0;
+        }
+
+        @Override
+        protected double computeMinHeight(double width) {
+            return bias == Orientation.HORIZONTAL ? computeDependentSize(width) : 0;
+        }
+
+        @Override
+        protected double computePrefWidth(double height) {
+            return bias == Orientation.VERTICAL ? computeDependentSize(height) : preferredPrimarySize;
+        }
+
+        @Override
+        protected double computePrefHeight(double width) {
+            return bias == Orientation.HORIZONTAL ? computeDependentSize(width) : preferredPrimarySize;
+        }
+
+        @Override
+        protected double computeMaxWidth(double height) {
+            return bias == Orientation.VERTICAL ? computeDependentSize(height) : Double.MAX_VALUE;
+        }
+
+        @Override
+        protected double computeMaxHeight(double width) {
+            return bias == Orientation.HORIZONTAL ? computeDependentSize(width) : Double.MAX_VALUE;
+        }
+
+        private double computeDependentSize(double primarySize) {
+            dependentArguments.add(primarySize);
+            return dependentSize.applyAsDouble(primarySize);
         }
     }
 }


### PR DESCRIPTION
`Region.layoutInArea()` calls `Region.boundedNodeSizeWithBias()`, which derives the dependent value from a potentially unsnapped value, after which `layoutInArea()` assigns a potentially different, snapped value to the child. This is wrong, because the dependent value is effectively computed against a value that might not be assigned to the child.

For a horizontally biased child, the current sequence is effectively:

```
double rawWidth = boundedSize(...);
double rawHeight = boundedSize(
        child.minHeight(rawWidth),
        ... child.prefHeight(rawWidth) ...,
        child.maxHeight(rawWidth));

child.resize(
        snapSize(rawWidth),
        snapSize(rawHeight));
```

The correct sequence would be:

```
double width = snapSize(boundedSize(...));
double height = snapSize(boundedSize(
        child.minHeight(width),
        ... child.prefHeight(width) ...,
        child.maxHeight(width)));

child.resize(width, height);
```

This snapping bug can only be observed when all of the following conditions are met:
1. pixel snapping is enabled
2. the child is resizable and has a horizontal or vertical content bias
3. the bounded primary dimension is not already correctly snapped
4. the dependent size constraints change between the raw and snapped primary dimensions

This came out of the "snapping rules" I've compiled for PR #2260, specifically the rule [Use the same snapped dependent dimension for measurement and layout](https://github.com/openjdk/jfx/pull/2260/changes#diff-3fe4ab83269e3ae0ec167ebe622893aff218168e7cab666e5a64c99e6dfbfd4fR464).

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390440](https://bugs.openjdk.org/browse/JDK-8390440): Region.layoutInArea measures content-biased children against an unsnapped value (**Bug** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2261/head:pull/2261` \
`$ git checkout pull/2261`

Update a local copy of the PR: \
`$ git checkout pull/2261` \
`$ git pull https://git.openjdk.org/jfx.git pull/2261/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2261`

View PR using the GUI difftool: \
`$ git pr show -t 2261`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2261.diff">https://git.openjdk.org/jfx/pull/2261.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2261#issuecomment-5305016348)
</details>
