### PR TITLE
[Draft] RichTextArea: View and Model separation

### DIFF
--- a/apps/samples/RichTextAreaDemo/README.md
+++ b/apps/samples/RichTextAreaDemo/README.md
@@ -12,6 +12,8 @@ for the purposes of demonstration of capabilities as well as testing.
   provides a demo application primarily for testing of the CodeArea behavior.
 - [NotebookMockupApp.java](src/com/oracle/demo/richtext/notebook/NotebookMockupApp.java)
   provides an example of a GUI for an interactive notebook application.
+- [HeadingsDemoApp.java](src/com/oracle/demo/richtext/headings/HeadingsDemoApp.java)
+  provides an example of a GUI for testing collapsing and expanding headings of a structured document.
   
 
 ## Building
@@ -39,4 +41,6 @@ Notebook Demo: `ant run-notebook-demo`
 Rich Editor Demo: `ant run-richeditor-demo`
 
 RichTextArea Tester: `ant run-richtextarea-demo`
+
+Headings Demo: `ant run-headings-demo`
 

--- a/apps/samples/RichTextAreaDemo/build.xml
+++ b/apps/samples/RichTextAreaDemo/build.xml
@@ -102,6 +102,12 @@ unless built as a part of openjfx repository where the default value is sufficie
 		</exec>
 	</target>
 
+	<target name="run-headings-demo">
+		<exec executable="java">
+			<arg line="--module-path ${javafx.home}/lib --add-modules javafx.base,javafx.graphics,javafx.controls,jfx.incubator.input,jfx.incubator.richtext -classpath dist/${TARGET}.jar --enable-native-access=javafx.graphics com.oracle.demo.richtext.headings.HeadingsDemoApp" />
+		</exec>
+	</target>
+
 
 	<!-- alias to build-all target, to make it compatible with the rest of the apps -->
 	<target name="jar" depends="build-all" />

--- a/apps/samples/RichTextAreaDemo/src/com/oracle/demo/richtext/headings/HeadingsDecorator.java
+++ b/apps/samples/RichTextAreaDemo/src/com/oracle/demo/richtext/headings/HeadingsDecorator.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates.
+ * All rights reserved. Use is subject to license terms.
+ *
+ * This file is available and licensed under the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the distribution.
+ *  - Neither the name of Oracle Corporation nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.oracle.demo.richtext.headings;
+
+import java.text.DecimalFormat;
+import java.util.Arrays;
+
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.SimpleBooleanProperty;
+import javafx.event.Event;
+import javafx.geometry.Pos;
+import javafx.scene.Node;
+import javafx.scene.control.Label;
+import javafx.scene.control.Tooltip;
+import javafx.scene.layout.HBox;
+import jfx.incubator.scene.control.richtext.SideDecorator;
+
+public class HeadingsDecorator implements SideDecorator {
+    private static final String COLLAPSED = "\u25B8"; // ▸
+    private static final String EXPANDED = "\u25BE"; // ▾
+    private static final DecimalFormat FORMAT = new DecimalFormat("###0");
+
+    private final HeadingsRTA control;
+    private final BooleanProperty showLineNumbers = new SimpleBooleanProperty(this, "showLineNumbers", false) {
+        @Override
+        protected void invalidated() {
+            refreshDecorator();
+        }
+    };
+
+    public HeadingsDecorator(HeadingsRTA control) {
+        this.control = control;
+    }
+
+    public final BooleanProperty showLineNumbersProperty() {
+        return showLineNumbers;
+    }
+
+    @Override
+    public double getPrefWidth(double height) {
+        return showLineNumbersProperty().get() ? 0.0 : 20.0;
+    }
+
+    @Override
+    public Node getMeasurementNode(int index) {
+        String s = FORMAT.format(index + 300);
+        char[] cs = new char[s.length()];
+        Arrays.fill(cs, '8');
+        return createGutterNode(new String(cs), -1);
+    }
+
+    @Override
+    public Node getNode(int index) {
+        return createGutterNode(FORMAT.format(index + 1), index);
+    }
+
+    public void refreshDecorator() {
+        if (control.getLeftDecorator() == this) {
+            control.setLeftDecorator(null);
+            control.setLeftDecorator(this);
+        }
+    }
+
+    private Node createGutterNode(String text, int index) {
+        Label chevron = new Label();
+        chevron.getStyleClass().add("section-chevron");
+        chevron.setOnMousePressed(Event::consume);
+        chevron.setOnMouseReleased(Event::consume);
+        setChevron(chevron, index);
+
+        Label numberLabel = new Label(text);
+        numberLabel.getStyleClass().add("line-number-decorator-label");
+        numberLabel.setMaxSize(Double.MAX_VALUE, Double.MAX_VALUE);
+        numberLabel.setMinHeight(1);
+        numberLabel.setPrefHeight(1);
+        numberLabel.setAlignment(Pos.CENTER_RIGHT);
+        numberLabel.visibleProperty().bind(showLineNumbersProperty());
+        numberLabel.managedProperty().bind(showLineNumbersProperty());
+
+        HBox container = new HBox(numberLabel, chevron);
+        container.getStyleClass().add("line-number-decorator");
+        container.setAlignment(Pos.CENTER_RIGHT);
+        return container;
+    }
+
+    private void setChevron(Label chevron, int index) {
+        ParagraphRange section = control.getSection(index);
+        boolean collapsed = control.isSectionCollapsed(section);
+        chevron.setText(collapsed ? COLLAPSED : EXPANDED);
+        chevron.setTooltip(new Tooltip(collapsed ? "Expand this section" : "Collapse this section"));
+        chevron.setVisible(section != null);
+        chevron.setOnMouseClicked(event -> {
+            event.consume();
+            control.toggleSection(section);
+        });
+    }
+}

--- a/apps/samples/RichTextAreaDemo/src/com/oracle/demo/richtext/headings/HeadingsDemoApp.java
+++ b/apps/samples/RichTextAreaDemo/src/com/oracle/demo/richtext/headings/HeadingsDemoApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates.
+ * Copyright (c) 2026, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:
@@ -30,25 +30,30 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+package com.oracle.demo.richtext.headings;
+
+import javafx.application.Application;
+import javafx.stage.Stage;
+import com.oracle.demo.richtext.settings.FxSettings;
+
 /**
- * RichTextArea Control demos and sample code.
- *
- * <BR><b><a href="https://openjdk.org/jeps/11">Incubating Feature.</a>
- * Will be removed in a future release.</b>
- *
- * @moduleGraph
+ * Headings Demo Application.
+ * <p>
+ * It's a minimal app that can show and hide headings of a structured document, based on the new
+ * {@link jfx.incubator.scene.control.richtext.RichTextArea} control.
  */
+public class HeadingsDemoApp extends Application {
+    public static void main(String[] args) {
+        Application.launch(HeadingsDemoApp.class, args);
+    }
 
-module RichTextAreaDemo {
-    exports com.oracle.demo.richtext.codearea;
-    exports com.oracle.demo.richtext.editor;
-    exports com.oracle.demo.richtext.notebook;
-    exports com.oracle.demo.richtext.rta;
-    exports com.oracle.demo.richtext.headings;
+    @Override
+    public void init() {
+        FxSettings.useDirectory(".HeadingsDemoApp");
+    }
 
-    requires javafx.base;
-    requires javafx.controls;
-    requires javafx.graphics;
-    requires jfx.incubator.input;
-    requires jfx.incubator.richtext;
+    @Override
+    public void start(Stage stage) throws Exception {
+        new HeadingsWindow().show();
+    }
 }

--- a/apps/samples/RichTextAreaDemo/src/com/oracle/demo/richtext/headings/HeadingsDemoPane.java
+++ b/apps/samples/RichTextAreaDemo/src/com/oracle/demo/richtext/headings/HeadingsDemoPane.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates.
+ * All rights reserved. Use is subject to license terms.
+ *
+ * This file is available and licensed under the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the distribution.
+ *  - Neither the name of Oracle Corporation nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.oracle.demo.richtext.headings;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import javafx.geometry.Insets;
+import javafx.geometry.Orientation;
+import javafx.scene.control.Button;
+import javafx.scene.control.CheckBox;
+import javafx.scene.control.SplitPane;
+import javafx.scene.layout.BorderPane;
+import javafx.scene.layout.Pane;
+import com.oracle.demo.richtext.rta.ROptionPane;
+import com.oracle.demo.richtext.util.FX;
+import jfx.incubator.scene.control.richtext.RichTextArea;
+
+public class HeadingsDemoPane extends BorderPane {
+
+    public final ROptionPane op;
+
+    public HeadingsDemoPane() {
+        HeadingsRTA control = new HeadingsRTA();
+        control.loadDocument(loadDocument());
+
+        SplitPane hsplit = new SplitPane(control, pane());
+        FX.name(hsplit, "hsplit");
+        hsplit.setBorder(null);
+        hsplit.setDividerPositions(1.0);
+        hsplit.setOrientation(Orientation.HORIZONTAL);
+
+        SplitPane vsplit = new SplitPane(hsplit, pane());
+        FX.name(vsplit, "vsplit");
+        vsplit.setBorder(null);
+        vsplit.setDividerPositions(1.0);
+        vsplit.setOrientation(Orientation.VERTICAL);
+
+        CheckBox wrapText = new CheckBox("wrap text");
+        FX.name(wrapText, "wrapText");
+        wrapText.selectedProperty().bindBidirectional(control.wrapTextProperty());
+
+        CheckBox lineNumbers = new CheckBox("line numbers");
+        FX.name(lineNumbers, "lineNumbers");
+        lineNumbers.selectedProperty().addListener((_, _, s) -> {
+            control.getHeadingsDecorator().showLineNumbersProperty().set(s);
+        });
+
+        op = new ROptionPane();
+        op.label("Headings Demo");
+        op.option(wrapText);
+        op.option(lineNumbers);
+        op.option(addButton("Collapse All", () -> control.collapseAllSections()));
+        op.option(addButton("Expand All", () -> control.expandAllSections()));
+
+        setCenter(vsplit);
+        setRight(op);
+    }
+
+    public Button addButton(String name, Runnable action) {
+        Button b = new Button(name);
+        b.setOnAction((ev) -> {
+            action.run();
+        });
+        return b;
+    }
+
+    protected static Pane pane() {
+        Pane p = new Pane();
+        SplitPane.setResizableWithParent(p, false);
+        p.setStyle("-fx-background-color:#dddddd;");
+        return p;
+    }
+
+    private String loadDocument() {
+        try (InputStream is = getClass().getResourceAsStream("document.txt")) {
+            if (is == null) {
+                throw new IOException("Resource not found: document.txt");
+            }
+            return new String(is.readAllBytes(), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            e.printStackTrace();
+            return "";
+        }
+    }
+}

--- a/apps/samples/RichTextAreaDemo/src/com/oracle/demo/richtext/headings/HeadingsRTA.java
+++ b/apps/samples/RichTextAreaDemo/src/com/oracle/demo/richtext/headings/HeadingsRTA.java
@@ -1,0 +1,284 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates.
+ * All rights reserved. Use is subject to license terms.
+ *
+ * This file is available and licensed under the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the distribution.
+ *  - Neither the name of Oracle Corporation nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.oracle.demo.richtext.headings;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.TreeSet;
+import java.util.regex.Pattern;
+
+import javafx.application.Platform;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableSet;
+import javafx.collections.SetChangeListener;
+import javafx.geometry.Insets;
+import javafx.scene.paint.Color;
+import jfx.incubator.scene.control.richtext.RichTextArea;
+import jfx.incubator.scene.control.richtext.TextPos;
+import jfx.incubator.scene.control.richtext.model.ContentChange;
+import jfx.incubator.scene.control.richtext.model.RichTextModel;
+import jfx.incubator.scene.control.richtext.model.StyleAttributeMap;
+import jfx.incubator.scene.control.richtext.model.StyledTextModel;
+import jfx.incubator.scene.control.richtext.skin.RichTextAreaSkin;
+
+public class HeadingsRTA extends RichTextArea {
+
+    public static final double HEADING_FONT_SIZE = 16.0;
+    public static final double BODY_FONT_SIZE = 13.0;
+    private static final Pattern HEADING_PATTERN = Pattern.compile("\\s*Header\\s+\\d+\\..*");
+
+    private static final StyleAttributeMap HEADING_ATTRS = StyleAttributeMap.builder().
+            setBold(true).
+            setFontSize(HEADING_FONT_SIZE).
+            setTextColor(Color.FIREBRICK).
+            setSpaceAbove(12).
+            setSpaceBelow(4).
+            build();
+
+    private static final StyleAttributeMap BODY_ATTRS = StyleAttributeMap.builder().
+            setBold(false).
+            setFontSize(BODY_FONT_SIZE).
+            setTextColor(Color.BLACK).
+            setSpaceAbove(2).
+            setSpaceBelow(2).
+            build();
+
+    private final ObservableSet<ParagraphRange> collapsedSections =
+            FXCollections.observableSet(new TreeSet<>());
+    private final ObservableSet<ParagraphRange> unmodifiableCollapsedSections =
+            FXCollections.unmodifiableObservableSet(collapsedSections);
+
+    private final StyledTextModel.Listener modelListener = this::handleModelChange;
+    private final HeadingsDecorator headingsDecorator = new HeadingsDecorator(this);
+
+    public HeadingsRTA() {
+        super(new RichTextModel());
+        setWrapText(true);
+        setContentPadding(new Insets(10));
+        setHighlightCurrentParagraph(true);
+        setLeftDecorator(headingsDecorator);
+
+        getModel().addListener(modelListener);
+        modelProperty().addListener((_, oldModel, newModel) -> {
+            if (oldModel != null) {
+                oldModel.removeListener(modelListener);
+            }
+            if (newModel != null) {
+                newModel.addListener(modelListener);
+            }
+            expandAllSections();
+        });
+        collapsedSections.addListener((SetChangeListener<ParagraphRange>) _ -> {
+            getHeadingsDecorator().refreshDecorator();
+        });
+    }
+
+    @Override
+    protected RichTextAreaSkin createDefaultSkin() {
+        return new HeadingsRTASkin(this);
+    }
+
+    public final HeadingsDecorator getHeadingsDecorator() {
+        return headingsDecorator;
+    }
+
+    public void loadDocument(String text) {
+        expandAllSections();
+        clear();
+        appendText(text);
+
+        int sz = getParagraphCount();
+        for (int i = 0; i < sz; i++) {
+            String s = getPlainText(i);
+            if (s != null) {
+                setHeading(i, HEADING_PATTERN.matcher(s).matches());
+            }
+        }
+        clearUndoRedo();
+        select(TextPos.ZERO);
+    }
+
+    public void setHeading(int index, boolean heading) {
+        if (index >= 0 && index < getParagraphCount()) {
+            applyStyle(TextPos.ofLeading(index, 0), getParagraphEnd(index), heading ? HEADING_ATTRS : BODY_ATTRS);
+        }
+    }
+
+    public boolean isHeading(int index) {
+        if (index < 0 || index >= getParagraphCount()) {
+            return false;
+        }
+        String text = getPlainText(index);
+        if (text == null || text.isBlank()) {
+            return false;
+        }
+        StyleAttributeMap a = getStyleAttributeMap(TextPos.ofLeading(index, 0), false);
+        Double size = a.getFontSize();
+        return a.isBold() && size != null && size >= HEADING_FONT_SIZE;
+    }
+
+    public void collapseAllSections() {
+        collapsedSections.addAll(getSections());
+    }
+
+    public void expandAllSections() {
+        collapsedSections.clear();
+    }
+
+    public final ObservableSet<ParagraphRange> getCollapsedSections() {
+        return unmodifiableCollapsedSections;
+    }
+
+    public boolean isSectionCollapsed(ParagraphRange section) {
+        return section != null && findCollapsedSection(section.start()) != null;
+    }
+
+    public void collapseSection(ParagraphRange section) {
+        if (section != null) {
+            ParagraphRange s = getSection(section.start());
+            if (s != null) {
+                collapsedSections.add(s);
+            }
+        }
+    }
+
+    public void expandSection(ParagraphRange section) {
+        if (section != null) {
+            ParagraphRange s = findCollapsedSection(section.start());
+            if (s != null) {
+                collapsedSections.remove(s);
+            }
+        }
+    }
+
+    public void toggleSection(ParagraphRange section) {
+        if (isSectionCollapsed(section)) {
+            expandSection(section);
+        } else {
+            collapseSection(section);
+        }
+    }
+
+    ParagraphRange getSection(int headingIndex) {
+        if (!isHeading(headingIndex)) {
+            return null;
+        }
+        int maxCount = getParagraphCount();
+        int index = headingIndex + 1;
+        while (index < maxCount && !isHeading(index)) {
+            index++;
+        }
+        return new ParagraphRange(headingIndex, index);
+    }
+
+    private List<ParagraphRange> getSections() {
+        int maxCount = getParagraphCount();
+        List<ParagraphRange> list = new ArrayList<>();
+        int start = -1;
+        for (int i = 0; i < maxCount; i++) {
+            if (isHeading(i)) {
+                if (start >= 0) {
+                    list.add(new ParagraphRange(start, i));
+                }
+                start = i;
+            }
+        }
+        if (start >= 0) {
+            list.add(new ParagraphRange(start, maxCount));
+        }
+        return list;
+    }
+
+    private ParagraphRange findCollapsedSection(int headingIndex) {
+        for (ParagraphRange r : collapsedSections) {
+            if (r.start() == headingIndex) {
+                return r;
+            }
+            if (r.start() > headingIndex) {
+                break;
+            }
+        }
+        return null;
+    }
+
+    private void handleModelChange(ContentChange change) {
+        if (!change.isEdit()) {
+            return;
+        }
+        if (collapsedSections.isEmpty()) {
+            getHeadingsDecorator().refreshDecorator();
+            return;
+        }
+
+        int start = change.getStart().index();
+        int end = change.getEnd().index();
+        int delta = change.getLinesAdded() - end + start;
+        boolean insertion = start == end;
+        boolean atParagraphStart = change.getStart().offset() == 0;
+        int expandedStart = change.getLinesAdded() > 0 && !atParagraphStart ? start : -1;
+
+        if (isHeading(start) && change.getLinesAdded() > 0 && start == end &&
+                change.getStart().offset() == getParagraphEnd(start).offset()) {
+            String text = getPlainText(start + 1);
+            if (text != null && text.isBlank()) {
+                Platform.runLater(() ->
+                        applyStyle(TextPos.ofLeading(start + 1, 0), TextPos.ofLeading(start + 1, 0), BODY_ATTRS));
+            }
+        }
+
+        TreeSet<ParagraphRange> updatedSections = new TreeSet<>();
+        for (ParagraphRange range : collapsedSections) {
+            int index = range.start();
+            if (index > end) {
+                index += delta;
+            } else if (index >= start) {
+                if (insertion) {
+                    index = atParagraphStart ? index + delta : index;
+                } else if (index > start) {
+                    continue;
+                }
+            }
+            if (index == expandedStart) {
+                continue;
+            }
+            ParagraphRange updatedRange = getSection(index);
+            if (updatedRange != null) {
+                updatedSections.add(updatedRange);
+            }
+        }
+
+        collapsedSections.retainAll(updatedSections);
+        collapsedSections.addAll(updatedSections);
+        getHeadingsDecorator().refreshDecorator();
+    }
+}

--- a/apps/samples/RichTextAreaDemo/src/com/oracle/demo/richtext/headings/HeadingsRTASkin.java
+++ b/apps/samples/RichTextAreaDemo/src/com/oracle/demo/richtext/headings/HeadingsRTASkin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates.
+ * Copyright (c) 2026, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:
@@ -30,25 +30,19 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-/**
- * RichTextArea Control demos and sample code.
- *
- * <BR><b><a href="https://openjdk.org/jeps/11">Incubating Feature.</a>
- * Will be removed in a future release.</b>
- *
- * @moduleGraph
- */
+package com.oracle.demo.richtext.headings;
 
-module RichTextAreaDemo {
-    exports com.oracle.demo.richtext.codearea;
-    exports com.oracle.demo.richtext.editor;
-    exports com.oracle.demo.richtext.notebook;
-    exports com.oracle.demo.richtext.rta;
-    exports com.oracle.demo.richtext.headings;
+import jfx.incubator.scene.control.richtext.skin.RichTextAreaSkin;
+import jfx.incubator.scene.control.richtext.skin.RowMap;
 
-    requires javafx.base;
-    requires javafx.controls;
-    requires javafx.graphics;
-    requires jfx.incubator.input;
-    requires jfx.incubator.richtext;
+public class HeadingsRTASkin extends RichTextAreaSkin {
+
+    public HeadingsRTASkin(HeadingsRTA control) {
+        super(control);
+    }
+
+    @Override
+    protected RowMap createRowMap() {
+        return new HeadingsRowMap((HeadingsRTA) getSkinnable());
+    }
 }

--- a/apps/samples/RichTextAreaDemo/src/com/oracle/demo/richtext/headings/HeadingsRowMap.java
+++ b/apps/samples/RichTextAreaDemo/src/com/oracle/demo/richtext/headings/HeadingsRowMap.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates.
+ * All rights reserved. Use is subject to license terms.
+ *
+ * This file is available and licensed under the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the distribution.
+ *  - Neither the name of Oracle Corporation nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.oracle.demo.richtext.headings;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import javafx.collections.SetChangeListener;
+import jfx.incubator.scene.control.richtext.skin.RowMap;
+
+public class HeadingsRowMap extends RowMap {
+    private final HeadingsRTA control;
+    private final List<ParagraphRange> hiddenRanges = new ArrayList<>();
+    private int[] starts = new int[0];
+    private int[] ends = new int[0];
+    private int[] hiddenBefore = new int[0];
+    private final SetChangeListener<ParagraphRange> collapsedSectionsListener = this::handleCollapsedSectionsChange;
+
+    public HeadingsRowMap(HeadingsRTA control) {
+        this.control = control;
+        control.getCollapsedSections().addListener(collapsedSectionsListener);
+    }
+
+    @Override
+    protected int getRowCountImpl(int modelParagraphCount) {
+        return modelParagraphCount - countHiddenParagraphsBefore(modelParagraphCount);
+    }
+
+    @Override
+    protected int getViewRowImpl(int modelIndex) {
+        return modelIndex - countHiddenParagraphsBefore(modelIndex);
+    }
+
+    @Override
+    protected int getModelIndexImpl(int row) {
+        int modelIndex = row;
+        for (int i = 0; i < starts.length; i++) {
+            if (starts[i] - hiddenBefore[i] <= row) {
+                modelIndex = row + hiddenBefore[i] + ends[i] - starts[i];
+            } else {
+                break;
+            }
+        }
+        return modelIndex;
+    }
+
+    @Override
+    protected boolean isHiddenImpl(int modelIndex) {
+        int index = indexOfRange(modelIndex);
+        return index >= 0 && modelIndex < ends[index];
+    }
+
+    @Override
+    protected void refreshMap() {
+        hiddenRanges.clear();
+        int maxCount = control.getParagraphCount();
+        for (ParagraphRange range : control.getCollapsedSections()) {
+            ParagraphRange.ofNextParagraph(range, maxCount).ifPresent(this::addHiddenRange);
+        }
+
+        int size = hiddenRanges.size();
+        starts = new int[size];
+        ends = new int[size];
+        hiddenBefore = new int[size];
+        int hiddenCount = 0;
+        for (int i = 0; i < size; i++) {
+            ParagraphRange range = hiddenRanges.get(i);
+            starts[i] = range.start();
+            ends[i] = range.end();
+            hiddenBefore[i] = hiddenCount;
+            hiddenCount += range.length();
+        }
+    }
+
+    @Override
+    protected void dispose() {
+        control.getCollapsedSections().removeListener(collapsedSectionsListener);
+        super.dispose();
+    }
+
+    private void addHiddenRange(ParagraphRange newRange) {
+        int index = Collections.binarySearch(hiddenRanges, newRange);
+        if (index < 0) {
+            index = -index - 1;
+        }
+        hiddenRanges.add(index, newRange);
+    }
+
+    private int countHiddenParagraphsBefore(int modelIndex) {
+        int index = indexOfRange(modelIndex);
+        return index >= 0 ? hiddenBefore[index] + Math.min(modelIndex, ends[index]) - starts[index] : 0;
+    }
+
+    private int indexOfRange(int modelIndex) {
+        int index = Arrays.binarySearch(starts, modelIndex);
+        return index >= 0 ? index : -index - 2;
+    }
+
+    private void handleCollapsedSectionsChange(SetChangeListener.Change<? extends ParagraphRange> change) {
+        notifyChange(true);
+    }
+
+}

--- a/apps/samples/RichTextAreaDemo/src/com/oracle/demo/richtext/headings/HeadingsWindow.java
+++ b/apps/samples/RichTextAreaDemo/src/com/oracle/demo/richtext/headings/HeadingsWindow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates.
+ * Copyright (c) 2026, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:
@@ -30,25 +30,57 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+package com.oracle.demo.richtext.headings;
+
+import javafx.application.Platform;
+import javafx.geometry.Insets;
+import javafx.scene.Scene;
+import javafx.scene.control.MenuBar;
+import javafx.scene.layout.BorderPane;
+import javafx.stage.Stage;
+import com.oracle.demo.richtext.util.FX;
+
 /**
- * RichTextArea Control demos and sample code.
- *
- * <BR><b><a href="https://openjdk.org/jeps/11">Incubating Feature.</a>
- * Will be removed in a future release.</b>
- *
- * @moduleGraph
+ * Headings Demo window
  */
+public class HeadingsWindow extends Stage {
+    public final HeadingsDemoPane demoPane;
 
-module RichTextAreaDemo {
-    exports com.oracle.demo.richtext.codearea;
-    exports com.oracle.demo.richtext.editor;
-    exports com.oracle.demo.richtext.notebook;
-    exports com.oracle.demo.richtext.rta;
-    exports com.oracle.demo.richtext.headings;
+    public HeadingsWindow() {
+        demoPane = new HeadingsDemoPane();
 
-    requires javafx.base;
-    requires javafx.controls;
-    requires javafx.graphics;
-    requires jfx.incubator.input;
-    requires jfx.incubator.richtext;
+        MenuBar mb = new MenuBar();
+        FX.menu(mb, "File");
+        FX.item(mb, "New Window", this::newWindow);
+        FX.separator(mb);
+        FX.item(mb, "Close Window", this::hide);
+        FX.separator(mb);
+        FX.item(mb, "Quit", () -> Platform.exit());
+
+        BorderPane bp = new BorderPane();
+        bp.setTop(mb);
+        bp.setCenter(demoPane);
+
+        Scene scene = new Scene(bp);
+        scene.getStylesheets().add(getClass().getResource("headings.css").toExternalForm());
+        setScene(scene);
+        setTitle(
+            "Headings Tester  JFX:" + System.getProperty("javafx.runtime.version") +
+            "  JDK:" + System.getProperty("java.version")
+        );
+        setWidth(1200);
+        setHeight(600);
+
+    }
+
+    protected void newWindow() {
+        double offset = 20;
+
+        HeadingsWindow w = new HeadingsWindow();
+        w.setX(getX() + offset);
+        w.setY(getY() + offset);
+        w.setWidth(getWidth());
+        w.setHeight(getHeight());
+        w.show();
+    }
 }

--- a/apps/samples/RichTextAreaDemo/src/com/oracle/demo/richtext/headings/ParagraphRange.java
+++ b/apps/samples/RichTextAreaDemo/src/com/oracle/demo/richtext/headings/ParagraphRange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates.
+ * Copyright (c) 2026, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:
@@ -30,25 +30,46 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-/**
- * RichTextArea Control demos and sample code.
- *
- * <BR><b><a href="https://openjdk.org/jeps/11">Incubating Feature.</a>
- * Will be removed in a future release.</b>
- *
- * @moduleGraph
- */
+package com.oracle.demo.richtext.headings;
 
-module RichTextAreaDemo {
-    exports com.oracle.demo.richtext.codearea;
-    exports com.oracle.demo.richtext.editor;
-    exports com.oracle.demo.richtext.notebook;
-    exports com.oracle.demo.richtext.rta;
-    exports com.oracle.demo.richtext.headings;
+import java.util.Optional;
 
-    requires javafx.base;
-    requires javafx.controls;
-    requires javafx.graphics;
-    requires jfx.incubator.input;
-    requires jfx.incubator.richtext;
+public record ParagraphRange(int start, int end) implements Comparable<ParagraphRange> {
+
+    public ParagraphRange {
+        if (start < 0) {
+            throw new IllegalArgumentException("start must be non-negative: " + start);
+        }
+        if (end < start) {
+            throw new IllegalArgumentException("end must not precede start: " + start + ", " + end);
+        }
+    }
+
+    public int length() {
+        return end - start;
+    }
+
+    public boolean isEmpty() {
+        return length() == 0;
+    }
+
+    public boolean contains(int modelIndex) {
+        return this.start <= modelIndex && modelIndex < this.end;
+    }
+
+    @Override
+    public int compareTo(ParagraphRange other) {
+        int result = Integer.compare(this.start, other.start);
+        if (result == 0) {
+            result = Integer.compare(this.end, other.end);
+        }
+        return result;
+    }
+
+    public static Optional<ParagraphRange> ofNextParagraph(ParagraphRange range, int max) {
+        if (range.start + 1 >= Math.min(range.end, max)) {
+            return Optional.empty();
+        }
+        return Optional.of(new ParagraphRange(range.start + 1, Math.min(range.end, max)));
+    }
 }

--- a/apps/samples/RichTextAreaDemo/src/com/oracle/demo/richtext/headings/document.txt
+++ b/apps/samples/RichTextAreaDemo/src/com/oracle/demo/richtext/headings/document.txt
@@ -1,0 +1,37 @@
+Header 1. Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
+
+Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa.
+Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem.
+Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo.
+
+Header 2. Aenean commodo ligula eget dolor.
+
+Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. Vivamus elementum semper nisi. Aenean vulputate eleifend tellus.
+Aenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante, dapibus in, viverra quis, feugiat a, tellus.
+Phasellus viverra nulla ut metus varius laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. Curabitur ullamcorper ultricies nisi. Nam eget dui.
+Etiam rhoncus. Maecenas tempus, tellus eget condimentum rhoncus, sem quam semper libero, sit amet adipiscing sem neque sed ipsum.
+
+Header 3. Aenean massa.
+
+Nam quam nunc, blandit vel, luctus pulvinar, hendrerit id, lorem. Maecenas nec odio et ante tincidunt tempus. Donec vitae sapien ut libero venenatis faucibus. Nullam quis ante.
+Etiam sit amet orci eget eros faucibus tincidunt. Duis leo. Sed fringilla mauris sit amet nibh. Donec sodales sagittis magna.
+Sed consequat, leo eget bibendum sodales, augue velit cursus nunc, quis gravida magna mi a libero. Fusce vulputate eleifend sapien.
+Vestibulum purus quam, scelerisque ut, mollis sed, nonummy id, metus. Nullam accumsan lorem in dui. Cras ultricies mi eu turpis hendrerit fringilla.
+Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; In ac dui quis mi consectetuer lacinia. Nam pretium turpis et arcu.
+
+Header 4. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
+
+Duis arcu tortor, suscipit eget, imperdiet nec, imperdiet iaculis, ipsum. Sed aliquam ultrices mauris. Integer ante arcu, accumsan a, consectetuer eget, posuere ut, mauris. Praesent adipiscing.
+Phasellus ullamcorper ipsum rutrum nunc. Nunc nonummy metus. Vestibulum volutpat pretium libero. Cras id dui. Aenean ut eros et nisl sagittis vestibulum.
+Nullam nulla eros, ultricies sit amet, nonummy id, imperdiet feugiat, pede. Sed lectus. Donec mollis hendrerit risus. Phasellus nec sem in justo pellentesque facilisis. Etiam imperdiet imperdiet orci.
+
+Header 5. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem.
+
+Nunc nec neque. Phasellus leo dolor, tempus non, auctor et, hendrerit quis, nisi. Curabitur ligula sapien, tincidunt non, euismod vitae, posuere imperdiet, leo. Maecenas malesuada. Praesent congue erat at massa.
+Sed cursus turpis vitae tortor. Donec posuere vulputate arcu. Phasellus accumsan cursus velit.
+Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Sed aliquam, nisi quis porttitor congue, elit erat euismod orci, ac placerat dolor lectus quis orci. Phasellus consectetuer vestibulum elit.
+
+Header 6. Nulla consequat massa quis enim.
+
+Aenean tellus metus, bibendum sed, posuere ac, mattis non, nunc. Vestibulum fringilla pede sit amet augue. In turpis. Pellentesque posuere. Praesent turpis. Aenean posuere, tortor sed cursus feugiat, nunc augue blandit nunc, eu sollicitudin urna dolor sagittis lacus.
+Donec elit libero, sodales nec, volutpat a, suscipit non, turpis. Nullam sagittis. Suspendisse pulvinar, augue ac venenatis condimentum, sem libero volutpat nibh, nec pellentesque velit pede quis nunc. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Fusce id purus. Ut varius tincidunt libero. Phasellus dolor.

--- a/apps/samples/RichTextAreaDemo/src/com/oracle/demo/richtext/headings/headings.css
+++ b/apps/samples/RichTextAreaDemo/src/com/oracle/demo/richtext/headings/headings.css
@@ -1,0 +1,10 @@
+.rich-text-area .section-chevron {
+    -fx-font-size: 16px;
+    -fx-text-fill: firebrick;
+    -fx-padding: 0 2 0 6;
+    -fx-cursor: hand;
+}
+
+.rich-text-area .section-chevron:hover {
+    -fx-text-fill: sandybrown;
+}

--- a/modules/jfx.incubator.richtext/src/main/java/com/sun/jfx/incubator/scene/control/richtext/CaretInfo.java
+++ b/modules/jfx.incubator.richtext/src/main/java/com/sun/jfx/incubator/scene/control/richtext/CaretInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package com.sun.jfx.incubator.scene.control.richtext;
 
+import java.util.Arrays;
 import java.util.Objects;
 import javafx.scene.shape.LineTo;
 import javafx.scene.shape.MoveTo;
@@ -160,7 +161,7 @@ public final class CaretInfo {
      * @return the non-null array of path elements
      */
     public final PathElement[] path() {
-        return path;
+        return Arrays.copyOf(path, path.length);
     }
 
     /**

--- a/modules/jfx.incubator.richtext/src/main/java/com/sun/jfx/incubator/scene/control/richtext/CellArrangement.java
+++ b/modules/jfx.incubator.richtext/src/main/java/com/sun/jfx/incubator/scene/control/richtext/CellArrangement.java
@@ -28,6 +28,7 @@
 package com.sun.jfx.incubator.scene.control.richtext;
 
 import java.util.ArrayList;
+
 import javafx.collections.ObservableList;
 import javafx.geometry.Point2D;
 import javafx.scene.Node;
@@ -38,6 +39,7 @@ import javafx.scene.text.HitInfo;
 import javafx.scene.text.TextFlow;
 import com.sun.jfx.incubator.scene.control.richtext.util.RichUtils;
 import jfx.incubator.scene.control.richtext.TextPos;
+import jfx.incubator.scene.control.richtext.skin.RowMap;
 
 /**
  * Manages TextCells in a sliding window, comprised of the visible area and some number of screenfuls
@@ -54,6 +56,9 @@ public class CellArrangement {
     private final double contentPaddingTop; // snapped
     private final double contentPaddingBottom; // snapped
     private final Origin origin;
+    private final RowMap rowMap;
+    private final int originRow;
+    private final int rowCount;
     private int visibleCount;
     private int bottomCount;
     private double unwrappedWidth;
@@ -62,13 +67,16 @@ public class CellArrangement {
     private Node[] left;
     private Node[] right;
 
-    public CellArrangement(VFlow f, double contentPaddingTop, double contentPaddingBottom) {
+    public CellArrangement(VFlow f, double contentPaddingTop, double contentPaddingBottom, RowMap rowMap) {
         this.flowWidth = f.getWidth();
         this.flowHeight = f.getViewPortHeight();
         this.origin = f.getOrigin();
         this.lineCount = f.getParagraphCount();
+        this.rowCount = f.getRowCount();
+        this.originRow = Math.min(rowMap.getViewRow(origin.index()), Math.max(0, rowCount - 1));
         this.contentPaddingTop = contentPaddingTop;
         this.contentPaddingBottom = contentPaddingBottom;
+        this.rowMap = rowMap;
     }
 
     // TODO not called right now, use it to skip reflow when not necessary
@@ -93,6 +101,7 @@ public class CellArrangement {
             ", topHeight=" + topHeight +
             ", bottomHeight=" + bottomHeight +
             ", lineCount=" + lineCount +
+            ", rowCount=" + rowCount +
             ", average=" + averageHeight() +
             ", unwrapped=" + getUnwrappedWidth() +
             "}";
@@ -129,7 +138,7 @@ public class CellArrangement {
         int btmIx = bottomIndex();
 
         int ix = binarySearch(cellY, topIx, btmIx - 1);
-        TextCell cell = getCell(ix);
+        TextCell cell = getCellForRow(ix);
         if (cell != null) {
             Region r = cell.getContent();
             double y = cellY - cell.getY() - r.snappedTopInset();
@@ -160,7 +169,15 @@ public class CellArrangement {
 
     /** returns the cell contained in this layout, or null */
     public TextCell getCell(int modelIndex) {
-        int ix = modelIndex - origin.index();
+        if (rowMap.isHidden(modelIndex)) {
+            return null;
+        }
+        return getCellForRow(rowMap.getViewRow(modelIndex));
+    }
+
+    /** Returns the cell at the given view row contained in this layout, or null */
+    public TextCell getCellForRow(int row) {
+        int ix = row - originRow;
         if (ix < 0) {
             if ((ix + topCount()) >= 0) {
                 // cells in the top part come after bottom part, and in reverse order
@@ -175,7 +192,11 @@ public class CellArrangement {
 
     /** returns a visible cell, or null */
     public TextCell getVisibleCell(int modelIndex) {
-        int ix = modelIndex - origin.index();
+        if (rowMap.isHidden(modelIndex)) {
+            return null;
+        }
+        int row = rowMap.getViewRow(modelIndex);
+        int ix = row - originRow;
         if ((ix >= 0) && (ix < visibleCount)) {
             return cells.get(ix);
         }
@@ -264,7 +285,7 @@ public class CellArrangement {
     }
 
     public double estimatedMax() {
-        return (lineCount - topCount() - bottomCount) * averageHeight() + topHeight + bottomHeight;
+        return (rowCount - topCount() - bottomCount) * averageHeight() + topHeight + bottomHeight;
     }
 
     /**
@@ -275,7 +296,7 @@ public class CellArrangement {
     private int binarySearch(double localY, int low, int high) {
         while (low <= high) {
             int mid = (low + high) >>> 1;
-            TextCell cell = getCell(mid);
+            TextCell cell = getCellForRow(mid);
             int cmp = compare(cell, localY);
             if (cmp < 0) {
                 low = mid + 1;
@@ -293,7 +314,7 @@ public class CellArrangement {
         if (localY < y) {
             return 1;
         } else if (localY >= y + cell.getCellHeight()) {
-            if (cell.getIndex() == (lineCount - 1)) {
+            if (rowMap.getViewRow(cell.getIndex()) == (rowCount - 1)) {
                 return 0;
             }
             return -1;
@@ -303,12 +324,12 @@ public class CellArrangement {
 
     /** returns a model index of the first cell in the sliding window top margin */
     public int topIndex() {
-        return origin.index() - topCount();
+        return originRow - topCount();
     }
 
     /** returns a model index of the last cell in the sliding window bottom margin + 1 */
     public int bottomIndex() {
-        return origin.index() + bottomCount;
+        return originRow + bottomCount;
     }
 
     /** returns the new origin after scrolling for delta pixels within the arrangement */
@@ -329,7 +350,7 @@ public class CellArrangement {
         }
 
         int ix = binarySearch(y, topIx, btmIx - 1);
-        TextCell cell = getCell(ix);
+        TextCell cell = getCellForRow(ix);
         double off = y - cell.getY();
 
         // do not scroll beyond the top edge

--- a/modules/jfx.incubator.richtext/src/main/java/com/sun/jfx/incubator/scene/control/richtext/RichTextAreaBehavior.java
+++ b/modules/jfx.incubator.richtext/src/main/java/com/sun/jfx/incubator/scene/control/richtext/RichTextAreaBehavior.java
@@ -580,7 +580,9 @@ public class RichTextAreaBehavior extends BehaviorBase<RichTextArea> {
         int ix = caret.index();
         TextPos end = control.getParagraphEnd(ix);
         if (caret.isSameInsertionIndex(end)) {
-            ix++;
+            do {
+                ix++;
+            } while (ix < control.getParagraphCount() && vflow.isParagraphHidden(ix));
             if (ix >= control.getParagraphCount()) {
                 return null;
             }
@@ -593,7 +595,9 @@ public class RichTextAreaBehavior extends BehaviorBase<RichTextArea> {
         int ix = caret.index();
         TextPos p = TextPos.ofLeading(ix, 0);
         if (caret.isSameInsertionIndex(p)) {
-            --ix;
+            do {
+                --ix;
+            } while (ix >= 0 && vflow.isParagraphHidden(ix));
             if (ix < 0) {
                 return null;
             }
@@ -745,56 +749,7 @@ public class RichTextAreaBehavior extends BehaviorBase<RichTextArea> {
     }
 
     protected TextPos nextCharacterVisually(TextPos start, boolean moveRight) {
-        if (isRTL()) {
-            moveRight = !moveRight;
-        }
-
-        RichTextArea control = getControl();
-        TextCell cell = vflow.getCell(start.index());
-        int cix = start.offset();
-        if (moveRight) {
-            cix++;
-            if (cix > cell.getTextLength()) {
-                int ix = cell.getIndex() + 1;
-                TextPos p;
-                if (ix < control.getParagraphCount()) {
-                    // next line
-                    p = TextPos.ofLeading(ix, 0);
-                } else {
-                    // end of last paragraph w/o newline
-                    p = TextPos.ofLeading(cell.getIndex(), cell.getTextLength());
-                }
-                return p;
-            }
-        } else {
-            if (start.offset() == 0) {
-                int ix = cell.getIndex() - 1;
-                if (ix >= 0) {
-                    // end of prev line
-                    return control.getParagraphEnd(ix);
-                }
-                return null;
-            }
-        }
-
-        // using default locale, same as TextInputControl.backward() for example
-        BreakIterator br = BreakIterator.getCharacterInstance();
-        String text = getPlainText(cell.getIndex());
-        br.setText(text);
-        int off = start.offset();
-        try {
-            int ix = moveRight ? br.following(off) : br.preceding(off);
-            if (ix == BreakIterator.DONE) {
-                System.err.println(" --- SHOULD NOT HAPPEN: BreakIterator.DONE off=" + off); // FIX
-                return null;
-            }
-            return TextPos.ofLeading(start.index(), ix);
-        } catch(Exception e) {
-            // TODO need to use a logger!
-            System.err.println("offset=" + off + " text=[" + text + "]"); // FIX
-            e.printStackTrace();
-            return null;
-        }
+        return vflow.nextCharacterVisually(start, moveRight);
     }
 
     /**

--- a/modules/jfx.incubator.richtext/src/main/java/com/sun/jfx/incubator/scene/control/richtext/RichTextAreaSkinHelper.java
+++ b/modules/jfx.incubator.richtext/src/main/java/com/sun/jfx/incubator/scene/control/richtext/RichTextAreaSkinHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,14 +30,16 @@ import com.sun.javafx.util.Utils;
 import com.sun.jfx.incubator.scene.control.richtext.util.ListenerHelper;
 import jfx.incubator.scene.control.richtext.RichTextArea;
 import jfx.incubator.scene.control.richtext.skin.RichTextAreaSkin;
+import jfx.incubator.scene.control.richtext.skin.RowMap;
 
 /**
  * Manages RichTextAreaSkin Accessor.
  */
 public class RichTextAreaSkinHelper {
     public interface Accessor {
-        public VFlow getVFlow(Skin<?> skin);
-        public ListenerHelper getListenerHelper(Skin<?> skin);
+        VFlow getVFlow(Skin<?> skin);
+        ListenerHelper getListenerHelper(Skin<?> skin);
+        RowMap getRowMap(Skin<?> skin);
     }
 
     static {
@@ -60,5 +62,9 @@ public class RichTextAreaSkinHelper {
 
     public static ListenerHelper getListenerHelper(RichTextAreaSkin skin) {
         return accessor.getListenerHelper(skin);
+    }
+
+    public static RowMap getRowMap(RichTextAreaSkin skin) {
+        return accessor.getRowMap(skin);
     }
 }

--- a/modules/jfx.incubator.richtext/src/main/java/com/sun/jfx/incubator/scene/control/richtext/RowMapHelper.java
+++ b/modules/jfx.incubator.richtext/src/main/java/com/sun/jfx/incubator/scene/control/richtext/RowMapHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,21 +23,42 @@
  * questions.
  */
 
-package jfx.incubator.scene.control.richtext;
+package com.sun.jfx.incubator.scene.control.richtext;
 
-import com.sun.jfx.incubator.scene.control.richtext.CellArrangement;
-import com.sun.jfx.incubator.scene.control.richtext.VFlow;
+import java.util.function.Consumer;
+
+import jfx.incubator.scene.control.richtext.model.ContentChange;
+import jfx.incubator.scene.control.richtext.skin.RowMap;
 
 /**
- * RichTextArea shim.
+ * Manages RowMap Accessor.
  */
-public class RichTextAreaShim {
-    /** for when we need to access VFlow */
-    public static VFlow vflow(RichTextArea t) {
-        return t.vflow();
+public class RowMapHelper {
+    public interface Accessor {
+        void dispose(RowMap rowMap);
+        void onContentChange(RowMap rowMap, ContentChange change);
+        void setOnChange(RowMap rowMap, Consumer<Boolean> callback);
     }
 
-    public static CellArrangement arrangement(RichTextArea t) {
-        return t.cellArrangement();
+    private static Accessor accessor;
+
+    public static void setAccessor(Accessor a) {
+        if (accessor != null) {
+            throw new IllegalStateException();
+        }
+        accessor = a;
     }
+
+    public static void dispose(RowMap rowMap) {
+        accessor.dispose(rowMap);
+    }
+
+    public static void onContentChange(RowMap rowMap, ContentChange change) {
+        accessor.onContentChange(rowMap, change);
+    }
+
+    public static void setOnChange(RowMap rowMap, Consumer<Boolean> callback) {
+        accessor.setOnChange(rowMap, callback);
+    }
+
 }

--- a/modules/jfx.incubator.richtext/src/main/java/com/sun/jfx/incubator/scene/control/richtext/TextCell.java
+++ b/modules/jfx.incubator.richtext/src/main/java/com/sun/jfx/incubator/scene/control/richtext/TextCell.java
@@ -34,6 +34,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CopyOnWriteArrayList;
+
 import javafx.geometry.Pos;
 import javafx.scene.Node;
 import javafx.scene.control.Label;
@@ -80,7 +81,7 @@ public final class TextCell extends BorderPane {
      * @param embedsNode whether the content is a paragraph
      */
     public TextCell(int index, Region content, boolean embedsNode) {
-        Objects.nonNull(content);
+        Objects.requireNonNull(content);
         this.index = index;
         this.content = content;
         this.embedsNode = embedsNode;

--- a/modules/jfx.incubator.richtext/src/main/java/com/sun/jfx/incubator/scene/control/richtext/VFlow.java
+++ b/modules/jfx.incubator.richtext/src/main/java/com/sun/jfx/incubator/scene/control/richtext/VFlow.java
@@ -27,10 +27,13 @@
 
 package com.sun.jfx.incubator.scene.control.richtext;
 
+import java.text.BreakIterator;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+
 import javafx.animation.Animation;
 import javafx.animation.KeyFrame;
 import javafx.animation.Timeline;
@@ -75,6 +78,7 @@ import jfx.incubator.scene.control.richtext.model.StyleAttributeMap;
 import jfx.incubator.scene.control.richtext.model.StyledSegment;
 import jfx.incubator.scene.control.richtext.model.StyledTextModel;
 import jfx.incubator.scene.control.richtext.skin.RichTextAreaSkin;
+import jfx.incubator.scene.control.richtext.skin.RowMap;
 
 /**
  * Contains all the parts representing the visuals of the RichTextAreaSkin.
@@ -116,6 +120,7 @@ public class VFlow extends Pane implements StyleResolver, StyledTextModel.Listen
     private final Timeline caretAnimation;
     private final FastCache<TextCell> cellCache;
     private CellArrangement arrangement;
+    private final RowMap rowMap;
     private boolean dirty = true;
     private FastCache<Node> leftCache;
     private FastCache<Node> rightCache;
@@ -147,6 +152,8 @@ public class VFlow extends Pane implements StyleResolver, StyledTextModel.Listen
         this.control = skin.getSkinnable();
         this.vscroll = vsb;
         this.hscroll = hsb;
+        this.rowMap = RichTextAreaSkinHelper.getRowMap(skin);
+        RowMapHelper.setOnChange(rowMap, this::rowMapUpdated);
 
         vscroll.setManaged(false);
         vscroll.setMin(0.0);
@@ -160,7 +167,7 @@ public class VFlow extends Pane implements StyleResolver, StyledTextModel.Listen
         hscroll.setUnitIncrement(Params.SCROLL_BARS_UNIT_INCREMENT);
         hscroll.setBlockIncrement(Params.SCROLL_BARS_BLOCK_INCREMENT);
 
-        cellCache = new FastCache(Params.CELL_CACHE_SIZE);
+        cellCache = new FastCache<>(Params.CELL_CACHE_SIZE);
 
         getStyleClass().add("vflow");
         setPadding(new Insets(Params.LAYOUT_FOCUS_BORDER));
@@ -228,8 +235,8 @@ public class VFlow extends Pane implements StyleResolver, StyledTextModel.Listen
         origin.addListener((p) -> handleOriginChange());
         widthProperty().addListener((p) -> handleWidthChange());
         heightProperty().addListener((p) -> handleHeightChange());
-        // there might be more subscriptions
-        subscriptions = control.dropTargetProperty().subscribe(this::handleDropTarget);
+        // there might be more subscriptions, make them lazy to avoid cascade effects during initialization
+        subscriptions = control.dropTargetProperty().subscribe((_, p) -> handleDropTarget(p));
 
         vscroll.addEventFilter(MouseEvent.ANY, this::handleVScrollMouseEvent);
 
@@ -237,9 +244,31 @@ public class VFlow extends Pane implements StyleResolver, StyledTextModel.Listen
         handleOriginChange();
     }
 
+    /** Called when the row map has been updated. */
+    protected final void rowMapUpdated(boolean clearCache) {
+        requestControlLayout(clearCache);
+
+        TextPos p = control.getCaretPosition();
+        if (p == null) {
+            return;
+        }
+        if (rowMap.isHidden(p.index())) {
+            // the caret is in a hidden paragraph, move it to the next visible paragraph
+            int rowCount = getRowCount();
+            if (rowCount == 0) {
+                return;
+            }
+            int row = Math.min(rowMap.getViewRow(p.index()), rowCount - 1);
+            control.select(TextPos.ofLeading(rowMap.getModelIndex(row), 0));
+        }
+    }
+
     public void dispose() {
         subscriptions.unsubscribe();
         caretPath.visibleProperty().unbind();
+        if (rowMap != null) {
+            RowMapHelper.dispose(rowMap);
+        }
     }
 
     public Pane getContentPane() {
@@ -499,8 +528,8 @@ public class VFlow extends Pane implements StyleResolver, StyledTextModel.Listen
         if (end.index() < topCellIndex) {
             // selection is above visible area
             return;
-        } else if (start.index() >= (topCellIndex + arrangement().getVisibleCellCount())) {
-            // selection is below visible area
+        } else if (rowMap.getViewRow(start.index()) >= (rowMap.getViewRow(topCellIndex) + arrangement().getVisibleCellCount())) {
+            // selection is below visible area (measured in visible rows, as paragraphs may be hidden)
             return;
         }
 
@@ -552,7 +581,7 @@ public class VFlow extends Pane implements StyleResolver, StyledTextModel.Listen
         }
     }
 
-    /** uses vflow.content cooridinates */
+    /** uses vflow.content coordinates */
     public TextPos getTextPosLocal(double localX, double localY) {
         return arrangement().getTextPos(localX - contentPaddingLeft, localY);
     }
@@ -643,6 +672,14 @@ public class VFlow extends Pane implements StyleResolver, StyledTextModel.Listen
     }
 
     /**
+     * Returns the number of rows in the control, which may be different from the number of paragraphs
+     * if some paragraphs are hidden.
+     */
+    public final int getRowCount() {
+        return rowMap.getRowCount(getParagraphCount());
+    }
+
+    /**
      * Returns control's content padding, always non-null.
      * @return the content padding
      */
@@ -673,7 +710,7 @@ public class VFlow extends Pane implements StyleResolver, StyledTextModel.Listen
             double av = ar.averageHeight();
             double max = ar.estimatedMax();
             double h = getViewPortHeight();
-            val = toScrollBarValue((topCellIndex() - ar.topCount()) * av + ar.topHeight(), h, max);
+            val = toScrollBarValue(ar.topIndex() * av + ar.topHeight(), h, max);
             visible = h / max;
         }
 
@@ -714,9 +751,9 @@ public class VFlow extends Pane implements StyleResolver, StyledTextModel.Listen
             double val = vscroll.getValue();
             double pos = (val - min) / max;
 
-            int lineCount = getParagraphCount();
-            int ix = Math.max(0, (int)Math.round(pos * (lineCount - 1)));
-            Origin p = new Origin(ix, 0.0);
+            int lineCount = getRowCount();
+            int row = Math.max(0, (int)Math.round(pos * (lineCount - 1)));
+            Origin p = new Origin(rowMap.getModelIndex(row), 0.0);
             setOrigin(p);
             layoutCells(false);
 
@@ -922,7 +959,7 @@ public class VFlow extends Pane implements StyleResolver, StyledTextModel.Listen
     }
 
     /** returns a non-null layout, laying out cells if necessary */
-    protected CellArrangement arrangement() {
+    public CellArrangement arrangement() {
         if (!inReflow && dirty || (arrangement == null)) {
             layoutChildren();
         }
@@ -1066,6 +1103,7 @@ public class VFlow extends Pane implements StyleResolver, StyledTextModel.Listen
 
     @Override
     public void onContentChange(ContentChange ch) {
+        RowMapHelper.onContentChange(rowMap, ch);
         if (ch.isEdit()) {
             Origin newOrigin = computeNewOrigin(ch);
             if (newOrigin != null) {
@@ -1156,14 +1194,76 @@ public class VFlow extends Pane implements StyleResolver, StyledTextModel.Listen
 
     public TextPos moveHorizontally(boolean start, int caretIndex, int caretOffset) {
         TextCell cell = getCell(caretIndex);
+        if (cell == null) {
+            // the paragraph is hidden
+            return null;
+        }
         Integer off = cell.lineEdge(start, caretIndex, caretOffset);
         if (off == null) {
             return null;
-        } else if(start || off == 0) {
+        } else if (start || off == 0) {
             return TextPos.ofLeading(caretIndex, off);
         } else {
             return new TextPos(caretIndex, off, off - 1, false);
         }
+    }
+
+    /**
+     * Computes the text position one character visually to the left or to the right of
+     * the given position, for the purpose of horizontal caret navigation.
+     */
+    public TextPos nextCharacterVisually(TextPos start, boolean moveRight) {
+        if (control.getEffectiveNodeOrientation() == NodeOrientation.RIGHT_TO_LEFT) {
+            moveRight = !moveRight;
+        }
+
+        int index = start.index();
+        // the cell may be null when the paragraph is hidden by the row map;
+        // navigation then works on the document text
+        TextCell cell = getCell(index);
+        int visibleLength = (cell != null) ? cell.getTextLength() : control.getPlainText(index).length();
+        int cix = start.offset();
+        if (moveRight) {
+            cix++;
+            if (cix > visibleLength) {
+                int ix = index + 1;
+                while (ix < control.getParagraphCount() && isParagraphHidden(ix)) {
+                    ix++;
+                }
+                TextPos p;
+                if (ix < control.getParagraphCount()) {
+                    // next line
+                    p = TextPos.ofLeading(ix, 0);
+                } else {
+                    // end of last paragraph w/o newline
+                    p = TextPos.ofLeading(index, visibleLength);
+                }
+                return p;
+            }
+        } else {
+            if (start.offset() == 0) {
+                int ix = index - 1;
+                while (ix >= 0 && isParagraphHidden(ix)) {
+                    ix--;
+                }
+                if (ix >= 0) {
+                    // end of prev line
+                    return control.getParagraphEnd(ix);
+                }
+                return null;
+            }
+        }
+
+        // using default locale, same as TextInputControl.backward() for example
+        BreakIterator br = BreakIterator.getCharacterInstance();
+        String text = control.getPlainText(index);
+        br.setText(text);
+        int off = start.offset();
+        int ix = moveRight ? br.following(off) : br.preceding(off);
+        if (ix == BreakIterator.DONE) {
+            return null;
+        }
+        return TextPos.ofLeading(index, ix);
     }
 
     /**
@@ -1179,6 +1279,10 @@ public class VFlow extends Pane implements StyleResolver, StyledTextModel.Listen
      */
     public TextPos moveVertically(int caretIndex, double x, double y, boolean down) {
         TextCell cell = getCell(caretIndex);
+        if (cell == null) {
+            // the paragraph is hidden
+            return null;
+        }
         // account for line spacing
         if (down) {
             y += cell.getLineSpacing();
@@ -1196,12 +1300,16 @@ public class VFlow extends Pane implements StyleResolver, StyledTextModel.Listen
         int ix = p.index();
         if (ix == caretIndex) {
             if (down) {
-                ix++;
-                if (ix >= skin.getSkinnable().getParagraphCount()) {
+                do {
+                    ix++;
+                } while (ix < getParagraphCount() && isParagraphHidden(ix));
+                if (ix >= getParagraphCount()) {
                     return skin.getSkinnable().getDocumentEnd();
                 }
             } else {
-                ix--;
+                do {
+                    ix--;
+                } while (ix >= 0 && isParagraphHidden(ix));
                 if (ix < 0) {
                     return TextPos.ZERO;
                 }
@@ -1209,9 +1317,18 @@ public class VFlow extends Pane implements StyleResolver, StyledTextModel.Listen
         }
 
         cell = getCell(ix);
+        if (cell == null) {
+            // the paragraph is hidden (e.g. inside a collapsed fold): keep the position
+            return p;
+        }
         double py = cell.findHitCandidate(y - cell.getY(), down);
         p = getTextPosLocal(x, py + cell.getY());
         return p;
+    }
+
+    /** Returns true if the paragraph at the given index is hidden by the {@link RowMap}. */
+    public boolean isParagraphHidden(int index) {
+        return rowMap.isHidden(index);
     }
 
     public void handleUseContentHeight() {
@@ -1309,7 +1426,12 @@ public class VFlow extends Pane implements StyleResolver, StyledTextModel.Listen
         try {
             layoutCells(false);
 
+            Origin oldOrigin = getOrigin();
             checkForExcessiveWhitespaceAtTheEnd();
+            if (!oldOrigin.equals(getOrigin())) {
+                // if the origin changed after the check, rebuild the arrangement again
+                layoutCells(false);
+            }
             updateCaretAndSelection();
 
             // eliminate VSB jitter during scrolling with a mouse
@@ -1348,9 +1470,11 @@ public class VFlow extends Pane implements StyleResolver, StyledTextModel.Listen
         return cell;
     }
 
-    /// When wrapped, returns the available text cell width (document width minus all the decorations and padding).
-    /// When not wrapped, returns -1.
-    /// This value is valid only within layoutCells().
+    /**
+     * When wrapped, returns the available text cell width (document width minus all the decorations and padding).
+     * When not wrapped, returns -1.
+     * This value is valid only within layoutCells().
+     */
     public double availableWidth() {
         return availableWidth;
     }
@@ -1365,7 +1489,7 @@ public class VFlow extends Pane implements StyleResolver, StyledTextModel.Listen
             arrangement.removeNodesFrom(content);
             arrangement = null;
         }
-        arrangement = new CellArrangement(this, contentPaddingTop, contentPaddingBottom);
+        arrangement = new CellArrangement(this, contentPaddingTop, contentPaddingBottom, rowMap);
 
         double width = getWidth();
         if (width == 0.0) {
@@ -1383,7 +1507,8 @@ public class VFlow extends Pane implements StyleResolver, StyledTextModel.Listen
         leftSide = computeSideWidth(leftDecorator);
         rightSide = computeSideWidth(rightDecorator);
 
-        int paragraphCount = getParagraphCount();
+        int rowCount = getRowCount();
+        int originRow = Math.min(rowMap.getViewRow(topCellIndex()), Math.max(0, rowCount - 1));
         boolean useContentHeight = control.isUseContentHeight();
         boolean useContentWidth = control.isUseContentWidth();
         boolean wrap = control.isWrapText() && !useContentWidth;
@@ -1412,9 +1537,9 @@ public class VFlow extends Pane implements StyleResolver, StyledTextModel.Listen
         double defaultInterval = getDefaultInterval();
 
         // populating visible part of the sliding window + bottom margin
-        int i = topCellIndex();
-        for ( ; i < paragraphCount; i++) {
-            TextCell cell = prepareCell(i, maxWidth, defaultInterval);
+        int row = originRow;
+        for ( ; row < rowCount; row++) {
+            TextCell cell = prepareCell(rowMap.getModelIndex(row), maxWidth, defaultInterval);
 
             double h = cell.prefHeight(availableWidth) + getLineSpacing(cell.getContent());
             h = snapSizeY(h);
@@ -1471,7 +1596,7 @@ public class VFlow extends Pane implements StyleResolver, StyledTextModel.Listen
             arrangement.setVisibleCellCount(count);
         }
 
-        if (i == paragraphCount) {
+        if (row == rowCount) {
             y += contentPaddingBottom;
         }
 
@@ -1481,8 +1606,8 @@ public class VFlow extends Pane implements StyleResolver, StyledTextModel.Listen
                 leftCache = updateSideCache(leftDecorator, null);
             }
 
-            for (i = 0; i < arrangement.getVisibleCellCount(); i++) {
-                TextCell cell = arrangement.getCellAt(i);
+            for (row = 0; row < arrangement.getVisibleCellCount(); row++) {
+                TextCell cell = arrangement.getCellAt(row);
                 int ix = cell.getIndex();
                 Node n = leftCache.get(ix);
                 if (n == null) {
@@ -1493,7 +1618,7 @@ public class VFlow extends Pane implements StyleResolver, StyledTextModel.Listen
                     }
                 }
                 if (n != null) {
-                    arrangement.addLeftNode(i, n);
+                    arrangement.addLeftNode(row, n);
                 }
             }
         }
@@ -1503,8 +1628,8 @@ public class VFlow extends Pane implements StyleResolver, StyledTextModel.Listen
                 rightCache = updateSideCache(rightDecorator, null);
             }
 
-            for (i = 0; i < arrangement.getVisibleCellCount(); i++) {
-                TextCell cell = arrangement.getCellAt(i);
+            for (row = 0; row < arrangement.getVisibleCellCount(); row++) {
+                TextCell cell = arrangement.getCellAt(row);
                 int ix = cell.getIndex();
                 Node n = rightCache.get(ix);
                 if (n == null) {
@@ -1515,7 +1640,7 @@ public class VFlow extends Pane implements StyleResolver, StyledTextModel.Listen
                     }
                 }
                 if (n != null) {
-                    arrangement.addRightNode(i, n);
+                    arrangement.addRightNode(row, n);
                 }
             }
         }
@@ -1528,8 +1653,9 @@ public class VFlow extends Pane implements StyleResolver, StyledTextModel.Listen
         count = 0;
         y = ytop;
 
-        // populate top margin, going backwards from topCellIndex
-        for (i = topCellIndex() - 1; i >= 0; i--) {
+        // populate top margin, going backwards from the origin row
+        for (row = originRow - 1; row >= 0; row--) {
+            int i = rowMap.getModelIndex(row);
             TextCell cell = prepareCell(i, maxWidth, defaultInterval);
 
             double h = cell.prefHeight(availableWidth) + getLineSpacing(cell.getContent());
@@ -1681,8 +1807,8 @@ public class VFlow extends Pane implements StyleResolver, StyledTextModel.Listen
         double x = wrap ? 0.0 : contentPaddingLeft;
 
         int sz = arrangement.getVisibleCellCount();
-        for (i = 0; i < sz; i++) {
-            TextCell cell = arrangement.getCellAt(i);
+        for (row = 0; row < sz; row++) {
+            TextCell cell = arrangement.getCellAt(row);
             double ch = cell.getCellHeight();
             double cy = cell.getY();
             double cw = wrap ? viewPortWidth : cell.getCellWidth();
@@ -1693,7 +1819,7 @@ public class VFlow extends Pane implements StyleResolver, StyledTextModel.Listen
 
             // place side nodes
             if (addLeft) {
-                Node n = arrangement.getLeftNodeAt(i);
+                Node n = arrangement.getLeftNodeAt(row);
                 if (n != null) {
                     leftGutter.getChildren().add(n);
                     n.applyCss();
@@ -1702,7 +1828,7 @@ public class VFlow extends Pane implements StyleResolver, StyledTextModel.Listen
             }
 
             if (addRight) {
-                Node n = arrangement.getRightNodeAt(i);
+                Node n = arrangement.getRightNodeAt(row);
                 if (n != null) {
                     rightGutter.getChildren().add(n);
                     n.applyCss();
@@ -1731,6 +1857,9 @@ public class VFlow extends Pane implements StyleResolver, StyledTextModel.Listen
         for (int ix = ix1; ix <= ix2; ix++) {
             TextCell cell = arrangement().getVisibleCell(ix);
             if (cell == null) {
+                if (rowMap.isHidden(ix)) {
+                    continue;
+                }
                 break;
             }
             int beginOffset = (ix == ix1) ? start.offset() : 0;
@@ -1779,6 +1908,13 @@ public class VFlow extends Pane implements StyleResolver, StyledTextModel.Listen
     }
 
     private void handleDropTarget(TextPos p) {
+        if (p == null) {
+            // if there is no drop target, don't force a layout pass, just hide the existing drop target if any
+            if (dropTarget != null) {
+                dropTarget.setVisible(false);
+            }
+            return;
+        }
         CaretInfo c = getCaretInfo(p);
         if (c == null) {
             if (dropTarget != null) {

--- a/modules/jfx.incubator.richtext/src/main/java/jfx/incubator/scene/control/richtext/RichTextArea.java
+++ b/modules/jfx.incubator.richtext/src/main/java/jfx/incubator/scene/control/richtext/RichTextArea.java
@@ -32,6 +32,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.List;
 import java.util.Objects;
+
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.ReadOnlyBooleanProperty;
@@ -61,6 +62,7 @@ import javafx.scene.control.Control;
 import javafx.scene.input.DataFormat;
 import javafx.util.Duration;
 import com.sun.jfx.incubator.scene.control.input.InputMapHelper;
+import com.sun.jfx.incubator.scene.control.richtext.CellArrangement;
 import com.sun.jfx.incubator.scene.control.richtext.CssStyles;
 import com.sun.jfx.incubator.scene.control.richtext.Params;
 import com.sun.jfx.incubator.scene.control.richtext.RTAccessibilityHelper;
@@ -2413,6 +2415,11 @@ public class RichTextArea extends Control {
     // package protected for testing
     VFlow vflow() {
         return RichTextAreaSkinHelper.getVFlow(this);
+    }
+
+    // package protected for testing
+    CellArrangement cellArrangement() {
+        return vflow().arrangement();
     }
 
     private RichTextAreaSkin richTextAreaSkin() {

--- a/modules/jfx.incubator.richtext/src/main/java/jfx/incubator/scene/control/richtext/skin/RichTextAreaSkin.java
+++ b/modules/jfx.incubator.richtext/src/main/java/jfx/incubator/scene/control/richtext/skin/RichTextAreaSkin.java
@@ -29,6 +29,7 @@ package jfx.incubator.scene.control.richtext.skin;
 
 import java.util.ArrayList;
 import java.util.List;
+
 import javafx.collections.ObservableList;
 import javafx.event.EventHandler;
 import javafx.geometry.Orientation;
@@ -87,6 +88,7 @@ import jfx.incubator.scene.control.richtext.model.StyledTextModel;
 public class RichTextAreaSkin extends SkinBase<RichTextArea> {
     private final ListenerHelper listenerHelper;
     private final RichTextAreaBehavior behavior;
+    private final RowMap rowMap;
     private final VFlow vflow;
     private final ScrollBar vscroll;
     private final ScrollBar hscroll;
@@ -108,6 +110,11 @@ public class RichTextAreaSkin extends SkinBase<RichTextArea> {
             public ListenerHelper getListenerHelper(Skin<?> skin) {
                 return ((RichTextAreaSkin)skin).listenerHelper;
             }
+
+            @Override
+            public RowMap getRowMap(Skin<?> skin) {
+                return ((RichTextAreaSkin)skin).getRowMap();
+            }
         });
     }
 
@@ -127,6 +134,8 @@ public class RichTextAreaSkin extends SkinBase<RichTextArea> {
         hscroll = createHScrollBar();
         hscroll.setOrientation(Orientation.HORIZONTAL);
         hscroll.addEventFilter(ScrollEvent.ANY, (ev) -> ev.consume());
+
+        rowMap = createRowMap();
 
         vflow = new VFlow(this, vscroll, hscroll);
         getChildren().add(vflow);
@@ -232,6 +241,26 @@ public class RichTextAreaSkin extends SkinBase<RichTextArea> {
 
             super.dispose();
         }
+    }
+
+    /**
+     * Creates the row map instance.
+     * <p>
+     * Subclasses may override this method to provide a custom {@link RowMap} implementation.
+     * It gets called when this skin is constructed.
+     *
+     * @return the row map
+     */
+    protected RowMap createRowMap() {
+        return new RowMap();
+    }
+
+    /**
+     * Returns the row map which maps the visible rows to the model paragraphs.
+     * @return the row map
+     */
+    protected final RowMap getRowMap() {
+        return rowMap;
     }
 
     private void handleInputMethodEvent(InputMethodEvent ev) {

--- a/modules/jfx.incubator.richtext/src/main/java/jfx/incubator/scene/control/richtext/skin/RowMap.java
+++ b/modules/jfx.incubator.richtext/src/main/java/jfx/incubator/scene/control/richtext/skin/RowMap.java
@@ -1,0 +1,239 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jfx.incubator.scene.control.richtext.skin;
+
+import java.util.function.Consumer;
+
+import com.sun.jfx.incubator.scene.control.richtext.RowMapHelper;
+import jfx.incubator.scene.control.richtext.model.ContentChange;
+
+/**
+ * Defines the mapping between visible row indices and model paragraph indices.
+ * <p>A "row" is the index of a paragraph in the visible sequence: hidden paragraphs do not occupy a row.
+ * When there are no hidden paragraphs (by default), row indices and model indices are identical.</p>
+ * <p>The RichTextArea uses the RowMap to determine the mapping between model indices that traverse the document,
+ * and view rows, which are the paragraphs rendered in the viewport. While the model is based on the document,
+ * the view is a filtered representation of the model. Therefore, subclasses can implement custom mapping logic
+ * and achieve features like:</p>
+ * <ul>
+ *     <li>Search/filter mode, showing only paragraphs with results</li>
+ *     <li>Log/console, filtering out paragraphs based on log levels</li>
+ *     <li>Outline/summary mode, showing headings and hiding details</li>
+ *     <li>Code folding in the {@code CodeArea}</li>
+ *     <li>Collapsible sections</li>
+ *     <li>Any other custom mapping logic to show and hide paragraphs</li>
+ * </ul>
+ * <p>In all cases, since the model doesn't change, applying or removing the filter is a fast operation,
+ * as the model doesn't need to be recreated. In other words, {@link RowMap} plays a role for {@code RichTextArea}
+ * and {@code CodeArea} similar to {@code FilteredList} for {@code ListView}.</p>
+ * <p>As the model can change at any time, notifications are sent via {@link #onContentChange(ContentChange)}
+ * so the view can be updated properly.</p>
+ * <p>Subclasses should override the impl methods to provide its custom mapping logic, override {@link #refreshMap()}
+ * to recompute the internal state, and call {@link #notifyChange(boolean)} when the external state changes.
+ * {@link #dispose()} can be overridden if added listeners need to be released.</p>
+ */
+public class RowMap {
+
+    private Consumer<Boolean> onChange;
+    private boolean dirty = true;
+
+    static {
+        RowMapHelper.setAccessor(new RowMapHelper.Accessor() {
+            @Override
+            public void dispose(RowMap rowMap) {
+                rowMap.dispose();
+            }
+
+            @Override
+            public void onContentChange(RowMap rowMap, ContentChange change) {
+                rowMap.onContentChange(change);
+            }
+
+            @Override
+            public void setOnChange(RowMap rowMap, Consumer<Boolean> callback) {
+                rowMap.setOnChange(callback);
+            }
+        });
+    }
+
+    /**
+     * Creates a new RowMap instance.
+     */
+    public RowMap() {
+
+    }
+
+    /**
+     * Returns the number of visible rows in the view, given the number of paragraphs in the model, once the map is
+     * validated.
+     * @param modelParagraphCount the number of paragraphs in the model
+     * @return the number of visible rows in the view
+     */
+    public final int getRowCount(int modelParagraphCount) {
+        validate();
+        return getRowCountImpl(modelParagraphCount);
+    }
+
+    /**
+     * Returns the number of visible rows in the view, given the number of paragraphs in the model.
+     * This method is called after the map is validated, and subclasses can override it to provide custom logic for
+     * computing the number of visible rows based on the model paragraph count.
+     * @param modelParagraphCount the number of paragraphs in the model
+     * @return the number of visible rows in the view
+     */
+    protected int getRowCountImpl(int modelParagraphCount) {
+        return modelParagraphCount;
+    }
+
+    /**
+     * Returns the model index of the paragraph at the given row in the view, once the map is
+     * validated.
+     * @param row the row index in the view
+     * @return the model index of the paragraph at the given row
+     */
+    public final int getModelIndex(int row) {
+        validate();
+        return getModelIndexImpl(row);
+    }
+
+    /**
+     * Returns the model index of the paragraph at the given row in the view.
+     * This method is called after the map is validated, and subclasses can override it to provide
+     * custom logic for computing the model index based on the view row index.
+     * @param row the row index in the view
+     * @return the model index of the paragraph at the given row
+     */
+    protected int getModelIndexImpl(int row) {
+        return row;
+    }
+
+    /**
+     * Returns the number of visible paragraphs preceding the given model index, once the mapping is validated.
+     * For a visible paragraph, this is its view row index. For a hidden paragraph, this is the
+     * view row index of the next visible paragraph.
+     * @param modelIndex the model index of the paragraph
+     * @return the view row index of the paragraph at the given model index
+     */
+    public final int getViewRow(int modelIndex) {
+        validate();
+        return getViewRowImpl(modelIndex);
+    }
+
+    /**
+     * Returns the number of visible paragraphs preceding the given model index.
+     * This method is called after the map is validated, and subclasses can override it to provide
+     * custom logic for computing the view row index based on the model index.
+     * @param modelIndex the model index of the paragraph
+     * @return the view row index of the paragraph at the given model index
+     */
+    protected int getViewRowImpl(int modelIndex) {
+        return modelIndex;
+    }
+
+    /**
+     * Returns whether the paragraph at the given model index is hidden, once the mapping is validated.
+     * @param modelIndex the model index of the paragraph
+     * @return true if the paragraph is hidden, false otherwise
+     */
+    public final boolean isHidden(int modelIndex) {
+        validate();
+        return isHiddenImpl(modelIndex);
+    }
+
+    /**
+     * Returns whether the paragraph at the given model index is hidden.
+     * This method is called after the map is validated, and subclasses can override it to provide
+     * custom logic for determining whether a paragraph is hidden based on its model index.
+     * @param modelIndex the model index of the paragraph
+     * @return true if the paragraph is hidden, false otherwise
+     */
+    protected boolean isHiddenImpl(int modelIndex) {
+        return false;
+    }
+
+    /**
+     * Called when the content of the model changes.
+     * @param ch the content change
+     */
+    protected void onContentChange(ContentChange ch) {
+        invalidate();
+    }
+
+    /**
+     * Notifies the owning flow that the mapping has changed, and the view should be updated
+     * by requesting a layout pass. The {@code clearCache} parameter indicates whether the cache should be cleared.
+     * <p>The map is invalidated and lazily refreshed via {@link #refreshMap()}.</p>
+     * @param clearCache whether to clear the cache of the owning flow
+     */
+    protected final void notifyChange(boolean clearCache) {
+        invalidate();
+        if (onChange != null) {
+            onChange.accept(clearCache);
+        }
+    }
+
+    /**
+     * Refreshes the mapping.
+     * Subclasses can override this method to recompute the mapping when it is marked as dirty.
+     */
+    protected void refreshMap() {
+        // no-op
+    }
+
+    /**
+     * Disposes of any resources held by this RowMap. Subclasses can override this method to perform
+     * cleanup when the RowMap is no longer needed.
+     */
+    protected void dispose() {
+        // no-op
+    }
+
+    /**
+     * Marks the mapping as dirty, indicating that it needs to be refreshed. This method is called when the mapping changes,
+     * but can be called for other purposes as well. The mapping will be refreshed the next time it is validated.
+     */
+    protected final void invalidate() {
+        dirty = true;
+    }
+
+    /**
+     * Validates the mapping, refreshing it if it is marked as dirty. This method is called before any mapping operations
+     * to ensure that the mapping is up-to-date, but can be called for other purposes as well.
+     */
+    protected final void validate() {
+        if (dirty) {
+            refreshMap();
+            dirty = false;
+        }
+    }
+
+    /**
+     * Installed by the owning flow to receive notifications when the mapping changes.
+     * @param onChange the callback to be invoked when the mapping changes
+     */
+    final void setOnChange(Consumer<Boolean> onChange) {
+        this.onChange = onChange;
+    }
+}

--- a/modules/jfx.incubator.richtext/src/test/java/test/jfx/incubator/scene/control/richtext/RowMapTest.java
+++ b/modules/jfx.incubator.richtext/src/test/java/test/jfx/incubator/scene/control/richtext/RowMapTest.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package test.jfx.incubator.scene.control.richtext;
+
+import com.sun.javafx.tk.Toolkit;
+import javafx.scene.Scene;
+import javafx.scene.shape.PathElement;
+import javafx.stage.Stage;
+import jfx.incubator.scene.control.richtext.RichTextArea;
+import jfx.incubator.scene.control.richtext.RichTextAreaShim;
+import jfx.incubator.scene.control.richtext.TextPos;
+import com.sun.jfx.incubator.scene.control.richtext.CellArrangement;
+import jfx.incubator.scene.control.richtext.skin.RichTextAreaSkin;
+import jfx.incubator.scene.control.richtext.skin.RowMap;
+import com.sun.jfx.incubator.scene.control.richtext.TextCell;
+import com.sun.jfx.incubator.scene.control.richtext.VFlow;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import test.jfx.incubator.scene.util.TUtil;
+
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class RowMapTest {
+    private static final int NUM_PARAGRAPHS = 20;
+    private static final int HIDDEN_PARAGRAPHS = 4;
+    private RichTextArea control;
+    private RowMap rowMap;
+    private Stage stage;
+
+    @BeforeEach
+    public void beforeEach() {
+        TUtil.setUncaughtExceptionHandler();
+
+        control = new RichTextArea();
+        TestRichTextAreaSkin skin = new TestRichTextAreaSkin(control);
+        rowMap = skin.getTestRowMap();
+        control.setSkin(skin);
+
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < NUM_PARAGRAPHS; i++) {
+            if (i > 0) {
+                sb.append("\n");
+            }
+            sb.append("line ").append(i);
+        }
+        control.appendText(sb.toString());
+    }
+
+    @AfterEach
+    public void afterEach() {
+        if (stage != null) {
+            stage.hide();
+            stage = null;
+        }
+        TUtil.removeUncaughtExceptionHandler();
+    }
+
+    @Test
+    public void countVisibleRowsTest() {
+        Scene scene = new Scene(control, 300, 200);
+        stage = new Stage();
+        stage.setScene(scene);
+        stage.show();
+
+        Toolkit.getToolkit().firePulse();
+        VFlow vFlow = RichTextAreaShim.vflow(control);
+
+        int visibleRowCount = rowMap.getRowCount(NUM_PARAGRAPHS);
+        assertEquals(16, visibleRowCount, "Expected 16 visible rows, but rowMap got " + visibleRowCount);
+        visibleRowCount = vFlow.getRowCount();
+        assertEquals(16, visibleRowCount, "Expected 16 visible rows, but vflow got " + visibleRowCount);
+    }
+
+    @Test
+    public void mapIndexToRowsTest() {
+        // hidden paragraphs are 0, 5, 10, 15, so the expected view rows for model indices 0-19 are:
+        int[] expectedViewRows = {0, 0, 1, 2, 3, 4, 4, 5, 6, 7, 8, 8, 9, 10, 11, 12, 12, 13, 14, 15};
+        for (int i = 0; i < NUM_PARAGRAPHS; i++) {
+            int viewRow = rowMap.getViewRow(i);
+            assertEquals(expectedViewRows[i], viewRow, "Expected view row " + expectedViewRows[i] + " for model index " + i + ", but got " + viewRow);
+        }
+    }
+
+    @Test
+    public void mapRowsToIndexTest() {
+        // hidden paragraphs are 0, 5, 10, 15, so the expected model indices are the visible ones:
+        int[] expectedModelIndices = {1, 2, 3, 4, 6, 7, 8, 9, 11, 12, 13, 14, 16, 17, 18, 19};
+        for (int i = 0; i < NUM_PARAGRAPHS - HIDDEN_PARAGRAPHS; i++) {
+            int modelIndex = rowMap.getModelIndex(i);
+            assertEquals(expectedModelIndices[i], modelIndex, "Expected model index " + expectedModelIndices[i] + " for view row " + i + ", but got " + modelIndex);
+            assertFalse(rowMap.isHidden(modelIndex), "Expected model index " + modelIndex + " to be visible, but it is hidden");
+        }
+    }
+
+    @Test
+    public void mapInvariantTest() {
+        for (int i = 0; i < NUM_PARAGRAPHS; i++) {
+            if (!rowMap.isHidden(i)) {
+                int viewRow = rowMap.getViewRow(i);
+                int modelIndex = rowMap.getModelIndex(viewRow);
+                assertEquals(i, modelIndex, "Expected model index " + i + " for view row " + viewRow + ", but got " + modelIndex);
+            }
+        }
+    }
+
+    @Test
+    public void arrangementTest() {
+        StringBuilder sb = new StringBuilder();
+        for (int i = NUM_PARAGRAPHS; i < 100; i++) {
+            if (i > NUM_PARAGRAPHS) {
+                sb.append("\n");
+            }
+            sb.append("line ").append(i + NUM_PARAGRAPHS);
+        }
+        control.appendText(sb.toString());
+        Scene scene = new Scene(control, 300, 200);
+        stage = new Stage();
+        stage.setScene(scene);
+        stage.show();
+
+        Toolkit.getToolkit().firePulse();
+        VFlow vFlow = RichTextAreaShim.vflow(control);
+        CellArrangement arrangement = RichTextAreaShim.arrangement(control);
+        assertNull(arrangement.getCell(0), "Expected cell for row 0 to be null, but got " + arrangement.getCell(0));
+        TextCell cell = arrangement.getCell(1);
+        assertNotNull(cell, "Expected cell for row 1 to be not null, but got " + cell);
+        assertEquals(1, cell.getIndex(), "Expected cell for row 1 to have index 1, but got " + cell.getIndex());
+
+        control.select(TextPos.ofLeading(0, 0));
+        assertNull(vFlow.getCaretInfo(), "Expected caret info to be null for hidden paragraph, but got " + vFlow.getCaretInfo());
+        control.select(TextPos.ofLeading(1, 0));
+        assertNotNull(vFlow.getCaretInfo(), "Expected caret info to be not null for visible paragraph, but got " + vFlow.getCaretInfo());
+        control.select(TextPos.ofLeading(4, 1), TextPos.ofLeading(6, 3));
+        List<PathElement> rangeShape = vFlow.getRangeShape(TextPos.ofLeading(4, 1), TextPos.ofLeading(6, 3));
+        assertNotNull(rangeShape, "Expected range shape to be not null for visible paragraphs, but got " + rangeShape);
+        assertFalse(rangeShape.isEmpty(), "Expected range shape to be not empty for visible paragraphs, but got " + rangeShape);
+        control.select(TextPos.ofLeading(4, 10));
+        control.selectParagraphDown();
+        assertEquals(6, control.getCaretPosition().index(), "Expected caret to move to paragraph 6, but got " + control.getCaretPosition().index());
+
+    }
+
+    private static class TestRowMap extends RowMap {
+
+        private final TreeSet<Integer> hiddenParagraphs;
+
+        public TestRowMap(TreeSet<Integer> hiddenParagraphs) {
+            this.hiddenParagraphs = hiddenParagraphs;
+        }
+
+        @Override
+        public int getViewRowImpl(int modelIndex) {
+            return modelIndex - hiddenParagraphs.headSet(modelIndex).size();
+        }
+
+        @Override
+        public int getModelIndexImpl(int row) {
+            int modelIndex = row;
+            for (int hiddenIndex : hiddenParagraphs) {
+                if (hiddenIndex <= modelIndex) {
+                    modelIndex++;
+                } else {
+                    break;
+                }
+            }
+            return modelIndex;
+        }
+
+        @Override
+        public int getRowCountImpl(int modelParagraphCount) {
+            return modelParagraphCount - hiddenParagraphs.size();
+        }
+
+        @Override
+        public boolean isHiddenImpl(int modelIndex) {
+            return hiddenParagraphs.contains(modelIndex);
+        }
+    }
+
+    private static class TestRichTextAreaSkin extends RichTextAreaSkin {
+
+        private TestRowMap testRowMap;
+        public TestRichTextAreaSkin(RichTextArea control) {
+            super(control);
+        }
+
+        @Override
+        protected RowMap createRowMap() {
+            testRowMap = new TestRowMap(new TreeSet<>(Set.of(0, 5, 10, 15)));
+            return testRowMap;
+        }
+
+        public TestRowMap getTestRowMap() {
+            return testRowMap;
+        }
+    }
+
+}


### PR DESCRIPTION
This draft PR introduces `RowMap`, a class that allows an extensible mapping between the view, defined by “rows”, the index of the visible and rendered paragraphs, and the model, defined by the index of the document paragraphs. The default implementation maps one to one, so there is no difference before and after this PR. However, it allows extensions to perform paragraph hiding as needed.

This PR includes a new demo app, the Headings app, that shows how a custom RowMap is used to hide and show (collapse and expand) different sections of a document, while keeping their hidings visible.

This PR doesn’t modify the visibility of some classes like `VFlow` or `TextCell`, that remain under com.sun, but at some point this will be a requirement, given that the lack of access to them limits the extension of changes that are possible. 

For instance, modifying the heading cell to show the chevron now is not possible (and it is has to be part of the left decorator). Features like code folding, that typically show some visual indication like "{...}" in the visible paragraph that indicates a collapsed block, would definitely some kind of public access to TextCell.

In any case, this is a first step towards a more customizable RichTextArea control, and more improvements should come in future follow-ups.

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[ \] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2276/head:pull/2276` \
`$ git checkout pull/2276`

Update a local copy of the PR: \
`$ git checkout pull/2276` \
`$ git pull https://git.openjdk.org/jfx.git pull/2276/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2276`

View PR using the GUI difftool: \
`$ git pr show -t 2276`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2276.diff">https://git.openjdk.org/jfx/pull/2276.diff</a>

</details>
