### PR TITLE
8276170: Create Sources when publishing to Maven

### DIFF
--- a/maven-publish.gradle
+++ b/maven-publish.gradle
@@ -77,6 +77,7 @@ ext.configurePublication = { List<Project> projects, CompileTarget t, Task previ
     projects.each { Project project ->
         def moduleName = project.ext.moduleName
         def buildDir = project.layout.buildDirectory.get()
+        def sourceDir = project.sourceSets.main.allJava
 
         def dstModularJarDir="${publicationDir}"
         def srcClassesDir = "${buildDir}/${platformPrefix}module-classes"
@@ -105,9 +106,18 @@ ext.configurePublication = { List<Project> projects, CompileTarget t, Task previ
             from srcClassesDir
         }
 
+        def modularPublicationSourcesJarName = "${moduleName}-sources.jar"
+        def modularPublicationSourceJarTask = project.tasks.register("modulePublicationSourcesJar${t.capital}", Jar) {
+            dependsOn modularPublicationJarTask
+
+            destinationDirectory = file("${dstModularJarDir}")
+            archiveFileName = modularPublicationSourcesJarName
+            from sourceDir
+        }
+
         // Only run during the all task.
         rootProject.tasks.named("all").configure {
-            dependsOn modularPublicationJarTask
+            dependsOn modularPublicationSourceJarTask
         }
     }
 }
@@ -179,6 +189,9 @@ void addMavenPublication(Project project, List<Project> projectDependencies) {
                         artifact project.tasks."moduleEmptyPublicationJar$t.capital"
                         artifact project.tasks."modularPublicationJar$t.capital" {
                             archiveClassifier.set("$t.name")
+                        }
+                        artifact project.tasks."modulePublicationSourcesJar$t.capital" {
+                            archiveClassifier.set("sources")
                         }
                     }
 


### PR DESCRIPTION
This is the continuation of the split of the Maven publishing made in https://github.com/openjdk/jfx/pull/1970.
Since the `build.gradle` file had become so large, adding more Maven code was out of question in the past.
Thanks to the split, we can now quickly and easily add support for JavaFX Sources, thereby significantly simplifying testing.

This can be tested by:

`./gradlew publishToMavenLocal -PMAVEN_PUBLISH=true -PMAVEN_VERSION=custom`

This will create a JavaFX version named 'custom' in your .m2 folder (under `~/.m2/org/openjfx/javafx-XXX/custom`).
The sources should be there as well now.

The original PR https://github.com/openjdk/jfx/pull/2144 can not be reopened because I force pushed it, see the bot comment here: https://github.com/openjdk/jfx/pull/2144#issuecomment-5398495316

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8276170](https://bugs.openjdk.org/browse/JDK-8276170): Create Sources when publishing to Maven (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2273/head:pull/2273` \
`$ git checkout pull/2273`

Update a local copy of the PR: \
`$ git checkout pull/2273` \
`$ git pull https://git.openjdk.org/jfx.git pull/2273/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2273`

View PR using the GUI difftool: \
`$ git pr show -t 2273`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2273.diff">https://git.openjdk.org/jfx/pull/2273.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2273#issuecomment-5398622559)
</details>
