### PR TITLE
8391309: Mouse-wheel scroll distance incorrectly depends on render scale

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassViewEventHandler.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassViewEventHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -463,7 +463,7 @@ class GlassViewEventHandler extends View.EventHandler {
                         spx = spy = sx = sy = 0.0;
                     }
                     scene.sceneListener.scrollEvent(ScrollEvent.SCROLL,
-                        deltaX / pScaleX, deltaY / pScaleY, 0, 0,
+                        deltaX, deltaY, 0, 0,
                         xMultiplier, yMultiplier,
                         0, // touchCount
                         chars, lines, defaultChars, defaultLines,

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassViewEventHandler.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassViewEventHandler.java
@@ -430,6 +430,18 @@ class GlassViewEventHandler extends View.EventHandler {
         }
     }
 
+    /**
+     * Handles a scroll-wheel event reported by the Windows or GTK toolkit.
+     * <p>
+     * The following scaling rules apply:
+     * <ul>
+     *     <li>{@code x}, {@code y}, {@code xAbs}, and {@code yAbs} are reported in platform coordinates and
+     *         must be divided by the platform scale in order to convert them into JavaFX layout coordinates.
+     *     <li>{@code deltaX} and {@code deltaY} are dimensionless wheel rotations that must not be scaled.
+     * </ul>
+     *
+     * Note: The macOS toolkit reports scroll-wheel events exclusively through {@link #handleScrollGestureEvent}.
+     */
     @Override public void handleScrollEvent(final View view, final long time,
                                             final int x, final int y, final int xAbs, final int yAbs,
                                             final double deltaX, final double deltaY, final int modifiers,
@@ -856,6 +868,21 @@ class GlassViewEventHandler extends View.EventHandler {
         }
     }
 
+    /**
+     * Handles a scroll gesture reported by the Windows, macOS, or iOS toolkit.
+     * <p>
+     * The following scaling rules apply:
+     * <ul>
+     *     <li>{@code x}, {@code y}, {@code xAbs}, and {@code yAbs} are reported in platform coordinates and
+     *         must be divided by the platform scale in order to convert them into JavaFX layout coordinates.
+     *     <li>{@code dx}, {@code dy}, {@code totaldx}, and {@code totaldy} are reported in platform scroll
+     *         units. Their products with {@code multiplierX} or {@code multiplierY} represent distances in
+     *         platform coordinates, so they must also be divided by the platform scale.
+     * </ul>
+     *
+     * Note: The macOS toolkit also reports normal mouse-wheel events through this method. On macOS, the
+     * platform scale is always {@code 1.0}, so the conversion does not change their dimensionless deltas.
+     */
     @Override public void handleScrollGestureEvent(
             View view, final long time, final int type,
             final int modifiers, final boolean isDirect, final boolean isInertia, final int touchCount,

--- a/tests/system/src/test/java/test/robot/javafx/scene/MouseWheelScaleTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/MouseWheelScaleTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.robot.javafx.scene;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+import javafx.application.Application;
+import javafx.application.Platform;
+import javafx.geometry.Point2D;
+import javafx.scene.Scene;
+import javafx.scene.input.ScrollEvent;
+import javafx.scene.layout.StackPane;
+import javafx.scene.robot.Robot;
+import javafx.stage.Stage;
+import javafx.stage.StageStyle;
+import javafx.stage.WindowEvent;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import com.sun.javafx.PlatformUtil;
+import test.util.Util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+public class MouseWheelScaleTest {
+
+    private static final double SCALE = 2.0;
+    private static final double EPSILON = 0.0001;
+
+    private static final CountDownLatch startupLatch = new CountDownLatch(1);
+    private static final CountDownLatch scrollLatch = new CountDownLatch(1);
+    private static final AtomicReference<ScrollEvent> scrollEvent = new AtomicReference<>();
+
+    private static volatile Stage stage;
+    private static volatile StackPane root;
+    private static Robot robot;
+
+    public static class TestApp extends Application {
+        @Override
+        public void start(Stage primaryStage) {
+            root = new StackPane();
+            Scene scene = new Scene(root, 300, 200);
+            scene.setOnScroll(event -> {
+                scrollEvent.compareAndSet(null, event);
+                scrollLatch.countDown();
+            });
+
+            stage = primaryStage;
+            stage.initStyle(StageStyle.UNDECORATED);
+            stage.setAlwaysOnTop(true);
+            stage.setScene(scene);
+            stage.addEventHandler(WindowEvent.WINDOW_SHOWN, _ -> Platform.runLater(startupLatch::countDown));
+            robot = new Robot();
+            stage.show();
+        }
+    }
+
+    @BeforeAll
+    public static void setupOnce() {
+        System.setProperty("glass.win.uiScale", String.valueOf(SCALE));
+        System.setProperty("glass.gtk.uiScale", String.valueOf(SCALE));
+
+        Util.launch(startupLatch, TestApp.class);
+    }
+
+    @AfterAll
+    public static void teardown() {
+        Util.shutdown();
+    }
+
+    @Test
+    public void testWheelRotationIsNotScaled() {
+        assumeTrue(PlatformUtil.isLinux() || PlatformUtil.isWindows());
+        assertEquals(SCALE, stage.getOutputScaleY(), EPSILON, "Wrong output scale");
+
+        Util.runAndWait(() -> {
+            Point2D center = root.localToScreen(root.getWidth() / 2, root.getHeight() / 2);
+            robot.mouseMove(center);
+            robot.mouseWheel(1);
+        });
+
+        Util.waitForLatch(scrollLatch, 5, "Timeout while waiting for a scroll event");
+
+        ScrollEvent event = scrollEvent.get();
+        assumeTrue(event.getMultiplierY() != 0, "Mouse-wheel scrolling is disabled");
+
+        // Dividing the pixel delta by its platform multiplier recovers the
+        // dimensionless wheel rotation, which must remain 1 at any scale.
+        double wheelRotation = event.getDeltaY() / event.getMultiplierY();
+        assertEquals(1.0, Math.abs(wheelRotation), EPSILON);
+    }
+}

--- a/tests/system/src/test/java/test/robot/javafx/scene/RobotTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/RobotTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -545,7 +545,7 @@ public class RobotTest {
         int scrollMultiplier = PlatformUtil.isMac() ? -1 : 40;
         Util.runAndWait(() -> {
             button.setOnScroll(event -> {
-                totalScroll[0] += event.getDeltaY() * Screen.getPrimary().getOutputScaleY();
+                totalScroll[0] += event.getDeltaY();
                 if (firstScrollMillis[0] == 0) {
                     firstScrollMillis[0] = System.currentTimeMillis();
                 } else {


### PR DESCRIPTION
For the longest time, I've had the impression that scrolling in JavaFX is not quite right. Looking at it, that suspicion is quickly confirmed: the scroll distance is incorrectly divided by the render scale.

To reproduce, open MonkeyTester and scroll a ListView. On Windows 11 with a system setting of 3 lines per detent, the ListView scrolls exactly 3 lines at 100% render scale, 2 lines at 150% render scale, and 1.5 lines at 200% render scale.

The render scale conversion was introduced in 2015 when High-DPI support was added. However, mouse wheel rotation is a dimensionless number, it shouldn't be scaled at all. A line is a line, no matter the render scale.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391309](https://bugs.openjdk.org/browse/JDK-8391309): Mouse-wheel scroll distance incorrectly depends on render scale (**Bug** - P4)


### Reviewers
 * [Marius Hanl](https://openjdk.org/census#mhanl) (@Maran23 - **Reviewer**)
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Lukasz Kostyra](https://openjdk.org/census#lkostyra) (@lukostyra - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2282/head:pull/2282` \
`$ git checkout pull/2282`

Update a local copy of the PR: \
`$ git checkout pull/2282` \
`$ git pull https://git.openjdk.org/jfx.git pull/2282/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2282`

View PR using the GUI difftool: \
`$ git pr show -t 2282`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2282.diff">https://git.openjdk.org/jfx/pull/2282.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2282#issuecomment-5445817086)
</details>
