### PR TITLE
8390605: Implement correct snapping for BorderPane

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/BorderPane.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/BorderPane.java
@@ -376,6 +376,9 @@ public class BorderPane extends Pane {
     }
 
     @Override protected double computeMinWidth(double height) {
+        final double leftInset = snappedLeftInset();
+        final double rightInset = snappedRightInset();
+        final double insideHeight = height < 0 ? -1 : snapSpaceY(height - snappedTopInset() - snappedBottomInset());
         double topMinWidth = getAreaWidth(getTop(), -1, true);
         double bottomMinWidth = getAreaWidth(getBottom(), -1, true);
 
@@ -383,13 +386,12 @@ public class BorderPane extends Pane {
         double rightPrefWidth;
         double centerMinWidth;
 
-        if (height != -1 && (childHasContentBias(getLeft(), Orientation.VERTICAL) ||
-                childHasContentBias(getRight(), Orientation.VERTICAL) ||
-            childHasContentBias(getCenter(), Orientation.VERTICAL))) {
+        if (insideHeight != -1 && (childHasContentBias(getLeft(), Orientation.VERTICAL)
+                || childHasContentBias(getRight(), Orientation.VERTICAL)
+                || childHasContentBias(getCenter(), Orientation.VERTICAL))) {
             double topPrefHeight = getAreaHeight(getTop(), -1, false);
             double bottomPrefHeight = getAreaHeight(getBottom(), -1, false);
-
-            double middleAreaHeight = Math.max(0, height - topPrefHeight - bottomPrefHeight);
+            double middleAreaHeight = snapSpaceY(Math.max(0, insideHeight - topPrefHeight - bottomPrefHeight));
 
             leftPrefWidth = getAreaWidth(getLeft(), middleAreaHeight, false);
             rightPrefWidth = getAreaWidth(getRight(), middleAreaHeight, false);
@@ -400,38 +402,42 @@ public class BorderPane extends Pane {
             centerMinWidth = getAreaWidth(getCenter(), -1, true);
         }
 
-        final Insets insets = getInsets();
-        return insets.getLeft() +
-                Math.max(leftPrefWidth + centerMinWidth + rightPrefWidth, Math.max(topMinWidth,bottomMinWidth)) +
-                insets.getRight();
+        double middleAreaWidth = snapSpaceX(leftPrefWidth + centerMinWidth + rightPrefWidth);
+        double contentWidth = Math.max(middleAreaWidth, Math.max(topMinWidth, bottomMinWidth));
+        return snapSpaceX(leftInset + contentWidth + rightInset);
     }
 
     @Override protected double computeMinHeight(double width) {
-        final Insets insets = getInsets();
+        final double topInset = snappedTopInset();
+        final double bottomInset = snappedBottomInset();
+        final double insideWidth = width < 0 ? -1 : snapSpaceX(width - snappedLeftInset() - snappedRightInset());
 
         // Bottom and top are always at their pref height
-        double topPrefHeight = getAreaHeight(getTop(), width, false);
-        double bottomPrefHeight = getAreaHeight(getBottom(), width, false);
+        double topPrefHeight = getAreaHeight(getTop(), insideWidth, false);
+        double bottomPrefHeight = getAreaHeight(getBottom(), insideWidth, false);
 
         double leftMinHeight = getAreaHeight(getLeft(), -1, true);
         double rightMinHeight = getAreaHeight(getRight(), -1, true);
-
         double centerMinHeight;
-        if (width != -1 && childHasContentBias(getCenter(), Orientation.HORIZONTAL)) {
+
+        if (insideWidth != -1 && childHasContentBias(getCenter(), Orientation.HORIZONTAL)) {
             double leftPrefWidth = getAreaWidth(getLeft(), -1, false);
             double rightPrefWidth = getAreaWidth(getRight(), -1, false);
-            centerMinHeight = getAreaHeight(getCenter(),
-                    Math.max(0, width - leftPrefWidth - rightPrefWidth) , true);
+            double centerWidth = snapSpaceX(Math.max(0, insideWidth - leftPrefWidth - rightPrefWidth));
+            centerMinHeight = getAreaHeight(getCenter(), centerWidth, true);
         } else {
             centerMinHeight = getAreaHeight(getCenter(), -1, true);
         }
 
-        double middleAreaMinHeigh = Math.max(centerMinHeight, Math.max(rightMinHeight, leftMinHeight));
+        double middleAreaMinHeight = Math.max(centerMinHeight, Math.max(rightMinHeight, leftMinHeight));
 
-        return insets.getTop() + topPrefHeight + middleAreaMinHeigh + bottomPrefHeight + insets.getBottom();
+        return snapSpaceY(topInset + topPrefHeight + middleAreaMinHeight + bottomPrefHeight + bottomInset);
     }
 
     @Override protected double computePrefWidth(double height) {
+        final double leftInset = snappedLeftInset();
+        final double rightInset = snappedRightInset();
+        final double insideHeight = height < 0 ? -1 : snapSpaceY(height - snappedTopInset() - snappedBottomInset());
         double topPrefWidth = getAreaWidth(getTop(), -1, false);
         double bottomPrefWidth = getAreaWidth(getBottom(), -1, false);
 
@@ -439,13 +445,12 @@ public class BorderPane extends Pane {
         double rightPrefWidth;
         double centerPrefWidth;
 
-        if ( height != -1 && (childHasContentBias(getLeft(), Orientation.VERTICAL) ||
-                childHasContentBias(getRight(), Orientation.VERTICAL) ||
-            childHasContentBias(getCenter(), Orientation.VERTICAL))) {
+        if (insideHeight != -1 && (childHasContentBias(getLeft(), Orientation.VERTICAL)
+                || childHasContentBias(getRight(), Orientation.VERTICAL)
+                || childHasContentBias(getCenter(), Orientation.VERTICAL))) {
             double topPrefHeight = getAreaHeight(getTop(), -1, false);
             double bottomPrefHeight = getAreaHeight(getBottom(), -1, false);
-
-            double middleAreaHeight = Math.max(0, height - topPrefHeight - bottomPrefHeight);
+            double middleAreaHeight = snapSpaceY(Math.max(0, insideHeight - topPrefHeight - bottomPrefHeight));
 
             leftPrefWidth = getAreaWidth(getLeft(), middleAreaHeight, false);
             rightPrefWidth = getAreaWidth(getRight(), middleAreaHeight, false);
@@ -456,37 +461,37 @@ public class BorderPane extends Pane {
             centerPrefWidth = getAreaWidth(getCenter(), -1, false);
         }
 
-        final Insets insets = getInsets();
-        return insets.getLeft() +
-                Math.max(leftPrefWidth + centerPrefWidth + rightPrefWidth, Math.max(topPrefWidth,bottomPrefWidth)) +
-                insets.getRight();
+        double middleAreaWidth = snapSpaceX(leftPrefWidth + centerPrefWidth + rightPrefWidth);
+        double contentWidth = Math.max(middleAreaWidth, Math.max(topPrefWidth, bottomPrefWidth));
+        return snapSpaceX(leftInset + contentWidth + rightInset);
     }
 
     @Override protected double computePrefHeight(double width) {
-        final Insets insets = getInsets();
+        final double topInset = snappedTopInset();
+        final double bottomInset = snappedBottomInset();
+        final double insideWidth = width < 0 ? -1 : snapSpaceX(width - snappedLeftInset() - snappedRightInset());
 
-        double topPrefHeight = getAreaHeight(getTop(), width, false);
-        double bottomPrefHeight = getAreaHeight(getBottom(), width, false);
+        double topPrefHeight = getAreaHeight(getTop(), insideWidth, false);
+        double bottomPrefHeight = getAreaHeight(getBottom(), insideWidth, false);
         double leftPrefHeight = getAreaHeight(getLeft(), -1, false);
         double rightPrefHeight = getAreaHeight(getRight(), -1, false);
-
         double centerPrefHeight;
-        if (width != -1 && childHasContentBias(getCenter(), Orientation.HORIZONTAL)) {
+
+        if (insideWidth != -1 && childHasContentBias(getCenter(), Orientation.HORIZONTAL)) {
             double leftPrefWidth = getAreaWidth(getLeft(), -1, false);
             double rightPrefWidth = getAreaWidth(getRight(), -1, false);
-            centerPrefHeight = getAreaHeight(getCenter(),
-                    Math.max(0, width - leftPrefWidth - rightPrefWidth) , false);
+            double centerWidth = snapSpaceX(Math.max(0, insideWidth - leftPrefWidth - rightPrefWidth));
+            centerPrefHeight = getAreaHeight(getCenter(), centerWidth, false);
         } else {
             centerPrefHeight = getAreaHeight(getCenter(), -1, false);
         }
 
-        double middleAreaPrefHeigh = Math.max(centerPrefHeight, Math.max(rightPrefHeight, leftPrefHeight));
+        double middleAreaPrefHeight = Math.max(centerPrefHeight, Math.max(rightPrefHeight, leftPrefHeight));
 
-        return insets.getTop() + topPrefHeight + middleAreaPrefHeigh + bottomPrefHeight + insets.getBottom();
+        return snapSpaceY(topInset + topPrefHeight + middleAreaPrefHeight + bottomPrefHeight + bottomInset);
     }
 
     @Override protected void layoutChildren() {
-        final Insets insets = getInsets();
         double width = getWidth();
         double height = getHeight();
         final Orientation bias = getContentBias();
@@ -494,27 +499,27 @@ public class BorderPane extends Pane {
         if (bias == null) {
             final double minWidth = minWidth(-1);
             final double minHeight = minHeight(-1);
-            width = width < minWidth ? minWidth : width;
-            height = height < minHeight ? minHeight : height;
+            width = snapSpaceX(Math.max(width, minWidth));
+            height = snapSpaceY(Math.max(height, minHeight));
         } else if (bias == Orientation.HORIZONTAL) {
             final double minWidth = minWidth(-1);
-            width = width < minWidth ? minWidth : width;
+            width = snapSpaceX(Math.max(width, minWidth));
             final double minHeight = minHeight(width);
-            height = height < minHeight ? minHeight : height;
+            height = snapSpaceY(Math.max(height, minHeight));
         } else {
             final double minHeight = minHeight(-1);
-            height = height < minHeight ? minHeight : height;
+            height = snapSpaceY(Math.max(height, minHeight));
             final double minWidth = minWidth(height);
-            width = width < minWidth ? minWidth : width;
+            width = snapSpaceX(Math.max(width, minWidth));
         }
 
         final boolean snapToPixel = isSnapToPixel();
         final double snapScaleX = getSnapScaleX(this);
         final double snapScaleY = getSnapScaleY(this);
-        final double insideX = insets.getLeft();
-        final double insideY = insets.getTop();
-        final double insideWidth = width - insideX - insets.getRight();
-        final double insideHeight = height - insideY - insets.getBottom();
+        final double insideX = snappedLeftInset();
+        final double insideY = snappedTopInset();
+        final double insideWidth = snapSpaceX(width - insideX - snappedRightInset());
+        final double insideHeight = snapSpaceY(height - insideY - snappedBottomInset());
         final Node c = getCenter();
         final Node r = getRight();
         final Node b = getBottom();
@@ -524,14 +529,13 @@ public class BorderPane extends Pane {
         double topHeight = 0;
         if (t != null && t.isManaged()) {
             Insets topMargin = getNodeMargin(t);
-            double adjustedWidth = adjustWidthByMargin(insideWidth, topMargin);
-            double adjustedHeight = adjustHeightByMargin(insideHeight, topMargin);
-            Vec2d result = boundedNodeSizeWithBias(t, adjustedWidth,
-                    adjustedHeight, true, false, snapToPixel, snapScaleX, snapScaleY, TEMP_VEC2D);
+            double adjustedWidth = snapSpaceX(adjustWidthByMargin(insideWidth, topMargin));
+            double adjustedHeight = snapSpaceY(adjustHeightByMargin(insideHeight, topMargin));
+            Vec2d result = boundedNodeSizeWithBias(t, adjustedWidth, adjustedHeight, true, false, snapToPixel,
+                                                   snapScaleX, snapScaleY, TEMP_VEC2D);
             topHeight = result.y;
             t.resize(result.x, topHeight);
-
-            topHeight = snapSpaceY(topMargin.getBottom()) + topHeight + snapSpaceY(topMargin.getTop());
+            topHeight = snapSpaceY(snapSpaceY(topMargin.getBottom()) + topHeight + snapSpaceY(topMargin.getTop()));
             Pos alignment = getAlignment(t);
             positionInArea(t, insideX, insideY, insideWidth, topHeight, 0/*ignore baseline*/,
                     topMargin,
@@ -542,36 +546,38 @@ public class BorderPane extends Pane {
         double bottomHeight = 0;
         if (b != null && b.isManaged()) {
             Insets bottomMargin = getNodeMargin(b);
-            double adjustedWidth = adjustWidthByMargin(insideWidth, bottomMargin);
-            double adjustedHeight = adjustHeightByMargin(insideHeight - topHeight, bottomMargin);
-            Vec2d result = boundedNodeSizeWithBias(b, adjustedWidth,
-                    adjustedHeight, true, false, snapToPixel, snapScaleX, snapScaleY, TEMP_VEC2D);
+            double adjustedWidth = snapSpaceX(adjustWidthByMargin(insideWidth, bottomMargin));
+            double remainingHeight = snapSpaceY(insideHeight - topHeight);
+            double adjustedHeight = snapSpaceY(adjustHeightByMargin(remainingHeight, bottomMargin));
+            Vec2d result = boundedNodeSizeWithBias(b, adjustedWidth, adjustedHeight, true, false, snapToPixel,
+                                                   snapScaleX, snapScaleY, TEMP_VEC2D);
             bottomHeight = result.y;
             b.resize(result.x, bottomHeight);
-
-            bottomHeight = snapSpaceY(bottomMargin.getBottom()) + bottomHeight + snapSpaceY(bottomMargin.getTop());
+            bottomHeight = snapSpaceY(snapSpaceY(bottomMargin.getBottom()) + bottomHeight + snapSpaceY(bottomMargin.getTop()));
             Pos alignment = getAlignment(b);
-            positionInArea(b, insideX, insideY + insideHeight - bottomHeight,
+            positionInArea(b, insideX, snapPositionY(insideY + insideHeight - bottomHeight),
                     insideWidth, bottomHeight, 0/*ignore baseline*/,
                     bottomMargin,
                     alignment != null? alignment.getHpos() : HPos.LEFT,
                     alignment != null? alignment.getVpos() : VPos.BOTTOM, snapToPixel);
         }
 
+        final double middleY = snapPositionY(insideY + topHeight);
+        final double middleHeight = snapSpaceY(insideHeight - topHeight - bottomHeight);
+
         double leftWidth = 0;
         if (l != null && l.isManaged()) {
             Insets leftMargin = getNodeMargin(l);
-            double adjustedWidth = adjustWidthByMargin(insideWidth, leftMargin);
-            double adjustedHeight = adjustHeightByMargin(insideHeight - topHeight - bottomHeight, leftMargin); // ????
-            Vec2d result = boundedNodeSizeWithBias(l, adjustedWidth, adjustedHeight,
-                    false, true, snapToPixel, snapScaleX, snapScaleY, TEMP_VEC2D);
+            double adjustedWidth = snapSpaceX(adjustWidthByMargin(insideWidth, leftMargin));
+            double adjustedHeight = snapSpaceY(adjustHeightByMargin(middleHeight, leftMargin));
+            Vec2d result = boundedNodeSizeWithBias(l, adjustedWidth, adjustedHeight, false, true, snapToPixel,
+                                                   snapScaleX, snapScaleY, TEMP_VEC2D);
             leftWidth = result.x;
             l.resize(leftWidth, result.y);
-
-            leftWidth = snapSpaceX(leftMargin.getLeft()) + leftWidth + snapSpaceX(leftMargin.getRight());
+            leftWidth = snapSpaceX(snapSpaceX(leftMargin.getLeft()) + leftWidth + snapSpaceX(leftMargin.getRight()));
             Pos alignment = getAlignment(l);
-            positionInArea(l, insideX, insideY + topHeight,
-                    leftWidth, insideHeight - topHeight - bottomHeight, 0/*ignore baseline*/,
+            positionInArea(l, insideX, middleY,
+                    leftWidth, middleHeight, 0/*ignore baseline*/,
                     leftMargin,
                     alignment != null? alignment.getHpos() : HPos.LEFT,
                     alignment != null? alignment.getVpos() : VPos.TOP, snapToPixel);
@@ -580,18 +586,17 @@ public class BorderPane extends Pane {
         double rightWidth = 0;
         if (r != null && r.isManaged()) {
             Insets rightMargin = getNodeMargin(r);
-            double adjustedWidth = adjustWidthByMargin(insideWidth - leftWidth, rightMargin);
-            double adjustedHeight = adjustHeightByMargin(insideHeight - topHeight - bottomHeight, rightMargin);
-
-            Vec2d result = boundedNodeSizeWithBias(r, adjustedWidth, adjustedHeight,
-                    false, true, snapToPixel, snapScaleX, snapScaleY, TEMP_VEC2D);
+            double remainingWidth = snapSpaceX(insideWidth - leftWidth);
+            double adjustedWidth = snapSpaceX(adjustWidthByMargin(remainingWidth, rightMargin));
+            double adjustedHeight = snapSpaceY(adjustHeightByMargin(middleHeight, rightMargin));
+            Vec2d result = boundedNodeSizeWithBias(r, adjustedWidth, adjustedHeight, false, true, snapToPixel,
+                                                   snapScaleX, snapScaleY, TEMP_VEC2D);
             rightWidth = result.x;
             r.resize(rightWidth, result.y);
-
-            rightWidth = snapSpaceX(rightMargin.getLeft()) + rightWidth + snapSpaceX(rightMargin.getRight());
+            rightWidth = snapSpaceX(snapSpaceX(rightMargin.getLeft()) + rightWidth + snapSpaceX(rightMargin.getRight()));
             Pos alignment = getAlignment(r);
-            positionInArea(r, insideX + insideWidth - rightWidth, insideY + topHeight,
-                    rightWidth, insideHeight - topHeight - bottomHeight, 0/*ignore baseline*/,
+            positionInArea(r, snapPositionX(insideX + insideWidth - rightWidth), middleY,
+                    rightWidth, middleHeight, 0/*ignore baseline*/,
                     rightMargin,
                     alignment != null? alignment.getHpos() : HPos.RIGHT,
                     alignment != null? alignment.getVpos() : VPos.TOP, snapToPixel);
@@ -599,10 +604,9 @@ public class BorderPane extends Pane {
 
         if (c != null && c.isManaged()) {
             Pos alignment = getAlignment(c);
-
-            layoutInArea(c, insideX + leftWidth, insideY + topHeight,
-                    insideWidth - leftWidth - rightWidth,
-                    insideHeight - topHeight - bottomHeight, 0/*ignore baseline*/,
+            layoutInArea(c, snapPositionX(insideX + leftWidth), middleY,
+                    snapSpaceX(insideWidth - leftWidth - rightWidth),
+                    middleHeight, 0/*ignore baseline*/,
                     getNodeMargin(c),
                     alignment != null? alignment.getHpos() : HPos.CENTER,
                     alignment != null? alignment.getVpos() : VPos.CENTER);
@@ -612,8 +616,9 @@ public class BorderPane extends Pane {
     private double getAreaWidth(Node child, double height, boolean minimum) {
         if (child != null && child.isManaged()) {
             Insets margin = getNodeMargin(child);
-            return minimum ? computeChildMinAreaWidth(child, -1, margin, height, false):
-                                   computeChildPrefAreaWidth(child, -1, margin, height, false);
+            double areaWidth = minimum ? computeChildMinAreaWidth(child, -1, margin, height, true):
+                                         computeChildPrefAreaWidth(child, -1, margin, height, true);
+            return snapSpaceX(areaWidth);
         }
         return 0;
     }
@@ -621,8 +626,9 @@ public class BorderPane extends Pane {
     private double getAreaHeight(Node child, double width, boolean minimum) {
         if (child != null && child.isManaged()) {
             Insets margin = getNodeMargin(child);
-            return minimum ? computeChildMinAreaHeight(child, -1, margin, width, true):
-                                   computeChildPrefAreaHeight(child, -1, margin, width, true);
+            double areaHeight = minimum ? computeChildMinAreaHeight(child, -1, margin, width, true):
+                                          computeChildPrefAreaHeight(child, -1, margin, width, true);
+            return snapSpaceY(areaHeight);
         }
         return 0;
     }

--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/BorderPane.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/BorderPane.java
@@ -562,8 +562,9 @@ public class BorderPane extends Pane {
             bottomHeight = result.y;
             b.resize(result.x, bottomHeight);
             bottomHeight = snapSpaceY(snapSpaceY(bottomMargin.getBottom()) + bottomHeight + snapSpaceY(bottomMargin.getTop()));
+            double bottomY = snapPositionY(insideY + insideHeight - bottomHeight);
             Pos alignment = getAlignment(b);
-            positionInArea(b, insideX, snapPositionY(insideY + insideHeight - bottomHeight),
+            positionInArea(b, insideX, bottomY,
                     insideWidth, bottomHeight, 0/*ignore baseline*/,
                     bottomMargin,
                     alignment != null? alignment.getHpos() : HPos.LEFT,
@@ -602,8 +603,9 @@ public class BorderPane extends Pane {
             rightWidth = result.x;
             r.resize(rightWidth, result.y);
             rightWidth = snapSpaceX(snapSpaceX(rightMargin.getLeft()) + rightWidth + snapSpaceX(rightMargin.getRight()));
+            double rightX = snapPositionX(insideX + insideWidth - rightWidth);
             Pos alignment = getAlignment(r);
-            positionInArea(r, snapPositionX(insideX + insideWidth - rightWidth), middleY,
+            positionInArea(r, rightX, middleY,
                     rightWidth, middleHeight, 0/*ignore baseline*/,
                     rightMargin,
                     alignment != null? alignment.getHpos() : HPos.RIGHT,
@@ -611,9 +613,11 @@ public class BorderPane extends Pane {
         }
 
         if (c != null && c.isManaged()) {
+            double middleX = snapPositionX(insideX + leftWidth);
+            double middleWidth = snapSpaceX(insideWidth - leftWidth - rightWidth);
             Pos alignment = getAlignment(c);
-            layoutInArea(c, snapPositionX(insideX + leftWidth), middleY,
-                    snapSpaceX(insideWidth - leftWidth - rightWidth),
+            layoutInArea(c, middleX, middleY,
+                    middleWidth,
                     middleHeight, 0/*ignore baseline*/,
                     getNodeMargin(c),
                     alignment != null? alignment.getHpos() : HPos.CENTER,

--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/BorderPane.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/BorderPane.java
@@ -435,7 +435,6 @@ public class BorderPane extends Pane {
         }
 
         double middleAreaMinHeight = Math.max(centerMinHeight, Math.max(rightMinHeight, leftMinHeight));
-
         return snapSpaceY(topInset + topPrefHeight + middleAreaMinHeight + bottomPrefHeight + bottomInset);
     }
 
@@ -497,7 +496,6 @@ public class BorderPane extends Pane {
         }
 
         double middleAreaPrefHeight = Math.max(centerPrefHeight, Math.max(rightPrefHeight, leftPrefHeight));
-
         return snapSpaceY(topInset + topPrefHeight + middleAreaPrefHeight + bottomPrefHeight + bottomInset);
     }
 

--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/BorderPane.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/BorderPane.java
@@ -378,7 +378,10 @@ public class BorderPane extends Pane {
     @Override protected double computeMinWidth(double height) {
         final double leftInset = snappedLeftInset();
         final double rightInset = snappedRightInset();
-        final double insideHeight = height < 0 ? -1 : snapSpaceY(height - snappedTopInset() - snappedBottomInset());
+        final double insideHeight = height < 0
+            ? -1
+            : Math.max(0, snapSpaceY(height - snappedTopInset() - snappedBottomInset()));
+
         double topMinWidth = getAreaWidth(getTop(), -1, true);
         double bottomMinWidth = getAreaWidth(getBottom(), -1, true);
 
@@ -410,7 +413,9 @@ public class BorderPane extends Pane {
     @Override protected double computeMinHeight(double width) {
         final double topInset = snappedTopInset();
         final double bottomInset = snappedBottomInset();
-        final double insideWidth = width < 0 ? -1 : snapSpaceX(width - snappedLeftInset() - snappedRightInset());
+        final double insideWidth = width < 0
+            ? -1
+            : Math.max(0, snapSpaceX(width - snappedLeftInset() - snappedRightInset()));
 
         // Bottom and top are always at their pref height
         double topPrefHeight = getAreaHeight(getTop(), insideWidth, false);
@@ -437,7 +442,10 @@ public class BorderPane extends Pane {
     @Override protected double computePrefWidth(double height) {
         final double leftInset = snappedLeftInset();
         final double rightInset = snappedRightInset();
-        final double insideHeight = height < 0 ? -1 : snapSpaceY(height - snappedTopInset() - snappedBottomInset());
+        final double insideHeight = height < 0
+            ? -1
+            : Math.max(0, snapSpaceY(height - snappedTopInset() - snappedBottomInset()));
+
         double topPrefWidth = getAreaWidth(getTop(), -1, false);
         double bottomPrefWidth = getAreaWidth(getBottom(), -1, false);
 
@@ -469,7 +477,9 @@ public class BorderPane extends Pane {
     @Override protected double computePrefHeight(double width) {
         final double topInset = snappedTopInset();
         final double bottomInset = snappedBottomInset();
-        final double insideWidth = width < 0 ? -1 : snapSpaceX(width - snappedLeftInset() - snappedRightInset());
+        final double insideWidth = width < 0
+            ? -1
+            : Math.max(0, snapSpaceX(width - snappedLeftInset() - snappedRightInset()));
 
         double topPrefHeight = getAreaHeight(getTop(), insideWidth, false);
         double bottomPrefHeight = getAreaHeight(getBottom(), insideWidth, false);

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/BorderPaneTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/BorderPaneTest.java
@@ -25,11 +25,16 @@
 
 package test.javafx.scene.layout;
 
+import javafx.beans.property.SimpleDoubleProperty;
 import javafx.geometry.Insets;
 import javafx.geometry.Orientation;
 import javafx.scene.ParentShim;
+import javafx.scene.Scene;
 import javafx.scene.layout.BorderPane;
+import javafx.scene.layout.Pane;
+import javafx.stage.Stage;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -40,11 +45,22 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BorderPaneTest {
 
+    private static final double EPSILON = 1e-10;
+
     BorderPane borderpane;
+    private Stage stage;
 
     @BeforeEach
     public void setUp() {
         this.borderpane = new BorderPane();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if (stage != null) {
+            stage.hide();
+            stage = null;
+        }
     }
 
     @Test
@@ -346,15 +362,18 @@ public class BorderPaneTest {
         /*
          * Note: there is a mix of horizontal and vertical biased children. The BorderPane
          * will favor the bias of the center node above all (see its implementation). This
-         * means the VERTICAL biased controls will have their bias ignored as they differ
-         * from the center's bias.
+         * determines the BorderPane's overall bias. Individual children still retain
+         * their own bias when a dependent size is available.
          */
 
         assertEquals(40/*l*/ + 60/*r*/ + 200/*c*/, borderpane.prefWidth(-1), 1e-100);
         assertEquals(240 /* l + r + c*/, borderpane.prefHeight(-1), 1e-10);
         assertEquals(110, borderpane.minWidth(-1), 1e-100); /* min center + 2x pref width (l, r) */
         assertEquals(20 /*t*/ + 200 /*c*/ + 20 /*b*/, borderpane.minHeight(-1), 1e-10);
-        assertEquals(110, borderpane.minWidth(240), 1e-100);
+
+        // The 240 height leaves 200 for the middle. The left and right preferred
+        // widths at that filled height are 20 and 60; the center minimum is 10.
+        assertEquals(90, borderpane.minWidth(240), 1e-100);
 
         // Top: at a width of 300, the biased control becomes 7 high (6.666)
         // Bottom: at a width of 300, the biased control becomes 14 high (13.333)
@@ -1045,6 +1064,120 @@ public class BorderPaneTest {
     }
 
     @Test
+    public void testSnapsInsetsAndChildSizesInMeasurements() {
+        MockResizable center = new MockResizable(10.1, 20.1, 10.1, 20.1, 10.1, 20.1);
+        borderpane.setPadding(new Insets(0.4));
+        borderpane.setCenter(center);
+
+        showAtScale(1.25, 1.75);
+
+        // X: 1 inset pixel + 13 child pixels + 1 inset pixel.
+        assertEquals(15 / 1.25, borderpane.minWidth(-1), EPSILON);
+        assertEquals(15 / 1.25, borderpane.prefWidth(-1), EPSILON);
+
+        // Y: 1 inset pixel + 36 child pixels + 1 inset pixel.
+        assertEquals(38 / 1.75, borderpane.minHeight(-1), EPSILON);
+        assertEquals(38 / 1.75, borderpane.prefHeight(-1), EPSILON);
+    }
+
+    @Test
+    public void testSnapsEdgeAllocationsAsCompleteSpans() {
+        MockResizable top = new MockResizable(0, 10.1);
+        MockResizable bottom = new MockResizable(0, 8.1);
+        MockResizable left = new MockResizable(7.1, 0);
+        MockResizable right = new MockResizable(6.1, 0);
+        MockResizable center = new MockResizable(0, 0);
+        Insets margin = new Insets(0.4);
+
+        BorderPane.setMargin(top, margin);
+        BorderPane.setMargin(bottom, margin);
+        BorderPane.setMargin(left, margin);
+        BorderPane.setMargin(right, margin);
+        borderpane.setPadding(new Insets(0.4));
+        borderpane.setTop(top);
+        borderpane.setBottom(bottom);
+        borderpane.setLeft(left);
+        borderpane.setRight(right);
+        borderpane.setCenter(center);
+
+        showAtScale(1.25, 1.75);
+        borderpane.resize(50.2, 60.2);
+        borderpane.layout();
+
+        // The snapped pane span is 63 x 105 physical pixels. Padding consumes
+        // one pixel on every side; each edge margin also consumes one pixel.
+        assertEquals(2 / 1.25, top.getLayoutX(), EPSILON);
+        assertEquals(2 / 1.75, top.getLayoutY(), EPSILON);
+        assertEquals(59 / 1.25, top.getWidth(), EPSILON);
+        assertEquals(18 / 1.75, top.getHeight(), EPSILON);
+
+        assertEquals(2 / 1.25, bottom.getLayoutX(), EPSILON);
+        assertEquals(88 / 1.75, bottom.getLayoutY(), EPSILON);
+        assertEquals(59 / 1.25, bottom.getWidth(), EPSILON);
+        assertEquals(15 / 1.75, bottom.getHeight(), EPSILON);
+
+        assertEquals(2 / 1.25, left.getLayoutX(), EPSILON);
+        assertEquals(22 / 1.75, left.getLayoutY(), EPSILON);
+        assertEquals(9 / 1.25, left.getWidth(), EPSILON);
+        assertEquals(64 / 1.75, left.getHeight(), EPSILON);
+
+        assertEquals(53 / 1.25, right.getLayoutX(), EPSILON);
+        assertEquals(22 / 1.75, right.getLayoutY(), EPSILON);
+        assertEquals(8 / 1.25, right.getWidth(), EPSILON);
+        assertEquals(64 / 1.75, right.getHeight(), EPSILON);
+
+        assertEquals(12 / 1.25, center.getLayoutX(), EPSILON);
+        assertEquals(21 / 1.75, center.getLayoutY(), EPSILON);
+        assertEquals(40 / 1.25, center.getWidth(), EPSILON);
+        assertEquals(66 / 1.75, center.getHeight(), EPSILON);
+    }
+
+    @Test
+    public void testHorizontalBiasUsesSnappedContentWidth() {
+        MockBiased top = new MockBiased(Orientation.HORIZONTAL, 100, 100);
+        borderpane.setPadding(new Insets(0.4));
+        borderpane.setTop(top);
+
+        showAtScale(1.25, 1.75);
+
+        // The 100.6-unit constraint becomes a 126-pixel pane width. After two
+        // one-pixel insets, the child receives exactly 124 pixels. Its dependent
+        // height is then ceiled to 177 pixels, plus two vertical inset pixels.
+        assertEquals(179 / 1.75, borderpane.prefHeight(100.6), EPSILON);
+
+        borderpane.resize(100.6, 150);
+        borderpane.layout();
+
+        assertEquals(1 / 1.25, top.getLayoutX(), EPSILON);
+        assertEquals(1 / 1.75, top.getLayoutY(), EPSILON);
+        assertEquals(124 / 1.25, top.getWidth(), EPSILON);
+        assertEquals(177 / 1.75, top.getHeight(), EPSILON);
+    }
+
+    @Test
+    public void testVerticalBiasUsesFilledSnappedContentHeight() {
+        MockBiased center = new MockBiased(Orientation.VERTICAL, 200, 100);
+        borderpane.setPadding(new Insets(0.4));
+        borderpane.setCenter(center);
+
+        showAtScale(1.25, 1.75);
+
+        // The 200.6-unit constraint becomes 351 physical pixels. Insets leave
+        // 349 pixels for the vertically-filled center, which requires 126 X pixels.
+        // Adding the two horizontal inset pixels gives a 128-pixel pane width.
+        assertEquals(128 / 1.25, borderpane.minWidth(200.6), EPSILON);
+        assertEquals(128 / 1.25, borderpane.prefWidth(200.6), EPSILON);
+
+        borderpane.resize(128 / 1.25, 200.6);
+        borderpane.layout();
+
+        assertEquals(1 / 1.25, center.getLayoutX(), EPSILON);
+        assertEquals(1 / 1.75, center.getLayoutY(), EPSILON);
+        assertEquals(126 / 1.25, center.getWidth(), EPSILON);
+        assertEquals(349 / 1.75, center.getHeight(), EPSILON);
+    }
+
+    @Test
     public void testResizeBelowMinimum() {
         MockResizable left = new MockResizable(10,10,100,100,150,150);
         MockResizable center = new MockResizable(30,30,100,100,200,200);
@@ -1065,32 +1198,13 @@ public class BorderPaneTest {
         assertEquals(30, center.getHeight(), 1e-100);
     }
 
-    @Test
-    public void testSnappedPrimarySizeForBiasedEdgeChildren() {
-        var top = new MockBiased(Orientation.HORIZONTAL, 100, 200);
-        var bottom = new MockBiased(Orientation.HORIZONTAL, 100, 200);
-        var horizontalPane = new BorderPane();
-        horizontalPane.setTop(top);
-        horizontalPane.setBottom(bottom);
-        horizontalPane.resize(99.2, 1000);
-        horizontalPane.layout();
-
-        assertEquals(100, top.getWidth());
-        assertEquals(200, top.getHeight());
-        assertEquals(100, bottom.getWidth());
-        assertEquals(200, bottom.getHeight());
-
-        var left = new MockBiased(Orientation.VERTICAL, 200, 100);
-        var right = new MockBiased(Orientation.VERTICAL, 200, 100);
-        var verticalPane = new BorderPane();
-        verticalPane.setLeft(left);
-        verticalPane.setRight(right);
-        verticalPane.resize(1000, 99.2);
-        verticalPane.layout();
-
-        assertEquals(200, left.getWidth());
-        assertEquals(100, left.getHeight());
-        assertEquals(200, right.getWidth());
-        assertEquals(100, right.getHeight());
+    private void showAtScale(double scaleX, double scaleY) {
+        borderpane.setManaged(false);
+        Pane root = new Pane(borderpane);
+        stage = new Stage();
+        stage.renderScaleXProperty().bind(new SimpleDoubleProperty(scaleX));
+        stage.renderScaleYProperty().bind(new SimpleDoubleProperty(scaleY));
+        stage.setScene(new Scene(root, 300, 300));
+        stage.show();
     }
 }

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/BorderPaneTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/BorderPaneTest.java
@@ -32,6 +32,7 @@ import javafx.scene.ParentShim;
 import javafx.scene.Scene;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.Pane;
+import javafx.scene.layout.Region;
 import javafx.stage.Stage;
 
 import org.junit.jupiter.api.AfterEach;
@@ -1178,6 +1179,66 @@ public class BorderPaneTest {
     }
 
     @Test
+    public void testWidthConstraintBelowSnappedInsetSumIsClampedToZero() {
+        var top = new ConstraintSensitiveRegion(Orientation.HORIZONTAL);
+        var center = new ConstraintSensitiveRegion(Orientation.HORIZONTAL);
+
+        borderpane.setPadding(new Insets(0.75));
+        borderpane.setTop(top);
+        borderpane.setCenter(center);
+
+        showAtScale(2, 2);
+
+        // At scale 2, each horizontal inset snaps from 0.75 to 1.0.
+        double snappedInsets = borderpane.snappedLeftInset() + borderpane.snappedRightInset();
+
+        assertEquals(2, snappedInsets);
+
+        // Verify the two intermediate values exercised below.
+        // In particular, the second one is exactly the -1  sentinel.
+        assertEquals(-2, borderpane.snapSpaceX(0 - snappedInsets));
+        assertEquals(-1, borderpane.snapSpaceX(1 - snappedInsets));
+
+        // After clamping, both the top and center receive a dependent width of
+        // zero and report a height of 10:
+        //     1 top inset + 10 top + 10 center + 1 bottom inset = 22.
+        for (double width : new double[] { 0, 1 }) {
+            assertEquals(22, borderpane.minHeight(width));
+            assertEquals(22, borderpane.prefHeight(width));
+        }
+    }
+
+    @Test
+    public void testHeightConstraintBelowSnappedInsetSumIsClampedToZero() {
+        var left = new ConstraintSensitiveRegion(Orientation.VERTICAL);
+        var center = new ConstraintSensitiveRegion(Orientation.VERTICAL);
+
+        borderpane.setPadding(new Insets(0.75));
+        borderpane.setLeft(left);
+        borderpane.setCenter(center);
+
+        showAtScale(2, 2);
+
+        // At scale 2, each vertical inset snaps from 0.75 to 1.0.
+        double snappedInsets = borderpane.snappedTopInset() + borderpane.snappedBottomInset();
+
+        assertEquals(2, snappedInsets);
+
+        // Verify the two intermediate values exercised below.
+        // In particular, the second one is exactly the -1  sentinel.
+        assertEquals(-2, borderpane.snapSpaceY(0 - snappedInsets));
+        assertEquals(-1, borderpane.snapSpaceY(1 - snappedInsets));
+
+        // After clamping, both the left and center receive a dependent height
+        // of zero and report a width of 10:
+        //     1 left inset + 10 left + 10 center + 1 right inset = 22.
+        for (double height : new double[] { 0, 1 }) {
+            assertEquals(22, borderpane.minWidth(height));
+            assertEquals(22, borderpane.prefWidth(height));
+        }
+    }
+
+    @Test
     public void testResizeBelowMinimum() {
         MockResizable left = new MockResizable(10,10,100,100,150,150);
         MockResizable center = new MockResizable(30,30,100,100,200,200);
@@ -1206,5 +1267,47 @@ public class BorderPaneTest {
         stage.renderScaleYProperty().bind(new SimpleDoubleProperty(scaleY));
         stage.setScene(new Scene(root, 300, 300));
         stage.show();
+    }
+
+    private static final class ConstraintSensitiveRegion extends Region {
+        private static final double CONSTRAINED_SIZE = 10;
+        private static final double NEGATIVE_CONSTRAINT_SIZE = 100;
+
+        private final Orientation bias;
+
+        private ConstraintSensitiveRegion(Orientation bias) {
+            this.bias = bias;
+        }
+
+        @Override
+        public Orientation getContentBias() {
+            return bias;
+        }
+
+        @Override
+        protected double computeMinWidth(double height) {
+            return bias == Orientation.VERTICAL ? sizeForConstraint(height) : 0;
+        }
+
+        @Override
+        protected double computePrefWidth(double height) {
+            return bias == Orientation.VERTICAL ? sizeForConstraint(height) : 0;
+        }
+
+        @Override
+        protected double computeMinHeight(double width) {
+            return bias == Orientation.HORIZONTAL ? sizeForConstraint(width) : 0;
+        }
+
+        @Override
+        protected double computePrefHeight(double width) {
+            return bias == Orientation.HORIZONTAL ? sizeForConstraint(width) : 0;
+        }
+
+        private static double sizeForConstraint(double constraint) {
+            // A negative value means that the constrained measurement was
+            // incorrectly exposed as either negative space or the -1 sentinel.
+            return constraint < 0 ? NEGATIVE_CONSTRAINT_SIZE : CONSTRAINED_SIZE;
+        }
     }
 }

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/BorderPaneTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/BorderPaneTest.java
@@ -46,8 +46,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BorderPaneTest {
 
-    private static final double EPSILON = 1e-10;
-
     BorderPane borderpane;
     private Stage stage;
 
@@ -1073,12 +1071,12 @@ public class BorderPaneTest {
         showAtScale(1.25, 1.75);
 
         // X: 1 inset pixel + 13 child pixels + 1 inset pixel.
-        assertEquals(15 / 1.25, borderpane.minWidth(-1), EPSILON);
-        assertEquals(15 / 1.25, borderpane.prefWidth(-1), EPSILON);
+        assertEquals(15 / 1.25, borderpane.minWidth(-1));
+        assertEquals(15 / 1.25, borderpane.prefWidth(-1));
 
         // Y: 1 inset pixel + 36 child pixels + 1 inset pixel.
-        assertEquals(38 / 1.75, borderpane.minHeight(-1), EPSILON);
-        assertEquals(38 / 1.75, borderpane.prefHeight(-1), EPSILON);
+        assertEquals(38 / 1.75, borderpane.minHeight(-1));
+        assertEquals(38 / 1.75, borderpane.prefHeight(-1));
     }
 
     @Test
@@ -1107,30 +1105,30 @@ public class BorderPaneTest {
 
         // The snapped pane span is 63 x 105 physical pixels. Padding consumes
         // one pixel on every side; each edge margin also consumes one pixel.
-        assertEquals(2 / 1.25, top.getLayoutX(), EPSILON);
-        assertEquals(2 / 1.75, top.getLayoutY(), EPSILON);
-        assertEquals(59 / 1.25, top.getWidth(), EPSILON);
-        assertEquals(18 / 1.75, top.getHeight(), EPSILON);
+        assertEquals(2 / 1.25, top.getLayoutX());
+        assertEquals(2 / 1.75, top.getLayoutY());
+        assertEquals(59 / 1.25, top.getWidth());
+        assertEquals(18 / 1.75, top.getHeight());
 
-        assertEquals(2 / 1.25, bottom.getLayoutX(), EPSILON);
-        assertEquals(88 / 1.75, bottom.getLayoutY(), EPSILON);
-        assertEquals(59 / 1.25, bottom.getWidth(), EPSILON);
-        assertEquals(15 / 1.75, bottom.getHeight(), EPSILON);
+        assertEquals(2 / 1.25, bottom.getLayoutX());
+        assertEquals(88 / 1.75, bottom.getLayoutY());
+        assertEquals(59 / 1.25, bottom.getWidth());
+        assertEquals(15 / 1.75, bottom.getHeight());
 
-        assertEquals(2 / 1.25, left.getLayoutX(), EPSILON);
-        assertEquals(22 / 1.75, left.getLayoutY(), EPSILON);
-        assertEquals(9 / 1.25, left.getWidth(), EPSILON);
-        assertEquals(64 / 1.75, left.getHeight(), EPSILON);
+        assertEquals(2 / 1.25, left.getLayoutX());
+        assertEquals(22 / 1.75, left.getLayoutY());
+        assertEquals(9 / 1.25, left.getWidth());
+        assertEquals(64 / 1.75, left.getHeight());
 
-        assertEquals(53 / 1.25, right.getLayoutX(), EPSILON);
-        assertEquals(22 / 1.75, right.getLayoutY(), EPSILON);
-        assertEquals(8 / 1.25, right.getWidth(), EPSILON);
-        assertEquals(64 / 1.75, right.getHeight(), EPSILON);
+        assertEquals(53 / 1.25, right.getLayoutX());
+        assertEquals(22 / 1.75, right.getLayoutY());
+        assertEquals(8 / 1.25, right.getWidth());
+        assertEquals(64 / 1.75, right.getHeight());
 
-        assertEquals(12 / 1.25, center.getLayoutX(), EPSILON);
-        assertEquals(21 / 1.75, center.getLayoutY(), EPSILON);
-        assertEquals(40 / 1.25, center.getWidth(), EPSILON);
-        assertEquals(66 / 1.75, center.getHeight(), EPSILON);
+        assertEquals(12 / 1.25, center.getLayoutX());
+        assertEquals(21 / 1.75, center.getLayoutY());
+        assertEquals(40 / 1.25, center.getWidth());
+        assertEquals(66 / 1.75, center.getHeight());
     }
 
     @Test
@@ -1144,15 +1142,15 @@ public class BorderPaneTest {
         // The 100.6-unit constraint becomes a 126-pixel pane width. After two
         // one-pixel insets, the child receives exactly 124 pixels. Its dependent
         // height is then ceiled to 177 pixels, plus two vertical inset pixels.
-        assertEquals(179 / 1.75, borderpane.prefHeight(100.6), EPSILON);
+        assertEquals(179 / 1.75, borderpane.prefHeight(100.6));
 
         borderpane.resize(100.6, 150);
         borderpane.layout();
 
-        assertEquals(1 / 1.25, top.getLayoutX(), EPSILON);
-        assertEquals(1 / 1.75, top.getLayoutY(), EPSILON);
-        assertEquals(124 / 1.25, top.getWidth(), EPSILON);
-        assertEquals(177 / 1.75, top.getHeight(), EPSILON);
+        assertEquals(1 / 1.25, top.getLayoutX());
+        assertEquals(1 / 1.75, top.getLayoutY());
+        assertEquals(124 / 1.25, top.getWidth());
+        assertEquals(177 / 1.75, top.getHeight());
     }
 
     @Test
@@ -1166,16 +1164,16 @@ public class BorderPaneTest {
         // The 200.6-unit constraint becomes 351 physical pixels. Insets leave
         // 349 pixels for the vertically-filled center, which requires 126 X pixels.
         // Adding the two horizontal inset pixels gives a 128-pixel pane width.
-        assertEquals(128 / 1.25, borderpane.minWidth(200.6), EPSILON);
-        assertEquals(128 / 1.25, borderpane.prefWidth(200.6), EPSILON);
+        assertEquals(128 / 1.25, borderpane.minWidth(200.6));
+        assertEquals(128 / 1.25, borderpane.prefWidth(200.6));
 
         borderpane.resize(128 / 1.25, 200.6);
         borderpane.layout();
 
-        assertEquals(1 / 1.25, center.getLayoutX(), EPSILON);
-        assertEquals(1 / 1.75, center.getLayoutY(), EPSILON);
-        assertEquals(126 / 1.25, center.getWidth(), EPSILON);
-        assertEquals(349 / 1.75, center.getHeight(), EPSILON);
+        assertEquals(1 / 1.25, center.getLayoutX());
+        assertEquals(1 / 1.75, center.getLayoutY());
+        assertEquals(126 / 1.25, center.getWidth());
+        assertEquals(349 / 1.75, center.getHeight());
     }
 
     @Test

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/SnappingTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/SnappingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@ import javafx.beans.property.SimpleDoubleProperty;
 import javafx.scene.Node;
 import javafx.scene.Scene;
 import javafx.scene.layout.AnchorPane;
+import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.GridPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Pane;
@@ -154,10 +155,10 @@ class SnappingTest {
                     gridPane.getChildren().add(node);
                     return gridPane;
                 }),
-                new ContainerCreator<>(AnchorPane::new)
+                new ContainerCreator<>(AnchorPane::new),
 //                new ContainerCreator<>(Pane::new),
 //                new ContainerCreator<>(StackPane::new),
-//                new ContainerCreator<>(BorderPane::new),
+                new ContainerCreator<>(BorderPane::new)
 //                new ContainerCreator<>(node -> {
 //                    TilePane tilePane = new TilePane(node);
 //                    tilePane.setPrefColumns(1);


### PR DESCRIPTION
BorderPane's measurement and layout calculations are not correct when pixel-snapping is enabled. Here is what's wrong with BorderPane, and what consequently needs to be fixed:

1. Insets are not snapped:
   * all measurement methods use raw insets
   * `layoutChildren()` also uses raw insets
3. Content-biased children use the wrong dependent dimension:
   * top and bottom children call `prefHeight(adjustedWidth)` before their final width is established; left and right have the same problem with height
   * measurement and layout can disagree because
       - constrained measurement passes the pane's total width/height without first removing its snapped insets
       - `getAreaWidth` uses `fillHeight=false`, while left/right/center layout uses `fillHeight=true`
5. Arithmetic results are not re-snapped.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390605](https://bugs.openjdk.org/browse/JDK-8390605): Implement correct snapping for BorderPane (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2262/head:pull/2262` \
`$ git checkout pull/2262`

Update a local copy of the PR: \
`$ git checkout pull/2262` \
`$ git pull https://git.openjdk.org/jfx.git pull/2262/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2262`

View PR using the GUI difftool: \
`$ git pr show -t 2262`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2262.diff">https://git.openjdk.org/jfx/pull/2262.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2262#issuecomment-5335988390)
</details>
