### PR TITLE
8090896: Allow skipping apps build

### DIFF
--- a/apps.gradle
+++ b/apps.gradle
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+import com.sun.javafx.gradle.CompileTarget
+
+project(":apps") {
+    // Download the Lucene libraries needed for the Ensemble8 app
+    getConfigurations().create("lucene");
+    dependencies {
+        lucene group: "org.apache.lucene", name: "lucene-core", version: "${luceneVersion}"
+        lucene group: "org.apache.lucene", name: "lucene-grouping", version: "${luceneVersion}"
+        lucene group: "org.apache.lucene", name: "lucene-queryparser", version: "${luceneVersion}"
+    }
+
+    // Copy Lucene libraries into the Ensemble8/lib directory
+    File ensembleLibDir = rootProject.file("apps/samples/Ensemble8/lib");
+    def libNames = [ "lucene-core-${luceneVersion}.jar",
+                     "lucene-grouping-${luceneVersion}.jar",
+                     "lucene-queryparser-${luceneVersion}.jar" ]
+
+
+    task getLucene(type: Copy) {
+        doFirst {
+            ensembleLibDir.mkdirs();
+        }
+        into ensembleLibDir
+        includeEmptyDirs = false
+        configurations.lucene.files.each { f ->
+            libNames.each { name ->
+                if (name == f.getName()) {
+                    from f.getPath()
+                }
+            }
+        }
+    }
+
+    compileTargets { CompileTarget t ->
+        List<String> params = []
+
+        params << "-DtargetBld=$t.name"
+
+        if (!rootProject.ext[t.upper].compileSwing) {
+            params << "-DJFX_CORE_ONLY=true"
+        }
+        params << "-Dplatforms.JDK_1.9.home=${rootProject.ext.JDK_HOME}"
+        params << "-Dcompile.patch=@${rootProject.buildDir}/${COMPILEARGSFILE}"
+        params << "-Drun.patch=@${rootProject.buildDir}/${RUNARGSFILE}"
+
+        def appsJar = project.task("appsJar${t.capital}") {
+            dependsOn(sdk, getLucene)
+            doLast() {
+                ant(t.name,
+                      projectDir.path,
+                      "appsJar",
+                      params);
+            }
+        }
+        rootProject.appsjar.dependsOn(appsJar)
+
+        def appsClean = project.task("clean${t.capital}") {
+            doLast() {
+                ant(t.name,
+                      project.projectDir.path,
+                      "clean",
+                      params);
+                delete(ensembleLibDir);
+            }
+        }
+        rootProject.clean.dependsOn(appsClean)
+    }
+}
+
+// Make a forked ANT call.
+// This needs to be forked so that ant can be used with the right JDK and updated modules
+// for testing obscure things like packaging of apps
+void ant(String conf,   // platform configuration
+         String dir,    // directory to run from
+         String target, // ant target
+         List<String>  params // parameters (usually -Dxxx=yyy)
+         ) {
+    // Try to use ANT_HOME
+    String antHomeEnv = System.getenv("ANT_HOME")
+    String antHome = antHomeEnv != null ? cygpath(antHomeEnv) : null;
+    String ant = (antHome != null && !antHome.equals("")) ? "$antHome/bin/ant" : "ant";
+
+    List<String> cmdArgs = new ArrayList<String>()
+    if (IS_WINDOWS) {
+        cmdArgs += !ant.matches("\\s+") ? '"' + ant + '"' : ant
+    }
+
+    cmdArgs += "-Dbuild.compiler=javac1.7"
+
+    if ((conf != null) && !rootProject.defaultHostTarget.equals(conf)) {
+        def targetProperties = rootProject.ext[conf.trim().toUpperCase()]
+        cmdArgs += "-Dcross.platform=$conf"
+        if (targetProperties.containsKey('arch')) {
+            cmdArgs += "-Dcross.platform.arch=${targetProperties.arch}"
+        }
+    }
+
+    if (params != null) {
+        params.each() { s->
+            cmdArgs += IS_WINDOWS && !s.matches("\\s+") ? '"' + s + '"' : s
+        }
+    }
+
+    if (IS_MILESTONE_FCS) {
+        cmdArgs += '-Djfx.release.suffix=""'
+    }
+
+    cmdArgs += target
+
+    def execOps = project.services.get(ExecOperations)
+    execOps.exec { spec ->
+        workingDir = dir
+        environment("JDK_HOME", JDK_HOME)
+        environment("JAVA_HOME", JDK_HOME)
+        if (IS_WINDOWS) {
+            environment([
+                    "VCINSTALLDIR"         : WINDOWS_VS_VCINSTALLDIR,
+                    "VSINSTALLDIR"         : WINDOWS_VS_VSINSTALLDIR,
+                    "DEVENVDIR"            : WINDOWS_VS_DEVENVDIR,
+                    "MSVCDIR"              : WINDOWS_VS_MSVCDIR,
+                    "INCLUDE"              : WINDOWS_VS_INCLUDE,
+                    "LIB"                  : WINDOWS_VS_LIB,
+                    "LIBPATH"              : WINDOWS_VS_LIBPATH,
+                    "PATH"                 : WINDOWS_VS_PATH
+            ]);
+            commandLine "cmd", "/s", "/c", '"' + String.join(" ", cmdArgs) + '"'
+        } else {
+            commandLine ant
+            args(cmdArgs)
+        }
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -474,6 +474,11 @@ ext.IS_COMPILE_HARFBUZZ = Boolean.parseBoolean(COMPILE_HARFBUZZ)
 defineProperty("COMPILE_PARFAIT", "false")
 ext.IS_COMPILE_PARFAIT = Boolean.parseBoolean(COMPILE_PARFAIT)
 
+// INCLUDE_APPS specifies whether the "apps" directory is part of the build.
+// When disabled, the "apps", "appsjar" and "clean" tasks will not compile or clean the apps in there.
+defineProperty("INCLUDE_APPS", "false")
+ext.IS_INCLUDE_APPS = Boolean.parseBoolean(INCLUDE_APPS)
+
 defineProperty("STATIC_BUILD", "false")
 ext.IS_STATIC_BUILD = Boolean.parseBoolean(STATIC_BUILD)
 
@@ -941,70 +946,6 @@ void fetchExternalTools(String configName, List packages, File destdir, boolean 
             throw new GradleException("Error: missing tool packages: $errors")
         } else {
             logger.quiet "all tool packages are present $packages"
-        }
-    }
-}
-
-// Make a forked ANT call.
-// This needs to be forked so that ant can be used with the right JDK and updated modules
-// for testing obscure things like packaging of apps
-void ant(String conf,   // platform configuration
-         String dir,    // directory to run from
-         String target, // ant target
-         List<String>  params // parameters (usually -Dxxx=yyy)
-         ) {
-    // Try to use ANT_HOME
-    String antHomeEnv = System.getenv("ANT_HOME")
-    String antHome = antHomeEnv != null ? cygpath(antHomeEnv) : null;
-    String ant = (antHome != null && !antHome.equals("")) ? "$antHome/bin/ant" : "ant";
-
-    List<String> cmdArgs = new ArrayList<String>()
-    if (IS_WINDOWS) {
-        cmdArgs += !ant.matches("\\s+") ? '"' + ant + '"' : ant
-    }
-
-    cmdArgs += "-Dbuild.compiler=javac1.7"
-
-    if ((conf != null) && !rootProject.defaultHostTarget.equals(conf)) {
-        def targetProperties = rootProject.ext[conf.trim().toUpperCase()]
-        cmdArgs += "-Dcross.platform=$conf"
-        if (targetProperties.containsKey('arch')) {
-            cmdArgs += "-Dcross.platform.arch=${targetProperties.arch}"
-        }
-    }
-
-    if (params != null) {
-        params.each() { s->
-            cmdArgs += IS_WINDOWS && !s.matches("\\s+") ? '"' + s + '"' : s
-        }
-    }
-
-    if (IS_MILESTONE_FCS) {
-        cmdArgs += '-Djfx.release.suffix=""'
-    }
-
-    cmdArgs += target
-
-    def execOps = project.services.get(ExecOperations)
-    execOps.exec { spec ->
-        workingDir = dir
-        environment("JDK_HOME", JDK_HOME)
-        environment("JAVA_HOME", JDK_HOME)
-        if (IS_WINDOWS) {
-            environment([
-                    "VCINSTALLDIR"         : WINDOWS_VS_VCINSTALLDIR,
-                    "VSINSTALLDIR"         : WINDOWS_VS_VSINSTALLDIR,
-                    "DEVENVDIR"            : WINDOWS_VS_DEVENVDIR,
-                    "MSVCDIR"              : WINDOWS_VS_MSVCDIR,
-                    "INCLUDE"              : WINDOWS_VS_INCLUDE,
-                    "LIB"                  : WINDOWS_VS_LIB,
-                    "LIBPATH"              : WINDOWS_VS_LIBPATH,
-                    "PATH"                 : WINDOWS_VS_PATH
-            ]);
-            commandLine "cmd", "/s", "/c", '"' + String.join(" ", cmdArgs) + '"'
-        } else {
-            commandLine ant
-            args(cmdArgs)
         }
     }
 }
@@ -1565,6 +1506,7 @@ logger.quiet("STUB_RUNTIME: $STUB_RUNTIME")
 logger.quiet("CONF: $CONF")
 logger.quiet("NUM_COMPILE_THREADS: $NUM_COMPILE_THREADS")
 logger.quiet("COMPILE_TARGETS: $COMPILE_TARGETS")
+logger.quiet("INCLUDE_APPS: $IS_INCLUDE_APPS")
 logger.quiet("COMPILE_FLAGS_FILES: $COMPILE_FLAGS_FILES")
 logger.quiet("HUDSON_JOB_NAME: $HUDSON_JOB_NAME")
 logger.quiet("HUDSON_BUILD_NUMBER: $HUDSON_BUILD_NUMBER")
@@ -4892,73 +4834,9 @@ compileTargets { t ->
     sdk.dependsOn(sdkTask)
 }
 
-project(":apps") {
-    // The apps build is Ant based, we will exec ant from gradle.
-
-    // Download the Lucene libraries needed for the Ensemble8 app
-    getConfigurations().create("lucene");
-    dependencies {
-        lucene group: "org.apache.lucene", name: "lucene-core", version: "${luceneVersion}"
-        lucene group: "org.apache.lucene", name: "lucene-grouping", version: "${luceneVersion}"
-        lucene group: "org.apache.lucene", name: "lucene-queryparser", version: "${luceneVersion}"
-    }
-
-    // Copy Lucene libraries into the Ensemble8/lib directory
-    File ensembleLibDir = rootProject.file("apps/samples/Ensemble8/lib");
-    def libNames = [ "lucene-core-${luceneVersion}.jar",
-                     "lucene-grouping-${luceneVersion}.jar",
-                     "lucene-queryparser-${luceneVersion}.jar" ]
-
-
-    task getLucene(type: Copy) {
-        doFirst {
-            ensembleLibDir.mkdirs();
-        }
-        into ensembleLibDir
-        includeEmptyDirs = false
-        configurations.lucene.files.each { f ->
-            libNames.each { name ->
-                if (name == f.getName()) {
-                    from f.getPath()
-                }
-            }
-        }
-    }
-
-    compileTargets { t ->
-        List<String> params = []
-
-        params << "-DtargetBld=$t.name"
-
-        if (!rootProject.ext[t.upper].compileSwing) {
-            params << "-DJFX_CORE_ONLY=true"
-        }
-        params << "-Dplatforms.JDK_1.9.home=${rootProject.ext.JDK_HOME}"
-        params << "-Dcompile.patch=@${rootProject.buildDir}/${COMPILEARGSFILE}"
-        params << "-Drun.patch=@${rootProject.buildDir}/${RUNARGSFILE}"
-
-        def appsJar = project.task("appsJar${t.capital}") {
-            dependsOn(sdk, getLucene)
-            doLast() {
-                ant(t.name,
-                      projectDir.path,
-                      "appsJar",
-                      params);
-            }
-        }
-        rootProject.appsjar.dependsOn(appsJar)
-
-        def appsClean = project.task("clean${t.capital}") {
-            doLast() {
-                ant(t.name,
-                      project.projectDir.path,
-                      "clean",
-                      params);
-                delete(ensembleLibDir);
-            }
-        }
-        rootProject.clean.dependsOn(appsClean)
-    }
+// The apps are built by a separate Ant based build, which is only wired into this build when INCLUDE_APPS is enabled.
+if (IS_INCLUDE_APPS) {
+    apply from: 'apps.gradle'
 }
 
 // Tasks to create the disk layout for the sdk, jmods, and docs

--- a/build.gradle
+++ b/build.gradle
@@ -475,8 +475,8 @@ defineProperty("COMPILE_PARFAIT", "false")
 ext.IS_COMPILE_PARFAIT = Boolean.parseBoolean(COMPILE_PARFAIT)
 
 // INCLUDE_APPS specifies whether the "apps" directory is part of the build.
-// When disabled, the "apps", "appsjar" and "clean" tasks will not compile or clean the apps in there.
-defineProperty("INCLUDE_APPS", "false")
+// When disabled, the "apps", "appsjar" and "clean" tasks will not compile or clean the "apps" directory.
+defineProperty("INCLUDE_APPS", "true")
 ext.IS_INCLUDE_APPS = Boolean.parseBoolean(INCLUDE_APPS)
 
 defineProperty("STATIC_BUILD", "false")


### PR DESCRIPTION
This is an idea to add an `INCLUDE_APPS` flag, that is `true` by default to control whether we actually want to build the `:apps` when running `gradle all` or if we actually need to clean them when running `gradle clean`.

I see two advantages:
- IMO, the main `build.gradle` should focus on JavaFX and not so much on anything else, like apps
- As of now, when I did run `gradle clean`, I always need to install `Ant`, just because the apps are also cleaned which I did not even build before.
This is problematic, because:
  - I think most of the people do not have `Ant`, it is very rarely used nowadays
  - It is also not preinstalled in pretty much every OS / distribution I tried. And I usually only installed for `OpenJFX` and never need it for anything else. If possible, it would be good if this is not needed if you just want to run tests and build JavaFX
    - For reference, when running CachyOS I could just build JavaFX out of the box without ever installing anything.  This is a very nice experience and should help people to contribute. The only thing I did run into was, well, `Ant` when running `gradle clean`

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8090896](https://bugs.openjdk.org/browse/JDK-8090896): Allow skipping apps build (**Enhancement** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Nir Lisker](https://openjdk.org/census#nlisker) (@nlisker - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2291/head:pull/2291` \
`$ git checkout pull/2291`

Update a local copy of the PR: \
`$ git checkout pull/2291` \
`$ git pull https://git.openjdk.org/jfx.git pull/2291/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2291`

View PR using the GUI difftool: \
`$ git pr show -t 2291`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2291.diff">https://git.openjdk.org/jfx/pull/2291.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2291#issuecomment-5523725150)
</details>
