### PR TITLE
8389783: Crash in JavaFX native glass toolkit during Timer shutdown

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinTimer.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinTimer.java
@@ -97,6 +97,4 @@ final class WinTimer extends Timer {
     @Override
     public void resume() {
     }
-
 }
-

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinTimer.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinTimer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,5 +60,43 @@ final class WinTimer extends Timer {
     @Override native protected void _stop(long timer);
     @Override protected void _pause(long timer) {}
     @Override protected void _resume(long timer) {}
+
+    /*
+     * Overrides the base class method and calls super.stop() in a try/catch so that an
+     * IllegalStateException won't abort QuantumToolkit.exit() or QuantumToolkit.dispose()
+     */
+    @Override
+    public void stop() {
+        try {
+            super.stop();
+        } catch (IllegalStateException ex) {
+            ex.printStackTrace();
+        }
+    }
+
+    /*
+     * Overrides the base class method as a non-synchronized no-op. This avoids
+     * a potential deadlock that could otherwise happen if pause() is called
+     * from a Timer callback concurrently with stop() being called from another thread.
+     * The stop() method holds the Timer monitor and won't release it until
+     * _stop() completes, so pause() cannot acquire the monitor; _stop() will not
+     * complete until the callback returns.
+     */
+    @Override
+    public void pause() {
+    }
+
+    /*
+     * Overrides the base class method as a non-synchronized no-op. This avoids
+     * a potential deadlock that could otherwise happen if resume() is called
+     * from a Timer callback concurrently with stop() being called from another thread.
+     * The stop() method holds the Timer monitor and won't release it until
+     * _stop() completes, so resume() cannot acquire the monitor; _stop() will not
+     * complete until the callback returns.
+     */
+    @Override
+    public void resume() {
+    }
+
 }
 

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinTimer.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinTimer.java
@@ -62,19 +62,6 @@ final class WinTimer extends Timer {
     @Override protected void _resume(long timer) {}
 
     /*
-     * Overrides the base class method and calls super.stop() in a try/catch so that an
-     * IllegalStateException won't abort QuantumToolkit.exit() or QuantumToolkit.dispose()
-     */
-    @Override
-    public void stop() {
-        try {
-            super.stop();
-        } catch (IllegalStateException ex) {
-            ex.printStackTrace();
-        }
-    }
-
-    /*
      * Overrides the base class method as a non-synchronized no-op. This avoids
      * a potential deadlock that could otherwise happen if pause() is called
      * from a Timer callback concurrently with stop() being called from another thread.

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/QuantumToolkit.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/QuantumToolkit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -547,6 +547,16 @@ public final class QuantumToolkit extends Toolkit {
         pulseTimer.resume();
     }
 
+    private void stopTimer() {
+        // Stop the timer in a try/catch so that an IllegalStateException won't
+        // abort toolkit shutdown.
+        try {
+            pulseTimer.stop();
+        } catch (IllegalStateException ex) {
+            ex.printStackTrace();
+        }
+    }
+
     private String pulseString() {
         return ((toolkitRunning.get() ? "T" : "t") +
                 (animationRunning.get() ? "A" : "a") +
@@ -866,7 +876,7 @@ public final class QuantumToolkit extends Toolkit {
         checkFxUserThread();
 
         // Turn off pulses so no extraneous runnables are submitted
-        pulseTimer.stop();
+        stopTimer();
 
         // We need to wait for the last frame to finish so that the renderer
         // is not running while we are shutting down glass.
@@ -889,7 +899,7 @@ public final class QuantumToolkit extends Toolkit {
 
     public void dispose() {
         if (toolkitRunning.compareAndSet(true, false)) {
-            pulseTimer.stop();
+            stopTimer();
             renderer.stopRenderer();
 
             try {

--- a/modules/javafx.graphics/src/main/native-glass/win/Timer.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/win/Timer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,9 +45,14 @@ class RunnableTimer : public Timer {
             }
         }
 
-        static void Stop(jlong timer)
+        static bool Stop(jlong timer)
         {
-            delete (RunnableTimer*)jlong_to_ptr(timer);
+            RunnableTimer* runnableTimer = (RunnableTimer*)jlong_to_ptr(timer);
+            if (runnableTimer->cancel()) {
+                delete runnableTimer;
+                return true;
+            }
+            return false;
         }
 
         RunnableTimer(jobject r, jint period) : env(NULL), runnable(r)
@@ -98,7 +103,12 @@ JNIEXPORT jlong JNICALL Java_com_sun_glass_ui_win_WinTimer__1start
 JNIEXPORT void JNICALL Java_com_sun_glass_ui_win_WinTimer__1stop
   (JNIEnv * env, jobject jThis, jlong timer)
 {
-    RunnableTimer::Stop(timer);
+    if (!RunnableTimer::Stop(timer)) {
+        jclass ise = env->FindClass("java/lang/IllegalStateException");
+        if (ise) {
+            env->ThrowNew(ise, "Unable to stop timer");
+        }
+    }
 }
 
 /*

--- a/modules/javafx.graphics/src/main/native-glass/win/Timer.h
+++ b/modules/javafx.graphics/src/main/native-glass/win/Timer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,9 +56,7 @@ class Timer {
 
         virtual ~Timer()
         {
-            if (id) {
-                ::timeKillEvent(id);
-            }
+            (void)cancel();
             if (--timersCount == 0 && wTimerRes != 0) {
                 ::timeEndPeriod(wTimerRes);
             }
@@ -69,9 +67,21 @@ class Timer {
             // on the internets say is provides less accurate timers, so
             // let's use timeSetEvent.
             id = ::timeSetEvent(period, wTimerRes, StaticTimeCallback,
-                    (DWORD_PTR)this, TIME_PERIODIC);
+                    (DWORD_PTR)this,
+                    TIME_PERIODIC | TIME_KILL_SYNCHRONOUS | TIME_CALLBACK_FUNCTION);
 
             return id != 0;
+        }
+
+        bool cancel() {
+            if (id == 0) {
+                return true;
+            }
+            if (::timeKillEvent(id) == TIMERR_NOERROR) {
+                id = 0;
+                return true;
+            }
+            return false;
         }
 
         virtual void TimerCallback() = 0;

--- a/tests/system/src/test/java/test/com/sun/glass/ui/WinTimerTest.java
+++ b/tests/system/src/test/java/test/com/sun/glass/ui/WinTimerTest.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.com.sun.glass.ui;
+
+import com.sun.glass.ui.Application;
+import com.sun.glass.ui.Timer;
+import com.sun.javafx.PlatformUtil;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import test.util.Util;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+public class WinTimerTest {
+
+    private static final int TIMEOUT = 10000;
+    private static final int TIMED_WAIT = 4000;
+
+    private static final CountDownLatch startupLatch = new CountDownLatch(1);
+
+    private final CountDownLatch callbackEntered = new CountDownLatch(1);
+    private final CountDownLatch releaseCallback = new CountDownLatch(1);
+    private final CountDownLatch aboutToStop = new CountDownLatch(1);
+    private final CountDownLatch stopped = new CountDownLatch(1);
+
+    private final AtomicBoolean firstTime = new AtomicBoolean(true);
+    private final AtomicBoolean checkPause = new AtomicBoolean(false);
+    private Timer timer;
+
+    final AtomicReference<Throwable> throwable = new AtomicReference<>(null);
+
+    @BeforeAll
+    public static void setup() throws Exception {
+        assumeTrue(PlatformUtil.isWindows());
+        Util.startup(startupLatch, () -> startupLatch.countDown());
+    }
+
+    @AfterAll
+    public static void cleanup() {
+        assumeTrue(PlatformUtil.isWindows());
+        Util.shutdown();
+    }
+
+    // Sets the throwable if not already set
+    private void setThrowable(Throwable throwable) {
+        this.throwable.compareAndSet(null, throwable);
+    }
+
+    /*
+     * Method that is called by the timer as a callback on the timer thread.
+     * Do the following:
+     *   1. Signal that the timer thread has entered its callback
+     *   2. wait for the main thread to release the callback latch
+     *   3. call pause (skipped if an earlier error is detected)
+     *
+     * This method logs an exception or error if caught
+     */
+    private void timerCallback() {
+        if (!firstTime.getAndSet(false)) {
+            return;
+        }
+
+        callbackEntered.countDown();
+        try {
+            assertTrue(releaseCallback.await(TIMEOUT, TimeUnit.MILLISECONDS),
+                    "Callback: timeout waiting for release notification");
+            // pause() is a no-op on Windows, but we call it to ensure no deadlock
+            if (checkPause.get()) {
+                timer.pause();
+            }
+        } catch (Throwable t) {
+            setThrowable(t);
+        }
+    }
+
+    /*
+     * @test
+     * @bug 8389783
+     *
+     * Tests the Windows native Timer life-cycle. The test does the following:
+     *   1. Create a new Timer object with a callback
+     *   2. Start the timer with the minimum timer period
+     *   3. Wait for the callback to be called
+     *   4. Start a new "stopper" thread that stops the timer via timer.stop()
+     *   5. Wait for up to 4 second for a signal that timer.stop() has returned
+     *      (it should not return until the callback does)
+     *   6. release the callback
+     *   7. Wait for a signal that timer.stop() has returned (this time it should)
+     *   8. Join the "stopper" thread and verify that it is terminated
+     *   9. Check for any logged exceptions from the callback or the stopper thread
+     */
+    @Test
+    public void timerLifeCycleTest() throws Exception {
+        Application application = Application.GetApplication();
+        timer = application.createTimer(this::timerCallback);
+        timer.start(Timer.getMinPeriod());
+
+        /*
+         * Thread to stop the timer. It does the following:
+         *   1. Signal that the thread is about to call timer.stop()
+         *   2. Call timer.stop();
+         *   3. Signal that the timer is stopped.
+         *
+         * This thread logs an exception or error if caught
+         */
+        Thread stopperThread = new Thread(() -> {
+            aboutToStop.countDown();
+            try {
+                timer.stop();
+            } catch (Throwable t) {
+                setThrowable(t);
+            } finally {
+                stopped.countDown();
+            }
+        });
+        stopperThread.setDaemon(true);
+
+        try {
+            try {
+                assertTrue(callbackEntered.await(TIMEOUT, TimeUnit.MILLISECONDS),
+                        "Timeout waiting for callback to run");
+                stopperThread.start();
+                assertTrue(aboutToStop.await(TIMEOUT, TimeUnit.MILLISECONDS),
+                        "Timeout waiting for stopper thread to run");
+                // Check for early release
+                assertFalse(stopped.await(TIMED_WAIT, TimeUnit.MILLISECONDS),
+                        "Timer.stop completed while callback still running");
+                checkPause.set(true);
+            } finally {
+                releaseCallback.countDown();
+            }
+            assertTrue(stopped.await(TIMEOUT, TimeUnit.MILLISECONDS),
+                    "Timeout waiting for stop to return");
+        } finally {
+            stopperThread.join(TIMEOUT);
+        }
+        assertFalse(stopperThread.isAlive(), "Stopper thread is still running");
+        assertNull(throwable.get());
+    }
+
+}

--- a/tests/system/src/test/java/test/com/sun/glass/ui/WinTimerTest.java
+++ b/tests/system/src/test/java/test/com/sun/glass/ui/WinTimerTest.java
@@ -82,7 +82,7 @@ public class WinTimerTest {
      *   2. wait for the main thread to release the callback latch
      *   3. call pause (skipped if an earlier error is detected)
      *
-     * This method logs an exception or error if caught
+     * This method records an exception or error if caught
      */
     private void timerCallback() {
         if (!firstTime.getAndSet(false)) {
@@ -111,12 +111,12 @@ public class WinTimerTest {
      *   2. Start the timer with the minimum timer period
      *   3. Wait for the callback to be called
      *   4. Start a new "stopper" thread that stops the timer via timer.stop()
-     *   5. Wait for up to 4 second for a signal that timer.stop() has returned
+     *   5. Wait for up to 4 seconds for a signal that timer.stop() has returned
      *      (it should not return until the callback does)
      *   6. release the callback
      *   7. Wait for a signal that timer.stop() has returned (this time it should)
      *   8. Join the "stopper" thread and verify that it is terminated
-     *   9. Check for any logged exceptions from the callback or the stopper thread
+     *   9. Check for any recorded exceptions from the callback or the stopper thread
      */
     @Test
     public void timerLifeCycleTest() throws Exception {
@@ -129,9 +129,9 @@ public class WinTimerTest {
          * Thread to stop the timer. It does the following:
          *   1. Signal that the thread is about to call timer.stop()
          *   2. Call timer.stop();
-         *   3. Signal that the timer is stopped.
+         *   3. Signal that timer.stop() has completed.
          *
-         * This thread logs an exception or error if caught
+         * This thread records an exception or error if caught
          */
         Thread stopperThread = new Thread(() -> {
             aboutToStop.countDown();
@@ -153,19 +153,22 @@ public class WinTimerTest {
                 assertTrue(aboutToStop.await(TIMEOUT, TimeUnit.MILLISECONDS),
                         "Timeout waiting for stopper thread to run");
                 // Check for early release
-                assertFalse(stopped.await(TIMED_WAIT, TimeUnit.MILLISECONDS),
+                boolean stoppedEarly = stopped.await(TIMED_WAIT, TimeUnit.MILLISECONDS);
+                assertNull(throwable.get());
+                assertFalse(stoppedEarly,
                         "Timer.stop completed while callback still running");
                 checkPause.set(true);
             } finally {
                 releaseCallback.countDown();
             }
-            assertTrue(stopped.await(TIMEOUT, TimeUnit.MILLISECONDS),
-                    "Timeout waiting for stop to return");
+            boolean stoppedAfterRelease = stopped.await(TIMEOUT, TimeUnit.MILLISECONDS);
+            assertNull(throwable.get());
+            assertTrue(stoppedAfterRelease, "Timeout waiting for stop to return");
             assertFalse(timer.isRunning());
         } finally {
             stopperThread.join(TIMEOUT);
         }
-        assertFalse(stopperThread.isAlive(), "Stopper thread is still running");
         assertNull(throwable.get());
+        assertFalse(stopperThread.isAlive(), "Stopper thread is still running");
     }
 }

--- a/tests/system/src/test/java/test/com/sun/glass/ui/WinTimerTest.java
+++ b/tests/system/src/test/java/test/com/sun/glass/ui/WinTimerTest.java
@@ -166,5 +166,4 @@ public class WinTimerTest {
         assertFalse(stopperThread.isAlive(), "Stopper thread is still running");
         assertNull(throwable.get());
     }
-
 }

--- a/tests/system/src/test/java/test/com/sun/glass/ui/WinTimerTest.java
+++ b/tests/system/src/test/java/test/com/sun/glass/ui/WinTimerTest.java
@@ -123,6 +123,7 @@ public class WinTimerTest {
         Application application = Application.GetApplication();
         timer = application.createTimer(this::timerCallback);
         timer.start(Timer.getMinPeriod());
+        assertTrue(timer.isRunning());
 
         /*
          * Thread to stop the timer. It does the following:
@@ -160,6 +161,7 @@ public class WinTimerTest {
             }
             assertTrue(stopped.await(TIMEOUT, TimeUnit.MILLISECONDS),
                     "Timeout waiting for stop to return");
+            assertFalse(timer.isRunning());
         } finally {
             stopperThread.join(TIMEOUT);
         }


### PR DESCRIPTION
This PR fixes a bug in `Timer.stop()` on Windows that can happen if stop is called while a Timer callback is running. There are three related problems with the way the Timer is implemented on Windows:

1. The native timer kill operation is asynchronous: `timeSetEvent` does not include `TIME_KILL_SYNCHRONOUS` so `timeKillEvent` will not wait for a callback that might be executing concurrently.
2. The native `RunnableTimer::Stop()` method deletes the Timer object while it might still be in use running a callback. The deletion triggers a call to kill the timer from the Timer base class destructor, after the derived class destructor has run, meaning that the `runnable` member will be deleted before `timeKillEvent` is called.
3. The Java-side `Timer.pause()` method, which is a no-op on Windows, is synchronized on the Timer instance as is the `Timer.stop()` method. The `pause()` method is called from the Timer callback, which can lead to deadlock.

This last problem might affect other platforms as well (e.g., it might contribute to a similar deadlock on macOS, tracked by [JDK-8238505](https://bugs.openjdk.org/browse/JDK-8238505)), but this fix is intentionally limited to Windows platform-specific code (except for the shared try/catch around `Timer.stop()` in toolkit shutdown).

The fix is as follows:

1. Pass `TIME_KILL_SYNCHRONOUS` to `timeSetEvent`.
2. Move the `timeKillEvent` call from the Timer destructor to an explicit `cancel()` method. The destructor calls this method defensively (which should be a no-op in the typical case).
3. Call `cancel()` from `Stop()`, checking the return code. Delete the timer after a successful cancel operation; throw an exception if the timer cannot be canceled. This should never occur, but if it does, it is safer to leak the Timer object than free an object that might still be in use.
4. WinTimer.java - Override `pause()` and `resume()` to be unsynchronized no-op methods.
5. QuantumToolkit.java - Call `pulseTimer.stop()` in a try/catch from `QuantumToolkit.exit()` and `QuantumToolkit.dispose()` so that a cancellation failure doesn't abort toolkit shutdown; print the exception's stack trace if caught.

I have included a test for this. To run just the new test:

```
gradle sdk shims
gradle --info -PTEST_ONLY=true -PFULL_TEST=true :systemTests:test --tests test.com.sun.glass.ui.WinTimerTest
```

Without the fix, it will either crash (without generating an hs_err log) or fail with an AssertionError. With the fix, it passes.


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8389783](https://bugs.openjdk.org/browse/JDK-8389783): Crash in JavaFX native glass toolkit during Timer shutdown (**Bug** - P3)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Michael Strauß](https://openjdk.org/census#mstrauss) (@mstr2 - **Reviewer**)
 * [Lukasz Kostyra](https://openjdk.org/census#lkostyra) (@lukostyra - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2290/head:pull/2290` \
`$ git checkout pull/2290`

Update a local copy of the PR: \
`$ git checkout pull/2290` \
`$ git pull https://git.openjdk.org/jfx.git pull/2290/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2290`

View PR using the GUI difftool: \
`$ git pr show -t 2290`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2290.diff">https://git.openjdk.org/jfx/pull/2290.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2290#issuecomment-5515844041)
</details>
