### PR TITLE
8391823: Intermittent WebView crash when running TextureMapperTest

### DIFF
--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/java/FontCacheJava.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/java/FontCacheJava.cpp
@@ -47,8 +47,7 @@ Ref<Font> FontCache::lastResortFallbackFont(const FontDescription& fontDescripti
 {
     // We want to return a fallback font here, otherwise the logic preventing FontConfig
     // matches for non-fallback fonts might return 0. See isFallbackFontAllowed.
-    static AtomString timesStr("serif"_s);
-    return *fontForFamily(fontDescription, timesStr);
+    return *fontForFamily(fontDescription, AtomString { "serif"_s });
 }
 
 Vector<String> FontCache::systemFontFamilies()
@@ -87,4 +86,3 @@ RefPtr<Font> FontCache::systemFallbackForCharacterCluster(const FontDescription&
     return nullptr;
 }
 }
-

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/texmap/TextureMapper.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/texmap/TextureMapper.cpp
@@ -1392,6 +1392,10 @@ void TextureMapper::bindDefaultSurface()
 
 void TextureMapper::bindSurface(BitmapTexture *surface)
 {
+#if PLATFORM(JAVA)
+    UNUSED_PARAM(surface);
+    return;
+#else
     if (!surface) {
         bindDefaultSurface();
         return;
@@ -1400,6 +1404,7 @@ void TextureMapper::bindSurface(BitmapTexture *surface)
     surface->bindAsSurface();
     data().currentSurface = surface;
     updateProjectionMatrix();
+#endif
 }
 
 BitmapTexture* TextureMapper::currentSurface()
@@ -1633,7 +1638,11 @@ void TextureMapper::setDepthRange(double zNear, double zFar)
 
 std::pair<double, double> TextureMapper::depthRange() const
 {
+#if PLATFORM(JAVA)
+    return { 0, 0 };
+#else
     return { data().zNear, data().zFar };
+#endif
 }
 
 void TextureMapper::updateProjectionMatrix()
@@ -1664,12 +1673,21 @@ void TextureMapper::drawTextureExternalOES(GLuint texture, OptionSet<TextureMapp
 
 Ref<TextureMapperGPUBuffer> TextureMapper::acquireBufferFromPool(size_t size, TextureMapperGPUBuffer::Type type)
 {
+#if PLATFORM(JAVA)
+    // The Java port does not have a GL buffer upload path. Callers still use
+    // the CPU-side clip vertices, while the zero buffer ID is never consumed
+    // by the Java clipping implementation.
+    UNUSED_PARAM(size);
+    static auto buffer = TextureMapperGPUBuffer::create(0, type, TextureMapperGPUBuffer::Usage::Dynamic);
+    return buffer;
+#else
     size_t ceil = roundUpToPowerOfTwo(size);
     size_t floor = ceil >> 1; // half of ceil
     size_t mid = floor + (floor >> 1); // (1.5 times floor)
     size_t requestSize = (size <= mid) ? mid : ceil;
 
     return data().getBufferFromPool(requestSize, type);
+#endif
 }
 
 } // namespace WebCore

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/texmap/TextureMapper.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/texmap/TextureMapper.h
@@ -155,7 +155,11 @@ private:
     WrapMode m_wrapMode { WrapMode::Stretch };
     std::optional<FloatSize> m_uvClampMax;
     std::optional<FloatSize> m_uvClampTexelSize;
+#if !PLATFORM(JAVA)
     TextureMapperGLData* m_data;
+#else
+    TextureMapperGLData* m_data { nullptr };
+#endif
     ClipStack m_clipStack;
 #if ENABLE(DAMAGE_TRACKING)
     std::optional<Damage> m_damage;

--- a/tests/system/src/test/java/test/javafx/scene/web/TextureMapperTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/web/TextureMapperTest.java
@@ -105,6 +105,6 @@ public class TextureMapperTest {
         });
 
         assertTrue(Util.await(transitionStarted), "Timeout waiting for the view transition to start");
-        Util.sleep(500);
+        Util.sleep(800);
     }
 }


### PR DESCRIPTION
Intermittent WebView crash happens due to web view transition feature activates GL buffer upload path in headfull test mode which JavaFX does not support and the AtomicString is being destroyed by texture mapper thread which not owner of associated string table of AtomicString. There is pre written system test TextureMapperTest. The fix has been tested rigorously. 

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391823](https://bugs.openjdk.org/browse/JDK-8391823): Intermittent WebView crash when running TextureMapperTest (**Bug** - P2)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2293/head:pull/2293` \
`$ git checkout pull/2293`

Update a local copy of the PR: \
`$ git checkout pull/2293` \
`$ git pull https://git.openjdk.org/jfx.git pull/2293/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2293`

View PR using the GUI difftool: \
`$ git pr show -t 2293`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2293.diff">https://git.openjdk.org/jfx/pull/2293.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2293#issuecomment-5541596018)
</details>
