### PR TITLE
8390608: Implement correct snapping for AnchorPane

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/AnchorPane.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/AnchorPane.java
@@ -363,7 +363,8 @@ public class AnchorPane extends Pane {
         }
 
         if (leftAnchor != null && rightAnchor != null) {
-            return snapSpaceX(areaWidth - snappedLeftInset() - snappedRightInset() - leftAnchor - rightAnchor);
+            return Math.max(0, snapSpaceX(
+                areaWidth - snappedLeftInset() - snappedRightInset() - leftAnchor - rightAnchor));
         }
 
         return computeChildPrefWidth(child, height);
@@ -376,7 +377,8 @@ public class AnchorPane extends Pane {
         }
 
         if (topAnchor != null && bottomAnchor != null) {
-            return snapSpaceY(areaHeight - snappedTopInset() - snappedBottomInset() - topAnchor - bottomAnchor);
+            return Math.max(0, snapSpaceY(
+                areaHeight - snappedTopInset() - snappedBottomInset() - topAnchor - bottomAnchor));
         }
 
         return computeChildPrefHeight(child, width);

--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/AnchorPane.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/AnchorPane.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,6 @@ package javafx.scene.layout;
 
 import java.util.List;
 import javafx.geometry.Bounds;
-import javafx.geometry.Insets;
 import javafx.geometry.Orientation;
 import javafx.scene.Node;
 
@@ -262,7 +261,7 @@ public class AnchorPane extends Pane {
 
     private double computeWidth(final boolean minimum, final double height) {
         double max = 0;
-        double contentHeight = height != -1 ? height - getInsets().getTop() - getInsets().getBottom() : -1;
+        double areaHeight = height != -1 ? snapSpaceY(height) : -1;
         final List<Node> children = getManagedChildren();
         for (Node child : children) {
             Double leftAnchor = getSnappedLeftAnchor(child);
@@ -272,15 +271,25 @@ public class AnchorPane extends Pane {
                 (rightAnchor != null? 0 : child.getLayoutBounds().getMinX() + child.getLayoutX());
             double right = rightAnchor != null? rightAnchor : 0;
             double childHeight = -1;
-            if (child.getContentBias() == Orientation.VERTICAL && contentHeight != -1) {
+
+            if (child.getContentBias() == Orientation.VERTICAL && areaHeight != -1) {
                 // The width depends on the node's height!
-                childHeight = computeChildHeight(child, getSnappedTopAnchor(child), getSnappedBottomAnchor(child), contentHeight, -1);
+                childHeight = computeChildHeight(
+                    child, getSnappedTopAnchor(child), getSnappedBottomAnchor(child), areaHeight, -1);
             }
-            max = Math.max(max, left + (minimum && leftAnchor != null && rightAnchor != null?
-                    child.minWidth(childHeight) : computeChildPrefAreaWidth(child, -1, null, childHeight, false)) + right);
+
+            double childWidth = minimum && leftAnchor != null && rightAnchor != null
+                ? snapSizeX(child.minWidth(childHeight))
+                : computeChildPrefWidth(child, childHeight);
+
+            double childAreaWidth = leftAnchor == null && rightAnchor == null
+                ? snapSizeX(left + childWidth)
+                : snapSpaceX(left + childWidth + right);
+
+            max = Math.max(max, childAreaWidth);
         }
 
-        return snappedLeftInset() + max + snappedRightInset();
+        return snapSpaceX(snappedLeftInset() + max + snappedRightInset());
     }
 
     private Double getSnappedTopAnchor(Node child) {
@@ -288,7 +297,7 @@ public class AnchorPane extends Pane {
         if (topAnchor == null) {
             return null;
         }
-        return snapPositionY(topAnchor);
+        return snapSpaceY(topAnchor);
     }
 
     private Double getSnappedBottomAnchor(Node child) {
@@ -296,7 +305,7 @@ public class AnchorPane extends Pane {
         if (bottomAnchor == null) {
             return null;
         }
-        return snapPositionY(bottomAnchor);
+        return snapSpaceY(bottomAnchor);
     }
 
     private Double getSnappedLeftAnchor(Node child) {
@@ -304,7 +313,7 @@ public class AnchorPane extends Pane {
         if (leftAnchor == null) {
             return null;
         }
-        return snapPositionX(leftAnchor);
+        return snapSpaceX(leftAnchor);
     }
 
     private Double getSnappedRightAnchor(Node child) {
@@ -312,12 +321,12 @@ public class AnchorPane extends Pane {
         if (rightAnchor == null) {
             return null;
         }
-        return snapPositionX(rightAnchor);
+        return snapSpaceX(rightAnchor);
     }
 
     private double computeHeight(final boolean minimum, final double width) {
         double max = 0;
-        double contentWidth = width != -1 ? width - getInsets().getLeft()- getInsets().getRight() : -1;
+        double areaWidth = width != -1 ? snapSpaceX(width) : -1;
         final List<Node> children = getManagedChildren();
         for (Node child : children) {
             Double topAnchor = getSnappedTopAnchor(child);
@@ -327,31 +336,63 @@ public class AnchorPane extends Pane {
                 (bottomAnchor != null? 0 : child.getLayoutBounds().getMinY() + child.getLayoutY());
             double bottom = bottomAnchor != null? bottomAnchor : 0;
             double childWidth = -1;
-            if (child.getContentBias() == Orientation.HORIZONTAL && contentWidth != -1) {
-                childWidth = computeChildWidth(child, getSnappedLeftAnchor(child), getSnappedRightAnchor(child), contentWidth, -1);
+
+            if (child.getContentBias() == Orientation.HORIZONTAL && areaWidth != -1) {
+                childWidth = computeChildWidth(
+                    child, getSnappedLeftAnchor(child), getSnappedRightAnchor(child), areaWidth, -1);
             }
-            max = Math.max(max, top + (minimum && topAnchor != null && bottomAnchor != null?
-                    child.minHeight(childWidth) : computeChildPrefAreaHeight(child, -1, null, childWidth, true)) + bottom);
+
+            double childHeight = minimum && topAnchor != null && bottomAnchor != null
+                ? snapSizeY(child.minHeight(childWidth))
+                : computeChildPrefHeight(child, childWidth);
+
+            double childAreaHeight = topAnchor == null && bottomAnchor == null
+                ? snapSizeY(top + childHeight)
+                : snapSpaceY(top + childHeight + bottom);
+
+            max = Math.max(max, childAreaHeight);
         }
 
-        return snappedTopInset() + max + snappedBottomInset();
+        return snapSpaceY(snappedTopInset() + max + snappedBottomInset());
     }
 
-    private double computeChildWidth(Node child, Double leftAnchor, Double rightAnchor, double areaWidth, double height) {
-        if (leftAnchor != null && rightAnchor != null && child.isResizable()) {
-            return areaWidth - snappedLeftInset() - snappedRightInset() - leftAnchor - rightAnchor;
+    private double computeChildWidth(Node child, Double leftAnchor, Double rightAnchor,
+                                     double areaWidth, double height) {
+        if (!child.isResizable()) {
+            return child.getLayoutBounds().getWidth();
         }
-        return computeChildPrefAreaWidth(child, -1, Insets.EMPTY, height, true);
+
+        if (leftAnchor != null && rightAnchor != null) {
+            return snapSpaceX(areaWidth - snappedLeftInset() - snappedRightInset() - leftAnchor - rightAnchor);
+        }
+
+        return computeChildPrefWidth(child, height);
     }
 
-    private double computeChildHeight(Node child, Double topAnchor, Double bottomAnchor, double areaHeight, double width) {
-        if (topAnchor != null && bottomAnchor != null && child.isResizable()) {
-            return areaHeight - snappedTopInset() - snappedBottomInset() - topAnchor - bottomAnchor;
+    private double computeChildHeight(Node child, Double topAnchor, Double bottomAnchor,
+                                      double areaHeight, double width) {
+        if (!child.isResizable()) {
+            return child.getLayoutBounds().getHeight();
         }
-        return computeChildPrefAreaHeight(child, -1, Insets.EMPTY, width, true);
+
+        if (topAnchor != null && bottomAnchor != null) {
+            return snapSpaceY(areaHeight - snappedTopInset() - snappedBottomInset() - topAnchor - bottomAnchor);
+        }
+
+        return computeChildPrefHeight(child, width);
+    }
+
+    private double computeChildPrefWidth(Node child, double height) {
+        return snapSizeX(boundedSize(child.minWidth(height), child.prefWidth(height), child.maxWidth(height)));
+    }
+
+    private double computeChildPrefHeight(Node child, double width) {
+        return snapSizeY(boundedSize(child.minHeight(width), child.prefHeight(width), child.maxHeight(width)));
     }
 
     @Override protected void layoutChildren() {
+        final double areaWidth = snapSpaceX(getWidth());
+        final double areaHeight = snapSpaceY(getHeight());
         final List<Node> children = getManagedChildren();
         for (Node child : children) {
             final Double topAnchor = getSnappedTopAnchor(child);
@@ -368,32 +409,33 @@ public class AnchorPane extends Pane {
 
             if (bias == Orientation.VERTICAL) {
                 // width depends on height
-                // WARNING: The order of these calls is crucial, there is some
-                // hidden ordering dependency here!
-                h = computeChildHeight(child, topAnchor, bottomAnchor, getHeight(), -1);
-                w = computeChildWidth(child, leftAnchor, rightAnchor, getWidth(), h);
+                h = computeChildHeight(child, topAnchor, bottomAnchor, areaHeight, -1);
+                w = computeChildWidth(child, leftAnchor, rightAnchor, areaWidth, h);
             } else if (bias == Orientation.HORIZONTAL) {
-                w = computeChildWidth(child, leftAnchor, rightAnchor, getWidth(), -1);
-                h = computeChildHeight(child, topAnchor, bottomAnchor, getHeight(), w);
+                w = computeChildWidth(child, leftAnchor, rightAnchor, areaWidth, -1);
+                h = computeChildHeight(child, topAnchor, bottomAnchor, areaHeight, w);
             } else {
                 // bias may be null
-                w = computeChildWidth(child, leftAnchor, rightAnchor, getWidth(), -1);
-                h = computeChildHeight(child, topAnchor, bottomAnchor, getHeight(), -1);
+                w = computeChildWidth(child, leftAnchor, rightAnchor, areaWidth, -1);
+                h = computeChildHeight(child, topAnchor, bottomAnchor, areaHeight, -1);
             }
 
+            child.resize(w, h);
+            final Bounds resizedBounds = child.getLayoutBounds();
+
             if (leftAnchor != null) {
-                x = snappedLeftInset() + leftAnchor;
+                x = snapPositionX(snappedLeftInset() + leftAnchor);
             } else if (rightAnchor != null) {
-                x = getWidth() - snappedRightInset() - rightAnchor - w;
+                x = snapPositionX(areaWidth - snappedRightInset() - rightAnchor - resizedBounds.getWidth());
             }
 
             if (topAnchor != null) {
-                y = snappedTopInset() + topAnchor;
+                y = snapPositionY(snappedTopInset() + topAnchor);
             } else if (bottomAnchor != null) {
-                y = getHeight() - snappedBottomInset() - bottomAnchor - h;
+                y = snapPositionY(areaHeight - snappedBottomInset() - bottomAnchor - resizedBounds.getHeight());
             }
 
-            child.resizeRelocate(x, y, w, h);
+            child.relocate(x, y);
         }
     }
 }

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/AnchorPaneTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/AnchorPaneTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,6 @@
 
 package test.javafx.scene.layout;
 
-import javafx.beans.property.DoubleProperty;
-import javafx.beans.property.SimpleDoubleProperty;
 import javafx.geometry.Bounds;
 import javafx.scene.Scene;
 import javafx.scene.layout.StackPane;
@@ -38,11 +36,14 @@ import javafx.geometry.Insets;
 import javafx.geometry.Orientation;
 import javafx.scene.ParentShim;
 import javafx.scene.layout.AnchorPane;
+import javafx.scene.layout.Region;
 import javafx.scene.shape.Rectangle;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class AnchorPaneTest {
+
+    private static final double EPSILON = 0.000001;
 
     @Test
     public void testNoAnchorsSet() {
@@ -746,36 +747,40 @@ public class AnchorPaneTest {
         AnchorPane.setBottomAnchor(child, 0d);
         AnchorPane.setRightAnchor(child, 0d);
 
-        DoubleProperty renderScaleProperty = new SimpleDoubleProperty(scale);
-
         Stage stage = new Stage();
-        stage.renderScaleXProperty().bind(renderScaleProperty);
-        stage.renderScaleYProperty().bind(renderScaleProperty);
+        stage.setRenderScaleX(scale);
+        stage.setRenderScaleY(scale);
 
         int widthHeight = 500;
         Scene scene = new Scene(anchorPane, widthHeight, widthHeight);
         stage.setScene(scene);
-        stage.show();
 
-        Bounds boundsInParent = child.getBoundsInParent();
+        try {
+            stage.show();
 
-        double snappedPaddingX = child.snapPositionX(padding);
-        double snappedPaddingY = child.snapPositionY(padding);
+            Bounds boundsInParent = child.getBoundsInParent();
+            double areaWidth = anchorPane.snapSpaceX(anchorPane.getWidth());
+            double areaHeight = anchorPane.snapSpaceY(anchorPane.getHeight());
+            double snappedPaddingX = anchorPane.snapSpaceX(padding);
+            double snappedPaddingY = anchorPane.snapSpaceY(padding);
 
-        assertEquals(snappedPaddingX, boundsInParent.getMinX(), 0.0001);
-        assertEquals(snappedPaddingY, boundsInParent.getMinY(), 0.0001);
+            assertEquals(snappedPaddingX, boundsInParent.getMinX(), 0.0001);
+            assertEquals(snappedPaddingY, boundsInParent.getMinY(), 0.0001);
 
-        double expectedMaxX = widthHeight - snappedPaddingX;
-        assertEquals(expectedMaxX, boundsInParent.getMaxX(), 0.0001);
+            double expectedMaxX = anchorPane.snapPositionX(areaWidth - snappedPaddingX);
+            assertEquals(expectedMaxX, boundsInParent.getMaxX(), 0.0001);
 
-        double expectedMaxY = widthHeight - snappedPaddingY;
-        assertEquals(expectedMaxY, boundsInParent.getMaxY(), 0.0001);
+            double expectedMaxY = anchorPane.snapPositionY(areaHeight - snappedPaddingY);
+            assertEquals(expectedMaxY, boundsInParent.getMaxY(), 0.0001);
 
-        double expectedWidth = widthHeight - snappedPaddingX * 2;
-        assertEquals(expectedWidth, boundsInParent.getWidth(), 0.0001);
+            double expectedWidth = anchorPane.snapSpaceX(areaWidth - snappedPaddingX * 2);
+            assertEquals(expectedWidth, boundsInParent.getWidth(), 0.0001);
 
-        double expectedHeight = widthHeight - snappedPaddingY * 2;
-        assertEquals(expectedHeight, boundsInParent.getHeight(), 0.0001);
+            double expectedHeight = anchorPane.snapSpaceY(areaHeight - snappedPaddingY * 2);
+            assertEquals(expectedHeight, boundsInParent.getHeight(), 0.0001);
+        } finally {
+            stage.hide();
+        }
     }
 
     /**
@@ -800,40 +805,342 @@ public class AnchorPaneTest {
         AnchorPane.setBottomAnchor(child, bottomAnchor);
         AnchorPane.setRightAnchor(child, rightAnchor);
 
-        DoubleProperty renderScaleProperty = new SimpleDoubleProperty(scale);
-
         Stage stage = new Stage();
-        stage.renderScaleXProperty().bind(renderScaleProperty);
-        stage.renderScaleYProperty().bind(renderScaleProperty);
+        stage.setRenderScaleX(scale);
+        stage.setRenderScaleY(scale);
 
         int widthHeight = 500;
         Scene scene = new Scene(anchorPane, widthHeight, widthHeight);
         stage.setScene(scene);
-        stage.show();
 
-        Bounds boundsInParent = child.getBoundsInParent();
+        try {
+            stage.show();
 
-        double snappedLeftAnchor = child.snapPositionY(leftAnchor);
-        double snappedRightAnchor = child.snapPositionY(rightAnchor);
-        double horizontalAnchor = snappedLeftAnchor + snappedRightAnchor;
+            Bounds boundsInParent = child.getBoundsInParent();
+            double areaWidth = anchorPane.snapSpaceX(anchorPane.getWidth());
+            double areaHeight = anchorPane.snapSpaceY(anchorPane.getHeight());
+            double snappedLeftAnchor = anchorPane.snapSpaceX(leftAnchor);
+            double snappedRightAnchor = anchorPane.snapSpaceX(rightAnchor);
+            double snappedTopAnchor = anchorPane.snapSpaceY(topAnchor);
+            double snappedBottomAnchor = anchorPane.snapSpaceY(bottomAnchor);
 
-        double snappedTopAnchor = child.snapPositionX(topAnchor);
-        double snappedBottomAnchor = child.snapPositionX(bottomAnchor);
-        double verticalAnchor = snappedTopAnchor + snappedBottomAnchor;
+            assertEquals(snappedLeftAnchor, boundsInParent.getMinX(), 0.0001);
+            assertEquals(snappedTopAnchor, boundsInParent.getMinY(), 0.0001);
 
-        assertEquals(snappedLeftAnchor, boundsInParent.getMinX(), 0.0001);
-        assertEquals(snappedTopAnchor, boundsInParent.getMinY(), 0.0001);
+            double expectedMaxX = anchorPane.snapPositionX(areaWidth - snappedRightAnchor);
+            assertEquals(expectedMaxX, boundsInParent.getMaxX(), 0.0001);
 
-        double expectedMaxX = widthHeight - snappedRightAnchor;
-        assertEquals(expectedMaxX, boundsInParent.getMaxX(), 0.0001);
+            double expectedMaxY = anchorPane.snapPositionY(areaHeight - snappedBottomAnchor);
+            assertEquals(expectedMaxY, boundsInParent.getMaxY(), 0.0001);
 
-        double expectedMaxY = widthHeight - snappedBottomAnchor;
-        assertEquals(expectedMaxY, boundsInParent.getMaxY(), 0.0001);
+            double expectedWidth = anchorPane.snapSpaceX(areaWidth - snappedLeftAnchor - snappedRightAnchor);
+            assertEquals(expectedWidth, boundsInParent.getWidth(), 0.0001);
 
-        double expectedWidth = widthHeight - horizontalAnchor;
-        assertEquals(expectedWidth, boundsInParent.getWidth(), 0.0001);
+            double expectedHeight = anchorPane.snapSpaceY(areaHeight - snappedTopAnchor - snappedBottomAnchor);
+            assertEquals(expectedHeight, boundsInParent.getHeight(), 0.0001);
+        } finally {
+            stage.hide();
+        }
+    }
 
-        double expectedHeight = widthHeight - verticalAnchor;
-        assertEquals(expectedHeight, boundsInParent.getHeight(), 0.0001);
+    @Test
+    void testDualAnchoredChildSnapsFractionalAllocatedSize() {
+        Region child = new Region();
+        AnchorPane anchorPane = new AnchorPane(child);
+        AnchorPane.setTopAnchor(child, 0.0);
+        AnchorPane.setRightAnchor(child, 0.0);
+        AnchorPane.setBottomAnchor(child, 0.0);
+        AnchorPane.setLeftAnchor(child, 0.0);
+
+        anchorPane.resize(100.4, 50.4);
+        anchorPane.layout();
+
+        assertEquals(anchorPane.snapSpaceX(anchorPane.getWidth()), child.getWidth(), 0.0);
+        assertEquals(anchorPane.snapSpaceY(anchorPane.getHeight()), child.getHeight(), 0.0);
+        assertEquals(0.0, child.getLayoutX(), 0.0);
+        assertEquals(0.0, child.getLayoutY(), 0.0);
+    }
+
+    @Test
+    void testUnsnappedPreservesFractionalAnchorGeometry() {
+        Region child = new Region();
+        AnchorPane anchorPane = new AnchorPane(child);
+        anchorPane.setSnapToPixel(false);
+        AnchorPane.setTopAnchor(child, 0.2);
+        AnchorPane.setRightAnchor(child, 0.3);
+        AnchorPane.setBottomAnchor(child, 0.4);
+        AnchorPane.setLeftAnchor(child, 0.1);
+
+        anchorPane.resize(100.4, 50.4);
+        anchorPane.layout();
+
+        assertEquals(0.1, child.getBoundsInParent().getMinX(), EPSILON);
+        assertEquals(0.2, child.getBoundsInParent().getMinY(), EPSILON);
+        assertEquals(100.4 - 0.1 - 0.3, child.getWidth(), EPSILON);
+        assertEquals(50.4 - 0.2 - 0.4, child.getHeight(), EPSILON);
+    }
+
+    @Test
+    void testRightBottomAnchoredChildSnapsFractionalPosition() {
+        Region child = new Region();
+        child.setMinSize(10, 10);
+        child.setPrefSize(10, 10);
+        child.setMaxSize(10, 10);
+
+        AnchorPane anchorPane = new AnchorPane(child);
+        AnchorPane.setRightAnchor(child, 0.0);
+        AnchorPane.setBottomAnchor(child, 0.0);
+
+        anchorPane.resize(100.4, 50.4);
+        anchorPane.layout();
+
+        double expectedX = anchorPane.snapPositionX(
+            anchorPane.snapSpaceX(anchorPane.getWidth()) - child.getLayoutBounds().getWidth());
+
+        double expectedY = anchorPane.snapPositionY(
+            anchorPane.snapSpaceY(anchorPane.getHeight()) - child.getLayoutBounds().getHeight());
+
+        assertEquals(expectedX, child.getBoundsInParent().getMinX(), 0.0);
+        assertEquals(expectedY, child.getBoundsInParent().getMinY(), 0.0);
+    }
+
+    @Test
+    void testDualAnchoredMinimumSizeSnapsChildContentSize() {
+        Region child = new Region();
+        child.setMinSize(0.4, 0.4);
+        child.setPrefSize(0.4, 0.4);
+        child.setMaxSize(0.4, 0.4);
+
+        AnchorPane anchorPane = new AnchorPane(child);
+        AnchorPane.setTopAnchor(child, 0.0);
+        AnchorPane.setRightAnchor(child, 0.0);
+        AnchorPane.setBottomAnchor(child, 0.0);
+        AnchorPane.setLeftAnchor(child, 0.0);
+
+        assertEquals(anchorPane.snapSizeX(0.4), anchorPane.minWidth(-1), 0.0);
+        assertEquals(anchorPane.snapSizeY(0.4), anchorPane.minHeight(-1), 0.0);
+        assertEquals(anchorPane.snapSizeX(0.4), anchorPane.prefWidth(-1), 0.0);
+        assertEquals(anchorPane.snapSizeY(0.4), anchorPane.prefHeight(-1), 0.0);
+    }
+
+    @Test
+    void testVerticalBiasUsesStretchedHeightForMeasurementAndLayout() {
+        VerticalBiasedRegion child = new VerticalBiasedRegion(10);
+        AnchorPane anchorPane = new AnchorPane(child);
+        AnchorPane.setTopAnchor(child, 0.0);
+        AnchorPane.setBottomAnchor(child, 0.0);
+        AnchorPane.setLeftAnchor(child, 0.0);
+
+        assertEquals(10.0, anchorPane.prefWidth(100), 0.0);
+        assertEquals(100.0, child.lastHeight, 0.0);
+
+        anchorPane.resize(200, 100);
+        anchorPane.layout();
+
+        assertEquals(100.0, child.getHeight(), 0.0);
+        assertEquals(10.0, child.getWidth(), 0.0);
+        assertEquals(child.getHeight(), child.lastHeight, 0.0);
+    }
+
+    @Test
+    void testBiasedMeasurementSubtractsSnappedInsetsOnce() {
+        VerticalBiasedRegion child = new VerticalBiasedRegion(1000);
+        AnchorPane anchorPane = new AnchorPane(child);
+        anchorPane.setPadding(new Insets(0.6));
+        AnchorPane.setTopAnchor(child, 0.0);
+        AnchorPane.setBottomAnchor(child, 0.0);
+        AnchorPane.setLeftAnchor(child, 0.0);
+
+        double expectedHeight = anchorPane.snapSpaceY(anchorPane.snapSpaceY(100) - 2 * anchorPane.snapSpaceY(0.6));
+        anchorPane.prefWidth(100);
+        assertEquals(expectedHeight, child.lastHeight, 0.0);
+
+        anchorPane.resize(50, 100);
+        anchorPane.layout();
+        assertEquals(expectedHeight, child.getHeight(), 0.0);
+        assertEquals(child.getHeight(), child.lastHeight, 0.0);
+    }
+
+    @Test
+    void testHorizontalBiasUsesSameSnappedWidthForMeasurementAndLayout() {
+        HorizontalBiasedRegion child = new HorizontalBiasedRegion();
+        AnchorPane anchorPane = new AnchorPane(child);
+        AnchorPane.setLeftAnchor(child, 0.0);
+        AnchorPane.setRightAnchor(child, 0.0);
+        AnchorPane.setTopAnchor(child, 0.0);
+
+        anchorPane.resize(100.4, 50);
+        anchorPane.layout();
+
+        assertEquals(anchorPane.snapSpaceX(anchorPane.getWidth()), child.getWidth(), 0.0);
+        assertEquals(child.getWidth(), child.lastWidth, 0.0);
+    }
+
+    @Test
+    void testRightBottomAnchoringUsesActualNonResizableSize() {
+        Rectangle child = new Rectangle(1.4, 1.4);
+        AnchorPane anchorPane = new AnchorPane(child);
+        AnchorPane.setRightAnchor(child, 0.0);
+        AnchorPane.setBottomAnchor(child, 0.0);
+
+        anchorPane.resize(100, 100);
+        anchorPane.layout();
+
+        double expectedX = anchorPane.snapPositionX(
+            anchorPane.snapSpaceX(anchorPane.getWidth()) - child.getLayoutBounds().getWidth());
+
+        double expectedY = anchorPane.snapPositionY(
+            anchorPane.snapSpaceY(anchorPane.getHeight()) - child.getLayoutBounds().getHeight());
+
+        assertEquals(expectedX, child.getBoundsInParent().getMinX(), EPSILON);
+        assertEquals(expectedY, child.getBoundsInParent().getMinY(), EPSILON);
+    }
+
+    @Test
+    void testFinalMeasurementAndPositionArithmeticIsResnapped() {
+        Region child = new Region();
+        child.setMinSize(0.1, 10);
+        child.setPrefSize(0.1, 10);
+        child.setMaxSize(0.1, 10);
+
+        AnchorPane anchorPane = new AnchorPane(child);
+        anchorPane.setPadding(new Insets(0.8, 0, 0, 0));
+        AnchorPane.setTopAnchor(child, 1.6);
+        AnchorPane.setRightAnchor(child, 1.6);
+
+        Stage stage = new Stage();
+        stage.setRenderScaleX(1.25);
+        stage.setRenderScaleY(1.25);
+        stage.setScene(new Scene(anchorPane, 100, 100));
+
+        try {
+            stage.show();
+
+            double expectedPrefWidth = anchorPane.snapSpaceX(anchorPane.snapSizeX(0.1) + anchorPane.snapSpaceX(1.6));
+            assertEquals(expectedPrefWidth, anchorPane.prefWidth(-1), 0.0);
+
+            double expectedY = anchorPane.snapPositionY(anchorPane.snapSpaceY(0.8) + anchorPane.snapSpaceY(1.6));
+            assertEquals(expectedY, child.getBoundsInParent().getMinY(), 0.0);
+        } finally {
+            stage.hide();
+        }
+    }
+
+    @Test
+    void testUsesOwningPanePolicyWithDifferentAxisScales() {
+        StackPane child = new StackPane();
+        child.setSnapToPixel(false);
+        AnchorPane anchorPane = new AnchorPane(child);
+
+        double topAnchor = 1.0;
+        double leftAnchor = 1.0;
+        double bottomAnchor = 1.4;
+        double rightAnchor = 1.4;
+        AnchorPane.setTopAnchor(child, topAnchor);
+        AnchorPane.setLeftAnchor(child, leftAnchor);
+        AnchorPane.setBottomAnchor(child, bottomAnchor);
+        AnchorPane.setRightAnchor(child, rightAnchor);
+
+        Stage stage = new Stage();
+        stage.setRenderScaleX(1.25);
+        stage.setRenderScaleY(1.5);
+        stage.setScene(new Scene(anchorPane, 100, 100));
+
+        try {
+            stage.show();
+
+            Bounds bounds = child.getBoundsInParent();
+            double left = anchorPane.snapSpaceX(leftAnchor);
+            double right = anchorPane.snapSpaceX(rightAnchor);
+            double top = anchorPane.snapSpaceY(topAnchor);
+            double bottom = anchorPane.snapSpaceY(bottomAnchor);
+            double areaWidth = anchorPane.snapSpaceX(anchorPane.getWidth());
+            double areaHeight = anchorPane.snapSpaceY(anchorPane.getHeight());
+
+            assertEquals(anchorPane.snapPositionX(left), bounds.getMinX(), EPSILON);
+            assertEquals(anchorPane.snapPositionY(top), bounds.getMinY(), EPSILON);
+            assertEquals(anchorPane.snapSpaceX(areaWidth - left - right), bounds.getWidth(), EPSILON);
+            assertEquals(anchorPane.snapSpaceY(areaHeight - top - bottom), bounds.getHeight(), EPSILON);
+
+            assertEquals(leftAnchor, AnchorPane.getLeftAnchor(child), 0.0);
+            assertEquals(topAnchor, AnchorPane.getTopAnchor(child), 0.0);
+        } finally {
+            stage.hide();
+        }
+    }
+
+    private static final class HorizontalBiasedRegion extends Region {
+        private double lastWidth = -1;
+
+        @Override public Orientation getContentBias() {
+            return Orientation.HORIZONTAL;
+        }
+
+        @Override protected double computeMinWidth(double height) {
+            return 0;
+        }
+
+        @Override protected double computePrefWidth(double height) {
+            return 10;
+        }
+
+        @Override protected double computeMaxWidth(double height) {
+            return 1000;
+        }
+
+        @Override protected double computeMinHeight(double width) {
+            lastWidth = width;
+            return 1;
+        }
+
+        @Override protected double computePrefHeight(double width) {
+            lastWidth = width;
+            return 10;
+        }
+
+        @Override protected double computeMaxHeight(double width) {
+            lastWidth = width;
+            return 1000;
+        }
+    }
+
+    private static final class VerticalBiasedRegion extends Region {
+        private final double preferredHeight;
+        private double lastHeight = -1;
+
+        private VerticalBiasedRegion(double preferredHeight) {
+            this.preferredHeight = preferredHeight;
+        }
+
+        @Override public Orientation getContentBias() {
+            return Orientation.VERTICAL;
+        }
+
+        @Override protected double computeMinWidth(double height) {
+            lastHeight = height;
+            return 1;
+        }
+
+        @Override protected double computePrefWidth(double height) {
+            lastHeight = height;
+            return height == -1 ? 100 : 1000 / height;
+        }
+
+        @Override protected double computeMaxWidth(double height) {
+            lastHeight = height;
+            return 1000;
+        }
+
+        @Override protected double computeMinHeight(double width) {
+            return 0;
+        }
+
+        @Override protected double computePrefHeight(double width) {
+            return preferredHeight;
+        }
+
+        @Override protected double computeMaxHeight(double width) {
+            return 1000;
+        }
     }
 }

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/AnchorPaneTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/AnchorPaneTest.java
@@ -25,10 +25,12 @@
 
 package test.javafx.scene.layout;
 
-import javafx.geometry.Bounds;
+import javafx.beans.property.DoubleProperty;
+import javafx.beans.property.SimpleDoubleProperty;
 import javafx.scene.Scene;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -43,7 +45,16 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class AnchorPaneTest {
 
-    private static final double EPSILON = 0.000001;
+    private static final double EPSILON = 0.000000001;
+
+    private Stage stage;
+
+    @AfterEach
+    public void teardown() {
+        if (stage != null) {
+            stage.close();
+        }
+    }
 
     @Test
     public void testNoAnchorsSet() {
@@ -747,40 +758,36 @@ public class AnchorPaneTest {
         AnchorPane.setBottomAnchor(child, 0d);
         AnchorPane.setRightAnchor(child, 0d);
 
-        Stage stage = new Stage();
-        stage.setRenderScaleX(scale);
-        stage.setRenderScaleY(scale);
+        DoubleProperty renderScaleProperty = new SimpleDoubleProperty(scale);
+
+        stage = new Stage();
+        stage.renderScaleXProperty().bind(renderScaleProperty);
+        stage.renderScaleYProperty().bind(renderScaleProperty);
 
         int widthHeight = 500;
         Scene scene = new Scene(anchorPane, widthHeight, widthHeight);
         stage.setScene(scene);
+        stage.show();
 
-        try {
-            stage.show();
+        double areaWidth = anchorPane.snapSpaceX(anchorPane.getWidth());
+        double areaHeight = anchorPane.snapSpaceY(anchorPane.getHeight());
+        double snappedPaddingX = anchorPane.snapSpaceX(padding);
+        double snappedPaddingY = anchorPane.snapSpaceY(padding);
 
-            Bounds boundsInParent = child.getBoundsInParent();
-            double areaWidth = anchorPane.snapSpaceX(anchorPane.getWidth());
-            double areaHeight = anchorPane.snapSpaceY(anchorPane.getHeight());
-            double snappedPaddingX = anchorPane.snapSpaceX(padding);
-            double snappedPaddingY = anchorPane.snapSpaceY(padding);
+        assertEquals(snappedPaddingX, child.getLayoutX());
+        assertEquals(snappedPaddingY, child.getLayoutY());
 
-            assertEquals(snappedPaddingX, boundsInParent.getMinX(), 0.0001);
-            assertEquals(snappedPaddingY, boundsInParent.getMinY(), 0.0001);
+        double expectedMaxX = anchorPane.snapPositionX(areaWidth - snappedPaddingX);
+        assertEquals(expectedMaxX, child.getLayoutX() + child.getWidth(), EPSILON);
 
-            double expectedMaxX = anchorPane.snapPositionX(areaWidth - snappedPaddingX);
-            assertEquals(expectedMaxX, boundsInParent.getMaxX(), 0.0001);
+        double expectedMaxY = anchorPane.snapPositionY(areaHeight - snappedPaddingY);
+        assertEquals(expectedMaxY, child.getLayoutY() + child.getHeight(), EPSILON);
 
-            double expectedMaxY = anchorPane.snapPositionY(areaHeight - snappedPaddingY);
-            assertEquals(expectedMaxY, boundsInParent.getMaxY(), 0.0001);
+        double expectedWidth = anchorPane.snapSpaceX(areaWidth - snappedPaddingX * 2);
+        assertEquals(expectedWidth, child.getWidth());
 
-            double expectedWidth = anchorPane.snapSpaceX(areaWidth - snappedPaddingX * 2);
-            assertEquals(expectedWidth, boundsInParent.getWidth(), 0.0001);
-
-            double expectedHeight = anchorPane.snapSpaceY(areaHeight - snappedPaddingY * 2);
-            assertEquals(expectedHeight, boundsInParent.getHeight(), 0.0001);
-        } finally {
-            stage.hide();
-        }
+        double expectedHeight = anchorPane.snapSpaceY(areaHeight - snappedPaddingY * 2);
+        assertEquals(expectedHeight, child.getHeight());
     }
 
     /**
@@ -805,42 +812,38 @@ public class AnchorPaneTest {
         AnchorPane.setBottomAnchor(child, bottomAnchor);
         AnchorPane.setRightAnchor(child, rightAnchor);
 
-        Stage stage = new Stage();
-        stage.setRenderScaleX(scale);
-        stage.setRenderScaleY(scale);
+        DoubleProperty renderScaleProperty = new SimpleDoubleProperty(scale);
+
+        stage = new Stage();
+        stage.renderScaleXProperty().bind(renderScaleProperty);
+        stage.renderScaleYProperty().bind(renderScaleProperty);
 
         int widthHeight = 500;
         Scene scene = new Scene(anchorPane, widthHeight, widthHeight);
         stage.setScene(scene);
+        stage.show();
 
-        try {
-            stage.show();
+        double areaWidth = anchorPane.snapSpaceX(anchorPane.getWidth());
+        double areaHeight = anchorPane.snapSpaceY(anchorPane.getHeight());
+        double snappedLeftAnchor = anchorPane.snapSpaceX(leftAnchor);
+        double snappedRightAnchor = anchorPane.snapSpaceX(rightAnchor);
+        double snappedTopAnchor = anchorPane.snapSpaceY(topAnchor);
+        double snappedBottomAnchor = anchorPane.snapSpaceY(bottomAnchor);
 
-            Bounds boundsInParent = child.getBoundsInParent();
-            double areaWidth = anchorPane.snapSpaceX(anchorPane.getWidth());
-            double areaHeight = anchorPane.snapSpaceY(anchorPane.getHeight());
-            double snappedLeftAnchor = anchorPane.snapSpaceX(leftAnchor);
-            double snappedRightAnchor = anchorPane.snapSpaceX(rightAnchor);
-            double snappedTopAnchor = anchorPane.snapSpaceY(topAnchor);
-            double snappedBottomAnchor = anchorPane.snapSpaceY(bottomAnchor);
+        assertEquals(snappedLeftAnchor, child.getLayoutX());
+        assertEquals(snappedTopAnchor, child.getLayoutY());
 
-            assertEquals(snappedLeftAnchor, boundsInParent.getMinX(), 0.0001);
-            assertEquals(snappedTopAnchor, boundsInParent.getMinY(), 0.0001);
+        double expectedMaxX = anchorPane.snapPositionX(areaWidth - snappedRightAnchor);
+        assertEquals(expectedMaxX, child.getLayoutX() + child.getWidth(), EPSILON);
 
-            double expectedMaxX = anchorPane.snapPositionX(areaWidth - snappedRightAnchor);
-            assertEquals(expectedMaxX, boundsInParent.getMaxX(), 0.0001);
+        double expectedMaxY = anchorPane.snapPositionY(areaHeight - snappedBottomAnchor);
+        assertEquals(expectedMaxY, child.getLayoutY() + child.getHeight(), EPSILON);
 
-            double expectedMaxY = anchorPane.snapPositionY(areaHeight - snappedBottomAnchor);
-            assertEquals(expectedMaxY, boundsInParent.getMaxY(), 0.0001);
+        double expectedWidth = anchorPane.snapSpaceX(areaWidth - snappedLeftAnchor - snappedRightAnchor);
+        assertEquals(expectedWidth, child.getWidth());
 
-            double expectedWidth = anchorPane.snapSpaceX(areaWidth - snappedLeftAnchor - snappedRightAnchor);
-            assertEquals(expectedWidth, boundsInParent.getWidth(), 0.0001);
-
-            double expectedHeight = anchorPane.snapSpaceY(areaHeight - snappedTopAnchor - snappedBottomAnchor);
-            assertEquals(expectedHeight, boundsInParent.getHeight(), 0.0001);
-        } finally {
-            stage.hide();
-        }
+        double expectedHeight = anchorPane.snapSpaceY(areaHeight - snappedTopAnchor - snappedBottomAnchor);
+        assertEquals(expectedHeight, child.getHeight());
     }
 
     @Test
@@ -855,10 +858,10 @@ public class AnchorPaneTest {
         anchorPane.resize(100.4, 50.4);
         anchorPane.layout();
 
-        assertEquals(anchorPane.snapSpaceX(anchorPane.getWidth()), child.getWidth(), 0.0);
-        assertEquals(anchorPane.snapSpaceY(anchorPane.getHeight()), child.getHeight(), 0.0);
-        assertEquals(0.0, child.getLayoutX(), 0.0);
-        assertEquals(0.0, child.getLayoutY(), 0.0);
+        assertEquals(anchorPane.snapSpaceX(anchorPane.getWidth()), child.getWidth());
+        assertEquals(anchorPane.snapSpaceY(anchorPane.getHeight()), child.getHeight());
+        assertEquals(0.0, child.getLayoutX());
+        assertEquals(0.0, child.getLayoutY());
     }
 
     @Test
@@ -874,8 +877,8 @@ public class AnchorPaneTest {
         anchorPane.resize(100.4, 50.4);
         anchorPane.layout();
 
-        assertEquals(0.1, child.getBoundsInParent().getMinX(), EPSILON);
-        assertEquals(0.2, child.getBoundsInParent().getMinY(), EPSILON);
+        assertEquals(0.1, child.getLayoutX(), EPSILON);
+        assertEquals(0.2, child.getLayoutY(), EPSILON);
         assertEquals(100.4 - 0.1 - 0.3, child.getWidth(), EPSILON);
         assertEquals(50.4 - 0.2 - 0.4, child.getHeight(), EPSILON);
     }
@@ -894,14 +897,11 @@ public class AnchorPaneTest {
         anchorPane.resize(100.4, 50.4);
         anchorPane.layout();
 
-        double expectedX = anchorPane.snapPositionX(
-            anchorPane.snapSpaceX(anchorPane.getWidth()) - child.getLayoutBounds().getWidth());
+        double expectedX = anchorPane.snapPositionX(anchorPane.snapSpaceX(anchorPane.getWidth()) - child.getWidth());
+        double expectedY = anchorPane.snapPositionY(anchorPane.snapSpaceY(anchorPane.getHeight()) - child.getHeight());
 
-        double expectedY = anchorPane.snapPositionY(
-            anchorPane.snapSpaceY(anchorPane.getHeight()) - child.getLayoutBounds().getHeight());
-
-        assertEquals(expectedX, child.getBoundsInParent().getMinX(), 0.0);
-        assertEquals(expectedY, child.getBoundsInParent().getMinY(), 0.0);
+        assertEquals(expectedX, child.getLayoutX());
+        assertEquals(expectedY, child.getLayoutY());
     }
 
     @Test
@@ -917,10 +917,10 @@ public class AnchorPaneTest {
         AnchorPane.setBottomAnchor(child, 0.0);
         AnchorPane.setLeftAnchor(child, 0.0);
 
-        assertEquals(anchorPane.snapSizeX(0.4), anchorPane.minWidth(-1), 0.0);
-        assertEquals(anchorPane.snapSizeY(0.4), anchorPane.minHeight(-1), 0.0);
-        assertEquals(anchorPane.snapSizeX(0.4), anchorPane.prefWidth(-1), 0.0);
-        assertEquals(anchorPane.snapSizeY(0.4), anchorPane.prefHeight(-1), 0.0);
+        assertEquals(anchorPane.snapSizeX(0.4), anchorPane.minWidth(-1));
+        assertEquals(anchorPane.snapSizeY(0.4), anchorPane.minHeight(-1));
+        assertEquals(anchorPane.snapSizeX(0.4), anchorPane.prefWidth(-1));
+        assertEquals(anchorPane.snapSizeY(0.4), anchorPane.prefHeight(-1));
     }
 
     @Test
@@ -931,15 +931,15 @@ public class AnchorPaneTest {
         AnchorPane.setBottomAnchor(child, 0.0);
         AnchorPane.setLeftAnchor(child, 0.0);
 
-        assertEquals(10.0, anchorPane.prefWidth(100), 0.0);
-        assertEquals(100.0, child.lastHeight, 0.0);
+        assertEquals(10.0, anchorPane.prefWidth(100));
+        assertEquals(100.0, child.lastHeight);
 
         anchorPane.resize(200, 100);
         anchorPane.layout();
 
-        assertEquals(100.0, child.getHeight(), 0.0);
-        assertEquals(10.0, child.getWidth(), 0.0);
-        assertEquals(child.getHeight(), child.lastHeight, 0.0);
+        assertEquals(100.0, child.getHeight());
+        assertEquals(10.0, child.getWidth());
+        assertEquals(child.getHeight(), child.lastHeight);
     }
 
     @Test
@@ -953,12 +953,12 @@ public class AnchorPaneTest {
 
         double expectedHeight = anchorPane.snapSpaceY(anchorPane.snapSpaceY(100) - 2 * anchorPane.snapSpaceY(0.6));
         anchorPane.prefWidth(100);
-        assertEquals(expectedHeight, child.lastHeight, 0.0);
+        assertEquals(expectedHeight, child.lastHeight);
 
         anchorPane.resize(50, 100);
         anchorPane.layout();
-        assertEquals(expectedHeight, child.getHeight(), 0.0);
-        assertEquals(child.getHeight(), child.lastHeight, 0.0);
+        assertEquals(expectedHeight, child.getHeight());
+        assertEquals(child.getHeight(), child.lastHeight);
     }
 
     @Test
@@ -972,8 +972,8 @@ public class AnchorPaneTest {
         anchorPane.resize(100.4, 50);
         anchorPane.layout();
 
-        assertEquals(anchorPane.snapSpaceX(anchorPane.getWidth()), child.getWidth(), 0.0);
-        assertEquals(child.getWidth(), child.lastWidth, 0.0);
+        assertEquals(anchorPane.snapSpaceX(anchorPane.getWidth()), child.getWidth());
+        assertEquals(child.getWidth(), child.lastWidth);
     }
 
     @Test
@@ -986,14 +986,11 @@ public class AnchorPaneTest {
         anchorPane.resize(100, 100);
         anchorPane.layout();
 
-        double expectedX = anchorPane.snapPositionX(
-            anchorPane.snapSpaceX(anchorPane.getWidth()) - child.getLayoutBounds().getWidth());
+        double expectedX = anchorPane.snapPositionX(anchorPane.snapSpaceX(anchorPane.getWidth()) - child.getWidth());
+        double expectedY = anchorPane.snapPositionY(anchorPane.snapSpaceY(anchorPane.getHeight()) - child.getHeight());
 
-        double expectedY = anchorPane.snapPositionY(
-            anchorPane.snapSpaceY(anchorPane.getHeight()) - child.getLayoutBounds().getHeight());
-
-        assertEquals(expectedX, child.getBoundsInParent().getMinX(), EPSILON);
-        assertEquals(expectedY, child.getBoundsInParent().getMinY(), EPSILON);
+        assertEquals(expectedX, child.getLayoutX());
+        assertEquals(expectedY, child.getLayoutY());
     }
 
     @Test
@@ -1008,22 +1005,17 @@ public class AnchorPaneTest {
         AnchorPane.setTopAnchor(child, 1.6);
         AnchorPane.setRightAnchor(child, 1.6);
 
-        Stage stage = new Stage();
-        stage.setRenderScaleX(1.25);
-        stage.setRenderScaleY(1.25);
+        stage = new Stage();
+        stage.renderScaleXProperty().bind(new SimpleDoubleProperty(1.25));
+        stage.renderScaleYProperty().bind(new SimpleDoubleProperty(1.25));
         stage.setScene(new Scene(anchorPane, 100, 100));
+        stage.show();
 
-        try {
-            stage.show();
+        double expectedPrefWidth = anchorPane.snapSpaceX(anchorPane.snapSizeX(0.1) + anchorPane.snapSpaceX(1.6));
+        assertEquals(expectedPrefWidth, anchorPane.prefWidth(-1));
 
-            double expectedPrefWidth = anchorPane.snapSpaceX(anchorPane.snapSizeX(0.1) + anchorPane.snapSpaceX(1.6));
-            assertEquals(expectedPrefWidth, anchorPane.prefWidth(-1), 0.0);
-
-            double expectedY = anchorPane.snapPositionY(anchorPane.snapSpaceY(0.8) + anchorPane.snapSpaceY(1.6));
-            assertEquals(expectedY, child.getBoundsInParent().getMinY(), 0.0);
-        } finally {
-            stage.hide();
-        }
+        double expectedY = anchorPane.snapPositionY(anchorPane.snapSpaceY(0.8) + anchorPane.snapSpaceY(1.6));
+        assertEquals(expectedY, child.getLayoutY());
     }
 
     @Test
@@ -1041,32 +1033,26 @@ public class AnchorPaneTest {
         AnchorPane.setBottomAnchor(child, bottomAnchor);
         AnchorPane.setRightAnchor(child, rightAnchor);
 
-        Stage stage = new Stage();
-        stage.setRenderScaleX(1.25);
-        stage.setRenderScaleY(1.5);
+        stage = new Stage();
+        stage.renderScaleXProperty().bind(new SimpleDoubleProperty(1.25));
+        stage.renderScaleYProperty().bind(new SimpleDoubleProperty(1.5));
         stage.setScene(new Scene(anchorPane, 100, 100));
+        stage.show();
 
-        try {
-            stage.show();
+        double left = anchorPane.snapSpaceX(leftAnchor);
+        double right = anchorPane.snapSpaceX(rightAnchor);
+        double top = anchorPane.snapSpaceY(topAnchor);
+        double bottom = anchorPane.snapSpaceY(bottomAnchor);
+        double areaWidth = anchorPane.snapSpaceX(anchorPane.getWidth());
+        double areaHeight = anchorPane.snapSpaceY(anchorPane.getHeight());
 
-            Bounds bounds = child.getBoundsInParent();
-            double left = anchorPane.snapSpaceX(leftAnchor);
-            double right = anchorPane.snapSpaceX(rightAnchor);
-            double top = anchorPane.snapSpaceY(topAnchor);
-            double bottom = anchorPane.snapSpaceY(bottomAnchor);
-            double areaWidth = anchorPane.snapSpaceX(anchorPane.getWidth());
-            double areaHeight = anchorPane.snapSpaceY(anchorPane.getHeight());
+        assertEquals(anchorPane.snapPositionX(left), child.getLayoutX());
+        assertEquals(anchorPane.snapPositionY(top), child.getLayoutY());
+        assertEquals(anchorPane.snapSpaceX(areaWidth - left - right), child.getWidth());
+        assertEquals(anchorPane.snapSpaceY(areaHeight - top - bottom), child.getHeight());
 
-            assertEquals(anchorPane.snapPositionX(left), bounds.getMinX(), EPSILON);
-            assertEquals(anchorPane.snapPositionY(top), bounds.getMinY(), EPSILON);
-            assertEquals(anchorPane.snapSpaceX(areaWidth - left - right), bounds.getWidth(), EPSILON);
-            assertEquals(anchorPane.snapSpaceY(areaHeight - top - bottom), bounds.getHeight(), EPSILON);
-
-            assertEquals(leftAnchor, AnchorPane.getLeftAnchor(child), 0.0);
-            assertEquals(topAnchor, AnchorPane.getTopAnchor(child), 0.0);
-        } finally {
-            stage.hide();
-        }
+        assertEquals(leftAnchor, AnchorPane.getLeftAnchor(child));
+        assertEquals(topAnchor, AnchorPane.getTopAnchor(child));
     }
 
     private static final class HorizontalBiasedRegion extends Region {

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/AnchorPaneTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/AnchorPaneTest.java
@@ -865,6 +865,22 @@ public class AnchorPaneTest {
     }
 
     @Test
+    void testDualAnchoredChildClampsNegativeAllocatedSizeToZero() {
+        Region child = new Region();
+        AnchorPane anchorPane = new AnchorPane(child);
+        AnchorPane.setTopAnchor(child, 6.0);
+        AnchorPane.setRightAnchor(child, 5.0);
+        AnchorPane.setBottomAnchor(child, 5.0);
+        AnchorPane.setLeftAnchor(child, 6.0);
+
+        anchorPane.resize(10, 10);
+        anchorPane.layout();
+
+        assertEquals(0.0, child.getWidth());
+        assertEquals(0.0, child.getHeight());
+    }
+
+    @Test
     void testUnsnappedPreservesFractionalAnchorGeometry() {
         Region child = new Region();
         AnchorPane anchorPane = new AnchorPane(child);
@@ -977,6 +993,34 @@ public class AnchorPaneTest {
     }
 
     @Test
+    void testHorizontalBiasReceivesZeroForNegativeStretchedWidth() {
+        HorizontalBiasedRegion child = new HorizontalBiasedRegion();
+        AnchorPane anchorPane = new AnchorPane(child);
+        AnchorPane.setLeftAnchor(child, 6.0);
+        AnchorPane.setRightAnchor(child, 5.0);
+
+        anchorPane.resize(10, 100);
+        anchorPane.layout();
+
+        assertEquals(0.0, child.getWidth());
+        assertEquals(0.0, child.lastWidth);
+    }
+
+    @Test
+    void testVerticalBiasReceivesZeroForNegativeStretchedHeight() {
+        VerticalBiasedRegion child = new VerticalBiasedRegion(10);
+        AnchorPane anchorPane = new AnchorPane(child);
+        AnchorPane.setTopAnchor(child, 6.0);
+        AnchorPane.setBottomAnchor(child, 5.0);
+
+        anchorPane.resize(100, 10);
+        anchorPane.layout();
+
+        assertEquals(0.0, child.getHeight());
+        assertEquals(0.0, child.lastHeight);
+    }
+
+    @Test
     void testRightBottomAnchoringUsesActualNonResizableSize() {
         Rectangle child = new Rectangle(1.4, 1.4);
         AnchorPane anchorPane = new AnchorPane(child);
@@ -991,6 +1035,26 @@ public class AnchorPaneTest {
 
         assertEquals(expectedX, child.getLayoutX());
         assertEquals(expectedY, child.getLayoutY());
+    }
+
+    @Test
+    void testRightBottomAnchoredOversizedChildKeepsNegativePosition() {
+        Region child = new Region();
+        child.setMinSize(50, 50);
+        child.setPrefSize(50, 50);
+        child.setMaxSize(50, 50);
+
+        AnchorPane anchorPane = new AnchorPane(child);
+        AnchorPane.setRightAnchor(child, 5.0);
+        AnchorPane.setBottomAnchor(child, 5.0);
+
+        anchorPane.resize(40, 40);
+        anchorPane.layout();
+
+        assertEquals(-15.0, child.getLayoutX());
+        assertEquals(-15.0, child.getLayoutY());
+        assertEquals(35.0, child.getLayoutX() + child.getWidth());
+        assertEquals(35.0, child.getLayoutY() + child.getHeight());
     }
 
     @Test


### PR DESCRIPTION
AnchorPane's measurement and layout calculations are not correct when pixel-snapping is enabled. The following problems are fixed in this PR:

* Stretched sizes and right/bottom positions are not snapped:
   `computeChildWidth`/`computeChildHeight` subtract anchors and insets from raw `getWidth()`/`getHeight()`, while `layoutChildren()` passes those values directly to `resizeRelocate`.
* Content-biased measurement and layout use different dependent dimensions:
   `computeWidth()` passes `fillHeight=false`, while layout eventually uses `fillHeight=true`
* Result of snapped calculations is not re-snapped.
* Anchors use `snapPositionX/Y`. However, anchors are empty space and should use `snapSpaceX/Y`.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390608](https://bugs.openjdk.org/browse/JDK-8390608): Implement correct snapping for AnchorPane (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2264/head:pull/2264` \
`$ git checkout pull/2264`

Update a local copy of the PR: \
`$ git checkout pull/2264` \
`$ git pull https://git.openjdk.org/jfx.git pull/2264/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2264`

View PR using the GUI difftool: \
`$ git pr show -t 2264`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2264.diff">https://git.openjdk.org/jfx/pull/2264.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2264#issuecomment-5336332565)
</details>
