### PR TITLE
8391664: Add API to track Accessibility Events

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/scene/Accessibility.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Accessibility.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package javafx.scene;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * Observes accessibility attribute changes across the scene graph, for example from
+ * tooling or tests, regardless of whether an assistive technology is active.
+ *
+ * @since 28
+ */
+public final class Accessibility {
+
+    private static final List<AccessibleAttributeObserver> observers = new CopyOnWriteArrayList<>();
+
+    private Accessibility() {
+    }
+
+    /**
+     * Adds an observer notified whenever any {@link Node} reports an accessibility
+     * attribute change.
+     *
+     * @param observer the observer to add
+     */
+    public static void addAccessibleAttributeObserver(AccessibleAttributeObserver observer) {
+        observers.add(observer);
+    }
+
+    /**
+     * Removes a previously added observer.
+     *
+     * @param observer the observer to remove
+     */
+    public static void removeAccessibleAttributeObserver(AccessibleAttributeObserver observer) {
+        observers.remove(observer);
+    }
+
+    static void notifyObservers(Node node, AccessibleAttribute attribute) {
+        for (AccessibleAttributeObserver observer : observers) {
+            observer.attributeChanged(node, attribute);
+        }
+    }
+}

--- a/modules/javafx.graphics/src/main/java/javafx/scene/AccessibleAttributeObserver.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/AccessibleAttributeObserver.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package javafx.scene;
+
+/**
+ * A listener notified when a {@link Node} reports an accessibility attribute change.
+ *
+ * @see Accessibility#addAccessibleAttributeObserver(AccessibleAttributeObserver)
+ * @since 28
+ */
+@FunctionalInterface
+public interface AccessibleAttributeObserver {
+
+    /**
+     * Called when {@code node} reports a change to the given {@code attribute}.
+     *
+     * @param node the node reporting the change
+     * @param attribute the changed attribute
+     */
+    void attributeChanged(Node node, AccessibleAttribute attribute);
+}

--- a/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
@@ -10536,6 +10536,8 @@ public abstract sealed class Node
      * @since JavaFX 8u40
      */
     public final void notifyAccessibleAttributeChanged(AccessibleAttribute attributes) {
+        // Notify observers even when no assistive technology is attached.
+        Accessibility.notifyObservers(this, attributes);
         if (accessible == null) {
             Scene scene = getScene();
             if (scene != null) {


### PR DESCRIPTION
Currently it's very hard or impossible to write tests to check whether accessibility features work.
The Accessibility notifications only reach the assistive technology bridge - which isn't present without a running screen reader."
I would suggest adding a simple API like the following:

```
package javafx.scene (new class)
@FunctionalInterface
public interface AccessibleAttributeObserver {
    void attributeChanged(Node node, AccessibleAttribute attribute);
}

package javafx.scene (new class)
class Accessibility {
  void addAccessibleAttributeObserver(observer)
  void removeAccessibleAttributeObserver(observer)
} 
```

This would allow us to write reasonable unit tests for accessibility.
It would work - independent whether the accessibility bridge is used and would allow
to write unit tests easily.


I think this needs a CSR.
I would create one - once i get some initial feedback.


---------
- [ ] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change requires a CSR request matching fixVersion jfx28 to be approved (needs to be created)
- \[ \] Change must be properly reviewed (3 reviews required, with at least 3 [Reviewers](https://openjdk.org/bylaws#reviewer))

### Error
&nbsp;⚠️ Pull request body is missing required line: `- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).`

### Issue
 * [JDK-8391664](https://bugs.openjdk.org/browse/JDK-8391664): Add API to track Accessibility Events (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2289/head:pull/2289` \
`$ git checkout pull/2289`

Update a local copy of the PR: \
`$ git checkout pull/2289` \
`$ git pull https://git.openjdk.org/jfx.git pull/2289/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2289`

View PR using the GUI difftool: \
`$ git pr show -t 2289`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2289.diff">https://git.openjdk.org/jfx/pull/2289.diff</a>

</details>
