### PR TITLE
8390873: CSS BinarySerializer writes set of pseudo-classes in arbitrary order

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/css/BinarySerializer.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/css/BinarySerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,20 +25,20 @@
 
 package com.sun.javafx.css;
 
+import static javafx.geometry.NodeOrientation.LEFT_TO_RIGHT;
+import static javafx.geometry.NodeOrientation.RIGHT_TO_LEFT;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
-
+import java.util.TreeSet;
 import javafx.css.PseudoClass;
 import javafx.css.Selector;
 import javafx.css.StyleConverter;
 import javafx.geometry.NodeOrientation;
-
-import static javafx.geometry.NodeOrientation.LEFT_TO_RIGHT;
-import static javafx.geometry.NodeOrientation.RIGHT_TO_LEFT;
 
 /**
  * Class which can read and write selectors in a binary format.
@@ -46,6 +46,7 @@ import static javafx.geometry.NodeOrientation.RIGHT_TO_LEFT;
 public class BinarySerializer {
     private static final int TYPE_SIMPLE = 1;
     private static final int TYPE_COMPOUND = 2;
+    private static final Comparator<PseudoClass> PSEUDO_CLASS_COMPARATOR = initPseudoClassComparator();
 
     public static Selector read(DataInputStream is, String[] strings) throws IOException {
         int type = is.readByte();
@@ -169,6 +170,11 @@ public class BinarySerializer {
         os.writeShort(stringStore.addString(selector.getId()));
 
         Set<PseudoClass> pseudoClassStates = selector.getPseudoClassStates();
+        if (!pseudoClassStates.isEmpty()) {
+            Set<PseudoClass> sorted = new TreeSet<>(PSEUDO_CLASS_COMPARATOR);
+            sorted.addAll(pseudoClassStates);
+            pseudoClassStates = sorted;
+        }
         NodeOrientation nodeOrientation = selector.getNodeOrientation();
 
         int pclassSize = pseudoClassStates.size()
@@ -186,5 +192,14 @@ public class BinarySerializer {
         else if (nodeOrientation == LEFT_TO_RIGHT) {
             os.writeShort(stringStore.addString("dir(ltr)"));
         }
+    }
+
+    private static Comparator<PseudoClass> initPseudoClassComparator() {
+        return new Comparator<PseudoClass>() {
+            @Override
+            public int compare(PseudoClass a, PseudoClass b) {
+                return a.getPseudoClassName().compareTo(b.getPseudoClassName());
+            }
+        };
     }
 }

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/css/BinarySerializer.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/css/BinarySerializer.java
@@ -170,7 +170,7 @@ public class BinarySerializer {
         os.writeShort(stringStore.addString(selector.getId()));
 
         Set<PseudoClass> pseudoClassStates = selector.getPseudoClassStates();
-        if (!pseudoClassStates.isEmpty()) {
+        if (pseudoClassStates.size() > 1) {
             Set<PseudoClass> sorted = new TreeSet<>(PSEUDO_CLASS_COMPARATOR);
             sorted.addAll(pseudoClassStates);
             pseudoClassStates = sorted;

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/css/BinarySerializer.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/css/BinarySerializer.java
@@ -45,7 +45,9 @@ import javafx.geometry.NodeOrientation;
 public class BinarySerializer {
     private static final int TYPE_SIMPLE = 1;
     private static final int TYPE_COMPOUND = 2;
-    private static final Comparator<PseudoClass> PSEUDO_CLASS_COMPARATOR = initPseudoClassComparator();
+    private static final Comparator<PseudoClass> PSEUDO_CLASS_COMPARATOR = (a, b) -> {
+        return a.getPseudoClassName().compareTo(b.getPseudoClassName());
+    };
 
     public static Selector read(DataInputStream is, String[] strings) throws IOException {
         int type = is.readByte();
@@ -191,14 +193,5 @@ public class BinarySerializer {
         else if (nodeOrientation == LEFT_TO_RIGHT) {
             os.writeShort(stringStore.addString("dir(ltr)"));
         }
-    }
-
-    private static Comparator<PseudoClass> initPseudoClassComparator() {
-        return new Comparator<PseudoClass>() {
-            @Override
-            public int compare(PseudoClass a, PseudoClass b) {
-                return a.getPseudoClassName().compareTo(b.getPseudoClassName());
-            }
-        };
     }
 }

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/css/BinarySerializer.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/css/BinarySerializer.java
@@ -31,10 +31,9 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Set;
-import java.util.TreeSet;
 import javafx.css.PseudoClass;
 import javafx.css.Selector;
 import javafx.css.StyleConverter;
@@ -169,10 +168,10 @@ public class BinarySerializer {
 
         os.writeShort(stringStore.addString(selector.getId()));
 
-        Set<PseudoClass> pseudoClassStates = selector.getPseudoClassStates();
+        Collection<PseudoClass> pseudoClassStates = selector.getPseudoClassStates();
         if (pseudoClassStates.size() > 1) {
-            Set<PseudoClass> sorted = new TreeSet<>(PSEUDO_CLASS_COMPARATOR);
-            sorted.addAll(pseudoClassStates);
+            ArrayList<PseudoClass> sorted = new ArrayList<>(pseudoClassStates);
+            sorted.sort(PSEUDO_CLASS_COMPARATOR);
             pseudoClassStates = sorted;
         }
         NodeOrientation nodeOrientation = selector.getNodeOrientation();

--- a/modules/javafx.graphics/src/test/java/test/javafx/css/StylesheetTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/css/StylesheetTest.java
@@ -25,17 +25,12 @@
 
 package test.javafx.css;
 
-import com.sun.javafx.css.RuleHelper;
-import com.sun.javafx.css.SimpleSelector;
-import com.sun.javafx.css.StyleManager;
-import com.sun.javafx.css.media.MediaFeaturesShim;
-import com.sun.javafx.css.media.TriState;
-import com.sun.javafx.css.media.expression.FunctionExpression;
-import javafx.application.ColorScheme;
-import javafx.css.StyleConverter.StringStore;
-import javafx.css.converter.EnumConverter;
-import javafx.css.converter.StringConverter;
-
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
@@ -46,10 +41,12 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+import javafx.application.ColorScheme;
 import javafx.css.CssParser;
 import javafx.css.CssParserShim;
 import javafx.css.Declaration;
@@ -58,11 +55,13 @@ import javafx.css.Rule;
 import javafx.css.RuleShim;
 import javafx.css.Selector;
 import javafx.css.StyleConverter;
+import javafx.css.StyleConverter.StringStore;
 import javafx.css.StyleOrigin;
 import javafx.css.StyleableProperty;
 import javafx.css.Stylesheet;
 import javafx.css.StylesheetShim;
-
+import javafx.css.converter.EnumConverter;
+import javafx.css.converter.StringConverter;
 import javafx.geometry.NodeOrientation;
 import javafx.geometry.Orientation;
 import javafx.geometry.Pos;
@@ -79,9 +78,14 @@ import javafx.scene.text.Font;
 import javafx.scene.text.FontSmoothingType;
 import javafx.scene.text.TextAlignment;
 import javafx.stage.Stage;
-
 import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assertions.*;
+import com.sun.javafx.css.BinarySerializer;
+import com.sun.javafx.css.RuleHelper;
+import com.sun.javafx.css.SimpleSelector;
+import com.sun.javafx.css.StyleManager;
+import com.sun.javafx.css.media.MediaFeaturesShim;
+import com.sun.javafx.css.media.TriState;
+import com.sun.javafx.css.media.expression.FunctionExpression;
 
 public class StylesheetTest {
 
@@ -864,5 +868,35 @@ public class StylesheetTest {
         } finally {
             MediaFeaturesShim.setDefault(oldDefault);
         }
+    }
+
+    @Test
+    public void testSortedPseudoClasses() throws Exception {
+        String name = "yo";
+        List<String> styleClasses = List.of("test", "TEST");
+        List<String> pseudoClasses = List.of(
+            "z",
+            "a",
+            "d",
+            "b",
+            "x",
+            "gggg",
+            "uu",
+            "zzz"
+            );
+        String id = "id";
+        Selector selector = new SimpleSelector(name, styleClasses, pseudoClasses, id);
+
+        StringStore store = new StringStore();
+        DataOutputStream out = new DataOutputStream(new ByteArrayOutputStream());
+        BinarySerializer.write(selector, out, store);
+
+        ArrayList<String> expected = new ArrayList();
+        expected.add(name);
+        expected.addAll(styleClasses);
+        expected.add(id);
+        expected.addAll(pseudoClasses.stream().sorted().toList());
+
+        assertEquals(expected, store.strings);
     }
 }

--- a/modules/javafx.graphics/src/test/java/test/javafx/css/StylesheetTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/css/StylesheetTest.java
@@ -891,7 +891,7 @@ public class StylesheetTest {
         DataOutputStream out = new DataOutputStream(new ByteArrayOutputStream());
         BinarySerializer.write(selector, out, store);
 
-        ArrayList<String> expected = new ArrayList();
+        ArrayList<String> expected = new ArrayList<>();
         expected.add(name);
         expected.addAll(styleClasses);
         expected.add(id);


### PR DESCRIPTION
Changes the `BinarySerializer.writeSimpleSelector` to emit sorted pseudoclasses' names.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390873](https://bugs.openjdk.org/browse/JDK-8390873): CSS BinarySerializer writes set of pseudo-classes in arbitrary order (**Bug** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Michael Strauß](https://openjdk.org/census#mstrauss) (@mstr2 - **Reviewer**)
 * [Marius Hanl](https://openjdk.org/census#mhanl) (@Maran23 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2271/head:pull/2271` \
`$ git checkout pull/2271`

Update a local copy of the PR: \
`$ git checkout pull/2271` \
`$ git pull https://git.openjdk.org/jfx.git pull/2271/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2271`

View PR using the GUI difftool: \
`$ git pr show -t 2271`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2271.diff">https://git.openjdk.org/jfx/pull/2271.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2271#issuecomment-5374003915)
</details>
