### PR TITLE
8391663: Cell index and selection changes do not send accessibility notifications

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/Cell.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/Cell.java
@@ -32,6 +32,7 @@ import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.collections.ObservableList;
+import javafx.scene.AccessibleAttribute;
 import javafx.scene.Node;
 import javafx.scene.layout.GridPane;
 import javafx.scene.layout.HBox;
@@ -456,6 +457,7 @@ public class Cell<T> extends Labeled {
     private ReadOnlyBooleanWrapper selected = new ReadOnlyBooleanWrapper() {
         @Override protected void invalidated() {
             pseudoClassStateChanged(PSEUDO_CLASS_SELECTED, get());
+            notifyAccessibleAttributeChanged(AccessibleAttribute.SELECTED);
         }
 
         @Override

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/IndexedCell.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/IndexedCell.java
@@ -26,6 +26,7 @@
 package javafx.scene.control;
 
 import javafx.css.PseudoClass;
+import javafx.scene.AccessibleAttribute;
 import javafx.beans.property.ReadOnlyIntegerProperty;
 import javafx.beans.property.ReadOnlyIntegerWrapper;
 
@@ -138,7 +139,9 @@ public class IndexedCell<T> extends Cell<T> {
      * @param newIndex the new index
      */
     void indexChanged(int oldIndex, int newIndex) {
-        // no-op
+        if (oldIndex != newIndex) {
+            notifyAccessibleAttributeChanged(AccessibleAttribute.INDEX);
+        }
     }
 
     /* *************************************************************************


### PR DESCRIPTION
When the index of an IndexedCell is changed with `IndexedCell.indexChanged(int, int)`
then currently no `INDEX` accessibility notification is sent.

And when the selected element changes, then no `SELECTED` notification is sent.

As a result, assistive technology is not informed and it breaks the rule - that for every change
to the accessibility attributes must be notified with `Node.notifyAccessibleAttributeChanged(attribute)`.

The change is on the
base classes, so it covers `ListCell`, `TableCell`, `TableRow`, `TreeCell`,
`TreeTableCell`, and `TreeTableRow`.


---------
- [ ] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Error
&nbsp;⚠️ Pull request body is missing required line: `- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).`

### Issue
 * [JDK-8391663](https://bugs.openjdk.org/browse/JDK-8391663): Cell index and selection changes do not send accessibility notifications (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2288/head:pull/2288` \
`$ git checkout pull/2288`

Update a local copy of the PR: \
`$ git checkout pull/2288` \
`$ git pull https://git.openjdk.org/jfx.git pull/2288/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2288`

View PR using the GUI difftool: \
`$ git pr show -t 2288`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2288.diff">https://git.openjdk.org/jfx/pull/2288.diff</a>

</details>
