### PR TITLE
8390773: Mark deprecated snap methods for removal

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/Region.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/Region.java
@@ -1688,7 +1688,7 @@ public class Region extends Parent {
      * @return value rounded to nearest pixel
      * @deprecated replaced by {@code snapSpaceX()} and {@code snapSpaceY()}
      */
-    @Deprecated(since="9")
+    @Deprecated(since = "9", forRemoval = true)
     protected double snapSpace(double value) {
         return snapSpaceX(value, isSnapToPixel());
     }
@@ -1727,7 +1727,7 @@ public class Region extends Parent {
      * @return value ceiled to nearest pixel
      * @deprecated replaced by {@code snapSizeX()} and {@code snapSizeY()}
      */
-    @Deprecated(since="9")
+    @Deprecated(since = "9", forRemoval = true)
     protected double snapSize(double value) {
         return snapSizeX(value, isSnapToPixel());
     }
@@ -1766,7 +1766,7 @@ public class Region extends Parent {
      * @return value rounded to nearest pixel
      * @deprecated replaced by {@code snapPositionX()} and {@code snapPositionY()}
      */
-    @Deprecated(since="9")
+    @Deprecated(since = "9", forRemoval = true)
     protected double snapPosition(double value) {
         return snapPositionX(value, isSnapToPixel());
     }


### PR DESCRIPTION
As commented in the pixel snapping documentation PR: https://github.com/openjdk/jfx/pull/2260#discussion_r3813067929, we should finally mark the axis-unaware snapping methods `forRemoval = true`.
This will finally allow us to remove these methods in a future release.

/csr

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change requires CSR request [JDK-8390815](https://bugs.openjdk.org/browse/JDK-8390815) to be approved
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issues
 * [JDK-8390773](https://bugs.openjdk.org/browse/JDK-8390773): Mark deprecated snap methods for removal (**Bug** - P4)
 * [JDK-8390815](https://bugs.openjdk.org/browse/JDK-8390815): Mark deprecated snap methods for removal (**CSR**)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2270/head:pull/2270` \
`$ git checkout pull/2270`

Update a local copy of the PR: \
`$ git checkout pull/2270` \
`$ git pull https://git.openjdk.org/jfx.git pull/2270/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2270`

View PR using the GUI difftool: \
`$ git pr show -t 2270`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2270.diff">https://git.openjdk.org/jfx/pull/2270.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2270#issuecomment-5356749436)
</details>
