### PR TITLE
8391279: Fix pixel-snapping in Region

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/Region.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/Region.java
@@ -244,6 +244,23 @@ public class Region extends Parent {
         return a <= b ? a : b;
     }
 
+    /**
+     * Returns {@code width} reduced by the horizontal margins. If pixel snapping is enabled, the left and
+     * right margins are independently snapped as horizontal space before they are subtracted.
+     * <p>
+     * This method deliberately does not snap {@code width} or the returned value. It performs only the
+     * margin adjustment and does not choose a fitting policy for a potentially unsnapped input width.
+     * A caller that chooses to consume the result as a pixel-aligned allocated content span is responsible
+     * for applying the appropriate snapping operation.
+     * <p>
+     * A {@code null} or empty margin is equivalent to zero margins and leaves {@code width} unchanged;
+     * in particular, it does not cause {@code width} to be normalized.
+     *
+     * @param width the width to adjust
+     * @param margin the margins to subtract, or {@code null}
+     * @return {@code width} minus the left and right margins, independently snapped when
+     *         pixel snapping is enabled; the result itself is not snapped
+     */
     double adjustWidthByMargin(double width, Insets margin) {
         if (margin == null || margin == Insets.EMPTY) {
             return width;
@@ -252,6 +269,23 @@ public class Region extends Parent {
         return width - snapSpaceX(margin.getLeft(), isSnapToPixel) - snapSpaceX(margin.getRight(), isSnapToPixel);
     }
 
+    /**
+     * Returns {@code height} reduced by the vertical margins. If pixel snapping is enabled, the top and
+     * bottom margins are independently snapped as vertical space before they are subtracted.
+     * <p>
+     * This method deliberately does not snap {@code height} or the returned value. It performs only the
+     * margin adjustment and does not choose a fitting policy for a potentially unsnapped input height.
+     * A caller that chooses to consume the result as a pixel-aligned allocated content span is responsible
+     * for applying the appropriate snapping operation, usually {@link #snapSpaceY(double)}.
+     * <p>
+     * A {@code null} or empty margin is equivalent to zero margins and leaves {@code height} unchanged;
+     * in particular, it does not cause {@code height} to be normalized.
+     *
+     * @param height the height to adjust
+     * @param margin the margins to subtract, or {@code null}
+     * @return {@code height} minus the top and bottom margins, independently snapped when
+     *         pixel snapping is enabled; the result itself is not snapped
+     */
     double adjustHeightByMargin(double height, Insets margin) {
         if (margin == null || margin == Insets.EMPTY) {
             return height;
@@ -391,6 +425,18 @@ public class Region extends Parent {
         double s = getSnapScaleY();
 
         return value > 0 ? ScaledMath.floor(value, s) : ScaledMath.ceil(value, s);
+    }
+
+    /**
+     * If snapToPixel is true, rounds the value to the nearest pixel. This method is used to
+     * remove floating-point drift after a calculation that involves known-aligned values.
+     * <p>
+     * This method is mathematically equivalent to {@link #snapSpace(double, boolean, double)},
+     * but has a distinct name that clearly communicates that the author knows that the value
+     * is already pixel-aligned.
+     */
+    private static double snapAligned(double value, boolean snapToPixel, double snapScale) {
+        return snapToPixel ? ScaledMath.round(value, snapScale) : value;
     }
 
     double getAreaBaselineOffset(List<Node> children, Callback<Node, Insets> margins,
@@ -1905,164 +1951,345 @@ public class Region extends Parent {
         return snappedRightInset;
     }
 
-
+    /**
+     * Returns the minimum horizontal space required to lay out the child, including its left and right margins.
+     * <p>
+     * When {@link #isSnapToPixel()} is true, the result is guaranteed to be aligned to the horizontal
+     * pixel grid. Otherwise, no pixel-alignment guarantee is made.
+     *
+     * @param child the child to measure
+     * @param margin the child's margin, or {@code null} for no margin
+     * @return the minimum horizontal space required to lay out the child
+     */
     double computeChildMinAreaWidth(Node child, Insets margin) {
         return computeChildMinAreaWidth(child, -1, margin, -1, false);
     }
 
-    double computeChildMinAreaWidth(Node child, double baselineComplement, Insets margin, double availableHeight, boolean fillHeight) {
-        final boolean snap = isSnapToPixel();
-        double left = margin != null? snapSpaceX(margin.getLeft(), snap) : 0;
-        double right = margin != null? snapSpaceX(margin.getRight(), snap) : 0;
+    /**
+     * Returns the minimum horizontal space required to lay out the child, including its left and right margins.
+     * For a resizable child with vertical content bias, {@code availableHeight} determines the height used to
+     * compute its width.
+     * <p>
+     * When {@link #isSnapToPixel()} is true, the result is guaranteed to be aligned to the horizontal pixel grid.
+     * Otherwise, no pixel-alignment guarantee is made.
+     *
+     * @param child the child to measure
+     * @param baselineComplement the extent below the common baseline, or {@code -1} when baseline alignment is not used
+     * @param margin the child's margin, or {@code null} for no margin
+     * @param availableHeight the available height including margins, or {@code -1} when unknown
+     * @param fillHeight whether the child may fill the available height instead of being limited to its preferred height
+     * @return the minimum horizontal space required to lay out the child
+     */
+    double computeChildMinAreaWidth(Node child, double baselineComplement, Insets margin,
+                                    double availableHeight, boolean fillHeight) {
+        boolean snap = isSnapToPixel();
+        double scaleX = getSnapScaleX();
+        double scaleY = getSnapScaleY();
+        double snappedLeft = margin != null ? snapSpace(margin.getLeft(), snap, scaleX) : 0;
+        double snappedRight = margin != null ? snapSpace(margin.getRight(), snap, scaleX) : 0;
         double alt = -1;
+
         if (availableHeight != -1 && child.isResizable() && child.getContentBias() == Orientation.VERTICAL) { // width depends on height
-            double top = margin != null? snapSpaceY(margin.getTop(), snap) : 0;
-            double bottom = (margin != null? snapSpaceY(margin.getBottom(), snap) : 0);
-            double bo = child.getBaselineOffset();
-            final double contentHeight = bo == BASELINE_OFFSET_SAME_AS_HEIGHT && baselineComplement != -1 ?
-                    availableHeight - top - bottom - baselineComplement :
-                    availableHeight - top - bottom;
-            alt = computedBoundedHeight(child, fillHeight, contentHeight);
+            double snappedContentHeight = computeContentHeight(margin, availableHeight, snap, scaleY);
+            double baseline = child.getBaselineOffset();
+            if (baseline == BASELINE_OFFSET_SAME_AS_HEIGHT && baselineComplement != -1) {
+                // The outer height is a size allocation, while the complement is space.
+                double snappedComplement = snapSpace(baselineComplement, snap, scaleY);
+                snappedContentHeight = snapAligned(snappedContentHeight - snappedComplement, snap, scaleY);
+            }
+
+            alt = computeBoundedHeight(child, fillHeight, snappedContentHeight, snap, scaleY);
         }
-        return left + snapSizeX(child.minWidth(alt)) + right;
+
+        double snappedChildWidth = snapSize(child.minWidth(alt), snap, scaleX);
+        return snapAligned(snappedLeft + snappedChildWidth + snappedRight, snap, scaleX);
     }
 
+    /**
+     * Returns the minimum vertical space required to lay out the child, including its top and bottom margins.
+     * <p>
+     * When {@link #isSnapToPixel()} is true, the result is guaranteed to be aligned to the vertical pixel grid.
+     * Otherwise, no pixel-alignment guarantee is made.
+     *
+     * @param child the child to measure
+     * @param margin the child's margin, or {@code null} for no margin
+     * @return the minimum vertical space required to lay out the child
+     */
     double computeChildMinAreaHeight(Node child, Insets margin) {
         return computeChildMinAreaHeight(child, -1, margin, -1, false);
     }
 
-    double computeChildMinAreaHeight(Node child, double minBaselineComplement, Insets margin, double availableWidth, boolean fillWidth) {
-        final boolean snap = isSnapToPixel();
-        double top =margin != null? snapSpaceY(margin.getTop(), snap) : 0;
-        double bottom = margin != null? snapSpaceY(margin.getBottom(), snap) : 0;
-
+    /**
+     * Returns the minimum vertical space required to lay out the child, taking its margins and optional
+     * common-baseline alignment into account. For a resizable child with horizontal content bias,
+     * {@code availableWidth} determines the width used to compute its height.
+     * <p>
+     * When {@link #isSnapToPixel()} is true, the result is guaranteed to be aligned to the vertical pixel grid.
+     * Otherwise, no pixel-alignment guarantee is made.
+     *
+     * @param child the child to measure
+     * @param minBaselineComplement the extent below the common baseline, or {@code -1} when baseline alignment is not used
+     * @param margin the child's margin, or {@code null} for no margin
+     * @param availableWidth the available width including margins, or {@code -1} when unknown
+     * @param fillWidth whether the child may fill the available width instead of being limited to its preferred width
+     * @return the minimum vertical space required to lay out the child
+     */
+    double computeChildMinAreaHeight(Node child, double minBaselineComplement, Insets margin,
+                                     double availableWidth, boolean fillWidth) {
+        boolean snap = isSnapToPixel();
+        double scaleX = getSnapScaleX();
+        double scaleY = getSnapScaleY();
+        double snappedTop = margin != null ? snapSpace(margin.getTop(), snap, scaleY) : 0;
+        double snappedBottom = margin != null ? snapSpace(margin.getBottom(), snap, scaleY) : 0;
         double alt = -1;
-        if (availableWidth != -1 && child.isResizable() && child.getContentBias() == Orientation.HORIZONTAL) { // height depends on width
-            double contentWidth = computeContentWidth(margin, availableWidth);
 
-            alt = computeBoundedWidth(child, fillWidth, contentWidth);
+        if (availableWidth != -1 && child.isResizable() && child.getContentBias() == Orientation.HORIZONTAL) { // height depends on width
+            double snappedContentWidth = computeContentWidth(margin, availableWidth, snap, scaleX);
+            alt = computeBoundedWidth(child, fillWidth, snappedContentWidth, snap, scaleX);
         }
 
-        // For explanation, see computeChildPrefAreaHeight
         if (minBaselineComplement != -1) {
             double baseline = child.getBaselineOffset();
-            if (child.isResizable() && baseline == BASELINE_OFFSET_SAME_AS_HEIGHT) {
-                return top + snapSizeY(child.minHeight(alt)) + bottom
-                        + minBaselineComplement;
+
+            // The baseline complement is the extent below the common baseline. It is deliberately kept raw because
+            // it is an intermediate part of the complete baseline-aligned area; snapping it separately could lose
+            // precision or over-allocate. Combine it with the extent above the baseline and snap the resulting
+            // content size instead.
+            if (baseline == BASELINE_OFFSET_SAME_AS_HEIGHT) {
+                double snappedChildMinHeight = snapSize(child.minHeight(alt), snap, scaleY);
+                double snappedAbove = snapAligned(snappedTop + snappedBottom + snappedChildMinHeight, snap, scaleY);
+                return snapSize(snappedAbove + minBaselineComplement, snap, scaleY);
             } else {
-                return baseline + minBaselineComplement;
+                return snapSize(baseline + minBaselineComplement, snap, scaleY);
             }
         } else {
-            return top + snapSizeY(child.minHeight(alt)) + bottom;
+            double snappedChildHeight = snapSize(child.minHeight(alt), snap, scaleY);
+            return snapAligned(snappedTop + snappedBottom + snappedChildHeight, snap, scaleY);
         }
     }
 
+    /**
+     * Returns the preferred horizontal space required to lay out the child, including its left and right margins.
+     * <p>
+     * When {@link #isSnapToPixel()} is true, the result is guaranteed to be aligned to the horizontal pixel grid.
+     * Otherwise, no pixel-alignment guarantee is made.
+     *
+     * @param child the child to measure
+     * @param margin the child's margin, or {@code null} for no margin
+     * @return the preferred horizontal space to lay out the child
+     */
     double computeChildPrefAreaWidth(Node child, Insets margin) {
         return computeChildPrefAreaWidth(child, -1, margin, -1, false);
     }
 
-    double computeChildPrefAreaWidth(Node child, double baselineComplement, Insets margin, double availableHeight, boolean fillHeight) {
-        final boolean snap = isSnapToPixel();
-        double left = margin != null? snapSpaceX(margin.getLeft(), snap) : 0;
-        double right = margin != null? snapSpaceX(margin.getRight(), snap) : 0;
+    /**
+     * Returns the preferred horizontal space required to lay out the child, including its left and right margins.
+     * For a resizable child with vertical content bias, {@code availableHeight} determines the height used
+     * to compute its width.
+     * <p>
+     * When {@link #isSnapToPixel()} is true, the result is guaranteed to be aligned to the horizontal pixel grid.
+     * Otherwise, no pixel-alignment guarantee is made.
+     *
+     * @param child the child to measure
+     * @param baselineComplement the extent below the common baseline, or {@code -1} when baseline alignment is not used
+     * @param margin the child's margin, or {@code null} for no margin
+     * @param availableHeight the available height including margins, or {@code -1} when unknown
+     * @param fillHeight whether the child may fill the available height instead of being limited to its preferred height
+     * @return the preferred horizontal space to lay out the child
+     */
+    double computeChildPrefAreaWidth(Node child, double baselineComplement, Insets margin,
+                                     double availableHeight, boolean fillHeight) {
+        boolean snap = isSnapToPixel();
+        double scaleX = getSnapScaleX();
+        double scaleY = getSnapScaleY();
+        double snappedLeft = margin != null ? snapSpace(margin.getLeft(), snap, scaleX) : 0;
+        double snappedRight = margin != null ? snapSpace(margin.getRight(), snap, scaleX) : 0;
         double alt = -1;
+
         if (availableHeight != -1 && child.isResizable() && child.getContentBias() == Orientation.VERTICAL) { // width depends on height
-            double top = margin != null? snapSpaceY(margin.getTop(), snap) : 0;
-            double bottom = margin != null? snapSpaceY(margin.getBottom(), snap) : 0;
-            double bo = child.getBaselineOffset();
-            final double contentHeight = bo == BASELINE_OFFSET_SAME_AS_HEIGHT && baselineComplement != -1 ?
-                    availableHeight - top - bottom - baselineComplement :
-                    availableHeight - top - bottom;
-            alt = computedBoundedHeight(child, fillHeight, contentHeight);
+            double snappedContentHeight = computeContentHeight(margin, availableHeight, snap, scaleY);
+            double baseline = child.getBaselineOffset();
+            if (baseline == BASELINE_OFFSET_SAME_AS_HEIGHT && baselineComplement != -1) {
+                // The outer height is a size allocation, while the complement is space.
+                double snappedComplement = snapSpace(baselineComplement, snap, scaleY);
+                snappedContentHeight = snapAligned(snappedContentHeight - snappedComplement, snap, scaleY);
+            }
+
+            alt = computeBoundedHeight(child, fillHeight, snappedContentHeight, snap, scaleY);
         }
-        return left + snapSizeX(boundedSize(child.minWidth(alt), child.prefWidth(alt), child.maxWidth(alt))) + right;
+
+        double rawChildPrefWidth = boundedSize(child.minWidth(alt), child.prefWidth(alt), child.maxWidth(alt));
+        return snapAligned(snappedLeft + snappedRight + snapSize(rawChildPrefWidth, snap, scaleX), snap, scaleX);
     }
 
+    /**
+     * Returns the preferred vertical space to lay out the child, including its top and bottom margins.
+     * <p>
+     * When {@link #isSnapToPixel()} is true, the result is guaranteed to be aligned to the vertical pixel grid.
+     * Otherwise, no pixel-alignment guarantee is made.
+     *
+     * @param child the child to measure
+     * @param margin the child's margin, or {@code null} for no margin
+     * @return the preferred vertical space to lay out the child
+     */
     double computeChildPrefAreaHeight(Node child, Insets margin) {
         return computeChildPrefAreaHeight(child, -1, margin, -1, false);
     }
 
-    double computeChildPrefAreaHeight(Node child, double prefBaselineComplement, Insets margin, double availableWidth, boolean fillWidth) {
-        final boolean snap = isSnapToPixel();
-        double top = margin != null? snapSpaceY(margin.getTop(), snap) : 0;
-        double bottom = margin != null? snapSpaceY(margin.getBottom(), snap) : 0;
-
+    /**
+     * Returns the preferred vertical space to lay out the child, taking its margins and optional common-baseline
+     * alignment into account. For a resizable child with horizontal content bias, {@code availableWidth}
+     * determines the width used to compute its height.
+     * <p>
+     * When {@link #isSnapToPixel()} is true, the result is guaranteed to be aligned to the vertical pixel grid.
+     * Otherwise, no pixel-alignment guarantee is made.
+     *
+     * @param child the child to measure
+     * @param prefBaselineComplement the extent below the common baseline, or {@code -1} when baseline alignment is not used
+     * @param margin the child's margin, or {@code null} for no margin
+     * @param availableWidth the available width including margins, or {@code -1} when unknown
+     * @param fillWidth whether the child may fill the available width instead of being limited to its preferred width
+     * @return the preferred vertical space to lay out the child
+     */
+    double computeChildPrefAreaHeight(Node child, double prefBaselineComplement, Insets margin,
+                                      double availableWidth, boolean fillWidth) {
+        boolean snap = isSnapToPixel();
+        double scaleX = getSnapScaleX();
+        double scaleY = getSnapScaleY();
+        double snappedTop = margin != null ? snapSpace(margin.getTop(), snap, scaleY) : 0;
+        double snappedBottom = margin != null ? snapSpace(margin.getBottom(), snap, scaleY) : 0;
         double alt = -1;
-        if (availableWidth != -1 && child.isResizable() && child.getContentBias() == Orientation.HORIZONTAL) { // height depends on width
-            double contentWidth = computeContentWidth(margin, availableWidth);
 
-            alt = computeBoundedWidth(child, fillWidth, contentWidth);
+        if (availableWidth != -1 && child.isResizable() && child.getContentBias() == Orientation.HORIZONTAL) { // height depends on width
+            double contentWidth = computeContentWidth(margin, availableWidth, snap, scaleX);
+            alt = computeBoundedWidth(child, fillWidth, contentWidth, snap, scaleX);
         }
 
         if (prefBaselineComplement != -1) {
-            double baseline = child.getBaselineOffset();
-            if (child.isResizable() && baseline == BASELINE_OFFSET_SAME_AS_HEIGHT) {
-                // When baseline is same as height, the preferred height of the node will be above the baseline, so we need to add
-                // the preferred complement to it
-                return top + snapSizeY(boundedSize(child.minHeight(alt), child.prefHeight(alt), child.maxHeight(alt))) + bottom
-                        + prefBaselineComplement;
+            double rawBaseline = child.getBaselineOffset();
+
+            // The baseline complement is the extent below the common baseline. It is deliberately kept raw because
+            // it is an intermediate part of the complete baseline-aligned area; snapping it separately could lose
+            // precision or over-allocate. Combine it with the extent above the baseline and snap the resulting
+            // content size instead.
+            if (rawBaseline == BASELINE_OFFSET_SAME_AS_HEIGHT) {
+                double rawChildPrefHeight = boundedSize(child.minHeight(alt), child.prefHeight(alt), child.maxHeight(alt));
+                double snappedChildPrefHeight = snapSize(rawChildPrefHeight, snap, scaleY);
+                double snappedAbove = snapAligned(snappedTop + snappedBottom + snappedChildPrefHeight, snap, scaleY);
+                return snapSize(snappedAbove + prefBaselineComplement, snap, scaleY);
             } else {
-                // For all other Nodes, it's just their baseline and the complement.
-                // Note that the complement already contain the Node's preferred (or fixed) height
-                return top + baseline + prefBaselineComplement + bottom;
+                double snappedMargins = snapAligned(snappedTop + snappedBottom, snap, scaleY);
+                return snapSize(snappedMargins + rawBaseline + prefBaselineComplement, snap, scaleY);
             }
         } else {
-            return top + snapSizeY(boundedSize(child.minHeight(alt), child.prefHeight(alt), child.maxHeight(alt))) + bottom;
+            double rawChildPrefHeight = boundedSize(child.minHeight(alt), child.prefHeight(alt), child.maxHeight(alt));
+            return snapAligned(snappedTop + snappedBottom + snapSize(rawChildPrefHeight, snap, scaleY), snap, scaleY);
         }
     }
 
-    double computeChildMaxAreaWidth(Node child, double baselineComplement, Insets margin, double availableHeight, boolean fillHeight) {
-        double max = child.maxWidth(-1);
-        if (max == Double.MAX_VALUE) {
-            return max;
-        }
-        final boolean snap = isSnapToPixel();
-        double left = margin != null? snapSpaceX(margin.getLeft(), snap) : 0;
-        double right = margin != null? snapSpaceX(margin.getRight(), snap) : 0;
+    /**
+     * Returns the maximum horizontal space to lay out the child, including its left and right margins.
+     * For a resizable child with vertical content bias, {@code availableHeight} determines the height used
+     * to compute its width. If the child has no finite maximum width, {@link Double#MAX_VALUE} is returned
+     * unchanged.
+     * <p>
+     * When {@link #isSnapToPixel()} is true, every result other than the {@code Double.MAX_VALUE} sentinel
+     * is guaranteed to be aligned to the horizontal pixel grid. Otherwise, no pixel-alignment guarantee
+     * is made.
+     *
+     * @param child the child to measure
+     * @param baselineComplement the extent below the common baseline, or {@code -1} when baseline alignment is not used
+     * @param margin the child's margin, or {@code null} for no margin
+     * @param availableHeight the available height including margins, or {@code -1} when unknown
+     * @param fillHeight whether the child may fill the available height instead of being limited to its preferred height
+     * @return the maximum horizontal space to lay out the child, or {@code Double.MAX_VALUE} if it has no finite maximum width
+     */
+    double computeChildMaxAreaWidth(Node child, double baselineComplement, Insets margin,
+                                    double availableHeight, boolean fillHeight) {
+        boolean snap = isSnapToPixel();
+        double scaleX = getSnapScaleX();
+        double scaleY = getSnapScaleY();
+        double snappedLeft = margin != null ? snapSpaceX(margin.getLeft(), snap) : 0;
+        double snappedRight = margin != null ? snapSpaceX(margin.getRight(), snap) : 0;
         double alt = -1;
+
         if (availableHeight != -1 && child.isResizable() && child.getContentBias() == Orientation.VERTICAL) { // width depends on height
-            double top = margin != null? snapSpaceY(margin.getTop(), snap) : 0;
-            double bottom = (margin != null? snapSpaceY(margin.getBottom(), snap) : 0);
-            double bo = child.getBaselineOffset();
-            final double contentHeight = bo == BASELINE_OFFSET_SAME_AS_HEIGHT && baselineComplement != -1 ?
-                    availableHeight - top - bottom - baselineComplement :
-                    availableHeight - top - bottom;
+            double snappedContentHeight = computeContentHeight(margin, availableHeight, snap, scaleY);
+            double rawBaseline = child.getBaselineOffset();
+            if (rawBaseline == BASELINE_OFFSET_SAME_AS_HEIGHT && baselineComplement != -1) {
+                // The outer height is a size allocation, while the complement is space.
+                double snappedComplement = snapSpace(baselineComplement, snap, scaleY);
+                snappedContentHeight = snapAligned(snappedContentHeight - snappedComplement, snap, scaleY);
+            }
 
-            alt = computedBoundedHeight(child, fillHeight, contentHeight);
-            max = child.maxWidth(alt);
+            alt = computeBoundedHeight(child, fillHeight, snappedContentHeight, snap, scaleY);
         }
-        // if min > max, min wins, so still need to call boundedSize()
-        return left + snapSizeX(boundedSize(child.minWidth(alt), max, Double.MAX_VALUE)) + right;
-    }
 
-    double computeChildMaxAreaHeight(Node child, double maxBaselineComplement, Insets margin, double availableWidth, boolean fillWidth) {
-        double max = child.maxHeight(-1);
+        double max = child.maxWidth(alt);
         if (max == Double.MAX_VALUE) {
             return max;
         }
 
-        final boolean snap = isSnapToPixel();
-        double top = margin != null? snapSpaceY(margin.getTop(), snap) : 0;
-        double bottom = margin != null? snapSpaceY(margin.getBottom(), snap) : 0;
-        double alt = -1;
-        if (availableWidth != -1 && child.isResizable() && child.getContentBias() == Orientation.HORIZONTAL) { // height depends on width
-            double contentWidth = computeContentWidth(margin, availableWidth);
+        double snappedChildWidth = snapSize(boundedSize(child.minWidth(alt), max, Double.MAX_VALUE), snap, scaleX);
+        return snapAligned(snappedLeft + snappedChildWidth + snappedRight, snap, scaleX);
+    }
 
-            alt = computeBoundedWidth(child, fillWidth, contentWidth);
-            max = child.maxHeight(alt);
+    /**
+     * Returns the maximum vertical space to lay out the child, taking its margins and optional common-baseline
+     * alignment into account. For a resizable child with horizontal content bias, {@code availableWidth}
+     * determines the width used to compute its height. If the child has no finite maximum height,
+     * {@link Double#MAX_VALUE} is returned unchanged.
+     * <p>
+     * When {@link #isSnapToPixel()} is true, every result other than the {@code Double.MAX_VALUE} sentinel
+     * is guaranteed to be aligned to the vertical pixel grid. Otherwise, no pixel-alignment guarantee
+     * is made.
+     *
+     * @param child the child to measure
+     * @param maxBaselineComplement the extent below the common baseline, or {@code -1} when baseline alignment is not used
+     * @param margin the child's margin, or {@code null} for no margin
+     * @param availableWidth the available width including margins, or {@code -1} when unknown
+     * @param fillWidth whether the child may fill the available width instead of being limited to its preferred width
+     * @return the maximum vertical space to lay out the child, or {@code Double.MAX_VALUE} if it has no finite maximum height
+     */
+    double computeChildMaxAreaHeight(Node child, double maxBaselineComplement, Insets margin,
+                                     double availableWidth, boolean fillWidth) {
+        boolean snap = isSnapToPixel();
+        double scaleX = getSnapScaleX();
+        double scaleY = getSnapScaleY();
+        double snappedTop = margin != null ? snapSpace(margin.getTop(), snap, scaleY) : 0;
+        double snappedBottom = margin != null ? snapSpace(margin.getBottom(), snap, scaleY) : 0;
+        double alt = -1;
+
+        if (availableWidth != -1 && child.isResizable() && child.getContentBias() == Orientation.HORIZONTAL) { // height depends on width
+            double snappedContentWidth = computeContentWidth(margin, availableWidth, snap, scaleX);
+            alt = computeBoundedWidth(child, fillWidth, snappedContentWidth, snap, scaleX);
         }
-        // For explanation, see computeChildPrefAreaHeight
+
+        double max = child.maxHeight(alt);
+        if (max == Double.MAX_VALUE) {
+            return max;
+        }
+
         if (maxBaselineComplement != -1) {
-            double baseline = child.getBaselineOffset();
-            if (child.isResizable() && baseline == BASELINE_OFFSET_SAME_AS_HEIGHT) {
-                return top + snapSizeY(boundedSize(child.minHeight(alt), max, Double.MAX_VALUE)) + bottom
-                        + maxBaselineComplement;
+            double rawBaseline = child.getBaselineOffset();
+
+            // The baseline complement is the extent below the common baseline. It is deliberately kept raw because
+            // it is an intermediate part of the complete baseline-aligned area; snapping it separately could lose
+            // precision or over-allocate. Combine it with the extent above the baseline and snap the resulting
+            // content size instead.
+            if (rawBaseline == BASELINE_OFFSET_SAME_AS_HEIGHT) {
+                double rawChildMaxHeight = boundedSize(child.minHeight(alt), max, Double.MAX_VALUE);
+                double snappedChildMaxHeight = snapSize(rawChildMaxHeight, snap, scaleY);
+                double snappedAbove = snapAligned(snappedTop + snappedBottom + snappedChildMaxHeight, snap, scaleY);
+                return snapSize(snappedAbove + maxBaselineComplement, snap, scaleY);
             } else {
-                return top + baseline + maxBaselineComplement + bottom;
+                double margins = snapAligned(snappedTop + snappedBottom, snap, scaleY);
+                return snapSize(margins + rawBaseline + maxBaselineComplement, snap, scaleY);
             }
         } else {
             // if min > max, min wins, so still need to call boundedSize()
-            return top + snapSizeY(boundedSize(child.minHeight(alt), max, Double.MAX_VALUE)) + bottom;
+            double snappedChildHeight = snapSize(boundedSize(child.minHeight(alt), max, Double.MAX_VALUE), snap, scaleY);
+            return snapAligned(snappedTop + snappedBottom + snappedChildHeight, snap, scaleY);
         }
     }
 
@@ -2094,15 +2321,16 @@ public class Region extends Parent {
      * controls whether the content width or the child's preferred width is used to compute
      * the bounded width.
      */
-    private double computeBoundedWidth(Node child, boolean fill, double contentWidth) {
+    private double computeBoundedWidth(Node child, boolean fill, double contentWidth,
+                                       boolean snapToPixel, double snapScale) {
         double min = child.minWidth(-1);
         double max = child.maxWidth(-1);
 
         if (fill) {
-            return snapSizeX(boundedSize(min, contentWidth, max));
+            return snapSize(boundedSize(min, contentWidth, max), snapToPixel, snapScale);
         }
 
-        return snapSizeX(boundedSize(min, child.prefWidth(-1), Math.min(max, contentWidth)));
+        return snapSize(boundedSize(min, child.prefWidth(-1), Math.min(max, contentWidth)), snapToPixel, snapScale);
     }
 
     /*
@@ -2110,27 +2338,38 @@ public class Region extends Parent {
      * controls whether the content height or the child's preferred height is used to compute
      * the bounded height.
      */
-    private double computedBoundedHeight(Node child, boolean fill, double contentHeight) {
+    private double computeBoundedHeight(Node child, boolean fill, double contentHeight,
+                                        boolean snapToPixel, double snapScale) {
         double min = child.minHeight(-1);
         double max = child.maxHeight(-1);
 
         if (fill) {
-            return snapSizeY(boundedSize(min, contentHeight, max));
+            return snapSize(boundedSize(min, contentHeight, max), snapToPixel, snapScale);
         }
 
-        return snapSizeY(boundedSize(min, child.prefHeight(-1), Math.min(max, contentHeight)));
+        return snapSize(boundedSize(min, child.prefHeight(-1), Math.min(max, contentHeight)), snapToPixel, snapScale);
     }
 
     /*
      * Removes the given Margin (if any) from a width which still includes margins
      * to create a content width.
      */
-    private double computeContentWidth(Insets margin, double width) {
-        boolean snap = isSnapToPixel();
-        double left = margin != null ? snapSpaceX(margin.getLeft(), snap) : 0;
-        double right = margin != null ? snapSpaceX(margin.getRight(), snap) : 0;
+    private double computeContentWidth(Insets margin, double width, boolean snapToPixel, double snapScale) {
+        double left = margin != null ? snapSpace(margin.getLeft(), snapToPixel, snapScale) : 0;
+        double right = margin != null ? snapSpace(margin.getRight(), snapToPixel, snapScale) : 0;
 
-        return width - left - right;
+        return snapAligned(snapSize(width, snapToPixel, snapScale) - left - right, snapToPixel, snapScale);
+    }
+
+    /*
+     * Removes the given Margin (if any) from a height which still includes margins
+     * to create a content height.
+     */
+    private double computeContentHeight(Insets margin, double height, boolean snapToPixel, double snapScale) {
+        double top = margin != null ? snapSpace(margin.getTop(), snapToPixel, snapScale) : 0;
+        double bottom = margin != null ? snapSpace(margin.getBottom(), snapToPixel, snapScale) : 0;
+
+        return snapAligned(snapSize(height, snapToPixel, snapScale) - top - bottom, snapToPixel, snapScale);
     }
 
     /* Max of children's minimum area widths */
@@ -2618,67 +2857,94 @@ public class Region extends Parent {
                                double areaBaselineOffset,
                                Insets margin, boolean fillWidth, boolean fillHeight,
                                HPos halignment, VPos valignment, boolean isSnapToPixel) {
-
+        //
+        // We need to be careful how we treat the provided arguments when pixel-snapping is enabled:
+        //
+        // areaWidth, areaHeight: Preserve raw values for positioning, but deliberately size-snap them when
+        //                        deriving the resizable child's size allocation.
+        // areaBaselineOffset:    Do not snap independently to preserve precision. Snap derived spans such as
+        //                        areaBaselineOffset-rawBaseline or areaHeight-areaBaselineOffset as space.
+        // margins:               Snap each margin independently as space.
+        //
         Insets childMargin = margin != null ? margin : Insets.EMPTY;
         double snapScaleX = isSnapToPixel ? getSnapScaleX(child) : 1.0;
         double snapScaleY = isSnapToPixel ? getSnapScaleY(child) : 1.0;
 
-        double top = snapSpace(childMargin.getTop(), isSnapToPixel, snapScaleY);
-        double bottom = snapSpace(childMargin.getBottom(), isSnapToPixel, snapScaleY);
-        double left = snapSpace(childMargin.getLeft(), isSnapToPixel, snapScaleX);
-        double right = snapSpace(childMargin.getRight(), isSnapToPixel, snapScaleX);
+        double snappedTop = snapSpace(childMargin.getTop(), isSnapToPixel, snapScaleY);
+        double snappedBottom = snapSpace(childMargin.getBottom(), isSnapToPixel, snapScaleY);
+        double snappedLeft = snapSpace(childMargin.getLeft(), isSnapToPixel, snapScaleX);
+        double snappedRight = snapSpace(childMargin.getRight(), isSnapToPixel, snapScaleX);
 
         if (valignment == VPos.BASELINE) {
-            double bo = child.getBaselineOffset();
-            if (bo == BASELINE_OFFSET_SAME_AS_HEIGHT) {
+            double rawBaseline = child.getBaselineOffset();
+            if (rawBaseline == BASELINE_OFFSET_SAME_AS_HEIGHT) {
                 if (child.isResizable()) {
-                    // Everything below the baseline is like an "inset". The Node with BASELINE_OFFSET_SAME_AS_HEIGHT cannot
-                    // be resized to this area
-                    bottom += snapSpace(areaHeight - areaBaselineOffset, isSnapToPixel, snapScaleY);
+                    // Everything below the baseline is like an "inset".
+                    // The Node with BASELINE_OFFSET_SAME_AS_HEIGHT cannot be resized to this area.
+                    snappedBottom = snapSpace(areaHeight - areaBaselineOffset, isSnapToPixel, snapScaleY);
                 } else {
-                    top = snapSpace(areaBaselineOffset - child.getLayoutBounds().getHeight(), isSnapToPixel, snapScaleY);
+                    snappedTop = snapSpace(areaBaselineOffset - child.getLayoutBounds().getHeight(), isSnapToPixel, snapScaleY);
                 }
             } else {
-                top = snapSpace(areaBaselineOffset - bo, isSnapToPixel, snapScaleY);
+                snappedTop = snapSpace(areaBaselineOffset - rawBaseline, isSnapToPixel, snapScaleY);
             }
         }
 
         if (child.isResizable()) {
-            Vec2d size = boundedNodeSizeWithBias(child, areaWidth - left - right, areaHeight - top - bottom,
-                    fillWidth, fillHeight, isSnapToPixel, snapScaleX, snapScaleY, TEMP_VEC2D);
+            double snappedAreaWidth = snapSize(areaWidth, isSnapToPixel, snapScaleX);
+            double snappedAreaHeight = snapSize(areaHeight, isSnapToPixel, snapScaleY);
+            double snappedAvailableWidth = snapAligned(snappedAreaWidth - snappedLeft - snappedRight, isSnapToPixel, snapScaleX);
+            double snappedAvailableHeight = snapAligned(snappedAreaHeight - snappedTop - snappedBottom, isSnapToPixel, snapScaleY);
+            Vec2d size = boundedNodeSizeWithBias(child, snappedAvailableWidth, snappedAvailableHeight,
+                fillWidth, fillHeight, isSnapToPixel, snapScaleX, snapScaleY, TEMP_VEC2D);
             child.resize(size.x, size.y);
         }
+
         position(child, areaX, areaY, areaWidth, areaHeight, areaBaselineOffset,
-                top, right, bottom, left, halignment, valignment, isSnapToPixel);
+                 snappedTop, snappedRight, snappedBottom, snappedLeft,
+                 halignment, valignment, isSnapToPixel);
     }
 
-    private static void position(Node child, double areaX, double areaY, double areaWidth, double areaHeight,
-                          double areaBaselineOffset,
-                          double topMargin, double rightMargin, double bottomMargin, double leftMargin,
-                          HPos hpos, VPos vpos, boolean isSnapToPixel) {
-        final double xoffset = leftMargin + computeXOffset(areaWidth - leftMargin - rightMargin,
-                                                     child.getLayoutBounds().getWidth(), hpos);
-        final double yoffset;
+    private static void position(Node child,
+                                 double rawAreaX, double rawAreaY,
+                                 double rawAreaWidth, double rawAreaHeight,
+                                 double rawAreaBaselineOffset,
+                                 double snappedTopMargin, double snappedRightMargin,
+                                 double snappedBottomMargin, double snappedLeftMargin,
+                                 HPos hpos, VPos vpos,
+                                 boolean isSnapToPixel) {
+        final double rawXOffset = snappedLeftMargin + computeXOffset(
+            rawAreaWidth - snappedLeftMargin - snappedRightMargin,
+            child.getLayoutBounds().getWidth(), hpos);
+
+        final double rawYOffset;
         if (vpos == VPos.BASELINE) {
             double bo = child.getBaselineOffset();
             if (bo == BASELINE_OFFSET_SAME_AS_HEIGHT) {
                 // We already know the layout bounds at this stage, so we can use them
-                yoffset = areaBaselineOffset - child.getLayoutBounds().getHeight();
+                rawYOffset = rawAreaBaselineOffset - child.getLayoutBounds().getHeight();
             } else {
-                yoffset = areaBaselineOffset - bo;
+                rawYOffset = rawAreaBaselineOffset - bo;
             }
         } else {
-            yoffset = topMargin + computeYOffset(areaHeight - topMargin - bottomMargin,
-                                         child.getLayoutBounds().getHeight(), vpos);
-        }
-        double x = areaX + xoffset;
-        double y = areaY + yoffset;
-        if (isSnapToPixel) {
-            x = snapPosition(x, true, getSnapScaleX(child));
-            y = snapPosition(y, true, getSnapScaleY(child));
+            rawYOffset = snappedTopMargin + computeYOffset(
+                rawAreaHeight - snappedTopMargin - snappedBottomMargin,
+                child.getLayoutBounds().getHeight(), vpos);
         }
 
-        child.relocate(x,y);
+        double rawX = rawAreaX + rawXOffset;
+        double rawY = rawAreaY + rawYOffset;
+        double snappedX, snappedY;
+
+        if (isSnapToPixel) {
+            snappedX = snapPosition(rawX, true, getSnapScaleX(child));
+            snappedY = snapPosition(rawY, true, getSnapScaleY(child));
+        } else {
+            snappedX = rawX;
+            snappedY = rawY;
+        }
+
+        child.relocate(snappedX, snappedY);
     }
 
      /* ************************************************************************

--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/Region.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/Region.java
@@ -276,7 +276,7 @@ public class Region extends Parent {
      * This method deliberately does not snap {@code height} or the returned value. It performs only the
      * margin adjustment and does not choose a fitting policy for a potentially unsnapped input height.
      * A caller that chooses to consume the result as a pixel-aligned allocated content span is responsible
-     * for applying the appropriate snapping operation, usually {@link #snapSpaceY(double)}.
+     * for applying the appropriate snapping operation.
      * <p>
      * A {@code null} or empty margin is equivalent to zero margins and leaves {@code height} unchanged;
      * in particular, it does not cause {@code height} to be normalized.
@@ -2209,8 +2209,8 @@ public class Region extends Parent {
         boolean snap = isSnapToPixel();
         double scaleX = getSnapScaleX();
         double scaleY = getSnapScaleY();
-        double snappedLeft = margin != null ? snapSpaceX(margin.getLeft(), snap) : 0;
-        double snappedRight = margin != null ? snapSpaceX(margin.getRight(), snap) : 0;
+        double snappedLeft = margin != null ? snapSpace(margin.getLeft(), snap, scaleX) : 0;
+        double snappedRight = margin != null ? snapSpace(margin.getRight(), snap, scaleX) : 0;
         double alt = -1;
 
         if (availableHeight != -1 && child.isResizable() && child.getContentBias() == Orientation.VERTICAL) { // width depends on height
@@ -2631,7 +2631,7 @@ public class Region extends Parent {
                 snapSpace(childMargin.getRight(), isSnapToPixel, snapScaleX),
                 snapSpace(childMargin.getBottom(), isSnapToPixel, snapScaleY),
                 snapSpace(childMargin.getLeft(), isSnapToPixel, snapScaleX),
-                halignment, valignment, isSnapToPixel);
+                halignment, valignment, isSnapToPixel, snapScaleX, snapScaleY);
     }
 
     /**
@@ -2902,7 +2902,7 @@ public class Region extends Parent {
 
         position(child, areaX, areaY, areaWidth, areaHeight, areaBaselineOffset,
                  snappedTop, snappedRight, snappedBottom, snappedLeft,
-                 halignment, valignment, isSnapToPixel);
+                 halignment, valignment, isSnapToPixel, snapScaleX, snapScaleY);
     }
 
     private static void position(Node child,
@@ -2912,7 +2912,8 @@ public class Region extends Parent {
                                  double snappedTopMargin, double snappedRightMargin,
                                  double snappedBottomMargin, double snappedLeftMargin,
                                  HPos hpos, VPos vpos,
-                                 boolean isSnapToPixel) {
+                                 boolean isSnapToPixel,
+                                 double snapScaleX, double snapScaleY) {
         final double rawXOffset = snappedLeftMargin + computeXOffset(
             rawAreaWidth - snappedLeftMargin - snappedRightMargin,
             child.getLayoutBounds().getWidth(), hpos);
@@ -2934,15 +2935,8 @@ public class Region extends Parent {
 
         double rawX = rawAreaX + rawXOffset;
         double rawY = rawAreaY + rawYOffset;
-        double snappedX, snappedY;
-
-        if (isSnapToPixel) {
-            snappedX = snapPosition(rawX, true, getSnapScaleX(child));
-            snappedY = snapPosition(rawY, true, getSnapScaleY(child));
-        } else {
-            snappedX = rawX;
-            snappedY = rawY;
-        }
+        double snappedX = snapPosition(rawX, isSnapToPixel, snapScaleX);
+        double snappedY = snapPosition(rawY, isSnapToPixel, snapScaleY);
 
         child.relocate(snappedX, snappedY);
     }

--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/Region.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/Region.java
@@ -1989,7 +1989,7 @@ public class Region extends Parent {
         double snappedRight = margin != null ? snapSpace(margin.getRight(), snap, scaleX) : 0;
         double alt = -1;
 
-        if (availableHeight != -1 && child.isResizable() && child.getContentBias() == Orientation.VERTICAL) { // width depends on height
+        if (availableHeight != -1 && child.isResizable() && child.getContentBias() == Orientation.VERTICAL) {
             double snappedContentHeight = computeContentHeight(margin, availableHeight, snap, scaleY);
             double baseline = child.getBaselineOffset();
             if (baseline == BASELINE_OFFSET_SAME_AS_HEIGHT && baselineComplement != -1) {
@@ -2043,7 +2043,7 @@ public class Region extends Parent {
         double snappedBottom = margin != null ? snapSpace(margin.getBottom(), snap, scaleY) : 0;
         double alt = -1;
 
-        if (availableWidth != -1 && child.isResizable() && child.getContentBias() == Orientation.HORIZONTAL) { // height depends on width
+        if (availableWidth != -1 && child.isResizable() && child.getContentBias() == Orientation.HORIZONTAL) {
             double snappedContentWidth = computeContentWidth(margin, availableWidth, snap, scaleX);
             alt = computeBoundedWidth(child, fillWidth, snappedContentWidth, snap, scaleX);
         }
@@ -2119,7 +2119,8 @@ public class Region extends Parent {
         }
 
         double rawChildPrefWidth = boundedSize(child.minWidth(alt), child.prefWidth(alt), child.maxWidth(alt));
-        return snapAligned(snappedLeft + snappedRight + snapSize(rawChildPrefWidth, snap, scaleX), snap, scaleX);
+        double snappedChildPrefWidth = snapSize(rawChildPrefWidth, snap, scaleX);
+        return snapAligned(snappedLeft + snappedRight + snappedChildPrefWidth, snap, scaleX);
     }
 
     /**
@@ -2175,15 +2176,16 @@ public class Region extends Parent {
             if (rawBaseline == BASELINE_OFFSET_SAME_AS_HEIGHT) {
                 double rawChildPrefHeight = boundedSize(child.minHeight(alt), child.prefHeight(alt), child.maxHeight(alt));
                 double snappedChildPrefHeight = snapSize(rawChildPrefHeight, snap, scaleY);
-                double snappedAbove = snapAligned(snappedTop + snappedBottom + snappedChildPrefHeight, snap, scaleY);
-                return snapSize(snappedAbove + prefBaselineComplement, snap, scaleY);
+                double snappedHeightAboveBaseline = snapAligned(snappedTop + snappedBottom + snappedChildPrefHeight, snap, scaleY);
+                return snapSize(snappedHeightAboveBaseline + prefBaselineComplement, snap, scaleY);
             } else {
                 double snappedMargins = snapAligned(snappedTop + snappedBottom, snap, scaleY);
                 return snapSize(snappedMargins + rawBaseline + prefBaselineComplement, snap, scaleY);
             }
         } else {
             double rawChildPrefHeight = boundedSize(child.minHeight(alt), child.prefHeight(alt), child.maxHeight(alt));
-            return snapAligned(snappedTop + snappedBottom + snapSize(rawChildPrefHeight, snap, scaleY), snap, scaleY);
+            double snappedChildPrefHeight = snapSize(rawChildPrefHeight, snap, scaleY);
+            return snapAligned(snappedTop + snappedBottom + snappedChildPrefHeight, snap, scaleY);
         }
     }
 
@@ -2280,11 +2282,11 @@ public class Region extends Parent {
             if (rawBaseline == BASELINE_OFFSET_SAME_AS_HEIGHT) {
                 double rawChildMaxHeight = boundedSize(child.minHeight(alt), max, Double.MAX_VALUE);
                 double snappedChildMaxHeight = snapSize(rawChildMaxHeight, snap, scaleY);
-                double snappedAbove = snapAligned(snappedTop + snappedBottom + snappedChildMaxHeight, snap, scaleY);
-                return snapSize(snappedAbove + maxBaselineComplement, snap, scaleY);
+                double snappedHeightAboveBaseline = snapAligned(snappedTop + snappedBottom + snappedChildMaxHeight, snap, scaleY);
+                return snapSize(snappedHeightAboveBaseline + maxBaselineComplement, snap, scaleY);
             } else {
-                double margins = snapAligned(snappedTop + snappedBottom, snap, scaleY);
-                return snapSize(margins + rawBaseline + maxBaselineComplement, snap, scaleY);
+                double snappedMargins = snapAligned(snappedTop + snappedBottom, snap, scaleY);
+                return snapSize(snappedMargins + rawBaseline + maxBaselineComplement, snap, scaleY);
             }
         } else {
             // if min > max, min wins, so still need to call boundedSize()
@@ -2351,25 +2353,25 @@ public class Region extends Parent {
     }
 
     /*
-     * Removes the given Margin (if any) from a width which still includes margins
+     * Removes the given margin (if any) from a width which still includes margins
      * to create a content width.
      */
     private double computeContentWidth(Insets margin, double width, boolean snapToPixel, double snapScale) {
         double left = margin != null ? snapSpace(margin.getLeft(), snapToPixel, snapScale) : 0;
         double right = margin != null ? snapSpace(margin.getRight(), snapToPixel, snapScale) : 0;
-
-        return snapAligned(snapSize(width, snapToPixel, snapScale) - left - right, snapToPixel, snapScale);
+        double snappedWidth = snapSize(width, snapToPixel, snapScale);
+        return snapAligned(snappedWidth - left - right, snapToPixel, snapScale);
     }
 
     /*
-     * Removes the given Margin (if any) from a height which still includes margins
+     * Removes the given margin (if any) from a height which still includes margins
      * to create a content height.
      */
     private double computeContentHeight(Insets margin, double height, boolean snapToPixel, double snapScale) {
         double top = margin != null ? snapSpace(margin.getTop(), snapToPixel, snapScale) : 0;
         double bottom = margin != null ? snapSpace(margin.getBottom(), snapToPixel, snapScale) : 0;
-
-        return snapAligned(snapSize(height, snapToPixel, snapScale) - top - bottom, snapToPixel, snapScale);
+        double snappedHeight = snapSize(height, snapToPixel, snapScale);
+        return snapAligned(snappedHeight - top - bottom, snapToPixel, snapScale);
     }
 
     /* Max of children's minimum area widths */
@@ -2857,15 +2859,6 @@ public class Region extends Parent {
                                double areaBaselineOffset,
                                Insets margin, boolean fillWidth, boolean fillHeight,
                                HPos halignment, VPos valignment, boolean isSnapToPixel) {
-        //
-        // We need to be careful how we treat the provided arguments when pixel-snapping is enabled:
-        //
-        // areaWidth, areaHeight: Preserve raw values for positioning, but deliberately size-snap them when
-        //                        deriving the resizable child's size allocation.
-        // areaBaselineOffset:    Do not snap independently to preserve precision. Snap derived spans such as
-        //                        areaBaselineOffset-rawBaseline or areaHeight-areaBaselineOffset as space.
-        // margins:               Snap each margin independently as space.
-        //
         Insets childMargin = margin != null ? margin : Insets.EMPTY;
         double snapScaleX = isSnapToPixel ? getSnapScaleX(child) : 1.0;
         double snapScaleY = isSnapToPixel ? getSnapScaleY(child) : 1.0;
@@ -2875,21 +2868,21 @@ public class Region extends Parent {
         double snappedLeft = snapSpace(childMargin.getLeft(), isSnapToPixel, snapScaleX);
         double snappedRight = snapSpace(childMargin.getRight(), isSnapToPixel, snapScaleX);
 
+        // Don't snap areaBaselineOffset independently, as this would lose precision.
+        // Instead, we only snap the final derived spans like snappedTop and snappedBottom.
         if (valignment == VPos.BASELINE) {
             double rawBaseline = child.getBaselineOffset();
-            if (rawBaseline == BASELINE_OFFSET_SAME_AS_HEIGHT) {
-                if (child.isResizable()) {
-                    // Everything below the baseline is like an "inset".
-                    // The Node with BASELINE_OFFSET_SAME_AS_HEIGHT cannot be resized to this area.
-                    snappedBottom = snapSpace(areaHeight - areaBaselineOffset, isSnapToPixel, snapScaleY);
-                } else {
-                    snappedTop = snapSpace(areaBaselineOffset - child.getLayoutBounds().getHeight(), isSnapToPixel, snapScaleY);
-                }
-            } else {
+            if (rawBaseline != BASELINE_OFFSET_SAME_AS_HEIGHT) {
                 snappedTop = snapSpace(areaBaselineOffset - rawBaseline, isSnapToPixel, snapScaleY);
+            } else if (child.isResizable()) {
+                // Everything below the baseline is like an "inset".
+                // The Node with BASELINE_OFFSET_SAME_AS_HEIGHT cannot be resized to this area.
+                snappedBottom = snapSpace(areaHeight - areaBaselineOffset, isSnapToPixel, snapScaleY);
             }
         }
 
+        // We size-snap areaWidth and areaHeight to derive the resizable child's size allocation,
+        // but deliberately don't use these snapped values for positioning later.
         if (child.isResizable()) {
             double snappedAreaWidth = snapSize(areaWidth, isSnapToPixel, snapScaleX);
             double snappedAreaHeight = snapSize(areaHeight, isSnapToPixel, snapScaleY);

--- a/modules/javafx.graphics/src/shims/java/javafx/scene/layout/RegionShim.java
+++ b/modules/javafx.graphics/src/shims/java/javafx/scene/layout/RegionShim.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,14 @@ public class RegionShim extends Region {
 
     public static double boundedSize(double min, double pref, double max) {
         return Region.boundedSize(min, pref, max);
+    }
+
+    public static double adjustWidthByMargin(Region r, double width, Insets margin) {
+        return r.adjustWidthByMargin(width, margin);
+    }
+
+    public static double adjustHeightByMargin(Region r, double height, Insets margin) {
+        return r.adjustHeightByMargin(height, margin);
     }
 
     public static void addImageListener(Region r, Image image) {

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/RegionTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/RegionTest.java
@@ -25,6 +25,7 @@
 
 package test.javafx.scene.layout;
 
+import javafx.beans.property.SimpleDoubleProperty;
 import javafx.geometry.HPos;
 import javafx.geometry.Insets;
 import javafx.geometry.Orientation;
@@ -44,6 +45,7 @@ import java.util.List;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.DoubleUnaryOperator;
+import java.util.stream.Stream;
 import com.sun.javafx.scene.DirtyBits;
 import com.sun.javafx.scene.NodeHelper;
 import com.sun.javafx.sg.prism.NGRegion;
@@ -63,6 +65,10 @@ import javafx.scene.layout.RegionShim;
 import test.com.sun.javafx.pgstub.StubToolkit;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -946,6 +952,25 @@ public class RegionTest {
     }
 
     @Test
+    public void testLayoutInAreaBaselineSameAsHeightWithMargins() {
+        Region child = new MockRegion(0, 0, 40, 40, 500, 500);
+        Insets margin = new Insets(0, 0, 20, 0);
+
+        // Establish the fill rectangle without baseline alignment.
+        Region.layoutInArea(child, 0, 0, 100, 100, 0, margin, true, true, HPos.LEFT, VPos.TOP, false);
+        assertEquals(80, child.getHeight());
+        assertEquals(0, child.getLayoutY());
+
+        // The child's baseline is equal to its height, so using its current bottom edge
+        // as the area baseline must preserve the same fill rectangle.
+        double areaBaselineOffset = child.getLayoutY() + child.getHeight();
+        Region.layoutInArea(child, 0, 0, 100, 100, areaBaselineOffset, margin, true, true, HPos.LEFT, VPos.BASELINE, false);
+
+        assertEquals(80, child.getHeight());
+        assertEquals(0, child.getLayoutY());
+    }
+
+    @Test
     public void testComputeChildPrefAreaWidthHonorsMaxWidthOverPref() {
         Pane pane = new Pane(); // Region extension which makes children sequence public
 
@@ -1532,6 +1557,19 @@ public class RegionTest {
     }
 
     @Test
+    public void testChildMaxAreaWidthChecksMaximumAtResolvedHeight() {
+        Pane pane = new Pane();
+        Region child = new RecordingBiasedRegion(
+            Orientation.VERTICAL, 100,
+            height -> height == -1 ? Double.MAX_VALUE : 10);
+
+        pane.getChildren().add(child);
+
+        assertEquals(10, RegionShim.computeChildMaxAreaWidth(
+            pane, child, -1, Insets.EMPTY, 50, true));
+    }
+
+    @Test
     public void testChildMaxAreaHeightExtensively() {
         Pane pane = new Pane();
 
@@ -1633,6 +1671,19 @@ public class RegionTest {
 
         assertEquals(2 + 200, RegionShim.computeChildMaxAreaHeight(pane, c1, -1, new Insets(1), 50000, false), 1e-100);
         assertEquals(2 + 10 + 200, RegionShim.computeChildMaxAreaHeight(pane, c1, 10, new Insets(1), 50000, false), 1e-100);
+    }
+
+    @Test
+    public void testChildMaxAreaHeightChecksMaximumAtResolvedWidth() {
+        Pane pane = new Pane();
+        Region child = new RecordingBiasedRegion(
+            Orientation.HORIZONTAL, 100,
+            width -> width == -1 ? Double.MAX_VALUE : 10);
+
+        pane.getChildren().add(child);
+
+        assertEquals(10, RegionShim.computeChildMaxAreaHeight(
+            pane, child, -1, Insets.EMPTY, 50, true));
     }
 
     @Test
@@ -2202,6 +2253,291 @@ public class RegionTest {
         assertEquals(200, child.getHeight());
         assertEquals(child.minHeight(child.getWidth()), child.getHeight());
         assertEquals(child.maxHeight(child.getWidth()), child.getHeight());
+    }
+
+    @ParameterizedTest
+    @MethodSource("renderScales")
+    public void layoutInAreaNormalizesAvailableSpanAfterSubtractingMargins(double scaleX, double scaleY) {
+        Pane root = new Pane();
+        Stage stage = showAtScale(root, scaleX, scaleY);
+        double areaWidth = 4 / scaleX;
+        double rightMargin = 3 / scaleX;
+        double expectedWidth = 1 / scaleX;
+        double areaHeight = 4 / scaleY;
+        double bottomMargin = 3 / scaleY;
+        double expectedHeight = 1 / scaleY;
+
+        try {
+            Region horizontal = new Region();
+            root.getChildren().setAll(horizontal);
+
+            Region.layoutInArea(
+                horizontal, 0, 0, areaWidth, 8, -1,
+                new Insets(0, rightMargin, 0, 0), true, true,
+                HPos.RIGHT, VPos.TOP, true);
+
+            // 4 pixels minus 3 pixels must be normalized to exactly 1 pixel.
+            assertEquals(expectedWidth, horizontal.getWidth());
+            assertEquals(0, horizontal.getLayoutX());
+
+            Region vertical = new Region();
+            root.getChildren().setAll(vertical);
+
+            Region.layoutInArea(
+                vertical, 0, 0, 8, areaHeight, -1,
+                new Insets(0, 0, bottomMargin, 0), true, true,
+                HPos.LEFT, VPos.BOTTOM, true);
+
+            assertEquals(expectedHeight, vertical.getHeight());
+            assertEquals(0, vertical.getLayoutY());
+        } finally {
+            stage.close();
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("renderScales")
+    public void layoutInAreaUsesNormalizedAvailableSpanForContentBias(double scaleX, double scaleY) {
+        Pane root = new Pane();
+        Stage stage = showAtScale(root, scaleX, scaleY);
+        double areaWidth = 4 / scaleX;
+        double rightMargin = 3 / scaleX;
+        double expectedWidth = 1 / scaleX;
+        double areaHeight = 4 / scaleY;
+        double bottomMargin = 3 / scaleY;
+        double expectedHeight = 1 / scaleY;
+
+        try {
+            var horizontal = new RecordingBiasedRegion(Orientation.HORIZONTAL, 0.1, _ -> 0.1);
+            root.getChildren().setAll(horizontal);
+
+            Region.layoutInArea(
+                horizontal, 0, 0, areaWidth, 8, -1,
+                new Insets(0, rightMargin, 0, 0), true, false,
+                HPos.LEFT, VPos.TOP, true);
+
+            assertEquals(expectedWidth, horizontal.getWidth());
+            assertEquals(expectedHeight, horizontal.getHeight());
+            assertDependentArguments(horizontal, expectedWidth);
+
+            var vertical = new RecordingBiasedRegion(Orientation.VERTICAL, 0.1, _ -> 0.1);
+            root.getChildren().setAll(vertical);
+            Region.layoutInArea(
+                vertical, 0, 0, 8, areaHeight, -1,
+                new Insets(0, 0, bottomMargin, 0), false, true,
+                HPos.LEFT, VPos.TOP, true);
+
+            assertEquals(expectedWidth, vertical.getWidth());
+            assertEquals(expectedHeight, vertical.getHeight());
+            assertDependentArguments(vertical, expectedHeight);
+        } finally {
+            stage.close();
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(doubles = { 1, 1.25, 1.5, 2.5 })
+    public void layoutInAreaNormalizesHeightRemainingAboveBaselineComplement(double scaleY) {
+        Pane root = new Pane();
+        Region child = new Region();
+        root.getChildren().add(child);
+        Stage stage = showAtScale(root, 1, scaleY);
+        double areaHeight = 4 / scaleY;
+        double areaBaselineOffset = 1 / scaleY;
+
+        try {
+            Region.layoutInArea(
+                child, 0, 0, 8, areaHeight, areaBaselineOffset,
+                Insets.EMPTY, true, true,
+                HPos.LEFT, VPos.BASELINE, true);
+
+            // The baseline complement is 3 pixels, leaving exactly 1 pixel above the baseline
+            // for a node whose baseline is equal to its height.
+            assertEquals(1 / scaleY, child.getHeight());
+            assertEquals(0, child.getLayoutY());
+        } finally {
+            stage.close();
+        }
+    }
+
+    @Test
+    public void layoutInAreaPreservesRawResidualSpanWhenSnappingIsDisabled() {
+        Region child = new Region();
+        double expectedWidth = 3.2 - 2.4;
+        double expectedHeight = 3.2 - 2.4;
+
+        Region.layoutInArea(
+            child, 0, 0, 3.2, 3.2, -1,
+            new Insets(0, 2.4, 2.4, 0), true, true,
+            HPos.LEFT, VPos.TOP, false);
+
+        assertEquals(expectedWidth, child.getWidth());
+        assertEquals(expectedHeight, child.getHeight());
+    }
+
+    @Test
+    public void adjustSizeByZeroMarginDoesNotNormalizeInput() {
+        Pane root = new Pane();
+
+        // Null, Insets.EMPTY, and a distinct zero-valued Insets instance
+        // are semantically equivalent. None of them normalizes the input.
+        assertEquals(3.3, RegionShim.adjustWidthByMargin(root, 3.3, null));
+        assertEquals(3.3, RegionShim.adjustWidthByMargin(root, 3.3, Insets.EMPTY));
+        assertEquals(3.3, RegionShim.adjustWidthByMargin(root, 3.3, new Insets(0)));
+        assertEquals(3.3, RegionShim.adjustHeightByMargin(root, 3.3, null));
+        assertEquals(3.3, RegionShim.adjustHeightByMargin(root, 3.3, Insets.EMPTY));
+        assertEquals(3.3, RegionShim.adjustHeightByMargin(root, 3.3, new Insets(0)));
+    }
+
+    @ParameterizedTest
+    @MethodSource("renderScales")
+    public void adjustSizeByMarginSnapsOnlyMargins(double scaleX, double scaleY) {
+        Pane root = new Pane();
+        Stage stage = showAtScale(root, scaleX, scaleY);
+        double width = 4 / scaleX;
+        double height = 4 / scaleY;
+        double left = 0.875 / scaleX;
+        double right = 1.875 / scaleX;
+        double top = 0.875 / scaleY;
+        double bottom = 1.875 / scaleY;
+        Insets margin = new Insets(top, right, bottom, left);
+
+        try {
+            // The leading margins snap to 1 pixel and the trailing margins snap to 2 pixels.
+            // The arithmetic result is not normalized afterward.
+            assertEquals(width - 1 / scaleX - 2 / scaleX, RegionShim.adjustWidthByMargin(root, width, margin));
+            assertEquals(height - 1 / scaleY - 2 / scaleY, RegionShim.adjustHeightByMargin(root, height, margin));
+        } finally {
+            stage.close();
+        }
+    }
+
+    @Test
+    public void adjustSizeByMarginPreservesRawValuesWhenSnappingIsDisabled() {
+        Pane root = new Pane();
+        root.setSnapToPixel(false);
+        Insets margin = new Insets(0.7, 1.5, 1.5, 0.7);
+
+        assertEquals(3.2 - 0.7 - 1.5, RegionShim.adjustWidthByMargin(root, 3.2, margin));
+        assertEquals(3.2 - 0.7 - 1.5, RegionShim.adjustHeightByMargin(root, 3.2, margin));
+    }
+
+    @ParameterizedTest
+    @MethodSource("renderScales")
+    public void childAreaMeasurementsNormalizeComposedSpans(double scaleX, double scaleY) {
+        Pane root = new Pane();
+        Region child = new Region();
+        child.setMinSize(0.1, 0.1);
+        child.setPrefSize(0.1, 0.1);
+        child.setMaxSize(0.1, 0.1);
+        root.getChildren().add(child);
+        Stage stage = showAtScale(root, scaleX, scaleY);
+
+        // The child receives 1 pixel and the trailing margin receives 2 pixels.
+        // Their composed area is exactly 3 pixels on each axis.
+        Insets margin = new Insets(0, 2 / scaleX, 2 / scaleY, 0);
+        double expectedWidth = 3 / scaleX;
+        double expectedHeight = 3 / scaleY;
+
+        try {
+            assertEquals(expectedWidth, RegionShim.computeChildMinAreaWidth(root, child, margin));
+            assertEquals(expectedWidth, RegionShim.computeChildPrefAreaWidth(root, child, margin));
+            assertEquals(expectedWidth, RegionShim.computeChildMaxAreaWidth(root, child, -1, margin, -1, false));
+
+            assertEquals(expectedHeight, RegionShim.computeChildMinAreaHeight(root, child, margin));
+            assertEquals(expectedHeight, RegionShim.computeChildPrefAreaHeight(root, child, margin));
+            assertEquals(expectedHeight, RegionShim.computeChildMaxAreaHeight(root, child, -1, margin, -1, false));
+        } finally {
+            stage.close();
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("renderScales")
+    public void childAreaMeasurementsPreservePixelAlignedResidualForDependentDimension(double scaleX, double scaleY) {
+        Pane root = new Pane();
+        Stage stage = showAtScale(root, scaleX, scaleY);
+        double availableWidth = 4 / scaleX;
+        double rightMargin = 3 / scaleX;
+        double expectedContentWidth = 1 / scaleX;
+        double availableHeight = 4 / scaleY;
+        double bottomMargin = 3 / scaleY;
+        double expectedContentHeight = 1 / scaleY;
+
+        try {
+            var horizontal = new RecordingBiasedRegion(Orientation.HORIZONTAL, 0.1, _ -> 0.1);
+            root.getChildren().setAll(horizontal);
+
+            assertEquals(expectedContentHeight, RegionShim.computeChildPrefAreaHeight(
+                root, horizontal, -1, new Insets(0, rightMargin, 0, 0), availableWidth, true));
+
+            assertDependentArguments(horizontal, expectedContentWidth);
+
+            var vertical = new RecordingBiasedRegion(Orientation.VERTICAL, 0.1, _ -> 0.1);
+            root.getChildren().setAll(vertical);
+
+            assertEquals(expectedContentWidth, RegionShim.computeChildPrefAreaWidth(
+                root, vertical, -1, new Insets(0, 0, bottomMargin, 0), availableHeight, true));
+
+            assertDependentArguments(vertical, expectedContentHeight);
+        } finally {
+            stage.close();
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("renderScales")
+    public void childAreaWidthMeasurementsSnapBaselineComplementAsSpace(double scaleX, double scaleY) {
+        Pane root = new Pane();
+        Stage stage = showAtScale(root, scaleX, scaleY);
+        double availableHeight = 10.2 / scaleY;
+        double baselineComplement = 0.6 / scaleY;
+        double expectedDependentArgument = 10 / scaleY;
+
+        try {
+            var child = new RecordingBiasedRegion(Orientation.VERTICAL, 100, value -> value);
+            root.getChildren().add(child);
+
+            // The outer height rounds up to 11 pixels, while the 0.6-pixel baseline
+            // complement rounds to 1 pixel of space, leaving a height of 10.
+            double expectedWidth = root.snapSizeX(expectedDependentArgument);
+            assertEquals(expectedWidth, RegionShim.computeChildMinAreaWidth(
+                root, child, baselineComplement, Insets.EMPTY, availableHeight, true));
+            assertEquals(List.of(expectedDependentArgument), child.dependentArguments);
+
+            child.dependentArguments.clear();
+            assertEquals(expectedWidth, RegionShim.computeChildPrefAreaWidth(
+                root, child, baselineComplement, Insets.EMPTY, availableHeight, true));
+            assertEquals(
+                List.of(expectedDependentArgument, expectedDependentArgument, expectedDependentArgument),
+                child.dependentArguments);
+
+            child.dependentArguments.clear();
+            assertEquals(expectedWidth, RegionShim.computeChildMaxAreaWidth(
+                root, child, baselineComplement, Insets.EMPTY, availableHeight, true));
+            assertEquals(List.of(expectedDependentArgument, expectedDependentArgument), child.dependentArguments);
+        } finally {
+            stage.close();
+        }
+    }
+
+    private static Stream<Arguments> renderScales() {
+        return Stream.of(
+            Arguments.of(1.0, 1.0),
+            Arguments.of(1.25, 1.25),
+            Arguments.of(1.5, 1.5),
+            Arguments.of(2.5, 2.5),
+            Arguments.of(1.25, 1.5),
+            Arguments.of(1.5, 1.25)
+        );
+    }
+
+    private static Stage showAtScale(Pane root, double scaleX, double scaleY) {
+        Stage stage = new Stage();
+        stage.renderScaleXProperty().bind(new SimpleDoubleProperty(scaleX));
+        stage.renderScaleYProperty().bind(new SimpleDoubleProperty(scaleY));
+        stage.setScene(new Scene(root));
+        return stage;
     }
 
     private static void assertDependentArguments(RecordingBiasedRegion child, double expected) {

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/RegionTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/RegionTest.java
@@ -2336,7 +2336,7 @@ public class RegionTest {
     }
 
     @ParameterizedTest
-    @ValueSource(doubles = { 1, 1.25, 1.5, 2.5 })
+    @ValueSource(doubles = { 1, 1.25, 1.5, 1.75, 2.0, 2.25 })
     public void layoutInAreaNormalizesHeightRemainingAboveBaselineComplement(double scaleY) {
         Pane root = new Pane();
         Region child = new Region();
@@ -2526,11 +2526,12 @@ public class RegionTest {
             Arguments.of(1.0, 1.0),
             Arguments.of(1.25, 1.25),
             Arguments.of(1.5, 1.5),
-            Arguments.of(2.5, 2.5),
+            Arguments.of(1.75, 1.75),
+            Arguments.of(2.0, 2.0),
+            Arguments.of(2.25, 2.25),
             Arguments.of(1.25, 1.5),
-            Arguments.of(1.5, 1.25),
-            Arguments.of(1.75, 2.0),
-            Arguments.of(2.25, 2.25)
+            Arguments.of(1.75, 2.25),
+            Arguments.of(2.25, 1.25)
         );
     }
 

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/RegionTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/RegionTest.java
@@ -2528,7 +2528,9 @@ public class RegionTest {
             Arguments.of(1.5, 1.5),
             Arguments.of(2.5, 2.5),
             Arguments.of(1.25, 1.5),
-            Arguments.of(1.5, 1.25)
+            Arguments.of(1.5, 1.25),
+            Arguments.of(1.75, 2.0),
+            Arguments.of(2.25, 2.25)
         );
     }
 

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/RegionTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/RegionTest.java
@@ -39,6 +39,7 @@ import javafx.scene.shape.ClosePath;
 import javafx.scene.shape.LineTo;
 import javafx.scene.shape.MoveTo;
 import javafx.scene.shape.Path;
+import javafx.scene.shape.Rectangle;
 import javafx.stage.Stage;
 import java.util.ArrayList;
 import java.util.List;
@@ -971,6 +972,26 @@ public class RegionTest {
     }
 
     @Test
+    public void testLayoutInAreaForNonResizableBaselineSameAsHeight() {
+        Rectangle child = new Rectangle(30, 40) {
+            @Override public double getBaselineOffset() {
+                return BASELINE_OFFSET_SAME_AS_HEIGHT;
+            }
+        };
+
+        Region.layoutInArea(
+            child, 10, 10, 100, 100, 60,
+            Insets.EMPTY, true, true,
+            HPos.CENTER, VPos.BASELINE, false);
+
+        assertFalse(child.isResizable());
+        assertEquals(30, child.getWidth());
+        assertEquals(40, child.getHeight());
+        assertEquals(45, child.getLayoutX());
+        assertEquals(30, child.getLayoutY());
+    }
+
+    @Test
     public void testComputeChildPrefAreaWidthHonorsMaxWidthOverPref() {
         Pane pane = new Pane(); // Region extension which makes children sequence public
 
@@ -1565,8 +1586,7 @@ public class RegionTest {
 
         pane.getChildren().add(child);
 
-        assertEquals(10, RegionShim.computeChildMaxAreaWidth(
-            pane, child, -1, Insets.EMPTY, 50, true));
+        assertEquals(10, RegionShim.computeChildMaxAreaWidth(pane, child, -1, Insets.EMPTY, 50, true));
     }
 
     @Test
@@ -1682,8 +1702,7 @@ public class RegionTest {
 
         pane.getChildren().add(child);
 
-        assertEquals(10, RegionShim.computeChildMaxAreaHeight(
-            pane, child, -1, Insets.EMPTY, 50, true));
+        assertEquals(10, RegionShim.computeChildMaxAreaHeight(pane, child, -1, Insets.EMPTY, 50, true));
     }
 
     @Test
@@ -2259,7 +2278,7 @@ public class RegionTest {
     @MethodSource("renderScales")
     public void layoutInAreaNormalizesAvailableSpanAfterSubtractingMargins(double scaleX, double scaleY) {
         Pane root = new Pane();
-        Stage stage = showAtScale(root, scaleX, scaleY);
+        Stage stage = createAtScale(root, scaleX, scaleY);
         double areaWidth = 4 / scaleX;
         double rightMargin = 3 / scaleX;
         double expectedWidth = 1 / scaleX;
@@ -2299,7 +2318,7 @@ public class RegionTest {
     @MethodSource("renderScales")
     public void layoutInAreaUsesNormalizedAvailableSpanForContentBias(double scaleX, double scaleY) {
         Pane root = new Pane();
-        Stage stage = showAtScale(root, scaleX, scaleY);
+        Stage stage = createAtScale(root, scaleX, scaleY);
         double areaWidth = 4 / scaleX;
         double rightMargin = 3 / scaleX;
         double expectedWidth = 1 / scaleX;
@@ -2341,7 +2360,7 @@ public class RegionTest {
         Pane root = new Pane();
         Region child = new Region();
         root.getChildren().add(child);
-        Stage stage = showAtScale(root, 1, scaleY);
+        Stage stage = createAtScale(root, 1, scaleY);
         double areaHeight = 4 / scaleY;
         double areaBaselineOffset = 1 / scaleY;
 
@@ -2393,7 +2412,7 @@ public class RegionTest {
     @MethodSource("renderScales")
     public void adjustSizeByMarginSnapsOnlyMargins(double scaleX, double scaleY) {
         Pane root = new Pane();
-        Stage stage = showAtScale(root, scaleX, scaleY);
+        Stage stage = createAtScale(root, scaleX, scaleY);
         double width = 4 / scaleX;
         double height = 4 / scaleY;
         double left = 0.875 / scaleX;
@@ -2431,7 +2450,7 @@ public class RegionTest {
         child.setPrefSize(0.1, 0.1);
         child.setMaxSize(0.1, 0.1);
         root.getChildren().add(child);
-        Stage stage = showAtScale(root, scaleX, scaleY);
+        Stage stage = createAtScale(root, scaleX, scaleY);
 
         // The child receives 1 pixel and the trailing margin receives 2 pixels.
         // Their composed area is exactly 3 pixels on each axis.
@@ -2456,7 +2475,7 @@ public class RegionTest {
     @MethodSource("renderScales")
     public void childAreaMeasurementsPreservePixelAlignedResidualForDependentDimension(double scaleX, double scaleY) {
         Pane root = new Pane();
-        Stage stage = showAtScale(root, scaleX, scaleY);
+        Stage stage = createAtScale(root, scaleX, scaleY);
         double availableWidth = 4 / scaleX;
         double rightMargin = 3 / scaleX;
         double expectedContentWidth = 1 / scaleX;
@@ -2489,7 +2508,7 @@ public class RegionTest {
     @MethodSource("renderScales")
     public void childAreaWidthMeasurementsSnapBaselineComplementAsSpace(double scaleX, double scaleY) {
         Pane root = new Pane();
-        Stage stage = showAtScale(root, scaleX, scaleY);
+        Stage stage = createAtScale(root, scaleX, scaleY);
         double availableHeight = 10.2 / scaleY;
         double baselineComplement = 0.6 / scaleY;
         double expectedDependentArgument = 10 / scaleY;
@@ -2535,7 +2554,7 @@ public class RegionTest {
         );
     }
 
-    private static Stage showAtScale(Pane root, double scaleX, double scaleY) {
+    private static Stage createAtScale(Pane root, double scaleX, double scaleY) {
         Stage stage = new Stage();
         stage.renderScaleXProperty().bind(new SimpleDoubleProperty(scaleX));
         stage.renderScaleYProperty().bind(new SimpleDoubleProperty(scaleY));
@@ -2545,6 +2564,13 @@ public class RegionTest {
 
     private static void assertDependentArguments(RecordingBiasedRegion child, double expected) {
         assertEquals(List.of(expected, expected, expected), child.dependentArguments);
+    }
+
+    private static final class HeightDependentBaselineRegion extends Region {
+        @Override
+        public double getBaselineOffset() {
+            return getHeight() / 2;
+        }
     }
 
     private static final class RecordingBiasedRegion extends Region {

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/RegionTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/RegionTest.java
@@ -2566,13 +2566,6 @@ public class RegionTest {
         assertEquals(List.of(expected, expected, expected), child.dependentArguments);
     }
 
-    private static final class HeightDependentBaselineRegion extends Region {
-        @Override
-        public double getBaselineOffset() {
-            return getHeight() / 2;
-        }
-    }
-
     private static final class RecordingBiasedRegion extends Region {
         private final Orientation bias;
         private final double preferredPrimarySize;


### PR DESCRIPTION
This PR is an audit of several snapping-related methods in `Region`, along with some bug fixes.

I've added a helper method `snapAligned()`, which does the exact same thing as `snapSpace()`, but clearly states that the author knows that the value is already pixel-aligned. In addition, I've renamed several local variables around a "rawFoo" and "snappedFoo" naming scheme, so as to make it easier to see what's what.

This PR should probably be integrated before the other layout container PRs, because those use the `Region` layout methods.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391279](https://bugs.openjdk.org/browse/JDK-8391279): Fix pixel-snapping in Region (**Bug** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**) Review applies to [4f0bef1c](https://git.openjdk.org/jfx/pull/2278/files/4f0bef1c0b7dc5612a7a67b0d0e5a70dc82418dc)
 * [John Hendrikx](https://openjdk.org/census#jhendrikx) (@hjohn - **Reviewer**)
 * [Marius Hanl](https://openjdk.org/census#mhanl) (@Maran23 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2278/head:pull/2278` \
`$ git checkout pull/2278`

Update a local copy of the PR: \
`$ git checkout pull/2278` \
`$ git pull https://git.openjdk.org/jfx.git pull/2278/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2278`

View PR using the GUI difftool: \
`$ git pr show -t 2278`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2278.diff">https://git.openjdk.org/jfx/pull/2278.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2278#issuecomment-5438281304)
</details>
