### PR TITLE
8390752: Implement correct snapping for TilePane

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/TilePane.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/TilePane.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -247,6 +247,9 @@ public class TilePane extends Pane {
 
     private double _tileWidth = -1;
     private double _tileHeight = -1;
+    private double lastSnapScaleX = Double.NaN;
+    private double lastSnapScaleY = Double.NaN;
+    private boolean lastSnapToPixel;
 
     /**
      * Creates a horizontal TilePane layout with prefColumn = 5 and hgap/vgap = 0.
@@ -579,6 +582,8 @@ public class TilePane extends Pane {
     }
 
     public final double getTileWidth() {
+        validateTileSizeCache();
+
         if (tileWidth != null) {
             return tileWidth.get();
         }
@@ -615,6 +620,8 @@ public class TilePane extends Pane {
     }
 
     public final double getTileHeight() {
+        validateTileSizeCache();
+
         if (tileHeight != null) {
             return tileHeight.get();
         }
@@ -794,78 +801,88 @@ public class TilePane extends Pane {
 
     @Override protected double computeMinWidth(double height) {
         if (getContentBias() == Orientation.HORIZONTAL) {
-            return getInsets().getLeft() + getTileWidth() + getInsets().getRight();
+            return snapSpaceX(snappedLeftInset() + getTileWidth() + snappedRightInset());
         }
         return computePrefWidth(height);
     }
 
     @Override protected double computeMinHeight(double width) {
         if (getContentBias() == Orientation.VERTICAL) {
-            return getInsets().getTop() + getTileHeight() + getInsets().getBottom();
+            return snapSpaceY(snappedTopInset() + getTileHeight() + snappedBottomInset());
         }
         return computePrefHeight(width);
     }
 
     @Override protected double computePrefWidth(double forHeight) {
         List<Node> managed = getManagedChildren();
-        final Insets insets = getInsets();
+        double top = snappedTopInset();
+        double right = snappedRightInset();
+        double bottom = snappedBottomInset();
+        double left = snappedLeftInset();
         int prefCols = 0;
         if (forHeight != -1) {
             // first compute number of rows that will fit in given height and
             // compute pref columns from that
-            int prefRows = computeRows(forHeight - snapSpaceY(insets.getTop()) - snapSpaceY(insets.getBottom()), getTileHeight());
+            int prefRows = computeRows(snapSpaceY(forHeight - top - bottom), getTileHeight());
             prefCols = computeOther(managed.size(), prefRows);
         } else {
             prefCols = getOrientation() == HORIZONTAL? getPrefColumns() : computeOther(managed.size(), getPrefRows());
         }
-        return snapSpaceX(insets.getLeft()) +
-               computeContentWidth(prefCols, getTileWidth()) +
-               snapSpaceX(insets.getRight());
+        return snapSpaceX(left + computeContentWidth(prefCols, getTileWidth()) + right);
     }
 
     @Override protected double computePrefHeight(double forWidth) {
         List<Node> managed = getManagedChildren();
-        final Insets insets = getInsets();
+        double top = snappedTopInset();
+        double right = snappedRightInset();
+        double bottom = snappedBottomInset();
+        double left = snappedLeftInset();
         int prefRows = 0;
         if (forWidth != -1) {
             // first compute number of columns that will fit in given width and
             // compute pref rows from that
-            int prefCols = computeColumns(forWidth - snapSpaceX(insets.getLeft()) - snapSpaceX(insets.getRight()), getTileWidth());
+            int prefCols = computeColumns(snapSpaceX(forWidth - left - right), getTileWidth());
             prefRows = computeOther(managed.size(), prefCols);
         } else {
             prefRows = getOrientation() == HORIZONTAL? computeOther(managed.size(), getPrefColumns()) : getPrefRows();
         }
-        return snapSpaceY(insets.getTop()) +
-               computeContentHeight(prefRows, getTileHeight()) +
-               snapSpaceY(insets.getBottom());
+        return snapSpaceY(top + computeContentHeight(prefRows, getTileHeight()) + bottom);
     }
 
     private double computeTileWidth() {
         List<Node> managed = getManagedChildren();
-        double preftilewidth = getPrefTileWidth();
-        if (preftilewidth == USE_COMPUTED_SIZE) {
+        double prefTileWidth = getPrefTileWidth();
+        if (prefTileWidth == USE_COMPUTED_SIZE) {
             double h = -1;
             boolean vertBias = false;
+            boolean horizBias = false;
             for (int i = 0, size = managed.size(); i < size; i++) {
                 Node child = managed.get(i);
                 if (child.getContentBias() == VERTICAL) {
                     vertBias = true;
-                    break;
+                } else if (child.getContentBias() == HORIZONTAL) {
+                    horizBias = true;
                 }
             }
             if (vertBias) {
                 // widest may depend on height of tile
-                h = computeMaxPrefAreaHeight(managed, marginAccessor, -1, true, getTileAlignmentInternal().getVpos());
+                double prefTileHeight = getPrefTileHeight();
+                if (prefTileHeight == USE_COMPUTED_SIZE) {
+                    double w = horizBias ? computeNaturalTileWidth(managed) : -1;
+                    h = computeComputedTileHeight(managed, w);
+                } else {
+                    h = snapSizeY(prefTileHeight);
+                }
             }
-            return snapSizeX(computeMaxPrefAreaWidth(managed, marginAccessor, h, true));
+            return computeComputedTileWidth(managed, h);
         }
-        return snapSizeX(preftilewidth);
+        return snapSizeX(prefTileWidth);
     }
 
     private double computeTileHeight() {
         List<Node> managed = getManagedChildren();
-        double preftileheight = getPrefTileHeight();
-        if (preftileheight == USE_COMPUTED_SIZE) {
+        double prefTileHeight = getPrefTileHeight();
+        if (prefTileHeight == USE_COMPUTED_SIZE) {
             double w = -1;
             boolean horizBias = false;
             for (int i = 0, size = managed.size(); i < size; i++) {
@@ -877,11 +894,31 @@ public class TilePane extends Pane {
             }
             if (horizBias) {
                 // tallest may depend on width of tile
-                w = computeMaxPrefAreaWidth(managed, marginAccessor);
+                w = computeTileWidth();
             }
-            return snapSizeY(computeMaxPrefAreaHeight(managed, marginAccessor, w, true, getTileAlignmentInternal().getVpos()));
+            return computeComputedTileHeight(managed, w);
         }
-        return snapSizeY(preftileheight);
+        return snapSizeY(prefTileHeight);
+    }
+
+    private double computeNaturalTileWidth(List<Node> managed) {
+        return snapSpaceX(computeMaxPrefAreaWidth(managed, marginAccessor));
+    }
+
+    private double computeComputedTileWidth(List<Node> managed, double height) {
+        return snapSpaceX(computeMaxPrefAreaWidth(managed, marginAccessor, height, true));
+    }
+
+    private double computeComputedTileHeight(List<Node> managed, double width) {
+        double height = computeMaxPrefAreaHeight(
+            managed, marginAccessor, width, true, getTileAlignmentInternal().getVpos());
+
+        // A baseline-aligned height can contain unsnapped baseline offsets from
+        // different children, so it is still a content size. All other results
+        // are sums of independently snapped child sizes and margins.
+        return getTileAlignmentInternal().getVpos() == VPos.BASELINE
+            ? snapSizeY(height)
+            : snapSpaceY(height);
     }
 
     private int computeOther(int numNodes, int numCells) {
@@ -891,22 +928,46 @@ public class TilePane extends Pane {
 
     private int computeColumns(double width, double tilewidth) {
         double snappedHgap = snapSpaceX(getHgap());
-        return Math.max(1,(int)((width + snappedHgap) / (tilewidth + snappedHgap)));
+        double availableWidth = snapSpaceX(width);
+        double cellWidth = snapSpaceX(tilewidth + snappedHgap);
+        int columns = Math.max(1, (int)(snapSpaceX(availableWidth + snappedHgap) / cellWidth));
+
+        if (cellWidth > 0 && availableWidth >= 0) {
+            if (columns < Integer.MAX_VALUE && computeContentWidth(columns + 1, tilewidth) <= availableWidth) {
+                columns++;
+            } else if (columns > 1 && computeContentWidth(columns, tilewidth) > availableWidth) {
+                columns--;
+            }
+        }
+
+        return columns;
     }
 
     private int computeRows(double height, double tileheight) {
         double snappedVgap = snapSpaceY(getVgap());
-        return Math.max(1, (int)((height + snappedVgap) / (tileheight + snappedVgap)));
+        double availableHeight = snapSpaceY(height);
+        double cellHeight = snapSpaceY(tileheight + snappedVgap);
+        int rows = Math.max(1, (int)(snapSpaceY(availableHeight + snappedVgap) / cellHeight));
+
+        if (cellHeight > 0 && availableHeight >= 0) {
+            if (rows < Integer.MAX_VALUE && computeContentHeight(rows + 1, tileheight) <= availableHeight) {
+                rows++;
+            } else if (rows > 1 && computeContentHeight(rows, tileheight) > availableHeight) {
+                rows--;
+            }
+        }
+
+        return rows;
     }
 
     private double computeContentWidth(int columns, double tilewidth) {
         if (columns == 0) return 0;
-        return columns * tilewidth + (columns - 1) * snapSpaceX(getHgap());
+        return snapSpaceX(columns * tilewidth + (columns - 1) * snapSpaceX(getHgap()));
     }
 
     private double computeContentHeight(int rows, double tileheight) {
         if (rows == 0) return 0;
-        return rows * tileheight + (rows - 1) * snapSpaceY(getVgap());
+        return snapSpaceY(rows * tileheight + (rows - 1) * snapSpaceY(getVgap()));
     }
 
     @Override protected void layoutChildren() {
@@ -921,14 +982,17 @@ public class TilePane extends Pane {
         double right = snapSpaceX(getInsets().getRight());
         double vgap = snapSpaceY(getVgap());
         double hgap = snapSpaceX(getHgap());
-        double insideWidth = width - left - right;
-        double insideHeight = height - top - bottom;
+        double insideWidth = snapSpaceX(width - left - right);
+        double insideHeight = snapSpaceY(height - top - bottom);
 
         double tileWidth = getTileWidth() > insideWidth ? insideWidth : getTileWidth();
         double tileHeight = getTileHeight() > insideHeight ? insideHeight : getTileHeight();
 
         int lastRowRemainder = 0;
         int lastColumnRemainder = 0;
+        int actualColumns;
+        int actualRows;
+
         if (getOrientation() == HORIZONTAL) {
             actualColumns = computeColumns(insideWidth, tileWidth);
             actualRows = computeOther(managed.size(), actualColumns);
@@ -993,8 +1057,19 @@ public class TilePane extends Pane {
         }
     }
 
-    private int actualRows = 0;
-    private int actualColumns = 0;
+    private void validateTileSizeCache() {
+        boolean snapToPixel = isSnapToPixel();
+        double snapScaleX = snapToPixel ? getSnapScaleX(this) : 1;
+        double snapScaleY = snapToPixel ? getSnapScaleY(this) : 1;
+
+        if (lastSnapToPixel != snapToPixel || lastSnapScaleX != snapScaleX || lastSnapScaleY != snapScaleY) {
+            lastSnapToPixel = snapToPixel;
+            lastSnapScaleX = snapScaleX;
+            lastSnapScaleY = snapScaleY;
+            invalidateTileWidth();
+            invalidateTileHeight();
+        }
+    }
 
     /* *************************************************************************
      *                                                                         *
@@ -1224,6 +1299,8 @@ public class TilePane extends Pane {
 
         @Override
         public double get() {
+            validateTileSizeCache();
+
             if (!valid) {
                 value = compute();
                 valid = true;
@@ -1241,5 +1318,4 @@ public class TilePane extends Pane {
 
         public abstract double compute();
     }
-
 }

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/TilePaneTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/TilePaneTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package test.javafx.scene.layout;
 
+import javafx.beans.property.SimpleDoubleProperty;
 import javafx.css.ParsedValue;
 import javafx.css.CssMetaData;
 import javafx.css.CssParserShim;
@@ -35,6 +36,7 @@ import javafx.geometry.Pos;
 import javafx.scene.Node;
 import javafx.scene.ParentShim;
 import javafx.scene.Scene;
+import javafx.scene.layout.Pane;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.TilePane;
 import javafx.scene.shape.Rectangle;
@@ -42,12 +44,16 @@ import javafx.stage.Stage;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.fail;
 
 
 public class TilePaneTest {
+
+    private static final double EPSILON = 0.0000001;
 
     TilePane tilepane;
     TilePane htilepane;
@@ -1080,6 +1086,231 @@ public class TilePaneTest {
         assertEquals(160, tilepane.getLayoutBounds().getHeight(), 1e-100);
     }
 
+    @ParameterizedTest
+    @CsvSource({
+        "1.0, 1.0",
+        "1.25, 1.5",
+        "1.5, 1.5",
+        "1.75, 2.25",
+        "1.0, 1.75",
+    })
+    public void testMinAndPrefSizeSnapInsetsAtRenderScale(double scaleX, double scaleY) {
+        var horizontal = new TilePane(Orientation.HORIZONTAL);
+        horizontal.setPadding(new Insets(9.6));
+        horizontal.setPrefColumns(1);
+        horizontal.setPrefTileWidth(100);
+        horizontal.setPrefTileHeight(100);
+        horizontal.getChildren().add(new Region());
+
+        var vertical = new TilePane(Orientation.VERTICAL);
+        vertical.setPadding(new Insets(9.6));
+        vertical.setPrefRows(1);
+        vertical.setPrefTileWidth(100);
+        vertical.setPrefTileHeight(100);
+        vertical.getChildren().add(new Region());
+
+        Stage stage = showAtScale(scaleX, scaleY, horizontal, vertical);
+
+        try {
+            double expectedWidth = horizontal.snapSpaceX(
+                horizontal.snappedLeftInset() + horizontal.getTileWidth() + horizontal.snappedRightInset());
+
+            double expectedHeight = vertical.snapSpaceY(
+                vertical.snappedTopInset() + vertical.getTileHeight() + vertical.snappedBottomInset());
+
+            assertEquals(expectedWidth, horizontal.minWidth(-1), EPSILON);
+            assertEquals(expectedWidth, horizontal.prefWidth(-1), EPSILON);
+            assertEquals(expectedHeight, vertical.minHeight(-1), EPSILON);
+            assertEquals(expectedHeight, vertical.prefHeight(-1), EPSILON);
+        } finally {
+            stage.hide();
+        }
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "1.0, 1.0",
+        "1.25, 1.5",
+        "1.5, 1.5",
+        "1.75, 2.25",
+        "1.0, 1.75",
+    })
+    public void testExactFitDoesNotWrapAtRenderScale(double scaleX, double scaleY) {
+        double tileWidth = 2 / scaleX;
+        double tileHeight = 2 / scaleY;
+        double hgap = 1 / scaleX;
+        double vgap = 1 / scaleY;
+        double twoTileWidth = 5 / scaleX;
+        double twoTileHeight = 5 / scaleY;
+        double secondTileX = 3 / scaleX;
+        double secondTileY = 3 / scaleY;
+
+        MockResizable firstHorizontal = new MockResizable(0, 0);
+        MockResizable secondHorizontal = new MockResizable(0, 0);
+        TilePane horizontal = new TilePane(Orientation.HORIZONTAL, hgap, 0, firstHorizontal, secondHorizontal);
+        horizontal.setPrefColumns(2);
+        horizontal.setPrefTileWidth(tileWidth);
+        horizontal.setPrefTileHeight(tileHeight);
+
+        MockResizable firstVertical = new MockResizable(0, 0);
+        MockResizable secondVertical = new MockResizable(0, 0);
+        TilePane vertical = new TilePane(Orientation.VERTICAL, 0, vgap, firstVertical, secondVertical);
+        vertical.setPrefRows(2);
+        vertical.setPrefTileWidth(tileWidth);
+        vertical.setPrefTileHeight(tileHeight);
+
+        Stage stage = showAtScale(scaleX, scaleY, horizontal, vertical);
+
+        try {
+            assertEquals(twoTileWidth, horizontal.prefWidth(-1), EPSILON);
+            assertEquals(twoTileHeight, vertical.prefHeight(-1), EPSILON);
+
+            horizontal.resize(twoTileWidth, tileHeight);
+            horizontal.requestLayout();
+            horizontal.layout();
+
+            assertEquals(firstHorizontal.getLayoutY(), secondHorizontal.getLayoutY(), EPSILON);
+            assertEquals(secondTileX, secondHorizontal.getLayoutX(), EPSILON);
+
+            vertical.resize(tileWidth, twoTileHeight);
+            vertical.requestLayout();
+            vertical.layout();
+
+            assertEquals(firstVertical.getLayoutX(), secondVertical.getLayoutX(), EPSILON);
+            assertEquals(secondTileY, secondVertical.getLayoutY(), EPSILON);
+        } finally {
+            stage.hide();
+        }
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "1.0, 1.0",
+        "1.25, 1.5",
+        "1.5, 1.5",
+        "1.75, 2.25",
+        "1.0, 1.75",
+    })
+    public void testComputedTileSizeDoesNotCeilSnappedAggregate(double scaleX, double scaleY) {
+        var child = new Region();
+        child.setPrefSize(0.1 / scaleX, 0.1 / scaleY);
+        TilePane.setMargin(child, new Insets(11 / scaleY, 1 / scaleX, 1 / scaleY, 11 / scaleX));
+
+        var tilePane = new TilePane(child);
+        tilePane.setPrefColumns(1);
+
+        Stage stage = showAtScale(scaleX, scaleY, tilePane);
+
+        try {
+            double expectedTileWidth = 13 / scaleX;
+            double expectedTileHeight = 13 / scaleY;
+
+            assertEquals(expectedTileWidth, tilePane.getTileWidth(), EPSILON);
+            assertEquals(expectedTileHeight, tilePane.getTileHeight(), EPSILON);
+            assertEquals(expectedTileWidth, tilePane.prefWidth(-1), EPSILON);
+            assertEquals(expectedTileHeight, tilePane.prefHeight(-1), EPSILON);
+        } finally {
+            stage.hide();
+        }
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "1.0, 1.0",
+        "1.25, 1.5",
+        "1.5, 1.5",
+        "1.75, 2.25",
+        "1.0, 1.75",
+    })
+    public void testBiasedChildUsesActualSnappedTileDimension(double scaleX, double scaleY) {
+        double naturalWidth = 100 / scaleX;
+        double naturalHeight = 100 / scaleY;
+        double fixedWidth = 50 / scaleX;
+        double fixedHeight = 50 / scaleY;
+        double dependentWidth = 200 / scaleX;
+        double dependentHeight = 200 / scaleY;
+
+        var horizontalChild = new MockBiased(Orientation.HORIZONTAL, naturalWidth, naturalHeight);
+        var horizontal = new TilePane(horizontalChild);
+        horizontal.setPrefColumns(1);
+        horizontal.setPrefTileWidth(fixedWidth);
+
+        var verticalChild = new MockBiased(Orientation.VERTICAL, naturalWidth, naturalHeight);
+        var vertical = new TilePane(Orientation.VERTICAL, verticalChild);
+        vertical.setPrefRows(1);
+        vertical.setPrefTileHeight(fixedHeight);
+
+        Stage stage = showAtScale(scaleX, scaleY, horizontal, vertical);
+
+        try {
+            assertEquals(fixedWidth, horizontal.getTileWidth(), EPSILON);
+            assertEquals(dependentHeight, horizontal.getTileHeight(), EPSILON);
+            assertEquals(dependentWidth, vertical.getTileWidth(), EPSILON);
+            assertEquals(fixedHeight, vertical.getTileHeight(), EPSILON);
+
+            horizontal.resize(fixedWidth, dependentHeight);
+            horizontal.requestLayout();
+            horizontal.layout();
+            assertEquals(fixedWidth, horizontalChild.getWidth(), EPSILON);
+            assertEquals(dependentHeight, horizontalChild.getHeight(), EPSILON);
+
+            vertical.resize(dependentWidth, fixedHeight);
+            vertical.requestLayout();
+            vertical.layout();
+            assertEquals(dependentWidth, verticalChild.getWidth(), EPSILON);
+            assertEquals(fixedHeight, verticalChild.getHeight(), EPSILON);
+        } finally {
+            stage.hide();
+        }
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "1.0, 1.0",
+        "1.25, 1.5",
+        "1.5, 1.5",
+        "1.75, 2.25",
+        "1.0, 1.75",
+    })
+    public void testTileSizeCacheTracksRenderScaleAndSnapPolicy(double scaleX, double scaleY) {
+        var tilePane = new TilePane();
+        tilePane.setPrefTileWidth(0.1);
+        tilePane.setPrefTileHeight(0.1);
+
+        var renderScaleX = new SimpleDoubleProperty(1);
+        var renderScaleY = new SimpleDoubleProperty(1);
+        var stage = new Stage();
+        stage.renderScaleXProperty().bind(renderScaleX);
+        stage.renderScaleYProperty().bind(renderScaleY);
+        stage.setScene(new Scene(tilePane, 100, 100));
+        stage.show();
+
+        try {
+            assertEquals(1, tilePane.tileWidthProperty().get(), EPSILON);
+            assertEquals(1, tilePane.tileHeightProperty().get(), EPSILON);
+
+            renderScaleX.set(scaleX);
+
+            assertEquals(1 / scaleX, tilePane.tileWidthProperty().get(), EPSILON);
+            assertEquals(1, tilePane.tileHeightProperty().get(), EPSILON);
+
+            renderScaleY.set(scaleY);
+
+            assertEquals(1 / scaleX, tilePane.tileWidthProperty().get(), EPSILON);
+            assertEquals(1 / scaleY, tilePane.tileHeightProperty().get(), EPSILON);
+
+            tilePane.setSnapToPixel(false);
+            assertEquals(0.1, tilePane.tileWidthProperty().get(), EPSILON);
+            assertEquals(0.1, tilePane.tileHeightProperty().get(), EPSILON);
+
+            tilePane.setSnapToPixel(true);
+            assertEquals(1 / scaleX, tilePane.tileWidthProperty().get(), EPSILON);
+            assertEquals(1 / scaleY, tilePane.tileHeightProperty().get(), EPSILON);
+        } finally {
+            stage.hide();
+        }
+    }
+
     @Test
     public void testCSSsetPrefTileWidthAndHeight_RT20388() {
         Scene scene = new Scene(tilepane);
@@ -1131,5 +1362,15 @@ public class TilePaneTest {
         } catch (Exception e) {
             fail(e.toString());
         }
+    }
+
+    private static Stage showAtScale(double scaleX, double scaleY, Node... nodes) {
+        Pane root = new Pane(nodes);
+        Stage stage = new Stage();
+        stage.renderScaleXProperty().bind(new SimpleDoubleProperty(scaleX));
+        stage.renderScaleYProperty().bind(new SimpleDoubleProperty(scaleY));
+        stage.setScene(new Scene(root, 400, 400));
+        stage.show();
+        return stage;
     }
 }

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/TilePaneTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/TilePaneTest.java
@@ -25,6 +25,7 @@
 
 package test.javafx.scene.layout;
 
+import java.util.stream.Stream;
 import javafx.beans.property.SimpleDoubleProperty;
 import javafx.css.ParsedValue;
 import javafx.css.CssMetaData;
@@ -45,11 +46,10 @@ import javafx.stage.Stage;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TilePaneTest {
 
@@ -1087,13 +1087,7 @@ public class TilePaneTest {
     }
 
     @ParameterizedTest
-    @CsvSource({
-        "1.0, 1.0",
-        "1.25, 1.5",
-        "1.5, 1.5",
-        "1.75, 2.25",
-        "1.0, 1.75",
-    })
+    @MethodSource("renderScales")
     public void testMinAndPrefSizeSnapInsetsAtRenderScale(double scaleX, double scaleY) {
         var horizontal = new TilePane(Orientation.HORIZONTAL);
         horizontal.setPadding(new Insets(9.6));
@@ -1128,13 +1122,7 @@ public class TilePaneTest {
     }
 
     @ParameterizedTest
-    @CsvSource({
-        "1.0, 1.0",
-        "1.25, 1.5",
-        "1.5, 1.5",
-        "1.75, 2.25",
-        "1.0, 1.75",
-    })
+    @MethodSource("renderScales")
     public void testExactFitDoesNotWrapAtRenderScale(double scaleX, double scaleY) {
         double tileWidth = 2 / scaleX;
         double tileHeight = 2 / scaleY;
@@ -1184,13 +1172,7 @@ public class TilePaneTest {
     }
 
     @ParameterizedTest
-    @CsvSource({
-        "1.0, 1.0",
-        "1.25, 1.5",
-        "1.5, 1.5",
-        "1.75, 2.25",
-        "1.0, 1.75",
-    })
+    @MethodSource("renderScales")
     public void testComputedTileSizeDoesNotCeilSnappedAggregate(double scaleX, double scaleY) {
         var child = new Region();
         child.setPrefSize(0.1 / scaleX, 0.1 / scaleY);
@@ -1215,13 +1197,7 @@ public class TilePaneTest {
     }
 
     @ParameterizedTest
-    @CsvSource({
-        "1.0, 1.0",
-        "1.25, 1.5",
-        "1.5, 1.5",
-        "1.75, 2.25",
-        "1.0, 1.75",
-    })
+    @MethodSource("renderScales")
     public void testBiasedChildUsesActualSnappedTileDimension(double scaleX, double scaleY) {
         double naturalWidth = 100 / scaleX;
         double naturalHeight = 100 / scaleY;
@@ -1265,13 +1241,7 @@ public class TilePaneTest {
     }
 
     @ParameterizedTest
-    @CsvSource({
-        "1.0, 1.0",
-        "1.25, 1.5",
-        "1.5, 1.5",
-        "1.75, 2.25",
-        "1.0, 1.75",
-    })
+    @MethodSource("renderScales")
     public void testTileSizeCacheTracksRenderScaleAndSnapPolicy(double scaleX, double scaleY) {
         var tilePane = new TilePane();
         tilePane.setPrefTileWidth(0.1);
@@ -1362,6 +1332,16 @@ public class TilePaneTest {
         } catch (Exception e) {
             fail(e.toString());
         }
+    }
+
+    private static Stream<Arguments> renderScales() {
+        return Stream.of(
+            Arguments.of(1.0, 1.0),
+            Arguments.of(1.25, 1.5),
+            Arguments.of(1.5, 1.5),
+            Arguments.of(1.75, 2.25),
+            Arguments.of(1.0, 1.75)
+        );
     }
 
     private static Stage showAtScale(double scaleX, double scaleY, Node... nodes) {


### PR DESCRIPTION
TilePane has the following defects:

1. Exact-fit layouts can wrap one tile too early.
2. Computed tile sizes can gain an entire unwanted pixel.
3. Minimum sizes use raw insets.
4. Content-biased children are not measured with the actual snapped tile dimension.
5. Snapped tile dimensions are cached without tracking the snapping policy or render scale.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390752](https://bugs.openjdk.org/browse/JDK-8390752): Implement correct snapping for TilePane (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2268/head:pull/2268` \
`$ git checkout pull/2268`

Update a local copy of the PR: \
`$ git checkout pull/2268` \
`$ git pull https://git.openjdk.org/jfx.git pull/2268/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2268`

View PR using the GUI difftool: \
`$ git pr show -t 2268`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2268.diff">https://git.openjdk.org/jfx/pull/2268.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2268#issuecomment-5352540648)
</details>
