### PR TITLE
8391822: Use Gradle's Java Toolchain

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2064,7 +2064,7 @@ allprojects {
             // 'jdkVersionInfo' is the resolved Runtime.Version. 'feature' is the new name for the 'major' element
             languageVersion = JavaLanguageVersion.of(jdkVersionInfo.feature())
         }
-    
+
         sourceCompatibility = JAVA_TARGET_VERSION
     }
 
@@ -4404,7 +4404,7 @@ allprojects {
 
         compile.options.debug = true // we always generate debugging info in the class files
         compile.options.debugOptions.debugLevel = IS_DEBUG_JAVA ? "source,lines,vars" : "source,lines"
-        
+
         // forces forking of the damon and build JVMs (even when it's the same JDK), no-op if the JVMs are different
         compile.options.fork = true
 

--- a/build.gradle
+++ b/build.gradle
@@ -806,6 +806,11 @@ try (BufferedReader inStream = new java.io.BufferedReader(new java.io.InputStrea
 }
 if (jdkVersionInfo == null) throw new Exception("Unable to determine the version of Java in JDK_HOME at $JDK_HOME");
 
+apply plugin: "jvm-toolchains"
+
+// 'jdkVersionInfo' is the resolved Runtime.Version. 'feature' is the new name for the 'major' element
+ext.JDK_TOOLCHAIN_VERSION = JavaLanguageVersion.of(jdkVersionInfo.feature())
+
 // Use --upgrade-module-path instead of --module-path when compiling and
 // running tests if we are using a JDK that includes an upgradable
 // jdk.jsobject module.  Currently, this is JDK 24 or later. Once
@@ -2061,8 +2066,7 @@ allprojects {
     // override this setting, but it is needed for those modules that can't.
     java {
         toolchain {
-            // 'jdkVersionInfo' is the resolved Runtime.Version. 'feature' is the new name for the 'major' element
-            languageVersion = JavaLanguageVersion.of(jdkVersionInfo.feature())
+            languageVersion = JDK_TOOLCHAIN_VERSION
         }
 
         sourceCompatibility = JAVA_TARGET_VERSION
@@ -4384,6 +4388,9 @@ allprojects {
     // task and manually provide the options necessary to fire up the
     // compiler with the right settings.
     tasks.withType(JavaCompile) { compile ->
+        compile.javaCompiler = javaToolchains.compilerFor {
+            languageVersion = JDK_TOOLCHAIN_VERSION
+        }
         if (compile.options.hasProperty("useAnt")) {
             compile.options.useAnt = true
             compile.options.useDepend = IS_USE_DEPEND
@@ -4647,6 +4654,9 @@ task createOverviewFile() {
 task javadoc(type: Javadoc, dependsOn: [createMSPfile, createOverviewFile]) {
     group = "Basic"
     description = "Generates the JavaDoc for all the public API"
+    javadocTool = javaToolchains.javadocToolFor {
+        languageVersion = JDK_TOOLCHAIN_VERSION
+    }
     def projectsToDocument = [
         project(":base"),
         project(":graphics"),

--- a/build.gradle
+++ b/build.gradle
@@ -2060,6 +2060,11 @@ allprojects {
     // set compiler.options.release (to the same target version), which will
     // override this setting, but it is needed for those modules that can't.
     java {
+        toolchain {
+            // 'jdkVersionInfo' is the resolved Runtime.Version. 'feature' is the new name for the 'major' element
+            languageVersion = JavaLanguageVersion.of(jdkVersionInfo.feature())
+        }
+    
         sourceCompatibility = JAVA_TARGET_VERSION
     }
 
@@ -4403,7 +4408,7 @@ allprojects {
         compile.options.debugOptions.debugLevel = IS_DEBUG_JAVA ? "source,lines,vars" : "source,lines"
         compile.options.fork = true
 
-        compile.options.forkOptions.executable = JAVAC
+//        compile.options.forkOptions.executable = JAVAC
 
         compile.options.compilerArgs += ["-encoding", "UTF-8"]
         compile.options.compilerArgs += [ "-Xmaxerrs", "1000" ]

--- a/build.gradle
+++ b/build.gradle
@@ -2100,7 +2100,6 @@ allprojects {
         // Tests are forced to rerun when they are *not* marked as up-to-date
         outputs.upToDateWhen { !IS_FORCE_TESTS }
 
-        executable = JAVA;
         enableAssertions = true;
         testLogging.exceptionFormat = "full";
         scanForTestClasses = true;
@@ -2324,7 +2323,6 @@ project(":graphics") {
             inJSL = inJSL.replace("/", "\\")
         }
 
-        executable = JAVA
         classpath = project.configurations.antlr
         workingDir = wd
         mainClass = "org.antlr.v4.Tool"
@@ -4406,9 +4404,9 @@ allprojects {
 
         compile.options.debug = true // we always generate debugging info in the class files
         compile.options.debugOptions.debugLevel = IS_DEBUG_JAVA ? "source,lines,vars" : "source,lines"
+        
+        // forces forking of the damon and build JVMs (even when it's the same JDK), no-op if the JVMs are different
         compile.options.fork = true
-
-//        compile.options.forkOptions.executable = JAVAC
 
         compile.options.compilerArgs += ["-encoding", "UTF-8"]
         compile.options.compilerArgs += [ "-Xmaxerrs", "1000" ]
@@ -4649,7 +4647,6 @@ task createOverviewFile() {
 task javadoc(type: Javadoc, dependsOn: [createMSPfile, createOverviewFile]) {
     group = "Basic"
     description = "Generates the JavaDoc for all the public API"
-    executable = JAVADOC
     def projectsToDocument = [
         project(":base"),
         project(":graphics"),

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,5 +23,5 @@
 # questions.
 #
 
-# Search for Java installations also in JDK_HOME - required for using the Java Toolchain
+# Search for Java installations also in JDK_HOME - used by the Java Toolchain
 org.gradle.java.installations.fromEnv=JDK_HOME


### PR DESCRIPTION
Adds the [Java Toolchain](https://docs.gradle.org/current/userguide/toolchains.html#sec:using-java-toolchains) to replace manual executions:

| Old | New
|------|------|
| `JAVA` | [JavaLauncher](https://docs.gradle.org/current/javadoc/org/gradle/jvm/toolchain/JavaLauncher.html) |
| `JAVAC` | [JavaCompiler](https://docs.gradle.org/current/javadoc/org/gradle/jvm/toolchain/JavaCompiler.html) |
| `JAVADOC` | [JavadocTool](https://docs.gradle.org/current/javadoc/org/gradle/jvm/toolchain/JavadocTool.html) |

## Instructions for reviewers

The build runs on Windows and Linux (Ubuntu), but the analysis was done on Windows.

### JVM detection and selection
The toolchain selects the JDKs to use based on all those that are made available to it. As detailed in the link above, JDKs can come from various sources on the user machine, including being auto-provisioned. The daemon JDK is always available (usually `JAVA_HOME`), and `gradle.properties` made `JDK_HOME` available in #2240.
Selection of the toolchain build/worker JDK from all available ones is done internally (as detailed in the link) based on the restrictions configured in the toolchain. I have restricted the major version to that of `jdkVersionInfo` (exact version, not minimum), which is determined by the *build file's JDK resolution*:
```gradle
def envJavaHome = cygpath(System.getenv("JDK_HOME"))
if (envJavaHome == null || envJavaHome.equals("")) envJavaHome = cygpath(System.getenv("JAVA_HOME"))
def javaHome = envJavaHome == null || envJavaHome.equals("") ? System.getProperty("java.home") : envJavaHome
```
However **the selected toolchain JDK might not be the same as the resolved build's JDK**. The toolchain always prefers the daemon JVM to avoid forking, so if it meets the restrictions, it's selected. Consider the following scenarios:

| `JAVA_HOME` | `JDK_HOME` | Selection                                                              |
|----------------|---------------|------------------------------------------------------|
| 25                  | 26                 | `JDK_HOME` - only it passes the restrictions       |
| 26                  | 25                 | `JDK_HOME` - only it passes the restrictions       |
| 25/26 Path A | 25/26 Path B | `JAVA_HOME` - internal toolchain preference >:( |
| 25/26 Path A | 25/26 Path A | `JAVA_HOME`==`JDK_HOME`                               |

For local testing:
1. Stop the daemon with `gradlew --stop`.
2. Show the detected toolchains and detection configuration with `gradlew javaToolchains`. The display order is not the selection preference order necessarily.
3. Find which one is used by running `gradlew :base:compileJava -i --rerun` (fastest execution that still compiles Java) and looking for something like `Compiling with toolchain 'C:\Program Files\Java\jdk-26'` near the end, and compare with step 2.

You will also see there `Compiling with JDK Java compiler API` instead of `Compiling with Java command line compiler 'C:\Program Files\Java\jdk-26\bin\javac.exe'` - this is the toolchain replacing the manual executions.

If you change your env vars, while the daemon is running, stop it so that it picks up the changes (1) and then verify the changes (2).

I think that the 3rd scenario will be very rare in practice, and problems arising from it even more so.

See also the related [JDK-8087537](https://bugs.openjdk.org/browse/JDK-8087537), although it's very old, so might be a coincidence that it's still relevant.

### Forking
The build specifies `compile.options.fork = true` to force forking. You will see `Compilation mode: forking compiler` (also at the end). If this option is removed and the same JDK can be used for both the daemon and the build (rows 3 and 4 above), you will see `Compilation mode: in-process compilation` because the same JVM is used. If different JDKs are required (rows 1 and 2), you will see `Compilation mode: default, forking compiler` because when the JVMs differ, the default is to fork.

It is kept to preserve the current behavior, but isn't strictly necessary. It does help with giving the build JVM its own memory rather than sharing it with the daemon.

### Memory
Using the CLI execution, Gradle had no say in memory allocation, and the default 1/4th of physical RAM was used (machine-dependent). When Gradle controls the build JVM, it defaults to 512MB (so does the daemon, but this is unchanged). I tested a full `sdk` build and didn't see a difference in running time, so it probably doesn't matter. It can be configured by adding, e.g., `compile.options.forkOptions.memoryMaximumSize = 2g` in the build file if you want to test it locally. I haven't tested if it's enough when running in the same daemon JVM because currently I'm forcing the forking.

### Native tasks
Native tasks such as Decora and Prism still use `executable = JAVA`, which will be resolved from the `JDK_HOME` path. As discussed above, the toolchain might be using a different JDK (of the same major version).

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391822](https://bugs.openjdk.org/browse/JDK-8391822): Use Gradle's Java Toolchain (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2294/head:pull/2294` \
`$ git checkout pull/2294`

Update a local copy of the PR: \
`$ git checkout pull/2294` \
`$ git pull https://git.openjdk.org/jfx.git pull/2294/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2294`

View PR using the GUI difftool: \
`$ git pr show -t 2294`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2294.diff">https://git.openjdk.org/jfx/pull/2294.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2294#issuecomment-5551247146)
</details>
