### PR TITLE
8390771: Implement correct snapping for FlowPane

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/FlowPane.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/FlowPane.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -582,11 +582,10 @@ public class FlowPane extends Pane {
             for (int i=0, size=children.size(); i<size; i++) {
                 Node child = children.get(i);
                 if (child.isManaged()) {
-                    maxPref = Math.max(maxPref, child.prefWidth(-1));
+                    maxPref = Math.max(maxPref, snapSizeX(child.prefWidth(-1)));
                 }
             }
-            final Insets insets = getInsets();
-            return insets.getLeft() + snapSizeX(maxPref) + insets.getRight();
+            return snapSpaceX(snappedLeftInset() + maxPref + snappedRightInset());
         }
         return computePrefWidth(height);
     }
@@ -598,48 +597,51 @@ public class FlowPane extends Pane {
             for (int i=0, size=children.size(); i<size; i++) {
                 Node child = children.get(i);
                 if (child.isManaged()) {
-                    maxPref = Math.max(maxPref, child.prefHeight(-1));
+                    maxPref = Math.max(maxPref, snapSizeY(child.prefHeight(-1)));
                 }
             }
-            final Insets insets = getInsets();
-            return insets.getTop() + snapSizeY(maxPref) + insets.getBottom();
+            return snapSpaceY(snappedTopInset() + maxPref + snappedBottomInset());
         }
         return computePrefHeight(width);
     }
 
     @Override protected double computePrefWidth(double forHeight) {
-        final Insets insets = getInsets();
+        final double left = snappedLeftInset();
+        final double right = snappedRightInset();
         if (getOrientation() == HORIZONTAL) {
             // horizontal
-            double maxRunWidth = getPrefWrapLength();
+            double maxRunWidth = snapSizeX(getPrefWrapLength());
             List<Run> hruns = getRuns(maxRunWidth);
             double w = computeContentWidth(hruns);
-            w = getPrefWrapLength() > w ? getPrefWrapLength() : w;
-            return insets.getLeft() + snapSizeX(w) + insets.getRight();
+            w = Math.max(maxRunWidth, w);
+            return snapSpaceX(left + w + right);
         } else {
             // vertical
-            double maxRunHeight = forHeight != -1?
-                forHeight - insets.getTop() - insets.getBottom() : getPrefWrapLength();
+            double maxRunHeight = forHeight != -1
+                ? snapSpaceY(forHeight - snappedTopInset() - snappedBottomInset())
+                : snapSizeY(getPrefWrapLength());
             List<Run> vruns = getRuns(maxRunHeight);
-            return insets.getLeft() + computeContentWidth(vruns) + insets.getRight();
+            return snapSpaceX(left + computeContentWidth(vruns) + right);
         }
     }
 
     @Override protected double computePrefHeight(double forWidth) {
-        final Insets insets = getInsets();
+        final double top = snappedTopInset();
+        final double bottom = snappedBottomInset();
         if (getOrientation() == HORIZONTAL) {
             // horizontal
-            double maxRunWidth = forWidth != -1?
-                forWidth - insets.getLeft() - insets.getRight() : getPrefWrapLength();
+            double maxRunWidth = forWidth != -1
+                ? snapSpaceX(forWidth - snappedLeftInset() - snappedRightInset())
+                : snapSizeX(getPrefWrapLength());
             List<Run> hruns = getRuns(maxRunWidth);
-            return insets.getTop() + computeContentHeight(hruns) + insets.getBottom();
+            return snapSpaceY(top + computeContentHeight(hruns) + bottom);
         } else {
             // vertical
-            double maxRunHeight = getPrefWrapLength();
+            double maxRunHeight = snapSizeY(getPrefWrapLength());
             List<Run> vruns = getRuns(maxRunHeight);
             double h = computeContentHeight(vruns);
-            h = getPrefWrapLength() > h ? getPrefWrapLength() : h;
-            return insets.getTop() + snapSizeY(h) + insets.getBottom();
+            h = Math.max(maxRunHeight, h);
+            return snapSpaceY(top + h + bottom);
         }
     }
 
@@ -652,154 +654,214 @@ public class FlowPane extends Pane {
 
     private List<Run> runs = null;
     private double lastMaxRunLength = -1;
+    private double lastSnapScaleX;
+    private double lastSnapScaleY;
+    private boolean lastSnapToPixel;
     boolean computingRuns = false;
 
     private List<Run> getRuns(double maxRunLength) {
-        if (runs == null || maxRunLength != lastMaxRunLength) {
-            computingRuns = true;
-            lastMaxRunLength = maxRunLength;
-            runs = new ArrayList();
-            double runLength = 0;
-            double runOffset = 0;
-            Run run = new Run();
-            double vgap = snapSpaceY(this.getVgap());
-            double hgap = snapSpaceX(this.getHgap());
+        maxRunLength = snapMainSpace(maxRunLength);
 
-            final List<Node> children = getChildren();
-            for (int i=0, size=children.size(); i<size; i++) {
-                Node child = children.get(i);
-                if (child.isManaged()) {
-                    LayoutRect nodeRect = new LayoutRect();
-                    nodeRect.node = child;
-                    Insets margin = getMargin(child);
-                    nodeRect.width = computeChildPrefAreaWidth(child, margin);
-                    nodeRect.height = computeChildPrefAreaHeight(child, -1, margin, nodeRect.width, false);
-                    double nodeLength = getOrientation() == HORIZONTAL ? nodeRect.width : nodeRect.height;
-                    if (runLength + nodeLength > maxRunLength && runLength > 0) {
-                        // wrap to next run *unless* its the only node in the run
-                        normalizeRun(run, runOffset);
-                        if (getOrientation() == HORIZONTAL) {
-                            // horizontal
-                            runOffset += run.height + vgap;
-                        } else {
-                            // vertical
-                            runOffset += run.width + hgap;
+        boolean snapToPixel = isSnapToPixel();
+        double snapScaleX = snapToPixel ? Region.getSnapScaleX(this) : 1;
+        double snapScaleY = snapToPixel ? Region.getSnapScaleY(this) : 1;
+
+        if (runs == null || maxRunLength != lastMaxRunLength ||
+                snapToPixel != lastSnapToPixel ||
+                snapScaleX != lastSnapScaleX || snapScaleY != lastSnapScaleY) {
+            computingRuns = true;
+            try {
+                lastMaxRunLength = maxRunLength;
+                lastSnapToPixel = snapToPixel;
+                lastSnapScaleX = snapScaleX;
+                lastSnapScaleY = snapScaleY;
+                runs = new ArrayList<>();
+                double runLength = 0;
+                double runOffset = 0;
+                Run run = new Run();
+                double vgap = snapSpaceY(getVgap());
+                double hgap = snapSpaceX(getHgap());
+
+                final List<Node> children = getChildren();
+                for (int i=0, size=children.size(); i<size; i++) {
+                    Node child = children.get(i);
+                    if (child.isManaged()) {
+                        LayoutRect nodeRect = createLayoutRect(child);
+                        double nodeLength = getOrientation() == HORIZONTAL ? nodeRect.width : nodeRect.height;
+                        double gap = run.rects.isEmpty() ? 0 : getOrientation() == HORIZONTAL ? hgap : vgap;
+                        double candidateLength = snapMainSpace(runLength + gap + nodeLength);
+
+                        if (candidateLength > maxRunLength && !run.rects.isEmpty()) {
+                            // wrap to next run unless this is the only node in the run
+                            normalizeRun(run, runOffset, runLength);
+                            if (getOrientation() == HORIZONTAL) {
+                                runOffset = snapPositionY(runOffset + run.height + vgap);
+                            } else {
+                                runOffset = snapPositionX(runOffset + run.width + hgap);
+                            }
+                            runs.add(run);
+                            runLength = 0;
+                            run = new Run();
+                            gap = 0;
+                            candidateLength = snapMainSpace(nodeLength);
                         }
-                        runs.add(run);
-                        runLength = 0;
-                        run = new Run();
+
+                        if (getOrientation() == HORIZONTAL) {
+                            nodeRect.x = snapPositionX(runLength + gap);
+                        } else {
+                            nodeRect.y = snapPositionY(runLength + gap);
+                        }
+
+                        runLength = candidateLength;
+                        run.rects.add(nodeRect);
                     }
-                    if (getOrientation() == HORIZONTAL) {
-                        // horizontal
-                        nodeRect.x = runLength;
-                        runLength += nodeRect.width + hgap;
-                    } else {
-                        // vertical
-                        nodeRect.y = runLength;
-                        runLength += nodeRect.height + vgap;
-                    }
-                    run.rects.add(nodeRect);
                 }
 
+                // insert last run
+                normalizeRun(run, runOffset, runLength);
+                runs.add(run);
+            } catch (RuntimeException | Error ex) {
+                runs = null;
+                throw ex;
+            } finally {
+                computingRuns = false;
             }
-            // insert last run
-            normalizeRun(run, runOffset);
-            runs.add(run);
-            computingRuns = false;
         }
         return runs;
     }
 
-    private void normalizeRun(final Run run, double runOffset) {
+    private LayoutRect createLayoutRect(Node child) {
+        LayoutRect rect = new LayoutRect();
+        rect.node = child;
+
+        Orientation bias = child.getContentBias();
+        double contentWidth;
+        double contentHeight;
+
+        if (bias == VERTICAL) {
+            contentHeight = computeChildPrefContentHeight(child, -1);
+            contentWidth = computeChildPrefContentWidth(child, contentHeight);
+        } else {
+            contentWidth = computeChildPrefContentWidth(child, -1);
+            contentHeight = computeChildPrefContentHeight(child, bias == HORIZONTAL ? contentWidth : -1);
+        }
+
+        Insets margin = getMargin(child);
+        double top = margin != null ? snapSpaceY(margin.getTop()) : 0;
+        double right = margin != null ? snapSpaceX(margin.getRight()) : 0;
+        double bottom = margin != null ? snapSpaceY(margin.getBottom()) : 0;
+        double left = margin != null ? snapSpaceX(margin.getLeft()) : 0;
+        rect.width = snapSpaceX(left + contentWidth + right);
+        rect.height = snapSpaceY(top + contentHeight + bottom);
+        return rect;
+    }
+
+    private double computeChildPrefContentWidth(Node child, double height) {
+        return snapSizeX(boundedSize(child.minWidth(height), child.prefWidth(height), child.maxWidth(height)));
+    }
+
+    private double computeChildPrefContentHeight(Node child, double width) {
+        return snapSizeY(boundedSize(child.minHeight(width), child.prefHeight(width), child.maxHeight(width)));
+    }
+
+    private double snapMainSpace(double value) {
+        return getOrientation() == HORIZONTAL ? snapSpaceX(value) : snapSpaceY(value);
+    }
+
+    private void normalizeRun(final Run run, double runOffset, double runLength) {
         if (getOrientation() == HORIZONTAL) {
             // horizontal
-            ArrayList<Node> rownodes = new ArrayList();
-            run.width = (run.rects.size()-1)*snapSpaceX(getHgap());
+            ArrayList<Node> rownodes = new ArrayList<>();
+            run.width = snapSpaceX(runLength);
+            double maxHeight = 0;
             for (int i=0, max=run.rects.size(); i<max; i++) {
                 LayoutRect lrect = run.rects.get(i);
                 rownodes.add(lrect.node);
-                run.width += lrect.width;
-                lrect.y = runOffset;
+                maxHeight = Math.max(maxHeight, lrect.height);
+                lrect.y = snapPositionY(runOffset);
             }
-            run.height = computeMaxPrefAreaHeight(rownodes, marginAccessor, run.width, false, getRowValignment());
-            run.baselineOffset = getRowValignment() == VPos.BASELINE?
+
+            VPos rowValignment = getRowValignmentInternal();
+            run.height = rowValignment == VPos.BASELINE ?
+                    snapSpaceY(computeMaxPrefAreaHeight(rownodes, marginAccessor, run.width, false, rowValignment)) :
+                    snapSpaceY(maxHeight);
+            run.baselineOffset = rowValignment == VPos.BASELINE?
                     getAreaBaselineOffset(rownodes, marginAccessor, i -> run.rects.get(i).width, run.height, true) : 0;
 
         } else {
             // vertical
-            run.height = (run.rects.size()-1)*snapSpaceY(getVgap());
+            run.height = snapSpaceY(runLength);
             double maxw = 0;
             for (int i=0, max=run.rects.size(); i<max; i++) {
                 LayoutRect lrect = run.rects.get(i);
-                run.height += lrect.height;
-                lrect.x = runOffset;
+                lrect.x = snapPositionX(runOffset);
                 maxw = Math.max(maxw, lrect.width);
             }
 
-            run.width = maxw;
+            run.width = snapSpaceX(maxw);
             run.baselineOffset = run.height;
         }
     }
 
     private double computeContentWidth(List<Run> runs) {
-        double cwidth = getOrientation() == HORIZONTAL ? 0 : (runs.size()-1)*snapSpaceX(getHgap());
+        double cwidth = 0;
+        double hgap = snapSpaceX(getHgap());
         for (int i=0, max=runs.size(); i<max; i++) {
             Run run = runs.get(i);
             if (getOrientation() == HORIZONTAL) {
                 cwidth = Math.max(cwidth, run.width);
             } else {
                 // vertical
-                cwidth += run.width;
+                cwidth = snapSpaceX(cwidth + (i == 0 ? 0 : hgap) + run.width);
             }
         }
-        return cwidth;
+        return snapSpaceX(cwidth);
     }
 
     private double computeContentHeight(List<Run> runs) {
-        double cheight = getOrientation() == VERTICAL ? 0 : (runs.size()-1)*snapSpaceY(getVgap());
+        double cheight = 0;
+        double vgap = snapSpaceY(getVgap());
         for (int i=0, max=runs.size(); i<max; i++) {
             Run run = runs.get(i);
             if (getOrientation() == VERTICAL) {
                 cheight = Math.max(cheight, run.height);
             } else {
                 // horizontal
-                cheight += run.height;
+                cheight = snapSpaceY(cheight + (i == 0 ? 0 : vgap) + run.height);
             }
         }
-        return cheight;
+        return snapSpaceY(cheight);
     }
 
     @Override protected void layoutChildren() {
-        final Insets insets = getInsets();
-        final double width = getWidth();
-        final double height = getHeight();
-        final double top = insets.getTop();
-        final double left = insets.getLeft();
-        final double bottom = insets.getBottom();
-        final double right = insets.getRight();
-        final double insideWidth = width - left - right;
-        final double insideHeight = height - top - bottom;
+        final double top = snappedTopInset();
+        final double left = snappedLeftInset();
+        final double bottom = snappedBottomInset();
+        final double right = snappedRightInset();
+        final double insideWidth = snapSpaceX(getWidth() - left - right);
+        final double insideHeight = snapSpaceY(getHeight() - top - bottom);
 
         //REMIND(aim): need to figure out how to cache the runs to avoid over-calculation
         final List<Run> runs = getRuns(getOrientation() == HORIZONTAL ? insideWidth : insideHeight);
+        final double contentWidth = computeContentWidth(runs);
+        final double contentHeight = computeContentHeight(runs);
 
         // Now that the nodes are broken into runs, figure out alignments
         for (int i=0, max=runs.size(); i<max; i++) {
             final Run run = runs.get(i);
-            final double xoffset = left + computeXOffset(insideWidth,
-                                     getOrientation() == HORIZONTAL ? run.width : computeContentWidth(runs),
-                                     getAlignmentInternal().getHpos());
-            final double yoffset = top + computeYOffset(insideHeight,
-                                    getOrientation() == VERTICAL ? run.height : computeContentHeight(runs),
-                                    getAlignmentInternal().getVpos());
+            final double xoffset = snapPositionX(left + computeXOffset(insideWidth,
+                                     getOrientation() == HORIZONTAL ? run.width : contentWidth,
+                                     getAlignmentInternal().getHpos()));
+            final double yoffset = snapPositionY(top + computeYOffset(insideHeight,
+                                    getOrientation() == VERTICAL ? run.height : contentHeight,
+                                    getAlignmentInternal().getVpos()));
             for (int j = 0; j < run.rects.size(); j++) {
                 final LayoutRect lrect = run.rects.get(j);
-//              System.out.println("flowpane.layout: run="+i+" "+run.width+"x"+run.height+" xoffset="+xoffset+" yoffset="+yoffset+" lrect="+lrect);
-                final double x = xoffset + lrect.x;
-                final double y = yoffset + lrect.y;
+                final double x = snapPositionX(xoffset + lrect.x);
+                final double y = snapPositionY(yoffset + lrect.y);
                 layoutInArea(lrect.node, x, y,
-                           getOrientation() == HORIZONTAL? lrect.width : run.width,
-                           getOrientation() == VERTICAL? lrect.height : run.height,
+                           snapSpaceX(getOrientation() == HORIZONTAL? lrect.width : run.width),
+                           snapSpaceY(getOrientation() == VERTICAL? lrect.height : run.height),
                            run.baselineOffset, getMargin(lrect.node),
                            getColumnHalignmentInternal(), getRowValignmentInternal());
             }

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/FlowPaneTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/FlowPaneTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package test.javafx.scene.layout;
 
+import java.util.stream.Stream;
 import javafx.geometry.HPos;
 import javafx.geometry.Insets;
 import javafx.geometry.Orientation;
@@ -32,22 +33,39 @@ import javafx.geometry.Pos;
 import javafx.geometry.VPos;
 import javafx.scene.Node;
 import javafx.scene.ParentShim;
+import javafx.scene.Scene;
 import javafx.scene.layout.FlowPane;
+import javafx.scene.layout.Pane;
+import javafx.scene.layout.Region;
 import javafx.scene.shape.Rectangle;
 import javafx.scene.text.Text;
 import javafx.scene.text.TextFlow;
+import javafx.stage.Stage;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
+import static org.junit.jupiter.api.Assertions.*;
 
 public class FlowPaneTest {
+
+    private static final double EPSILON = 0.000001;
+
     FlowPane flowpane;
+    Stage stage;
 
     @BeforeEach public void setUp() {
         this.flowpane = new FlowPane();
+    }
+
+    @AfterEach public void tearDown() {
+        if (stage != null) {
+            stage.hide();
+        }
     }
 
     @Test public void testFlowPaneDefaults() {
@@ -996,6 +1014,288 @@ public class FlowPaneTest {
             """,
             flowpane
         );
+    }
+
+    @ParameterizedTest
+    @MethodSource("renderScales")
+    void shouldSnapInsetsBeforeMeasuringAndWrapping(double scaleX, double scaleY) {
+        double pixelX = 1 / scaleX;
+        double pixelY = 1 / scaleY;
+        var subpixelInsets = new Insets(0.4 / scaleY, 0.4 / scaleX, 0.4 / scaleY, 0.4 / scaleX);
+
+        var h1 = new MockResizable(pixelX, pixelY);
+        var h2 = new MockResizable(pixelX, pixelY);
+        var horizontal = new FlowPane(h1, h2);
+        horizontal.setPadding(subpixelInsets);
+        horizontal.setPrefWrapLength(pixelX);
+
+        var v1 = new MockResizable(pixelX, pixelY);
+        var v2 = new MockResizable(pixelX, pixelY);
+        var vertical = new FlowPane(Orientation.VERTICAL, v1, v2);
+        vertical.setPadding(subpixelInsets);
+        vertical.setPrefWrapLength(pixelY);
+
+        attachToStage(scaleX, scaleY, horizontal, vertical);
+
+        assertEquals(pixelX, horizontal.minWidth(-1), EPSILON);
+        assertEquals(pixelX, horizontal.prefWidth(-1), EPSILON);
+        assertEquals(pixelY, vertical.minHeight(-1), EPSILON);
+        assertEquals(pixelY, vertical.prefHeight(-1), EPSILON);
+
+        horizontal.resize(2 * pixelX, 2 * pixelY);
+        horizontal.layout();
+        assertEquals(pixelX, h2.getLayoutX(), EPSILON);
+        assertEquals(0, h2.getLayoutY(), EPSILON);
+
+        vertical.resize(2 * pixelX, 2 * pixelY);
+        vertical.layout();
+        assertEquals(0, v2.getLayoutX(), EPSILON);
+        assertEquals(pixelY, v2.getLayoutY(), EPSILON);
+    }
+
+    @ParameterizedTest
+    @MethodSource("renderScales")
+    void shouldUseSnappedWrapLengthForMeasurementAndLayout(double scaleX, double scaleY) {
+        double pixelX = 1 / scaleX;
+        double pixelY = 1 / scaleY;
+
+        var h1 = new MockResizable(pixelX, pixelY);
+        var h2 = new MockResizable(pixelX, pixelY);
+        var horizontal = new FlowPane(h1, h2);
+        horizontal.setPrefWrapLength(1.6 / scaleX);
+
+        var v1 = new MockResizable(pixelX, pixelY);
+        var v2 = new MockResizable(pixelX, pixelY);
+        var vertical = new FlowPane(Orientation.VERTICAL, v1, v2);
+        vertical.setPrefWrapLength(1.6 / scaleY);
+
+        attachToStage(scaleX, scaleY, horizontal, vertical);
+
+        assertEquals(2 * pixelX, horizontal.prefWidth(-1), EPSILON);
+        assertEquals(pixelY, horizontal.prefHeight(-1), EPSILON);
+        horizontal.resize(1.6 / scaleX, pixelY);
+        horizontal.layout();
+        assertEquals(0, h2.getLayoutY(), EPSILON);
+
+        assertEquals(pixelX, vertical.prefWidth(-1), EPSILON);
+        assertEquals(2 * pixelY, vertical.prefHeight(-1), EPSILON);
+        vertical.resize(pixelX, 1.6 / scaleY);
+        vertical.layout();
+        assertEquals(0, v2.getLayoutX(), EPSILON);
+    }
+
+    @ParameterizedTest
+    @MethodSource("renderScales")
+    void shouldResnapCumulativeRunLengths(double scaleX, double scaleY) {
+        int childCount = 34;
+        double pixelX = 1 / scaleX;
+        double pixelY = 1 / scaleY;
+        var horizontal = new FlowPane();
+        var vertical = new FlowPane(Orientation.VERTICAL);
+
+        for (int i = 0; i < childCount; i++) {
+            horizontal.getChildren().add(new MockResizable(pixelX, pixelY));
+            vertical.getChildren().add(new MockResizable(pixelX, pixelY));
+        }
+
+        horizontal.setPrefWrapLength(childCount * pixelX);
+        vertical.setPrefWrapLength(childCount * pixelY);
+        attachToStage(scaleX, scaleY, horizontal, vertical);
+
+        assertEquals(pixelY, horizontal.prefHeight(-1), EPSILON);
+        horizontal.resize(childCount * pixelX, pixelY);
+        horizontal.layout();
+        assertEquals(0, horizontal.getChildren().get(childCount - 1).getLayoutY(), EPSILON);
+
+        assertEquals(pixelX, vertical.prefWidth(-1), EPSILON);
+        vertical.resize(pixelX, childCount * pixelY);
+        vertical.layout();
+        assertEquals(0, vertical.getChildren().get(childCount - 1).getLayoutX(), EPSILON);
+    }
+
+    @ParameterizedTest
+    @MethodSource("renderScales")
+    void shouldResnapChildAreaAfterAddingMargins(double scaleX, double scaleY) {
+        double contentWidth = 1 / scaleX;
+        double contentHeight = 1 / scaleY;
+        double marginX = 4 / scaleX;
+        double marginY = 4 / scaleY;
+        var child = new MockResizable(contentWidth, contentHeight);
+        var pane = new FlowPane(child);
+        pane.setPrefWrapLength(0);
+        FlowPane.setMargin(child, new Insets(0, marginX, marginY, 0));
+
+        attachToStage(scaleX, scaleY, pane);
+
+        double expectedWidth = 5 / scaleX;
+        double expectedHeight = 5 / scaleY;
+        assertEquals(expectedWidth, pane.prefWidth(-1), EPSILON);
+        assertEquals(expectedHeight, pane.prefHeight(-1), EPSILON);
+
+        pane.resize(expectedWidth, expectedHeight);
+        pane.layout();
+        assertEquals(0, child.getLayoutX(), EPSILON);
+        assertEquals(0, child.getLayoutY(), EPSILON);
+        assertEquals(contentWidth, child.getWidth(), EPSILON);
+        assertEquals(contentHeight, child.getHeight(), EPSILON);
+    }
+
+    @ParameterizedTest
+    @MethodSource("renderScales")
+    void shouldMeasureBiasedChildrenUsingSnappedDependentDimension(double scaleX, double scaleY) {
+        AreaBiasedRegion horizontalChild = new AreaBiasedRegion(Orientation.HORIZONTAL, 1.2 / scaleX, 10 / scaleY);
+        FlowPane horizontalPane = new FlowPane(horizontalChild);
+        horizontalPane.setPrefWrapLength(0);
+
+        AreaBiasedRegion verticalChild = new AreaBiasedRegion(Orientation.VERTICAL, 10 / scaleX, 1.2 / scaleY);
+        FlowPane verticalPane = new FlowPane(verticalChild);
+        verticalPane.setPrefWrapLength(0);
+
+        attachToStage(scaleX, scaleY, horizontalPane, verticalPane);
+
+        double horizontalWidth = horizontalPane.snapSizeX(horizontalChild.prefWidth(-1));
+        double horizontalHeight = horizontalPane.snapSizeY(horizontalChild.prefHeight(horizontalWidth));
+        assertEquals(horizontalWidth, horizontalPane.prefWidth(-1), EPSILON);
+        assertEquals(horizontalHeight, horizontalPane.prefHeight(-1), EPSILON);
+        horizontalPane.resize(horizontalWidth, horizontalHeight);
+        horizontalPane.layout();
+        assertEquals(horizontalWidth, horizontalChild.getWidth(), EPSILON);
+        assertEquals(horizontalHeight, horizontalChild.getHeight(), EPSILON);
+
+        double verticalHeight = verticalPane.snapSizeY(verticalChild.prefHeight(-1));
+        double verticalWidth = verticalPane.snapSizeX(verticalChild.prefWidth(verticalHeight));
+        assertEquals(verticalWidth, verticalPane.prefWidth(-1), EPSILON);
+        assertEquals(verticalHeight, verticalPane.prefHeight(-1), EPSILON);
+        verticalPane.resize(verticalWidth, verticalHeight);
+        verticalPane.layout();
+        assertEquals(verticalWidth, verticalChild.getWidth(), EPSILON);
+        assertEquals(verticalHeight, verticalChild.getHeight(), EPSILON);
+    }
+
+    @ParameterizedTest
+    @MethodSource("renderScales")
+    void shouldInvalidateRunCacheWhenSnapPolicyChanges(double scaleX, double scaleY) {
+        double rawWidth = 0.4 / scaleX;
+        double rawHeight = 0.4 / scaleY;
+        MockResizable verticalChild = new MockResizable(rawWidth, 10 / scaleY);
+        FlowPane vertical = new FlowPane(Orientation.VERTICAL, verticalChild);
+        vertical.setPrefWrapLength(10 / scaleY);
+        MockResizable horizontalChild = new MockResizable(10 / scaleX, rawHeight);
+        FlowPane horizontal = new FlowPane(horizontalChild);
+        horizontal.setPrefWrapLength(10 / scaleX);
+
+        attachToStage(scaleX, scaleY, vertical, horizontal);
+
+        double availableHeight = 10 / scaleY;
+        double availableWidth = 10 / scaleX;
+        assertNotEquals(rawWidth, vertical.prefWidth(availableHeight), EPSILON);
+        assertNotEquals(rawHeight, horizontal.prefHeight(availableWidth), EPSILON);
+
+        vertical.setSnapToPixel(false);
+        horizontal.setSnapToPixel(false);
+        assertEquals(rawWidth, vertical.prefWidth(availableHeight), EPSILON);
+        assertEquals(rawHeight, horizontal.prefHeight(availableWidth), EPSILON);
+    }
+
+    @ParameterizedTest
+    @MethodSource("renderScaleChanges")
+    void shouldInvalidateRunCacheWhenRenderScalesChange(double initialScaleX, double initialScaleY,
+                                                        double newScaleX, double newScaleY) {
+        double rawSize = 0.41;
+        MockResizable verticalChild = new MockResizable(rawSize, 100);
+        FlowPane vertical = new FlowPane(Orientation.VERTICAL, verticalChild);
+        vertical.setPrefWrapLength(100);
+        MockResizable horizontalChild = new MockResizable(100, rawSize);
+        FlowPane horizontal = new FlowPane(horizontalChild);
+        horizontal.setPrefWrapLength(100);
+
+        attachToStage(initialScaleX, initialScaleY, vertical, horizontal);
+
+        double initialWidth = vertical.snapSizeX(rawSize);
+        double initialHeight = horizontal.snapSizeY(rawSize);
+        assertEquals(initialWidth, vertical.prefWidth(100), EPSILON);
+        assertEquals(initialHeight, horizontal.prefHeight(100), EPSILON);
+
+        stage.setRenderScaleX(newScaleX);
+        stage.setRenderScaleY(newScaleY);
+        double newWidth = vertical.snapSizeX(rawSize);
+        double newHeight = horizontal.snapSizeY(rawSize);
+        assertNotEquals(initialWidth, newWidth, EPSILON);
+        assertNotEquals(initialHeight, newHeight, EPSILON);
+        assertEquals(newWidth, vertical.prefWidth(100), EPSILON);
+        assertEquals(newHeight, horizontal.prefHeight(100), EPSILON);
+    }
+
+    static Stream<Arguments> renderScales() {
+        return Stream.of(
+            Arguments.of(1.0, 1.0),
+            Arguments.of(1.25, 1.25),
+            Arguments.of(1.5, 1.5),
+            Arguments.of(1.75, 1.75),
+            Arguments.of(2.0, 2.0),
+            Arguments.of(1.25, 1.75),
+            Arguments.of(1.5, 2.0),
+            Arguments.of(2.0, 1.25));
+    }
+
+    static Stream<Arguments> renderScaleChanges() {
+        return Stream.of(
+            Arguments.of(1.0, 1.0, 1.5, 2.0),
+            Arguments.of(1.25, 1.75, 2.0, 1.5),
+            Arguments.of(1.5, 2.0, 1.25, 1.75),
+            Arguments.of(2.0, 1.25, 1.75, 2.0));
+    }
+
+    private void attachToStage(double scaleX, double scaleY, Node... nodes) {
+        Pane root = new Pane(nodes);
+        stage = new Stage();
+        stage.setRenderScaleX(scaleX);
+        stage.setRenderScaleY(scaleY);
+        stage.setScene(new Scene(root));
+    }
+
+    private static final class AreaBiasedRegion extends Region {
+        private final Orientation bias;
+        private final double prefWidth;
+        private final double prefHeight;
+        private final double area;
+
+        AreaBiasedRegion(Orientation bias, double prefWidth, double prefHeight) {
+            this.bias = bias;
+            this.prefWidth = prefWidth;
+            this.prefHeight = prefHeight;
+            this.area = prefWidth * prefHeight;
+        }
+
+        @Override public Orientation getContentBias() {
+            return bias;
+        }
+
+        @Override protected double computeMinWidth(double height) {
+            return 0;
+        }
+
+        @Override protected double computeMinHeight(double width) {
+            return 0;
+        }
+
+        @Override protected double computePrefWidth(double height) {
+            return bias == Orientation.HORIZONTAL ? prefWidth :
+                    area / (height == -1 ? prefHeight : height);
+        }
+
+        @Override protected double computePrefHeight(double width) {
+            return bias == Orientation.VERTICAL ? prefHeight :
+                    area / (width == -1 ? prefWidth : width);
+        }
+
+        @Override protected double computeMaxWidth(double height) {
+            return Double.MAX_VALUE;
+        }
+
+        @Override protected double computeMaxHeight(double width) {
+            return Double.MAX_VALUE;
+        }
     }
 
     private static TextFlow createTextFlow() {


### PR DESCRIPTION
FlowPane has the following defects:

1. Raw insets are used for measurement and layout.
2. Snapped allocations are not re-snapped after arithmetic.
3. The preferred-size methods sometimes apply `snapSizeX/Y` to an already composed run span.
4. `prefWrapLength`, supplied widths/heights, and the pane’s own allocated width/height are used raw when deciding where to wrap.
5. Content bias is only partially handled.
6. The cached runs contain snapped sizes and gaps, but the cache key records only `maxRunLength`; it does not include `isSnapToPixel` or the X/Y render scales.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390771](https://bugs.openjdk.org/browse/JDK-8390771): Implement correct snapping for FlowPane (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2269/head:pull/2269` \
`$ git checkout pull/2269`

Update a local copy of the PR: \
`$ git checkout pull/2269` \
`$ git pull https://git.openjdk.org/jfx.git pull/2269/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2269`

View PR using the GUI difftool: \
`$ git pr show -t 2269`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2269.diff">https://git.openjdk.org/jfx/pull/2269.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2269#issuecomment-5356364248)
</details>
