### PR TITLE
8390673: Implement correct snapping for StackPane

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/StackPane.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/StackPane.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -283,38 +283,42 @@ public class StackPane extends Pane {
     }
 
     @Override protected double computeMinWidth(double height) {
-        List<Node>managed = getManagedChildren();
-        return getInsets().getLeft() +
-               computeMaxMinAreaWidth(managed, marginAccessor, height, true) +
-               getInsets().getRight();
+        List<Node> managed = getManagedChildren();
+        return snapSpaceX(
+            snappedLeftInset() +
+            computeMaxMinAreaWidth(managed, marginAccessor, snapContentHeight(height), true) +
+            snappedRightInset());
     }
 
     @Override protected double computeMinHeight(double width) {
-        List<Node>managed = getManagedChildren();
-        return getInsets().getTop() +
-               computeMaxMinAreaHeight(managed, marginAccessor, width, true, getAlignmentInternal().getVpos()) +
-               getInsets().getBottom();
+        List<Node> managed = getManagedChildren();
+        VPos vpos = getAlignmentInternal().getVpos();
+        double contentWidth = snapContentWidth(width);
+        double contentHeight = vpos == VPos.BASELINE && contentWidth != -1
+            ? computeMaxMinAreaHeight(managed, marginAccessor, computeChildWidths(managed, contentWidth), true, vpos)
+            : computeMaxMinAreaHeight(managed, marginAccessor, contentWidth, true, vpos);
+
+        return snapSpaceY(snappedTopInset() + contentHeight + snappedBottomInset());
     }
 
     @Override protected double computePrefWidth(double height) {
-        List<Node>managed = getManagedChildren();
-        Insets padding = getInsets();
-        return padding.getLeft() +
-               computeMaxPrefAreaWidth(managed, marginAccessor,
-                                       (height == -1) ? -1 : (height - padding.getTop() - padding.getBottom()), true) +
-               padding.getRight();
+        List<Node> managed = getManagedChildren();
+        return snapSpaceX(
+            snappedLeftInset() +
+            computeMaxPrefAreaWidth(managed, marginAccessor, snapContentHeight(height), true) +
+            snappedRightInset());
     }
 
     @Override protected double computePrefHeight(double width) {
-        List<Node>managed = getManagedChildren();
-        Insets padding = getInsets();
-        return padding.getTop() +
-               computeMaxPrefAreaHeight(managed, marginAccessor,
-                                        (width == -1) ? -1 : (width - padding.getLeft() - padding.getRight()), true,
-                                        getAlignmentInternal().getVpos()) +
-               padding.getBottom();
-    }
+        List<Node> managed = getManagedChildren();
+        VPos vpos = getAlignmentInternal().getVpos();
+        double contentWidth = snapContentWidth(width);
+        double contentHeight = vpos == VPos.BASELINE && contentWidth != -1
+            ? computeMaxPrefAreaHeight(managed, marginAccessor, computeChildWidths(managed, contentWidth), true, vpos)
+            : computeMaxPrefAreaHeight(managed, marginAccessor, contentWidth, true, vpos);
 
+        return snapSpaceY(snappedTopInset() + contentHeight + snappedBottomInset());
+    }
 
     @Override public void requestLayout() {
         biasDirty = true;
@@ -327,17 +331,15 @@ public class StackPane extends Pane {
         Pos align = getAlignmentInternal();
         HPos alignHpos = align.getHpos();
         VPos alignVpos = align.getVpos();
-        final double width = getWidth();
-        double height = getHeight();
-        double top = getInsets().getTop();
-        double right = getInsets().getRight();
-        double left = getInsets().getLeft();
-        double bottom = getInsets().getBottom();
-        double contentWidth = width - left - right;
-        double contentHeight = height - top - bottom;
-        double baselineOffset = alignVpos == VPos.BASELINE ?
-                getAreaBaselineOffset(managed, marginAccessor, i -> width, contentHeight, true)
-                                    : 0;
+        double top = snappedTopInset();
+        double left = snappedLeftInset();
+        double contentWidth = snapContentWidth(getWidth());
+        double contentHeight = snapContentHeight(getHeight());
+        double baselineOffset = alignVpos == VPos.BASELINE
+            ? getAreaBaselineOffset(managed, marginAccessor,
+                i -> computeChildWidth(managed.get(i), contentWidth), contentHeight, true)
+            : 0;
+
         for (int i = 0, size = managed.size(); i < size; i++) {
             Node child = managed.get(i);
             Pos childAlignment = StackPane.getAlignment(child);
@@ -347,6 +349,35 @@ public class StackPane extends Pane {
                            childAlignment != null? childAlignment.getHpos() : alignHpos,
                            childAlignment != null? childAlignment.getVpos() : alignVpos);
         }
+    }
+
+    private double snapContentWidth(double width) {
+        return width < 0 ? -1 : snapSpaceX(snapSpaceX(width) - snappedLeftInset() - snappedRightInset());
+    }
+
+    private double snapContentHeight(double height) {
+        return height < 0 ? -1 : snapSpaceY(snapSpaceY(height) - snappedTopInset() - snappedBottomInset());
+    }
+
+    private double computeChildWidth(Node child, double areaWidth) {
+        if (!child.isResizable()) {
+            return child.getLayoutBounds().getWidth();
+        }
+
+        return snapSizeX(boundedSize(
+            child.minWidth(-1),
+            adjustWidthByMargin(areaWidth, getMargin(child)),
+            child.maxWidth(-1)));
+    }
+
+    private double[] computeChildWidths(List<Node> children, double areaWidth) {
+        double[] widths = new double[children.size()];
+
+        for (int i = 0; i < widths.length; ++i) {
+            widths[i] = computeChildWidth(children.get(i), areaWidth);
+        }
+
+        return widths;
     }
 
     /* *************************************************************************

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/StackPaneTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/StackPaneTest.java
@@ -25,6 +25,7 @@
 
 package test.javafx.scene.layout;
 
+import javafx.beans.property.SimpleDoubleProperty;
 import javafx.geometry.Insets;
 import javafx.geometry.Orientation;
 import javafx.geometry.Pos;
@@ -39,12 +40,18 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 
 public class StackPaneTest {
+
+    private static final double EPSILON = 1e-10;
 
     Stage stage;
     StackPane stack;
@@ -598,14 +605,14 @@ public class StackPaneTest {
     }
 
     @ParameterizedTest
-    @ValueSource(doubles = {1, 1.25, 1.5, 1.75, 2})
-    public void testSnappedInsetsAreUsedForMeasurementAndLayout(double renderScale) {
+    @MethodSource("renderScales")
+    public void testSnappedInsetsAreUsedForMeasurementAndLayout(double scaleX, double scaleY) {
         Region child = new Region();
         child.setMinSize(100, 100);
         child.setPrefSize(100, 100);
         ParentShim.getChildren(stack).add(child);
         stack.setPadding(new Insets(9.6));
-        showAtRenderScale(stack, renderScale);
+        showAtRenderScale(stack, scaleX, scaleY);
 
         double expectedWidth = stack.snapSpaceX(
             stack.snappedLeftInset() + stack.snapSizeX(100) + stack.snappedRightInset());
@@ -613,10 +620,10 @@ public class StackPaneTest {
         double expectedHeight = stack.snapSpaceY(
             stack.snappedTopInset() + stack.snapSizeY(100) + stack.snappedBottomInset());
 
-        assertEquals(expectedWidth, stack.minWidth(-1), 1e-10);
-        assertEquals(expectedHeight, stack.minHeight(-1), 1e-10);
-        assertEquals(expectedWidth, stack.prefWidth(-1), 1e-10);
-        assertEquals(expectedHeight, stack.prefHeight(-1), 1e-10);
+        assertEquals(expectedWidth, stack.minWidth(-1));
+        assertEquals(expectedHeight, stack.minHeight(-1));
+        assertEquals(expectedWidth, stack.prefWidth(-1));
+        assertEquals(expectedHeight, stack.prefHeight(-1));
 
         stack.resize(120.2, 120.2);
         stack.layout();
@@ -627,44 +634,44 @@ public class StackPaneTest {
         double expectedContentHeight = stack.snapSpaceY(
             stack.snapSpaceY(120.2) - stack.snappedTopInset() - stack.snappedBottomInset());
 
-        assertEquals(stack.snappedLeftInset(), child.getLayoutX(), 1e-10);
-        assertEquals(stack.snappedTopInset(), child.getLayoutY(), 1e-10);
-        assertEquals(expectedContentWidth, child.getLayoutBounds().getWidth(), 1e-10);
-        assertEquals(expectedContentHeight, child.getLayoutBounds().getHeight(), 1e-10);
+        assertEquals(stack.snappedLeftInset(), child.getLayoutX());
+        assertEquals(stack.snappedTopInset(), child.getLayoutY());
+        assertEquals(expectedContentWidth, child.getLayoutBounds().getWidth());
+        assertEquals(expectedContentHeight, child.getLayoutBounds().getHeight());
     }
 
     @ParameterizedTest
-    @ValueSource(doubles = {1, 1.25, 1.5, 1.75, 2})
-    public void testFractionalInsetsAndContentAreaArePreservedWhenSnappingIsDisabled(double renderScale) {
+    @MethodSource("renderScales")
+    public void testFractionalInsetsAndContentAreaArePreservedWhenSnappingIsDisabled(double scaleX, double scaleY) {
         Region child = new Region();
         child.setMinSize(100, 100);
         child.setPrefSize(100, 100);
         ParentShim.getChildren(stack).add(child);
         stack.setPadding(new Insets(9.6));
         stack.setSnapToPixel(false);
-        showAtRenderScale(stack, renderScale);
+        showAtRenderScale(stack, scaleX, scaleY);
 
-        assertEquals(119.2, stack.minWidth(-1), 1e-10);
-        assertEquals(119.2, stack.minHeight(-1), 1e-10);
-        assertEquals(119.2, stack.prefWidth(-1), 1e-10);
-        assertEquals(119.2, stack.prefHeight(-1), 1e-10);
+        assertEquals(119.2, stack.minWidth(-1), EPSILON);
+        assertEquals(119.2, stack.minHeight(-1), EPSILON);
+        assertEquals(119.2, stack.prefWidth(-1), EPSILON);
+        assertEquals(119.2, stack.prefHeight(-1), EPSILON);
 
         stack.resize(120.2, 120.2);
         stack.layout();
 
-        assertEquals(9.6, child.getLayoutX(), 1e-10);
-        assertEquals(9.6, child.getLayoutY(), 1e-10);
-        assertEquals(101, child.getLayoutBounds().getWidth(), 1e-10);
-        assertEquals(101, child.getLayoutBounds().getHeight(), 1e-10);
+        assertEquals(9.6, child.getLayoutX(), EPSILON);
+        assertEquals(9.6, child.getLayoutY(), EPSILON);
+        assertEquals(101, child.getLayoutBounds().getWidth(), EPSILON);
+        assertEquals(101, child.getLayoutBounds().getHeight(), EPSILON);
     }
 
     @ParameterizedTest
-    @ValueSource(doubles = {1, 1.25, 1.5, 1.75, 2})
-    public void testSnappedContentSizeIsUsedForBiasedMeasurements(double renderScale) {
+    @MethodSource("renderScales")
+    public void testSnappedContentSizeIsUsedForBiasedMeasurements(double scaleX, double scaleY) {
         stack.setPadding(new Insets(9.6));
         MockBiased horizontalChild = new MockBiased(Orientation.HORIZONTAL, 100, 200);
         ParentShim.getChildren(stack).add(horizontalChild);
-        showAtRenderScale(stack, renderScale);
+        showAtRenderScale(stack, scaleX, scaleY);
 
         double horizontalContentWidth = stack.snapSpaceX(
             stack.snapSpaceX(120) - stack.snappedLeftInset() - stack.snappedRightInset());
@@ -674,8 +681,8 @@ public class StackPaneTest {
         double expectedHorizontalHeight = stack.snapSpaceY(
             stack.snappedTopInset() + horizontalChildHeight + stack.snappedBottomInset());
 
-        assertEquals(expectedHorizontalHeight, stack.minHeight(120), 1e-10);
-        assertEquals(expectedHorizontalHeight, stack.prefHeight(120), 1e-10);
+        assertEquals(expectedHorizontalHeight, stack.minHeight(120));
+        assertEquals(expectedHorizontalHeight, stack.prefHeight(120));
 
         StackPane verticalStack = new StackPane();
         verticalStack.setPadding(new Insets(9.6));
@@ -691,15 +698,29 @@ public class StackPaneTest {
         double expectedVerticalWidth = verticalStack.snapSpaceX(
             verticalStack.snappedLeftInset() + verticalChildWidth + verticalStack.snappedRightInset());
 
-        assertEquals(expectedVerticalWidth, verticalStack.minWidth(220), 1e-10);
-        assertEquals(expectedVerticalWidth, verticalStack.prefWidth(220), 1e-10);
+        assertEquals(expectedVerticalWidth, verticalStack.minWidth(220));
+        assertEquals(expectedVerticalWidth, verticalStack.prefWidth(220));
     }
 
-    private void showAtRenderScale(StackPane root, double renderScale) {
+    private void showAtRenderScale(StackPane root, double scaleX, double scaleY) {
         stage = new Stage();
-        stage.setRenderScaleX(renderScale);
-        stage.setRenderScaleY(renderScale);
+        stage.renderScaleXProperty().bind(new SimpleDoubleProperty(scaleX));
+        stage.renderScaleYProperty().bind(new SimpleDoubleProperty(scaleY));
         stage.setScene(new Scene(root));
         stage.show();
+    }
+
+    static Stream<Arguments> renderScales() {
+        return Stream.of(
+            Arguments.of(1.0, 1.0),
+            Arguments.of(1.25, 1.25),
+            Arguments.of(1.5, 1.5),
+            Arguments.of(1.75, 1.75),
+            Arguments.of(2.0, 2.0),
+            Arguments.of(1.25, 1.75),
+            Arguments.of(1.5, 2.0),
+            Arguments.of(2.0, 1.25),
+            Arguments.of(2.25, 2.5)
+        );
     }
 }

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/StackPaneTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/StackPaneTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,21 +29,37 @@ import javafx.geometry.Insets;
 import javafx.geometry.Orientation;
 import javafx.geometry.Pos;
 import javafx.scene.ParentShim;
+import javafx.scene.Scene;
+import javafx.scene.layout.Region;
 import javafx.scene.layout.StackPane;
 import javafx.scene.shape.Rectangle;
+import javafx.stage.Stage;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 
 public class StackPaneTest {
+
+    Stage stage;
     StackPane stack;
 
     @BeforeEach
     public void setUp() {
         this.stack = new StackPane();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if (stage != null) {
+            stage.hide();
+            stage = null;
+        }
     }
 
     @Test
@@ -581,4 +597,109 @@ public class StackPaneTest {
         assertEquals(200, biased.getLayoutBounds().getHeight(), 1e-100);
     }
 
+    @ParameterizedTest
+    @ValueSource(doubles = {1, 1.25, 1.5, 1.75, 2})
+    public void testSnappedInsetsAreUsedForMeasurementAndLayout(double renderScale) {
+        Region child = new Region();
+        child.setMinSize(100, 100);
+        child.setPrefSize(100, 100);
+        ParentShim.getChildren(stack).add(child);
+        stack.setPadding(new Insets(9.6));
+        showAtRenderScale(stack, renderScale);
+
+        double expectedWidth = stack.snapSpaceX(
+            stack.snappedLeftInset() + stack.snapSizeX(100) + stack.snappedRightInset());
+
+        double expectedHeight = stack.snapSpaceY(
+            stack.snappedTopInset() + stack.snapSizeY(100) + stack.snappedBottomInset());
+
+        assertEquals(expectedWidth, stack.minWidth(-1), 1e-10);
+        assertEquals(expectedHeight, stack.minHeight(-1), 1e-10);
+        assertEquals(expectedWidth, stack.prefWidth(-1), 1e-10);
+        assertEquals(expectedHeight, stack.prefHeight(-1), 1e-10);
+
+        stack.resize(120.2, 120.2);
+        stack.layout();
+
+        double expectedContentWidth = stack.snapSpaceX(
+            stack.snapSpaceX(120.2) - stack.snappedLeftInset() - stack.snappedRightInset());
+
+        double expectedContentHeight = stack.snapSpaceY(
+            stack.snapSpaceY(120.2) - stack.snappedTopInset() - stack.snappedBottomInset());
+
+        assertEquals(stack.snappedLeftInset(), child.getLayoutX(), 1e-10);
+        assertEquals(stack.snappedTopInset(), child.getLayoutY(), 1e-10);
+        assertEquals(expectedContentWidth, child.getLayoutBounds().getWidth(), 1e-10);
+        assertEquals(expectedContentHeight, child.getLayoutBounds().getHeight(), 1e-10);
+    }
+
+    @ParameterizedTest
+    @ValueSource(doubles = {1, 1.25, 1.5, 1.75, 2})
+    public void testFractionalInsetsAndContentAreaArePreservedWhenSnappingIsDisabled(double renderScale) {
+        Region child = new Region();
+        child.setMinSize(100, 100);
+        child.setPrefSize(100, 100);
+        ParentShim.getChildren(stack).add(child);
+        stack.setPadding(new Insets(9.6));
+        stack.setSnapToPixel(false);
+        showAtRenderScale(stack, renderScale);
+
+        assertEquals(119.2, stack.minWidth(-1), 1e-10);
+        assertEquals(119.2, stack.minHeight(-1), 1e-10);
+        assertEquals(119.2, stack.prefWidth(-1), 1e-10);
+        assertEquals(119.2, stack.prefHeight(-1), 1e-10);
+
+        stack.resize(120.2, 120.2);
+        stack.layout();
+
+        assertEquals(9.6, child.getLayoutX(), 1e-10);
+        assertEquals(9.6, child.getLayoutY(), 1e-10);
+        assertEquals(101, child.getLayoutBounds().getWidth(), 1e-10);
+        assertEquals(101, child.getLayoutBounds().getHeight(), 1e-10);
+    }
+
+    @ParameterizedTest
+    @ValueSource(doubles = {1, 1.25, 1.5, 1.75, 2})
+    public void testSnappedContentSizeIsUsedForBiasedMeasurements(double renderScale) {
+        stack.setPadding(new Insets(9.6));
+        MockBiased horizontalChild = new MockBiased(Orientation.HORIZONTAL, 100, 200);
+        ParentShim.getChildren(stack).add(horizontalChild);
+        showAtRenderScale(stack, renderScale);
+
+        double horizontalContentWidth = stack.snapSpaceX(
+            stack.snapSpaceX(120) - stack.snappedLeftInset() - stack.snappedRightInset());
+
+        double horizontalChildHeight = stack.snapSizeY(horizontalChild.prefHeight(horizontalContentWidth));
+
+        double expectedHorizontalHeight = stack.snapSpaceY(
+            stack.snappedTopInset() + horizontalChildHeight + stack.snappedBottomInset());
+
+        assertEquals(expectedHorizontalHeight, stack.minHeight(120), 1e-10);
+        assertEquals(expectedHorizontalHeight, stack.prefHeight(120), 1e-10);
+
+        StackPane verticalStack = new StackPane();
+        verticalStack.setPadding(new Insets(9.6));
+        MockBiased verticalChild = new MockBiased(Orientation.VERTICAL, 100, 200);
+        ParentShim.getChildren(verticalStack).add(verticalChild);
+        stage.getScene().setRoot(verticalStack);
+
+        double verticalContentHeight = verticalStack.snapSpaceY(
+            verticalStack.snapSpaceY(220) - verticalStack.snappedTopInset() - verticalStack.snappedBottomInset());
+
+        double verticalChildWidth = verticalStack.snapSizeX(verticalChild.prefWidth(verticalContentHeight));
+
+        double expectedVerticalWidth = verticalStack.snapSpaceX(
+            verticalStack.snappedLeftInset() + verticalChildWidth + verticalStack.snappedRightInset());
+
+        assertEquals(expectedVerticalWidth, verticalStack.minWidth(220), 1e-10);
+        assertEquals(expectedVerticalWidth, verticalStack.prefWidth(220), 1e-10);
+    }
+
+    private void showAtRenderScale(StackPane root, double renderScale) {
+        stage = new Stage();
+        stage.setRenderScaleX(renderScale);
+        stage.setRenderScaleY(renderScale);
+        stage.setScene(new Scene(root));
+        stage.show();
+    }
 }


### PR DESCRIPTION
StackPane has the following defects:

1. All measurement methods use raw insets rather than `snappedTopInset()`, `snappedLeftInset()`, etc.
2. `layoutChildren()` also uses raw insets and raw subtraction for the content rectangle.
3. Calculated totals and spans are not re-snapped after addition or subtraction.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390673](https://bugs.openjdk.org/browse/JDK-8390673): Implement correct snapping for StackPane (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2266/head:pull/2266` \
`$ git checkout pull/2266`

Update a local copy of the PR: \
`$ git checkout pull/2266` \
`$ git pull https://git.openjdk.org/jfx.git pull/2266/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2266`

View PR using the GUI difftool: \
`$ git pr show -t 2266`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2266.diff">https://git.openjdk.org/jfx/pull/2266.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2266#issuecomment-5343595644)
</details>
