### PR TITLE
8390898: "Extended mnemonic" should be documented

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/Labeled.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/Labeled.java
@@ -805,12 +805,32 @@ public abstract class Labeled extends Control {
 
 
     /**
-     * MnemonicParsing property to enable/disable text parsing.
-     * If this is set to true, then the Label text will be
-     * parsed to see if it contains the mnemonic parsing character '_'.
-     * When a mnemonic is detected the key combination will
-     * be determined based on the succeeding character, and the mnemonic
-     * added.
+     * Determines whether the mnemonic character in the label text will be parsed.
+     * <p>
+     * The parsing recognizes two formats:
+     * <ul>
+     * <li>
+     * <p>
+     * <b>Simple mnemonic</b>: the first character preceded by the first {@code _}
+     * character will be treated as the mnemonic. For example, "E_xit" will cause
+     * the text to become "Exit" and the mnemonic will be "x". This is the most
+     * common designation of a mnemonic, which will typically be visualized with an underline.
+     * To prevent {@code _} from being
+     * treated as the mnemonic prefix character, repeat it twice in a row.
+     * </p>
+     * </li>
+     * <li>
+     * <p>
+     * <b>Extended mnemonic</b>: an optional representation of a mnemonic is
+     * {@code _(c)}, where {@code c} is the mnemonic character. For example,
+     * "Exit_(q)" will cause the text to become "Exit" and the
+     * mnemonic will be "q". This is typically provided in
+     * translated strings to support mnemonics where the main text does not have any
+     * characters that map to keyboard keys. In these cases, the skin for the
+     * control will typically present the mnemonic surrounded by parentheses.
+     * The extended mnemonic might be hidden on certain platforms and only displayed
+     * then the mnemonic modifier key is pressed.
+     * </ul>
      *
      * @defaultValue {@code false}; {@code true} for some {@code Control}s.
      */

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/Labeled.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/Labeled.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -809,30 +809,26 @@ public abstract class Labeled extends Control {
      * <p>
      * The parsing recognizes two formats:
      * <ul>
-     * <li>
-     * <p>
-     * <b>Simple mnemonic</b>: the first character preceded by the first {@code _}
-     * character will be treated as the mnemonic. For example, "E_xit" will cause
-     * the text to become "Exit" and the mnemonic will be "x". This is the most
-     * common designation of a mnemonic, which will typically be visualized with an underline.
-     * To prevent {@code _} from being
-     * treated as the mnemonic prefix character, repeat it twice in a row.
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <b>Extended mnemonic</b>: an optional representation of a mnemonic is
-     * {@code _(c)}, where {@code c} is the mnemonic character. For example,
-     * "Exit_(q)" will cause the text to become "Exit" and the
-     * mnemonic will be "q". This is typically provided in
-     * translated strings to support mnemonics where the main text does not have any
-     * characters that map to keyboard keys. In these cases, the skin for the
-     * control will typically present the mnemonic surrounded by parentheses.
-     * The extended mnemonic might be hidden on certain platforms and only displayed
-     * then the mnemonic modifier key is pressed.
+     *   <li><b>Simple mnemonic</b>:
+     *     the first character preceded by the first {@code _}
+     *     character will be treated as the mnemonic. For example, "E_xit" will cause
+     *     the text to become "Exit" and the mnemonic will be "x". This is the most
+     *     common designation of a mnemonic, which will typically be visualized with an underline.
+     *     To prevent {@code _} from being
+     *     treated as the mnemonic prefix character, repeat it twice in a row.
+     *   <li><b>Extended mnemonic</b>:
+     *     an optional representation of a mnemonic is
+     *     {@code _(c)}, where {@code c} is the mnemonic character. For example,
+     *     "Exit_(q)" will cause the text to become "Exit" and the
+     *     mnemonic will be "q". This is typically provided in
+     *     translated strings to support mnemonics where the main text does not have any
+     *     characters that map to keyboard keys. In these cases, the skin for the
+     *     control will typically present the mnemonic surrounded by parentheses.
+     *     The extended mnemonic might be hidden on certain platforms and only displayed
+     *     when the mnemonic modifier key is pressed.
      * </ul>
      *
-     * @defaultValue {@code false}; {@code true} for some {@code Control}s.
+     * @defaultValue {@code false}; {@code true} for some {@code Control}s
      */
     private BooleanProperty mnemonicParsing;
     public final void setMnemonicParsing(boolean value) {

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/MenuItem.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/MenuItem.java
@@ -417,16 +417,35 @@ public class MenuItem implements EventTarget, Styleable {
     }
 
     /**
-     * MnemonicParsing property to enable/disable text parsing.
-     * If this is set to true, then the MenuItem text will be
-     * parsed to see if it contains the mnemonic parsing character '_'.
-     * When a mnemonic is detected the key combination will
-     * be determined based on the succeeding character, and the mnemonic
-     * added.
-     *
+     * Determines whether the mnemonic character in the menu item text will be parsed.
      * <p>
-     * The default value for MenuItem is true.
+     * The parsing recognizes two formats:
+     * <ul>
+     * <li>
+     * <p>
+     * <b>Simple mnemonic</b>: the first character preceded by the first {@code _}
+     * character will be treated as the mnemonic. For example, "E_xit" will cause
+     * the text to become "Exit" and the mnemonic will be "x". This is the most
+     * common designation of a mnemonic, which will typically be visualized with an underline.
+     * To prevent {@code _} from being
+     * treated as the mnemonic prefix character, repeat it twice in a row.
      * </p>
+     * </li>
+     * <li>
+     * <p>
+     * <b>Extended mnemonic</b>: an optional representation of a mnemonic is
+     * {@code _(c)}, where {@code c} is the mnemonic character. For example,
+     * "Exit_(q)" will cause the text to become "Exit" and the
+     * mnemonic will be "q". This is typically provided in
+     * translated strings to support mnemonics where the main text does not have any
+     * characters that map to keyboard keys. In these cases, the skin for the
+     * control will typically present the mnemonic surrounded by parentheses.
+     * The extended mnemonic might be hidden on certain platforms and only displayed
+     * then the mnemonic modifier key is pressed.
+     * </ul>
+     *
+     * @defaultValue {@code true}.
+     * @see Labeled#mnemonicParsingProperty()
      */
     private BooleanProperty mnemonicParsing;
     public final void setMnemonicParsing(boolean value) {

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/MenuItem.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/MenuItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -421,30 +421,26 @@ public class MenuItem implements EventTarget, Styleable {
      * <p>
      * The parsing recognizes two formats:
      * <ul>
-     * <li>
-     * <p>
-     * <b>Simple mnemonic</b>: the first character preceded by the first {@code _}
-     * character will be treated as the mnemonic. For example, "E_xit" will cause
-     * the text to become "Exit" and the mnemonic will be "x". This is the most
-     * common designation of a mnemonic, which will typically be visualized with an underline.
-     * To prevent {@code _} from being
-     * treated as the mnemonic prefix character, repeat it twice in a row.
-     * </p>
-     * </li>
-     * <li>
-     * <p>
-     * <b>Extended mnemonic</b>: an optional representation of a mnemonic is
-     * {@code _(c)}, where {@code c} is the mnemonic character. For example,
-     * "Exit_(q)" will cause the text to become "Exit" and the
-     * mnemonic will be "q". This is typically provided in
-     * translated strings to support mnemonics where the main text does not have any
-     * characters that map to keyboard keys. In these cases, the skin for the
-     * control will typically present the mnemonic surrounded by parentheses.
-     * The extended mnemonic might be hidden on certain platforms and only displayed
-     * then the mnemonic modifier key is pressed.
+     *   <li><b>Simple mnemonic</b>:
+     *     the first character preceded by the first {@code _}
+     *     character will be treated as the mnemonic. For example, "E_xit" will cause
+     *     the text to become "Exit" and the mnemonic will be "x". This is the most
+     *     common designation of a mnemonic, which will typically be visualized with an underline.
+     *     To prevent {@code _} from being
+     *     treated as the mnemonic prefix character, repeat it twice in a row.
+     *   <li><b>Extended mnemonic</b>:
+     *     an optional representation of a mnemonic is
+     *     {@code _(c)}, where {@code c} is the mnemonic character. For example,
+     *     "Exit_(q)" will cause the text to become "Exit" and the
+     *     mnemonic will be "q". This is typically provided in
+     *     translated strings to support mnemonics where the main text does not have any
+     *     characters that map to keyboard keys. In these cases, the skin for the
+     *     control will typically present the mnemonic surrounded by parentheses.
+     *     The extended mnemonic might be hidden on certain platforms and only displayed
+     *     when the mnemonic modifier key is pressed.
      * </ul>
      *
-     * @defaultValue {@code true}.
+     * @defaultValue {@code true}
      * @see Labeled#mnemonicParsingProperty()
      */
     private BooleanProperty mnemonicParsing;


### PR DESCRIPTION
Added javadoc to `[Labeled,MenuItem].mnemonicParsing` property, taken from the `MnemonicInfo` internal class.

A CSR may not be needed since it's a mere clarification and not an API change, but I am not sure.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8390898](https://bugs.openjdk.org/browse/JDK-8390898): "Extended mnemonic" should be documented (**Bug** - P4)


### Reviewers
 * [Lukasz Kostyra](https://openjdk.org/census#lkostyra) (@lukostyra - **Reviewer**)
 * [Michael Strauß](https://openjdk.org/census#mstrauss) (@mstr2 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2287/head:pull/2287` \
`$ git checkout pull/2287`

Update a local copy of the PR: \
`$ git checkout pull/2287` \
`$ git pull https://git.openjdk.org/jfx.git pull/2287/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2287`

View PR using the GUI difftool: \
`$ git pr show -t 2287`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2287.diff">https://git.openjdk.org/jfx/pull/2287.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2287#issuecomment-5486014849)
</details>
