### PR TITLE
cell unify

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ListCell.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ListCell.java
@@ -388,25 +388,32 @@ public class ListCell<T> extends IndexedCell<T> {
     private int indexAtStartEdit;
 
     /** {@inheritDoc} */
+    @SuppressWarnings("removal")
     @Override public void startEdit() {
-        if (isEditing()) return;
-        final ListView<T> list = getListView();
-        if (!isEditable() || (list != null && ! list.isEditable())) {
+        if (isEditing()) {
             return;
         }
 
-        // it makes sense to get the cell into its editing state before firing
-        // the event to the ListView below, so that's what we're doing here
-        // by calling super.startEdit().
+        final ListView<T> list = getListView();
+        if (!isEditable() ||
+                (list != null && !list.isEditable())) {
+            return;
+        }
+
+        updateItem(-1);
+
         super.startEdit();
 
-        if (!isEditing()) return;
+        if (!isEditing()) {
+            return;
+        }
 
         indexAtStartEdit = getIndex();
          // Inform the ListView of the edit starting.
         if (list != null) {
             list.fireEvent(new ListView.EditEvent<>(list,
-                    ListView.<T>editStartEvent(),
+                    ListView.editStartEvent(),
+                    getItem(),
                     null,
                     indexAtStartEdit));
             list.edit(indexAtStartEdit);
@@ -416,8 +423,11 @@ public class ListCell<T> extends IndexedCell<T> {
     }
 
     /** {@inheritDoc} */
+    @SuppressWarnings("removal")
     @Override public void commitEdit(T newValue) {
-        if (! isEditing()) return;
+        if (!isEditing()) {
+            return;
+        }
 
         // inform parent classes of the commit, so that they can switch us
         // out of the editing state.
@@ -439,7 +449,8 @@ public class ListCell<T> extends IndexedCell<T> {
 
             // Inform the ListView of the edit being ready to be committed.
             list.fireEvent(new ListView.EditEvent<>(list,
-                    ListView.<T>editCommitEvent(),
+                    ListView.editCommitEvent(),
+                    getItem(),
                     newValue,
                     list.getEditingIndex()));
         }
@@ -464,6 +475,7 @@ public class ListCell<T> extends IndexedCell<T> {
     }
 
     /** {@inheritDoc} */
+    @SuppressWarnings("removal")
     @Override public void cancelEdit() {
         if (! isEditing()) return;
 
@@ -483,7 +495,8 @@ public class ListCell<T> extends IndexedCell<T> {
             ControlUtils.requestFocusOnControlOnlyIfCurrentFocusOwnerIsChild(list);
 
             list.fireEvent(new ListView.EditEvent<>(list,
-                    ListView.<T>editCancelEvent(),
+                    ListView.editCancelEvent(),
+                    getItem(),
                     null,
                     indexAtStartEdit));
         }
@@ -500,41 +513,40 @@ public class ListCell<T> extends IndexedCell<T> {
     private void updateItem(int oldIndex) {
         final ListView<T> lv = getListView();
         final List<T> items = lv == null ? null : lv.getItems();
-        final int index = getIndex();
         final int itemCount = items == null ? -1 : items.size();
 
-        // Compute whether the index for this cell is for a real item
-        boolean valid = items != null && index >=0 && index < itemCount;
-
+        final int index = getIndex();
         final T oldValue = getItem();
-        final boolean isEmpty = isEmpty();
 
-        // Cause the cell to update itself
-        outer: if (valid) {
-            final T newValue = items.get(index);
+        final boolean indexExceedsItemCount = index >= itemCount;
 
-            // JDK-8092593 - if the index didn't change, then avoid calling updateItem
-            // unless the item has changed.
-            if (oldIndex == index) {
-                if (!isItemChanged(oldValue, newValue)) {
-                    // JDK-8096969:  we break out of the if/else code here and
-                    // proceed with the code following this, so that we may
-                    // still update references, listeners, etc as required.
-                    break outer;
-                }
-            }
-            updateItem(newValue, false);
-        } else {
+        if (indexExceedsItemCount || index < 0) {
             // JDK-8116529 We need to allow a first run to be special-cased to allow
             // for the updateItem method to be called at least once to allow for
             // the correct visual state to be set up. In particular, in JDK-8116529
             // refer to Ensemble8PopUpTree.png - in this case the arrows are being
             // shown as the new cells are instantiated with the arrows in the
             // children list, and are only hidden in updateItem.
+            final boolean isEmpty = isEmpty();
             if (!isEmpty || firstRun) {
                 updateItem(null, true);
                 firstRun = false;
             }
+            return;
+        }
+
+        final T newValue = items.get(index);
+
+        // JDK-8092593 - if the index didn't change, then avoid calling updateItem
+        // unless the item has changed.
+        boolean shouldUpdate = true;
+        if (oldIndex == index) {
+            if (!isItemChanged(oldValue, newValue)) {
+                shouldUpdate = false;
+            }
+        }
+        if (shouldUpdate) {
+            updateItem(newValue, false);
         }
     }
 
@@ -551,10 +563,15 @@ public class ListCell<T> extends IndexedCell<T> {
     }
 
     private void updateSelection() {
-        if (isEmpty()) return;
         int index = getIndex();
+        if (index == -1) {
+            return;
+        }
+
         ListView<T> listView = getListView();
-        if (index == -1 || listView == null) return;
+        if (listView == null) {
+            return;
+        }
 
         SelectionModel<T> sm = listView.getSelectionModel();
         if (sm == null) {
@@ -562,16 +579,24 @@ public class ListCell<T> extends IndexedCell<T> {
             return;
         }
 
-        boolean isSelected = sm.isSelected(index);
-        if (isSelected() == isSelected) return;
+        boolean isSelectedNow = sm.isSelected(index);
+        if (isSelected() == isSelectedNow) {
+            return;
+        }
 
-        updateSelected(isSelected);
+        updateSelected(isSelectedNow);
     }
 
     private void updateFocus() {
         int index = getIndex();
+        if (index == -1) {
+            return;
+        }
+
         ListView<T> listView = getListView();
-        if (index == -1 || listView == null) return;
+        if (listView == null) {
+            return;
+        }
 
         FocusModel<T> fm = listView.getFocusModel();
         if (fm == null) {
@@ -583,28 +608,51 @@ public class ListCell<T> extends IndexedCell<T> {
     }
 
     private void updateEditing() {
-        final int index = getIndex();
-        final ListView<T> list = getListView();
-        final int editIndex = list == null ? -1 : list.getEditingIndex();
-        final boolean editing = isEditing();
-        final boolean match = (list != null) && (index != -1) && (index == editIndex);
-
-        if (match && !editing) {
-            startEdit();
-        } else if (!match && editing) {
-            // If my index is not the one being edited then I need to cancel
-            // the edit. The tricky thing here is that as part of this call
-            // I cannot end up calling list.edit(-1) the way that the standard
-            // cancelEdit method would do. Yet, I need to call cancelEdit
-            // so that subclasses which override cancelEdit can execute. So,
-            // I have to use a kind of hacky flag workaround.
-            try {
-                // try-finally to make certain that the flag is reliably reset to true
-                updateEditingIndex = false;
-                cancelEdit();
-            } finally {
-                updateEditingIndex = true;
+        int index = getIndex();
+        if (index == -1) {
+            if (isEditing()) {
+                // JDK-8265210: must cancel edit if index changed to -1 by re-use
+                doCancelEdit();
             }
+            return;
+        }
+
+        final ListView<T> list = getListView();
+        if (list == null) {
+            if (isEditing()) {
+                // JDK-8265210: must cancel edit if index changed to -1 by re-use
+                doCancelEdit();
+            }
+            return;
+        }
+
+        final int editIndex = list.getEditingIndex();
+        final boolean rowMatch = index == editIndex;
+
+        if (isEditing()) {
+            if (!rowMatch) {
+                doCancelEdit();
+            }
+        } else {
+            if (rowMatch) {
+                startEdit();
+            }
+        }
+    }
+
+    private void doCancelEdit() {
+        // If my index is not the one being edited then I need to cancel
+        // the edit. The tricky thing here is that as part of this call
+        // I cannot end up calling list.edit(-1) the way that the standard
+        // cancelEdit method would do. Yet, I need to call cancelEdit
+        // so that subclasses which override cancelEdit can execute. So,
+        // I have to use a kind of hacky flag workaround.
+        try {
+            // try-finally to make certain that the flag is reliably reset to true
+            updateEditingIndex = false;
+            cancelEdit();
+        } finally {
+            updateEditingIndex = true;
         }
     }
 
@@ -654,4 +702,3 @@ public class ListCell<T> extends IndexedCell<T> {
         }
     }
 }
-

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ListView.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ListView.java
@@ -1182,14 +1182,24 @@ public class ListView<T> extends Control {
      * @since JavaFX 2.0
      */
     public static class EditEvent<T> extends Event {
-        @SuppressWarnings("doclint:missing")
-        private final T newValue;
-        @SuppressWarnings("doclint:missing")
-        private final int editIndex;
-        @SuppressWarnings("doclint:missing")
-        private final ListView<T> source;
-
         private static final long serialVersionUID = 20130724L;
+
+        /**
+         * The {@link ListView} this event is sent to.
+         */
+        private final ListView<T> source;
+        /**
+         * The old value.
+         */
+        private final T oldValue;
+        /**
+         * The new value. This is NOT the value to necessary go back into the tree item.
+         */
+        private final T newValue;
+        /**
+         * The editing index.
+         */
+        private int editIndex;
 
         /**
          * Common supertype for all edit event types.
@@ -1203,17 +1213,42 @@ public class ListView<T> extends Control {
          * {@link #editCommitEvent()} and {@link #editCancelEvent()} types.
          * @param source the source
          * @param eventType the event type
+         * @param oldValue the old valuece = source;
+            oldValue
          * @param newValue the new value
          * @param editIndex the edit index
          */
+        public EditEvent(ListView<T> source,
+                         EventType<? extends ListView.EditEvent<T>> eventType,
+                         T oldValue,
+                         T newValue,
+                         int editIndex) {
+            super(source, Event.NULL_SOURCE_TARGET, eventType);
+            this.source = source;
+            this.oldValue = oldValue;
+            this.newValue = newValue;
+            this.editIndex = editIndex;
+        }
+
+        /**
+         * Creates a new EditEvent instance to represent an edit event. This
+         * event is used for {@link #editStartEvent()},
+         * {@link #editCommitEvent()} and {@link #editCancelEvent()} types.
+         * @param source the source
+         * @param eventType the event type
+         * @param newValue the new value
+         * @param editIndex the edit index
+         */
+        @Deprecated(forRemoval = true)
         public EditEvent(ListView<T> source,
                          EventType<? extends ListView.EditEvent<T>> eventType,
                          T newValue,
                          int editIndex) {
             super(source, Event.NULL_SOURCE_TARGET, eventType);
             this.source = source;
-            this.editIndex = editIndex;
+            oldValue = null;
             this.newValue = newValue;
+            this.editIndex = editIndex;
         }
 
         /**
@@ -1240,11 +1275,11 @@ public class ListView<T> extends Control {
         }
 
         /**
-         * Returns a string representation of this {@code EditEvent} object.
-         * @return a string representation of this {@code EditEvent} object.
+         * Returns the old value that existed prior to the current edit event.
+         * @return the old value that existed prior to the current edit event
          */
-        @Override public String toString() {
-            return "ListViewEditEvent [ newValue: " + getNewValue() + ", ListView: " + getSource() + " ]";
+        public T getOldValue() {
+            return oldValue;
         }
     }
 

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TableCell.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TableCell.java
@@ -43,7 +43,6 @@ import java.lang.ref.WeakReference;
 import java.util.List;
 import javafx.beans.property.ReadOnlyObjectProperty;
 import javafx.beans.property.ReadOnlyObjectWrapper;
-import javafx.collections.FXCollections;
 
 import javafx.scene.control.TableColumn.CellEditEvent;
 
@@ -307,9 +306,12 @@ public class TableCell<S,T> extends IndexedCell<T> {
 
     /** {@inheritDoc} */
     @Override public void startEdit() {
-        if (isEditing()) return;
+        if (isEditing()) {
+            return;
+        }
+
         final TableView<S> table = getTableView();
-        final TableColumn<S,T> column = getTableColumn();
+        final TableColumn<S, T> column = getTableColumn();
         final TableRow<S> row = getTableRow();
         if (!isEditable() ||
                 (table != null && !table.isEditable()) ||
@@ -320,16 +322,15 @@ public class TableCell<S,T> extends IndexedCell<T> {
 
         updateItem(-1);
 
-        // it makes sense to get the cell into its editing state before firing
-        // the event to listeners below, so that's what we're doing here
-        // by calling super.startEdit().
         super.startEdit();
 
-        if (!isEditing()) return;
+        if (!isEditing()) {
+            return;
+        }
 
         editingCellAtStartEdit = new TablePosition<>(table, getIndex(), column);
         if (column != null) {
-            CellEditEvent<S,?> editEvent = new CellEditEvent<>(
+            CellEditEvent<S, T> editEvent = new CellEditEvent<>(
                 table,
                 editingCellAtStartEdit,
                 TableColumn.editStartEvent(),
@@ -345,7 +346,9 @@ public class TableCell<S,T> extends IndexedCell<T> {
 
     /** {@inheritDoc} */
     @Override public void commitEdit(T newValue) {
-        if (!isEditing()) return;
+        if (!isEditing()) {
+            return;
+        }
 
         // inform parent classes of the commit, so that they can switch us
         // out of the editing state.
@@ -512,27 +515,23 @@ public class TableCell<S,T> extends IndexedCell<T> {
     }
 
     private void updateSelection() {
-        /*
-         * This cell should be selected if the selection mode of the table
-         * is cell-based, and if the row and column that this cell represents
-         * is selected.
-         *
-         * If the selection mode is not cell-based, then the listener in the
-         * TableRow class might pick up the need to set an entire row to be
-         * selected.
-         */
-        if (isEmpty()) return;
-
         final boolean isSelected = isSelected();
-        if (! isInCellSelectionMode()) {
+        if (!isInCellSelectionMode()) {
             if (isSelected) {
                 updateSelected(false);
             }
             return;
         }
 
+        int index = getIndex();
+        if (index == -1) {
+            return;
+        }
+
         final TableView<S> tableView = getTableView();
-        if (getIndex() == -1 || tableView == null) return;
+        if (tableView == null) {
+            return;
+        }
 
         TableSelectionModel<S> sm = tableView.getSelectionModel();
         if (sm == null) {
@@ -541,24 +540,31 @@ public class TableCell<S,T> extends IndexedCell<T> {
         }
 
         boolean isSelectedNow = sm.isSelected(getIndex(), getTableColumn());
-        if (isSelected == isSelectedNow) return;
+        if (isSelected == isSelectedNow) {
+            return;
+        }
 
         updateSelected(isSelectedNow);
     }
 
     private void updateFocus() {
         final boolean isFocused = isFocused();
-        if (! isInCellSelectionMode()) {
+        if (!isInCellSelectionMode()) {
             if (isFocused) {
                 setFocused(false);
             }
             return;
         }
 
+        int index = getIndex();
+        if (index == -1) {
+            return;
+        }
+
         final TableView<S> tableView = getTableView();
-        final TableRow<S> tableRow = getTableRow();
-        final int index = getIndex();
-        if (index == -1 || tableView == null || tableRow == null) return;
+        if (tableView == null || getTableRow() == null) {
+            return;
+        }
 
         final TableViewFocusModel<S> fm = tableView.getFocusModel();
         if (fm == null) {
@@ -570,7 +576,16 @@ public class TableCell<S,T> extends IndexedCell<T> {
     }
 
     private void updateEditing() {
-        if (getIndex() == -1 || getTableView() == null) {
+        int index = getIndex();
+        if (index == -1) {
+            if (isEditing()) {
+                doCancelEdit();
+            }
+            return;
+        }
+
+        TableView<S> table = getTableView();
+        if (table == null) {
             // JDK-8265206: must cancel edit if index changed to -1 by re-use
             if (isEditing()) {
                 doCancelEdit();
@@ -578,13 +593,19 @@ public class TableCell<S,T> extends IndexedCell<T> {
             return;
         }
 
-        TablePosition<S,?> editCell = getTableView().getEditingCell();
-        boolean match = match(editCell);
+        TablePosition<S, ?> editingCell = table.getEditingCell();
+        boolean rowMatch = editingCell != null
+                && editingCell.getRow() == index
+                && editingCell.getTableColumn() == getTableColumn();
 
-        if (match && ! isEditing()) {
-            startEdit();
-        } else if (! match && isEditing()) {
-            doCancelEdit();
+        if (isEditing()) {
+            if (!rowMatch) {
+                doCancelEdit();
+            }
+        } else {
+            if (rowMatch) {
+                startEdit();
+            }
         }
     }
 
@@ -609,10 +630,6 @@ public class TableCell<S,T> extends IndexedCell<T> {
     }
 
     private boolean updateEditingIndex = true;
-
-    private boolean match(TablePosition<S,?> pos) {
-        return pos != null && pos.getRow() == getIndex() && pos.getTableColumn() == getTableColumn();
-    }
 
     private boolean isInCellSelectionMode() {
         TableView<S> tableView = getTableView();
@@ -646,11 +663,11 @@ public class TableCell<S,T> extends IndexedCell<T> {
 
         // get the total number of items in the data model
         final TableView<S> tableView = getTableView();
-        final List<S> items = tableView == null ? FXCollections.<S>emptyObservableList() : tableView.getItems();
-        final TableColumn<S,T> tableColumn = getTableColumn();
+        final List<S> items = tableView == null ? null : tableView.getItems();
         final int itemCount = items == null ? -1 : items.size();
+        final TableColumn<S,T> tableColumn = getTableColumn();
+
         final int index = getIndex();
-        final boolean isEmpty = isEmpty();
         final T oldValue = getItem();
 
         final TableRow<S> tableRow = getTableRow();
@@ -659,7 +676,7 @@ public class TableCell<S,T> extends IndexedCell<T> {
         final boolean indexExceedsItemCount = index >= itemCount;
 
         // there is a whole heap of reasons why we should just punt...
-        outer: if (indexExceedsItemCount ||
+        if (indexExceedsItemCount ||
                 index < 0 ||
                 columnIndex < 0 ||
                 !isVisible() ||
@@ -677,33 +694,35 @@ public class TableCell<S,T> extends IndexedCell<T> {
             // JDK-8115233 identifies issues where a TreeTableView collapses a
             // TreeItem but the custom cells remain visible. This is now
             // resolved with the check for indexExceedsItemCount.
-            if ((!isEmpty && oldValue != null) || isFirstRun || indexExceedsItemCount) {
+            final boolean isEmpty = isEmpty();
+            if (!isEmpty || isFirstRun || indexExceedsItemCount) {
                 updateItem(null, true);
                 isFirstRun = false;
             }
             return;
-        } else {
-            currentObservableValue = tableColumn.getCellObservableValue(index);
-            final T newValue = currentObservableValue == null ? null : currentObservableValue.getValue();
+        }
 
-            // JDK-8092593 - if the index didn't change, then avoid calling updateItem
-            // unless the item has changed.
-            if (oldIndex == index) {
-                if (!isItemChanged(oldValue, newValue)) {
-                    // JDK-8096643: we need to check the row item here to prevent
-                    // the issue where the cell value and index doesn't change,
-                    // but the backing row object does.
-                    S oldRowItem = oldRowItemRef != null ? oldRowItemRef.get() : null;
-                    if (oldRowItem != null && oldRowItem.equals(rowItem)) {
-                        // JDK-8096969:  we break out of the if/else code here and
-                        // proceed with the code following this, so that we may
-                        // still update references, listeners, etc as required//.
-                        break outer;
-                    }
+        currentObservableValue = tableColumn.getCellObservableValue(index);
+        final T newValue = currentObservableValue == null ? null : currentObservableValue.getValue();
+
+        // JDK-8092593 - if the index didn't change, then avoid calling updateItem
+        // unless the item has changed.
+        boolean shouldUpdate = true;
+        if (oldIndex == index) {
+            if (!isItemChanged(oldValue, newValue)) {
+                // JDK-8096643: we need to check the row item here to prevent
+                // the issue where the cell value and index doesn't change,
+                // but the backing row object does.
+                S oldRowItem = oldRowItemRef != null ? oldRowItemRef.get() : null;
+                if (oldRowItem != null && oldRowItem.equals(rowItem)) {
+                    shouldUpdate = false;
                 }
             }
+        }
+        if (shouldUpdate) {
             updateItem(newValue, false);
         }
+
 
         oldRowItemRef = new WeakReferenceWrapper<>(rowItem);
 

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TableColumn.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TableColumn.java
@@ -762,15 +762,14 @@ public class TableColumn<S,T> extends TableColumnBase<S,T> implements EventTarge
          */
         public static final EventType<?> ANY = EDIT_ANY_EVENT;
 
-        // represents the new value input by the end user. This is NOT the value
-        // to go back into the TableView.items list - this new value represents
-        // just the input for a single cell, so it is likely that it needs to go
-        // back into a property within an item in the TableView.items list.
-        @SuppressWarnings("doclint:missing")
+        /**
+         * The new value. This is NOT the value to necessary go back into the items list.
+         */
         private final T newValue;
-
-        // The location of the edit event
-        private transient final TablePosition<S,T> pos;
+        /**
+         * The location where the edit event happened.
+         */
+        private final TablePosition<S, T> pos;
 
         /**
          * Creates a new event that can be subsequently fired to the relevant listeners.

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TableRow.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TableRow.java
@@ -228,107 +228,210 @@ public class TableRow<T> extends IndexedCell<T> {
         updateFocus();
     }
 
+    /** {@inheritDoc} */
+    @Override public void startEdit() {
+        if (isEditing()) {
+            return;
+        }
+
+        final TableView<T> table = getTableView();
+        if (!isEditable() ||
+                (table != null && !table.isEditable())) {
+            return;
+        }
+
+        // it makes sense to get the cell into its editing state before firing
+        // the event to the TableView below, so that's what we're doing here
+        // by calling super.startEdit().
+        super.startEdit();
+
+        if (!isEditing()) {
+            return;
+        }
+
+        // Inform the TableView of the edit starting.
+        if (table != null) {
+            table.fireEvent(new TableView.EditEvent<>(table,
+                    TableView.editStartEvent(),
+                    getItem(),
+                    null));
+
+            table.requestFocus();
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override public void commitEdit(T newValue) {
+        if (!isEditing()) {
+            return;
+        }
+
+        final TableView<T> table = getTableView();
+        if (table != null) {
+            // Inform the TableView of the edit being ready to be committed.
+            table.fireEvent(new TableView.EditEvent<>(table,
+                    TableView.<T>editCommitEvent(),
+                    getItem(),
+                    newValue));
+        }
+
+        // update the item within this cell, so that it represents the new value
+        updateItem(newValue, false);
+
+        // inform parent classes of the commit, so that they can switch us out of the editing state
+        super.commitEdit(newValue);
+
+        if (table != null) {
+            // reset the editing item in the TableView
+            table.edit(-1, null);
+            table.requestFocus();
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override public void cancelEdit() {
+        if (!isEditing()) {
+            return;
+        }
+
+        TableView<T> table = getTableView();
+        if (table != null) {
+            table.fireEvent(new TableView.EditEvent<>(table,
+                    TableView.editCancelEvent(),
+                    getItem(),
+                    null));
+        }
+
+        super.cancelEdit();
+
+        if (table != null) {
+            // reset the editing index on the TableView
+            table.edit(-1, null);
+            table.requestFocus();
+        }
+    }
+
     private boolean isFirstRun = true;
     private void updateItem(int oldIndex) {
         TableView<T> tv = getTableView();
-        if (tv == null || tv.getItems() == null) return;
-
-        final List<T> items = tv.getItems();
+        final List<T> items = tv == null ? null : tv.getItems();
         final int itemCount = items == null ? -1 : items.size();
 
         // Compute whether the index for this cell is for a real item
-        final int newIndex = getIndex();
-        boolean valid = newIndex >= 0 && newIndex < itemCount;
-
+        int index = getIndex();
         final T oldValue = getItem();
-        final boolean isEmpty = isEmpty();
 
-        // Cause the cell to update itself
-        outer: if (valid) {
-            final T newValue = items.get(newIndex);
+        final boolean indexExceedsItemCount = index >= itemCount;
 
-            // JDK-8092593 - if the index didn't change, then avoid calling updateItem
-            // unless the item has changed.
-            if (oldIndex == newIndex) {
-                if (!isItemChanged(oldValue, newValue)) {
-                    // JDK-8096969:  we break out of the if/else code here and
-                    // proceed with the code following this, so that we may
-                    // still update references, listeners, etc as required.
-                    break outer;
-                }
-            }
-            updateItem(newValue, false);
-        } else {
+        if (indexExceedsItemCount || index < 0) {
             // JDK-8116529 We need to allow a first run to be special-cased to allow
             // for the updateItem method to be called at least once to allow for
             // the correct visual state to be set up. In particular, in JDK-8116529
             // refer to Ensemble8PopUpTree.png - in this case the arrows are being
             // shown as the new cells are instantiated with the arrows in the
             // children list, and are only hidden in updateItem.
-            if ((!isEmpty && oldValue != null) || isFirstRun) {
+            final boolean isEmpty = isEmpty();
+            if (!isEmpty || isFirstRun) {
                 updateItem(null, true);
                 isFirstRun = false;
             }
+            return;
+        }
+
+        final T newValue = items.get(index);
+
+        // JDK-8092593 - if the index didn't change, then avoid calling updateItem
+        // unless the item has changed.
+        boolean shouldUpdate = true;
+        if (oldIndex == index) {
+            if (!isItemChanged(oldValue, newValue)) {
+                shouldUpdate = false;
+            }
+        }
+        if (shouldUpdate) {
+            updateItem(newValue, false);
         }
     }
 
     private void updateSelection() {
-        /*
-         * This cell should be selected if the selection mode of the table
-         * is row-based, and if the row that this cell represents is selected.
-         *
-         * If the selection mode is not row-based, then the listener in the
-         * TableCell class might pick up the need to set a single cell to be
-         * selected.
-         */
-        if (getIndex() == -1) return;
-
-        TableView<T> table = getTableView();
-        boolean isSelected = table != null &&
-                table.getSelectionModel() != null &&
-                ! table.getSelectionModel().isCellSelectionEnabled() &&
-                table.getSelectionModel().isSelected(getIndex());
-
-        updateSelected(isSelected);
-    }
-
-    private void updateFocus() {
-        if (getIndex() == -1) return;
-
-        TableView<T> table = getTableView();
-        if (table == null) return;
-
-        TableView.TableViewSelectionModel<T> sm = table.getSelectionModel();
-        TableView.TableViewFocusModel<T> fm = table.getFocusModel();
-        if (sm == null || fm == null) return;
-
-        boolean isFocused = ! sm.isCellSelectionEnabled() && fm.isFocused(getIndex());
-        setFocused(isFocused);
-    }
-
-    private void updateEditing() {
-        if (getIndex() == -1) return;
-
-        TableView<T> table = getTableView();
-        if (table == null) return;
-
-        TableView.TableViewSelectionModel<T> sm = table.getSelectionModel();
-        if (sm == null || sm.isCellSelectionEnabled()) return;
-
-        TablePosition<T,?> editCell = table.getEditingCell();
-        if (editCell != null && editCell.getTableColumn() != null) {
+        int index = getIndex();
+        if (index == -1) {
             return;
         }
 
-        boolean rowMatch = editCell == null ? false : editCell.getRow() == getIndex();
+        TableView<T> table = getTableView();
+        if (table == null) {
+            return;
+        }
 
-        if (! isEditing() && rowMatch) {
-            startEdit();
-        } else if (isEditing() && ! rowMatch) {
-            cancelEdit();
+        TableView.TableViewSelectionModel<T> sm = table.getSelectionModel();
+        if (sm == null) {
+            if (isSelected()) {
+                updateSelected(false);
+            }
+            return;
+        }
+
+        boolean isSelected = !sm.isCellSelectionEnabled() && sm.isSelected(index);
+        if (isSelected() != isSelected) {
+            updateSelected(isSelected);
         }
     }
 
+    private void updateFocus() {
+        int index = getIndex();
+        if (index == -1) {
+            return;
+        }
+
+        TableView<T> table = getTableView();
+        if (table == null) {
+            return;
+        }
+
+        TableView.TableViewFocusModel<T> fm = table.getFocusModel();
+        if (fm == null) {
+            return;
+        }
+
+        setFocused(fm.isFocused(index));
+    }
+
+    private void updateEditing() {
+        int index = getIndex();
+        if (index == -1) {
+            return;
+        }
+
+        TableView<T> table = getTableView();
+        if (table == null) {
+            return;
+        }
+
+        TablePosition<T, ?> editingCell = table.getEditingCell();
+        if (editingCell != null && editingCell.getTableColumn() != null) {
+            return;
+        }
+
+        boolean rowMatch = editingCell != null && editingCell.getRow() == index;
+
+        if (isEditing()) {
+            if (!rowMatch) {
+                cancelEdit();
+            }
+        } else {
+            if (rowMatch) {
+                startEdit();
+            }
+        }
+    }
+
+    private boolean isInRowSelectionMode() {
+        TableView<T> tableView = getTableView();
+        if (tableView == null) return false;
+        TableView.TableViewSelectionModel<T> sm = tableView.getSelectionModel();
+        return sm != null && !sm.isCellSelectionEnabled();
+    }
 
 
     /* *************************************************************************

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TableView.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TableView.java
@@ -74,6 +74,7 @@ import javafx.css.Styleable;
 import javafx.css.StyleableDoubleProperty;
 import javafx.css.StyleableProperty;
 import javafx.css.converter.SizeConverter;
+import javafx.event.Event;
 import javafx.event.EventHandler;
 import javafx.event.EventType;
 import javafx.scene.AccessibleAttribute;
@@ -435,6 +436,68 @@ public class TableView<S> extends Control {
      * Static properties and methods                                           *
      *                                                                         *
      **************************************************************************/
+
+    /**
+     * An EventType that indicates some edit event has occurred.
+     * It is the parent type of all other edit events:
+     * {@link #editStartEvent},
+     * {@link #editCommitEvent} and
+     * {@link #editCancelEvent}.
+     *
+     * @param <S> The type of the TreeItem instances used in this TableView
+     * @return An EventType that indicates some edit event has occurred
+     */
+    @SuppressWarnings("unchecked")
+    public static <S> EventType<TableView.EditEvent<S>> editAnyEvent() {
+        return (EventType<TableView.EditEvent<S>>) EDIT_ANY_EVENT;
+    }
+    private static final EventType<?> EDIT_ANY_EVENT =
+            new EventType<>(Event.ANY, "TABLE_VIEW_EDIT");
+
+    /**
+     * An EventType used to indicate that an edit event has started within the
+     * TableView upon which the event was fired.
+     *
+     * @param <S> The type of the Item instances used in this TableView
+     * @return An EventType used to indicate that an edit event has started
+     */
+    @SuppressWarnings("unchecked")
+    public static <S> EventType<TableView.EditEvent<S>> editStartEvent() {
+        return (EventType<TableView.EditEvent<S>>) EDIT_START_EVENT;
+    }
+    private static final EventType<?> EDIT_START_EVENT =
+            new EventType<>(editAnyEvent(), "EDIT_START");
+
+    /**
+     * An EventType used to indicate that an edit event has just been canceled
+     * within the TableView upon which the event was fired.
+     *
+     * @param <S> The type of the Item instances used in this TableView
+     * @return An EventType used to indicate that an edit event has just been
+     *      canceled
+     */
+    @SuppressWarnings("unchecked")
+    public static <S> EventType<TableView.EditEvent<S>> editCancelEvent() {
+        return (EventType<TableView.EditEvent<S>>) EDIT_CANCEL_EVENT;
+    }
+    private static final EventType<?> EDIT_CANCEL_EVENT =
+            new EventType<>(editAnyEvent(), "EDIT_CANCEL");
+
+    /**
+     * An EventType that is used to indicate that an edit in a TableView has been
+     * committed. This means that user has made changes to the data of an
+     * Item, and that the UI should be updated.
+     *
+     * @param <S> The type of the Item instances used in this TableView
+     * @return An EventType that is used to indicate that an edit in a TableView
+     *      has been committed
+     */
+    @SuppressWarnings("unchecked")
+    public static <S> EventType<TableView.EditEvent<S>> editCommitEvent() {
+        return (EventType<TableView.EditEvent<S>>) EDIT_COMMIT_EVENT;
+    }
+    private static final EventType<?> EDIT_COMMIT_EVENT =
+            new EventType<>(editAnyEvent(), "EDIT_COMMIT");
 
     // strings used to communicate via the TableView properties map between
     // the control and the skin. Because they are private here, the strings
@@ -2030,6 +2093,77 @@ public class TableView<S> extends Control {
         }
     }
 
+    /**
+     * An {@link Event} subclass used specifically in TableView for representing
+     * edit-related events. It provides API to easily access input provided by the end user.
+     *
+     * @param <S> The type of the input, which is the same type as the TableView itself.
+     */
+    public static class EditEvent<S> extends Event {
+        private static final long serialVersionUID = -4437033058917528975L;
+
+        /**
+         * Common supertype for all edit event types.
+         */
+        public static final EventType<?> ANY = EDIT_ANY_EVENT;
+
+        /**
+         * The {@link TableView} this event is sent to.
+         */
+        private final TableView<S> source;
+        /**
+         * The old value.
+         */
+        private final S oldValue;
+        /**
+         * The new value. This is NOT the value to necessary go back into the items list.
+         */
+        private final S newValue;
+
+        /**
+         * Creates a new EditEvent instance to represent an edit event.
+         * This event is used for
+         * {@link #editStartEvent()},
+         * {@link #editCommitEvent()} and
+         * {@link #editCancelEvent()} types.
+         * @param source the source
+         * @param eventType the eventType
+         * @param oldValue the oldValue
+         * @param newValue the newValue
+         */
+        public EditEvent(TableView<S> source,
+                         EventType<? extends TableView.EditEvent<S>> eventType,
+                         S oldValue, S newValue) {
+            super(source, Event.NULL_SOURCE_TARGET, eventType);
+            this.source = source;
+            this.oldValue = oldValue;
+            this.newValue = newValue;
+        }
+
+        /**
+         * Returns the TableView upon which the edit took place.
+         * @return the TableView upon which the edit took place
+         */
+        @Override public TableView<S> getSource() {
+            return source;
+        }
+
+        /**
+         * Returns the new value input into the item by the end user.
+         * @return the new value input into the item by the end user
+         */
+        public S getNewValue() {
+            return newValue;
+        }
+
+        /**
+         * Returns the old value that existed in the item prior to the current edit event.
+         * @return the old value that existed in the item prior to the current edit event
+         */
+        public S getOldValue() {
+            return oldValue;
+        }
+    }
 
 
     /* *************************************************************************

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeCell.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeCell.java
@@ -356,33 +356,29 @@ public class TreeCell<T> extends IndexedCell<T> {
 
     /** {@inheritDoc} */
     @Override public void startEdit() {
-        if (isEditing()) return;
+        if (isEditing()) {
+            return;
+        }
 
         final TreeView<T> tree = getTreeView();
-        if (! isEditable() || (tree != null && ! tree.isEditable())) {
-//            if (Logging.getControlsLogger().isLoggable(PlatformLogger.SEVERE)) {
-//                Logging.getControlsLogger().severe(
-//                    "Can not call TreeCell.startEdit() on this TreeCell, as it "
-//                        + "is not allowed to enter its editing state (TreeCell: "
-//                        + this + ", TreeView: " + tree + ").");
-//            }
+        if (!isEditable() ||
+                (tree != null && !tree.isEditable())) {
             return;
         }
 
         updateItem(-1);
 
-        // it makes sense to get the cell into its editing state before firing
-        // the event to the TreeView below, so that's what we're doing here
-        // by calling super.startEdit().
         super.startEdit();
 
-        if (!isEditing()) return;
+        if (!isEditing()) {
+            return;
+        }
 
         treeItemAtStartEdit = getTreeItem();
          // Inform the TreeView of the edit starting.
         if (tree != null) {
             tree.fireEvent(new TreeView.EditEvent<>(tree,
-                    TreeView.<T>editStartEvent(),
+                    TreeView.editStartEvent(),
                     treeItemAtStartEdit,
                     getItem(),
                     null));
@@ -393,7 +389,9 @@ public class TreeCell<T> extends IndexedCell<T> {
 
      /** {@inheritDoc} */
     @Override public void commitEdit(T newValue) {
-        if (! isEditing()) return;
+        if (!isEditing()) {
+            return;
+        }
 
         // inform parent classes of the commit, so that they can switch us
         // out of the editing state.
@@ -416,7 +414,7 @@ public class TreeCell<T> extends IndexedCell<T> {
 
             // Inform the TreeView of the edit being ready to be committed.
             tree.fireEvent(new TreeView.EditEvent<>(tree,
-                    TreeView.<T>editCommitEvent(),
+                    TreeView.editCommitEvent(),
                     treeItem,
                     getItem(),
                     newValue));
@@ -505,111 +503,137 @@ public class TreeCell<T> extends IndexedCell<T> {
     private boolean isFirstRun = true;
     private void updateItem(int oldIndex) {
         TreeView<T> tv = getTreeView();
-        if (tv == null) return;
+        final int itemCount = tv == null ? -1 : tv.getExpandedItemCount();
 
         // Compute whether the index for this cell is for a real item
         int index = getIndex();
-        boolean valid = index >=0 && index < tv.getExpandedItemCount();
-        final boolean isEmpty = isEmpty();
         final TreeItem<T> oldTreeItem = getTreeItem();
 
-        // Cause the cell to update itself
-        outer: if (valid) {
-            // update the TreeCell state.
-            // get the new treeItem that is about to go in to the TreeCell
-            TreeItem<T> newTreeItem = tv.getTreeItem(index);
-            T newValue = newTreeItem == null ? null : newTreeItem.getValue();
-            T oldValue = oldTreeItem == null ? null : oldTreeItem.getValue();
+        final boolean indexExceedsItemCount = index >= itemCount;
 
-            // For the sake of JDK-8113226, it is important that the order of these
-            // method calls is as shown below. If the order is switched, it is
-            // likely that events will be fired where the item is null, even
-            // though calling cell.getTreeItem().getValue() returns the value
-            // as expected
-
-            // JDK-8092593 - if the index didn't change, then avoid calling updateItem
-            // unless the item has changed.
-            if (oldIndex == index) {
-                if (!isItemChanged(oldValue, newValue)) {
-                    // JDK-8096969:  we break out of the if/else code here and
-                    // proceed with the code following this, so that we may
-                    // still update references, listeners, etc as required.
-                    break outer;
-                }
-            }
-            updateTreeItem(newTreeItem);
-            updateItem(newValue, false);
-        } else {
+        if (indexExceedsItemCount || index < 0) {
             // JDK-8116529 We need to allow a first run to be special-cased to allow
             // for the updateItem method to be called at least once to allow for
             // the correct visual state to be set up. In particular, in JDK-8116529
             // refer to Ensemble8PopUpTree.png - in this case the arrows are being
             // shown as the new cells are instantiated with the arrows in the
             // children list, and are only hidden in updateItem.
-            if ((!isEmpty && oldTreeItem != null) || isFirstRun) {
+            final boolean isEmpty = isEmpty();
+            if (!isEmpty || isFirstRun) {
                 updateTreeItem(null);
                 updateItem(null, true);
                 isFirstRun = false;
             }
+            return;
+        }
+
+        // update the TreeCell state.
+        // get the new treeItem that is about to go in to the TreeCell
+        TreeItem<T> newTreeItem = tv.getTreeItem(index);
+        T newValue = newTreeItem == null ? null : newTreeItem.getValue();
+        T oldValue = oldTreeItem == null ? null : oldTreeItem.getValue();
+
+        // For the sake of JDK-8113226, it is important that the order of these
+        // method calls is as shown below. If the order is switched, it is
+        // likely that events will be fired where the item is null, even
+        // though calling cell.getTreeItem().getValue() returns the value
+        // as expected
+
+        // JDK-8092593 - if the index didn't change, then avoid calling updateItem
+        // unless the item has changed.
+        boolean shouldUpdate = true;
+        if (oldIndex == index) {
+            if (!isItemChanged(oldValue, newValue)) {
+                shouldUpdate = false;
+            }
+        }
+        if (shouldUpdate) {
+            updateTreeItem(newTreeItem);
+            updateItem(newValue, false);
         }
     }
 
     private void updateSelection() {
-        if (isEmpty()) return;
-        if (getIndex() == -1 || getTreeView() == null) return;
+        int index = getIndex();
+        if (index == -1) {
+            return;
+        }
 
-        SelectionModel<TreeItem<T>> sm = getTreeView().getSelectionModel();
+        TreeView<T> treeView = getTreeView();
+        if (treeView == null) {
+            return;
+        }
+
+        SelectionModel<TreeItem<T>> sm = treeView.getSelectionModel();
         if (sm == null) {
             updateSelected(false);
             return;
         }
 
-        boolean isSelected = sm.isSelected(getIndex());
-        if (isSelected() == isSelected) return;
+        boolean isSelectedNow = sm.isSelected(index);
+        if (isSelected() == isSelectedNow) {
+            return;
+        }
 
-        updateSelected(isSelected);
+        updateSelected(isSelectedNow);
     }
 
     private void updateFocus() {
-        if (getIndex() == -1 || getTreeView() == null) return;
+        int index = getIndex();
+        if (index == -1) {
+            return;
+        }
 
-        FocusModel<TreeItem<T>> fm = getTreeView().getFocusModel();
+        TreeView<T> treeView = getTreeView();
+        if (treeView == null) {
+            return;
+        }
+
+        FocusModel<TreeItem<T>> fm = treeView.getFocusModel();
         if (fm == null) {
             setFocused(false);
             return;
         }
 
-        setFocused(fm.isFocused(getIndex()));
+        setFocused(fm.isFocused(index));
     }
 
     private boolean updateEditingIndex = true;
     private void updateEditing() {
-        final int index = getIndex();
-        final TreeView<T> tree = getTreeView();
-        final TreeItem<T> treeItem = getTreeItem();
-        final TreeItem<T> editItem = tree == null ? null : tree.getEditingItem();
-        final boolean editing = isEditing();
-
-        if (index == -1 || tree == null || treeItem == null) {
-            if (editing) {
+        int index = getIndex();
+        if (index == -1) {
+            if (isEditing()) {
                 // JDK-8265210: must cancel edit if index changed to -1 by re-use
-                doCancelEditing();
+                doCancelEdit();
             }
             return;
         }
 
-        final boolean match = treeItem.equals(editItem);
+        final TreeView<T> tree = getTreeView();
+        final TreeItem<T> treeItem = getTreeItem();
+        if (tree == null || treeItem == null) {
+            if (isEditing()) {
+                // JDK-8265210: must cancel edit if index changed to -1 by re-use
+                doCancelEdit();
+            }
+            return;
+        }
 
-        // If my tree item is the item being edited and I'm not currently in
-        // the edit mode, then I need to enter the edit mode
-        if (match && !editing) {
-            startEdit();
-        } else if (! match && editing) {
-            doCancelEditing();
+        final TreeItem<T> editingItem = tree.getEditingItem();
+        final boolean rowMatch = treeItem.equals(editingItem);
+
+        if (isEditing()) {
+            if (!rowMatch) {
+                doCancelEdit();
+            }
+        } else {
+            if (rowMatch) {
+                startEdit();
+            }
         }
     }
 
-    private void doCancelEditing() {
+    private void doCancelEdit() {
         // If my tree item is not the one being edited then I need to cancel
         // the edit. The tricky thing here is that as part of this call
         // I cannot end up calling tree.edit(null) the way that the standard

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableCell.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableCell.java
@@ -323,10 +323,12 @@ public class TreeTableCell<S,T> extends IndexedCell<T> {
 
     /** {@inheritDoc} */
     @Override public void startEdit() {
-        if (isEditing()) return;
+        if (isEditing()) {
+            return;
+        }
 
         final TreeTableView<S> table = getTreeTableView();
-        final TreeTableColumn<S,T> column = getTableColumn();
+        final TreeTableColumn<S, T> column = getTableColumn();
         final TreeTableRow<S> row = getTableRow();
         if (!isEditable() ||
                 (table != null && !table.isEditable()) ||
@@ -337,19 +339,18 @@ public class TreeTableCell<S,T> extends IndexedCell<T> {
 
         updateItem(-1);
 
-        // it makes sense to get the cell into its editing state before firing
-        // the event to listeners below, so that's what we're doing here
-        // by calling super.startEdit().
         super.startEdit();
 
-        if (!isEditing()) return;
+        if (!isEditing()) {
+            return;
+        }
 
         editingCellAtStartEdit = new TreeTablePosition<>(table, getIndex(), column);
         if (column != null) {
             CellEditEvent<S, T> editEvent = new CellEditEvent<>(
                 table,
                 editingCellAtStartEdit,
-                TreeTableColumn.<S,T>editStartEvent(),
+                TreeTableColumn.editStartEvent(),
                 null
             );
 
@@ -362,7 +363,9 @@ public class TreeTableCell<S,T> extends IndexedCell<T> {
 
     /** {@inheritDoc} */
     @Override public void commitEdit(T newValue) {
-        if (!isEditing()) return;
+        if (!isEditing()) {
+            return;
+        }
 
         // inform parent classes of the commit, so that they can switch us
         // out of the editing state.
@@ -508,27 +511,23 @@ public class TreeTableCell<S,T> extends IndexedCell<T> {
     }
 
     private void updateSelection() {
-        /*
-         * This cell should be selected if the selection mode of the table
-         * is cell-based, and if the row and column that this cell represents
-         * is selected.
-         *
-         * If the selection mode is not cell-based, then the listener in the
-         * TableRow class might pick up the need to set an entire row to be
-         * selected.
-         */
-        if (isEmpty()) return;
-
         final boolean isSelected = isSelected();
-        if (! isInCellSelectionMode()) {
+        if (!isInCellSelectionMode()) {
             if (isSelected) {
                 updateSelected(false);
             }
             return;
         }
 
+        int index = getIndex();
+        if (index == -1) {
+            return;
+        }
+
         final TreeTableView<S> tv = getTreeTableView();
-        if (getIndex() == -1 || tv == null) return;
+        if (tv == null) {
+            return;
+        }
 
         TreeTableView.TreeTableViewSelectionModel<S> sm = tv.getSelectionModel();
         if (sm == null) {
@@ -536,23 +535,32 @@ public class TreeTableCell<S,T> extends IndexedCell<T> {
             return;
         }
 
-        boolean isSelectedNow = sm.isSelected(getIndex(), getTableColumn());
-        if (isSelected == isSelectedNow) return;
+        boolean isSelectedNow = sm.isSelected(index, getTableColumn());
+        if (isSelected == isSelectedNow) {
+            return;
+        }
 
         updateSelected(isSelectedNow);
     }
 
     private void updateFocus() {
         final boolean isFocused = isFocused();
-        if (! isInCellSelectionMode()) {
+        if (!isInCellSelectionMode()) {
             if (isFocused) {
                 setFocused(false);
             }
             return;
         }
 
+        int index = getIndex();
+        if (index == -1) {
+            return;
+        }
+
         final TreeTableView<S> tv = getTreeTableView();
-        if (getIndex() == -1 || tv == null) return;
+        if (tv == null || getTableRow() == null) {
+            return;
+        }
 
         TreeTableView.TreeTableViewFocusModel<S> fm = tv.getFocusModel();
         if (fm == null) {
@@ -560,12 +568,20 @@ public class TreeTableCell<S,T> extends IndexedCell<T> {
             return;
         }
 
-        setFocused(fm.isFocused(getIndex(), getTableColumn()));
+        setFocused(fm.isFocused(index, getTableColumn()));
     }
 
     private void updateEditing() {
+        int index = getIndex();
+        if (index == -1) {
+            if (isEditing()) {
+                doCancelEdit();
+            }
+            return;
+        }
+
         final TreeTableView<S> tv = getTreeTableView();
-        if (getIndex() == -1 || tv == null) {
+        if (tv == null) {
             // JDK-8265206: must cancel edit if index changed to -1 by re-use
             if (isEditing()) {
                 doCancelEdit();
@@ -573,13 +589,19 @@ public class TreeTableCell<S,T> extends IndexedCell<T> {
             return;
         }
 
-        TreeTablePosition<S,?> editCell = tv.getEditingCell();
-        boolean match = match(editCell);
+        TreeTablePosition<S, ?> editingCell = tv.getEditingCell();
+        boolean rowMatch = editingCell != null
+                && editingCell.getRow() == index
+                && editingCell.getTableColumn() == getTableColumn();
 
-        if (match && ! isEditing()) {
-            startEdit();
-        } else if (! match && isEditing()) {
-            doCancelEdit();
+        if (isEditing()) {
+            if (!rowMatch) {
+                doCancelEdit();
+            }
+        } else {
+            if (rowMatch) {
+                startEdit();
+            }
         }
     }
 
@@ -604,10 +626,6 @@ public class TreeTableCell<S,T> extends IndexedCell<T> {
     }
 
     private boolean updateEditingIndex = true;
-
-    private boolean match(TreeTablePosition pos) {
-        return pos != null && pos.getRow() == getIndex() && pos.getTableColumn() == getTableColumn();
-    }
 
     private boolean isInCellSelectionMode() {
         TreeTableView<S> tv = getTreeTableView();
@@ -641,10 +659,10 @@ public class TreeTableCell<S,T> extends IndexedCell<T> {
 
         // get the total number of items in the data model
         final TreeTableView<S> tableView = getTreeTableView();
+        final int itemCount = tableView == null ? -1 : tableView.getExpandedItemCount();
         final TreeTableColumn<S,T> tableColumn = getTableColumn();
-        final int itemCount = tableView == null ? -1 : getTreeTableView().getExpandedItemCount();
+
         final int index = getIndex();
-        final boolean isEmpty = isEmpty();
         final T oldValue = getItem();
 
         final TreeTableRow<S> tableRow = getTableRow();
@@ -653,13 +671,12 @@ public class TreeTableCell<S,T> extends IndexedCell<T> {
         final boolean indexExceedsItemCount = index >= itemCount;
 
         // there is a whole heap of reasons why we should just punt...
-        outer: if (indexExceedsItemCount ||
+        if (indexExceedsItemCount ||
                 index < 0 ||
                 columnIndex < 0 ||
                 !isVisible() ||
                 tableColumn == null ||
-                !tableColumn.isVisible() ||
-                tableView.getRoot() == null) {
+                !tableColumn.isVisible()) {
 
             // JDK-8116529 We need to allow a first run to be special-cased to allow
             // for the updateItem method to be called at least once to allow for
@@ -672,32 +689,32 @@ public class TreeTableCell<S,T> extends IndexedCell<T> {
             // JDK-8115233 identifies issues where a TreeTableView collapses a
             // TreeItem but the custom cells remain visible. This is now
             // resolved with the check for indexExceedsItemCount.
-            if ((!isEmpty && oldValue != null) || isFirstRun || indexExceedsItemCount) {
+            final boolean isEmpty = isEmpty();
+            if (!isEmpty || isFirstRun || indexExceedsItemCount) {
                 updateItem(null, true);
                 isFirstRun = false;
             }
             return;
-        } else {
-            currentObservableValue = tableColumn.getCellObservableValue(index);
+        }
 
-            final T newValue = currentObservableValue == null ? null : currentObservableValue.getValue();
+        currentObservableValue = tableColumn.getCellObservableValue(index);
+        final T newValue = currentObservableValue == null ? null : currentObservableValue.getValue();
 
-            // JDK-8092593 - if the index didn't change, then avoid calling updateItem
-            // unless the item has changed.
-            if (oldIndex == index) {
-                if (!isItemChanged(oldValue, newValue)) {
-                    // JDK-8096643: we need to check the row item here to prevent
-                    // the issue where the cell value and index doesn't change,
-                    // but the backing row object does.
-                    S oldRowItem = oldRowItemRef != null ? oldRowItemRef.get() : null;
-                    if (oldRowItem != null && oldRowItem.equals(rowItem)) {
-                        // JDK-8096969:  we break out of the if/else code here and
-                        // proceed with the code following this, so that we may
-                        // still update references, listeners, etc as required.
-                        break outer;
-                    }
+        // JDK-8092593 - if the index didn't change, then avoid calling updateItem
+        // unless the item has changed.
+        boolean shouldUpdate = true;
+        if (oldIndex == index) {
+            if (!isItemChanged(oldValue, newValue)) {
+                // JDK-8096643: we need to check the row item here to prevent
+                // the issue where the cell value and index doesn't change,
+                // but the backing row object does.
+                S oldRowItem = oldRowItemRef != null ? oldRowItemRef.get() : null;
+                if (oldRowItem != null && oldRowItem.equals(rowItem)) {
+                    shouldUpdate = false;
                 }
             }
+        }
+        if (shouldUpdate) {
             updateItem(newValue, false);
         }
 

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableColumn.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableColumn.java
@@ -749,15 +749,15 @@ public class TreeTableColumn<S,T> extends TableColumnBase<TreeItem<S>,T> impleme
          */
         public static final EventType<?> ANY = EDIT_ANY_EVENT;
 
-        // represents the new value input by the end user. This is NOT the value
-        // to go back into the TableView.items list - this new value represents
-        // just the input for a single cell, so it is likely that it needs to go
-        // back into a property within an item in the TableView.items list.
-        @SuppressWarnings("doclint:missing")
+        /**
+         * The new value. This is NOT the value to necessary go back into the items list.
+         */
         private final T newValue;
 
-        // The location of the edit event
-        private transient final TreeTablePosition<S,T> pos;
+        /**
+         * The location where the edit event happened.
+         */
+        private  final TreeTablePosition<S, T> pos;
 
         /**
          * Creates a new event that can be subsequently fired to the relevant listeners.

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableRow.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableRow.java
@@ -303,15 +303,21 @@ public class TreeTableRow<T> extends IndexedCell<T> {
 
     /** {@inheritDoc} */
     @Override public void startEdit() {
-        final TreeTableView<T> treeTable = getTreeTableView();
-        if (! isEditable() || (treeTable != null && ! treeTable.isEditable())) {
+        if (isEditing()) {
             return;
         }
 
-        // it makes sense to get the cell into its editing state before firing
-        // the event to the TreeView below, so that's what we're doing here
-        // by calling super.startEdit().
+        final TreeTableView<T> treeTable = getTreeTableView();
+        if (!isEditable() ||
+                (treeTable != null && !treeTable.isEditable())) {
+            return;
+        }
+
         super.startEdit();
+
+        if (!isEditing()) {
+            return;
+        }
 
          // Inform the TreeView of the edit starting.
         if (treeTable != null) {
@@ -327,11 +333,14 @@ public class TreeTableRow<T> extends IndexedCell<T> {
 
      /** {@inheritDoc} */
     @Override public void commitEdit(T newValue) {
-        if (! isEditing()) return;
+        if (!isEditing()) {
+            return;
+        }
+
         final TreeItem<T> treeItem = getTreeItem();
         final TreeTableView<T> treeTable = getTreeTableView();
         if (treeTable != null) {
-            // Inform the TreeView of the edit being ready to be committed.
+            // Inform the TreeTableView of the edit being ready to be committed.
             treeTable.fireEvent(new TreeTableView.EditEvent<>(treeTable,
                     TreeTableView.<T>editCommitEvent(),
                     treeItem,
@@ -346,12 +355,11 @@ public class TreeTableRow<T> extends IndexedCell<T> {
             updateItem(newValue, false);
         }
 
-        // inform parent classes of the commit, so that they can switch us
-        // out of the editing state
+        // inform parent classes of the commit, so that they can switch us out of the editing state
         super.commitEdit(newValue);
 
         if (treeTable != null) {
-            // reset the editing item in the TreetView
+            // reset the editing item in the TreeTableView
             treeTable.edit(-1, null);
             treeTable.requestFocus();
         }
@@ -359,12 +367,14 @@ public class TreeTableRow<T> extends IndexedCell<T> {
 
     /** {@inheritDoc} */
     @Override public void cancelEdit() {
-        if (! isEditing()) return;
+        if (!isEditing()) {
+            return;
+        }
 
         TreeTableView<T> treeTable = getTreeTableView();
         if (treeTable != null) {
             treeTable.fireEvent(new TreeTableView.EditEvent<>(treeTable,
-                    TreeTableView.<T>editCancelEvent(),
+                    TreeTableView.editCancelEvent(),
                     getTreeItem(),
                     getItem(),
                     null));
@@ -373,7 +383,7 @@ public class TreeTableRow<T> extends IndexedCell<T> {
         super.cancelEdit();
 
         if (treeTable != null) {
-            // reset the editing index on the TreeView
+            // reset the editing index on the TreeTableView
             treeTable.edit(-1, null);
             treeTable.requestFocus();
         }
@@ -391,62 +401,66 @@ public class TreeTableRow<T> extends IndexedCell<T> {
 
     private void updateItem(int oldIndex) {
         TreeTableView<T> tv = getTreeTableView();
-        if (tv == null) return;
+        final int itemCount = tv == null ? -1 : tv.getExpandedItemCount();
 
         // Compute whether the index for this cell is for a real item
-        final int newIndex = getIndex();
-        boolean valid = newIndex >= 0 && newIndex < tv.getExpandedItemCount();
-
+        final int index = getIndex();
         final TreeItem<T> oldTreeItem = getTreeItem();
-        final boolean isEmpty = isEmpty();
 
-        // Cause the cell to update itself
-        if (valid) {
-            // update the TreeCell state.
-            // get the new treeItem that is about to go in to the TreeCell
-            final TreeItem<T> newTreeItem = tv.getTreeItem(newIndex);
-            final T newValue = newTreeItem == null ? null : newTreeItem.getValue();
-            final T oldValue = oldTreeItem == null ? null : oldTreeItem.getValue();
+        final boolean indexExceedsItemCount = index >= itemCount;
 
-            // For the sake of JDK-8113226, it is important that the order of these
-            // method calls is as shown below. If the order is switched, it is
-            // likely that events will be fired where the item is null, even
-            // though calling cell.getTreeItem().getValue() returns the value
-            // as expected
-
-            // JDK-8092593 - if the index didn't change, then avoid calling updateItem
-            // unless the item has changed.
-            if (oldIndex == newIndex) {
-                if (!isItemChanged(oldValue, newValue)) {
-                    // JDK-8096969:  we break out of the if/else code here and
-                    // proceed with the code following this, so that we may
-                    // still update references, listeners, etc as required.
-                    return;
-                }
-            }
-
-            updateTreeItem(newTreeItem);
-            updateItem(newValue, false);
-        } else {
+        if (indexExceedsItemCount || index < 0) {
             // JDK-8116529 We need to allow a first run to be special-cased to allow
             // for the updateItem method to be called at least once to allow for
             // the correct visual state to be set up. In particular, in JDK-8116529
             // refer to Ensemble8PopUpTree.png - in this case the arrows are being
             // shown as the new cells are instantiated with the arrows in the
             // children list, and are only hidden in updateItem.
-            if ((!isEmpty && oldTreeItem != null) || isFirstRun) {
+            final boolean isEmpty = isEmpty();
+            if (!isEmpty || isFirstRun) {
                 updateTreeItem(null);
                 updateItem(null, true);
                 isFirstRun = false;
             }
+            return;
         }
+
+        // update the TreeCell state.
+        // get the new treeItem that is about to go in to the TreeCell
+        final TreeItem<T> newTreeItem = tv.getTreeItem(index);
+        final T newValue = newTreeItem == null ? null : newTreeItem.getValue();
+        final T oldValue = oldTreeItem == null ? null : oldTreeItem.getValue();
+
+        // For the sake of JDK-8113226, it is important that the order of these
+        // method calls is as shown below. If the order is switched, it is
+        // likely that events will be fired where the item is null, even
+        // though calling cell.getTreeItem().getValue() returns the value
+        // as expected
+
+        // JDK-8092593 - if the index didn't change, then avoid calling updateItem
+        // unless the item has changed.
+        if (oldIndex == index) {
+            if (!isItemChanged(oldValue, newValue)) {
+                return;
+            }
+        }
+
+        updateTreeItem(newTreeItem);
+        updateItem(newValue, false);
     }
 
     private void updateSelection() {
-        if (isEmpty()) return;
-        if (getIndex() == -1 || getTreeTableView() == null) return;
+        int index = getIndex();
+        if (index == -1) {
+            return;
+        }
 
-        TreeTableViewSelectionModel<T> sm = getTreeTableView().getSelectionModel();
+        TreeTableView<T> treeTableView = getTreeTableView();
+        if (treeTableView == null) {
+            return;
+        }
+
+        TreeTableViewSelectionModel<T> sm = treeTableView.getSelectionModel();
         if (sm == null) {
             if (isSelected()) {
                 updateSelected(false);
@@ -454,36 +468,67 @@ public class TreeTableRow<T> extends IndexedCell<T> {
             return;
         }
 
-        boolean isSelected = !sm.isCellSelectionEnabled() && sm.isSelected(getIndex());
+        boolean isSelected = !sm.isCellSelectionEnabled() && sm.isSelected(index);
         if (isSelected() != isSelected) {
             updateSelected(isSelected);
         }
     }
 
     private void updateFocus() {
-        if (getIndex() == -1 || getTreeTableView() == null) return;
-        if (getTreeTableView().getFocusModel() == null) return;
+        int index = getIndex();
+        if (index == -1) {
+            return;
+        }
 
-        setFocused(getTreeTableView().getFocusModel().isFocused(getIndex()));
+        TreeTableView<T> table = getTreeTableView();
+        if (table == null) {
+            return;
+        }
+
+        TreeTableView.TreeTableViewFocusModel<T> fm = table.getFocusModel();
+        if (fm == null) {
+            return;
+        }
+
+        setFocused(fm.isFocused(index));
     }
 
     private void updateEditing() {
-        if (getIndex() == -1 || getTreeTableView() == null || getTreeItem() == null) return;
+        int index = getIndex();
+        if (index == -1) {
+            return;
+        }
 
-        final TreeTablePosition<T,?> editingCell = getTreeTableView().getEditingCell();
+        TreeTableView<T> table = getTreeTableView();
+        TreeItem<T> treeItem = getTreeItem();
+        if (table == null || treeItem == null) {
+            return;
+        }
+
+        final TreeTablePosition<T, ?> editingCell = table.getEditingCell();
         if (editingCell != null && editingCell.getTableColumn() != null) {
             return;
         }
 
-        final TreeItem<T> editItem = editingCell == null ? null : editingCell.getTreeItem();
-        if (! isEditing() && getTreeItem().equals(editItem)) {
-            startEdit();
-        } else if (isEditing() && ! getTreeItem().equals(editItem)) {
-            cancelEdit();
+        boolean rowMatch = editingCell != null && treeItem.equals(editingCell.getTreeItem());
+
+        if (isEditing()) {
+            if (!rowMatch) {
+                cancelEdit();
+            }
+        } else {
+            if (rowMatch) {
+                startEdit();
+            }
         }
     }
 
-
+    private boolean isInRowSelectionMode() {
+        TreeTableView<T> tableView = getTreeTableView();
+        if (tableView == null) return false;
+        TreeTableView.TreeTableViewSelectionModel<T> sm = tableView.getSelectionModel();
+        return sm != null && !sm.isCellSelectionEnabled();
+    }
 
     /* *************************************************************************
      *                                                                         *

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableView.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableView.java
@@ -503,8 +503,10 @@ public class TreeTableView<S> extends Control {
 
     /**
      * An EventType that indicates some edit event has occurred. It is the parent
-     * type of all other edit events: {@link #editStartEvent},
-     *  {@link #editCommitEvent} and {@link #editCancelEvent}.
+     * type of all other edit events:
+     * {@link #editStartEvent},
+     * {@link #editCommitEvent} and
+     * {@link #editCancelEvent}.
      *
      * @param <S> The type of the TreeItem instances used in this TreeTableView
      * @return An EventType that indicates some edit event has occurred
@@ -2394,13 +2396,22 @@ public class TreeTableView<S> extends Control {
          */
         public static final EventType<?> ANY = EDIT_ANY_EVENT;
 
-        @SuppressWarnings("doclint:missing")
+        /**
+         * The {@link TreeTableView} this event is sent to.
+         */
         private final TreeTableView<S> source;
-        @SuppressWarnings("doclint:missing")
+        /**
+         * The old value.
+         */
         private final S oldValue;
-        @SuppressWarnings("doclint:missing")
+        /**
+         * The new value. This is NOT the value to necessary go back into the tree item.
+         */
         private final S newValue;
-        private transient final TreeItem<S> treeItem;
+        /**
+         * The {@link TreeItem} this event belongs to.
+         */
+        private final TreeItem<S> treeItem;
 
         /**
          * Creates a new EditEvent instance to represent an edit event. This
@@ -2413,7 +2424,7 @@ public class TreeTableView<S> extends Control {
          * @param newValue the newValue
          */
         public EditEvent(TreeTableView<S> source,
-                         EventType<? extends TreeTableView.EditEvent> eventType,
+                         EventType<? extends TreeTableView.EditEvent<S>> eventType,
                          TreeItem<S> treeItem, S oldValue, S newValue) {
             super(source, Event.NULL_SOURCE_TARGET, eventType);
             this.source = source;

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeView.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeView.java
@@ -1264,13 +1264,22 @@ public class TreeView<T> extends Control {
          */
         public static final EventType<?> ANY = EDIT_ANY_EVENT;
 
-        @SuppressWarnings("doclint:missing")
+        /**
+         * The {@link TreeView} this event is sent to.
+         */
         private final TreeView<T> source;
-        @SuppressWarnings("doclint:missing")
+        /**
+         * The old value.
+         */
         private final T oldValue;
-        @SuppressWarnings("doclint:missing")
+        /**
+         * The new value. This is NOT the value to necessary go back into the tree item.
+         */
         private final T newValue;
-        private transient final TreeItem<T> treeItem;
+        /**
+         * The {@link TreeItem} this event belongs to.
+         */
+        private final TreeItem<T> treeItem;
 
         /**
          * Creates a new EditEvent instance to represent an edit event. This
@@ -1283,7 +1292,7 @@ public class TreeView<T> extends Control {
          * @param newValue the newValue
          */
         public EditEvent(TreeView<T> source,
-                         EventType<? extends EditEvent> eventType,
+                         EventType<? extends TreeView.EditEvent<T>> eventType,
                          TreeItem<T> treeItem, T oldValue, T newValue) {
             super(source, Event.NULL_SOURCE_TARGET, eventType);
             this.source = source;
@@ -1325,12 +1334,6 @@ public class TreeView<T> extends Control {
             return oldValue;
         }
     }
-
-
-
-
-
-
 
     // package for testing
     static class TreeViewBitSetSelectionModel<T> extends MultipleSelectionModelBase<TreeItem<T>> {

--- a/modules/javafx.controls/src/shims/java/javafx/scene/control/ListCellShim.java
+++ b/modules/javafx.controls/src/shims/java/javafx/scene/control/ListCellShim.java
@@ -26,9 +26,37 @@ package javafx.scene.control;
 
 public class ListCellShim<T> extends ListCell<T> {
 
+    /**
+     * Flag which is only used in conjunction with {@link #lockItemOnStartEdit} to lock the item when
+     * the {@link #startEdit()} method is called.
+     */
+    private boolean isStartEdit = false;
+    /**
+     * Flag to lock the item value when an edit process is started.
+     * While normally the {@link #updateItem(Object, boolean)} will change the underlying item,
+     * when locked the item will not be changed.
+     */
+    private boolean lockItemOnStartEdit = false;
+
+    @Override
+    public void startEdit() {
+        isStartEdit = true;
+        super.startEdit();
+    }
+
     @Override
     public void updateItem(T item, boolean empty) {
+        // startEdit() was called and wants to update the cell. When locked, we will ignore the update request.
+        if (lockItemOnStartEdit && isStartEdit) {
+            isStartEdit = false;
+            return;
+        }
+
         super.updateItem(item, empty);
+    }
+
+    public void setLockItemOnStartEdit(boolean lockItemOnEdit) {
+        this.lockItemOnStartEdit = lockItemOnEdit;
     }
 
 }

--- a/modules/javafx.controls/src/shims/java/javafx/scene/control/TreeCellShim.java
+++ b/modules/javafx.controls/src/shims/java/javafx/scene/control/TreeCellShim.java
@@ -26,9 +26,37 @@ package javafx.scene.control;
 
 public class TreeCellShim<T> extends TreeCell<T> {
 
+    /**
+     * Flag which is only used in conjunction with {@link #lockItemOnStartEdit} to lock the item when
+     * the {@link #startEdit()} method is called.
+     */
+    private boolean isStartEdit = false;
+    /**
+     * Flag to lock the item value when an edit process is started.
+     * While normally the {@link #updateItem(Object, boolean)} will change the underlying item,
+     * when locked the item will not be changed.
+     */
+    private boolean lockItemOnStartEdit = false;
+
+    @Override
+    public void startEdit() {
+        isStartEdit = true;
+        super.startEdit();
+    }
+
     @Override
     public void updateItem(T item, boolean empty) {
+        // startEdit() was called and wants to update the cell. When locked, we will ignore the update request.
+        if (lockItemOnStartEdit && isStartEdit) {
+            isStartEdit = false;
+            return;
+        }
+
         super.updateItem(item, empty);
+    }
+
+    public void setLockItemOnStartEdit(boolean lockItemOnEdit) {
+        this.lockItemOnStartEdit = lockItemOnEdit;
     }
 
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/CellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/CellTest.java
@@ -30,6 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import java.util.stream.Stream;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.SimpleBooleanProperty;
@@ -38,17 +39,21 @@ import javafx.scene.Scene;
 import javafx.scene.control.Button;
 import javafx.scene.control.Cell;
 import javafx.scene.control.CellShim;
+import javafx.scene.control.IndexedCell;
 import javafx.scene.control.ListCell;
+import javafx.scene.control.ListCellShim;
 import javafx.scene.control.TableCell;
 import javafx.scene.control.TableCellShim;
 import javafx.scene.control.TableRow;
 import javafx.scene.control.TreeCell;
+import javafx.scene.control.TreeCellShim;
 import javafx.scene.control.TreeTableCell;
 import javafx.scene.control.TreeTableCellShim;
 import javafx.scene.control.TreeTableRow;
 import javafx.scene.layout.HBox;
 import javafx.stage.Stage;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Named;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import com.sun.javafx.tk.Toolkit;
@@ -56,24 +61,9 @@ import test.com.sun.javafx.scene.control.infrastructure.ControlTestUtils;
 import test.com.sun.javafx.scene.control.infrastructure.StageLoader;
 
 /**
+ * Tests the behavior that all rows and cells have in common.
  */
 public class CellTest {
-
-    private static Stream<Class> parameters() {
-        return Stream.of(
-                Cell.class,
-                ListCell.class,
-                TableRow.class,
-                // Note: We use the shim here, so we can lock the item. The behaviour is the same otherwise.
-                TableCellShim.class,
-                TreeCell.class,
-                TreeTableRow.class,
-                // Note: We use the shim here, so we can lock the item.  The behaviour is the same otherwise.
-                TreeTableCellShim.class
-        );
-    }
-
-    private Cell<String> cell;
 
     private StageLoader stageLoader;
 
@@ -84,39 +74,65 @@ public class CellTest {
         }
     }
 
-    // @BeforeEach
-    // junit5 does not support parameterized class-level tests yet
-    private void setup(Class<?> type) {
-        try {
-            cell = (Cell<String>)type.getDeclaredConstructor().newInstance();
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-
-        // Empty TableCells can be selected, as long as the row they exist in
-        // is not empty, so here we set a TableRow to ensure testing works
-        // properly
-        if (cell instanceof TableCell) {
-            TableRow tableRow = new TableRow();
-            CellShim.updateItem(tableRow, "TableRow", false);
-            ((TableCell)cell).updateTableRow(tableRow);
-            ((TableCellShim)cell).setLockItemOnStartEdit(true);
-        } else if (cell instanceof TreeTableCell) {
-            TreeTableRow tableRow = new TreeTableRow();
-            CellShim.updateItem(tableRow, "TableRow", false);
-            ((TreeTableCell)cell).updateTableRow(tableRow);
-            ((TreeTableCellShim)cell).setLockItemOnStartEdit(true);
-        }
+    /**
+     * All cell implementations, ready to use and not attached to any (virtualized) view.
+     */
+    private static Stream<Named<Cell<String>>> cells() {
+        return Stream.of(
+                named("Cell", new Cell<>()),
+                named("ListCell", createListCell()),
+                named("TableRow", new TableRow<>()),
+                named("TableCell", createTableCell()),
+                named("TreeCell", createTreeCell()),
+                named("TreeTableRow", new TreeTableRow<>()),
+                named("TreeTableCell", createTreeTableCell()));
     }
 
-    /*********************************************************************
-     * Tests for the constructors                                        *
-     ********************************************************************/
+    private static Named<Cell<String>> named(String name, Cell<String> cell) {
+        return Named.of(name, cell);
+    }
+
+    private static boolean isInsideARow(Cell<String> cell) {
+        return cell instanceof TableCell || cell instanceof TreeTableCell;
+    }
+
+    private static ListCell<String> createListCell() {
+        ListCellShim<String> cell = new ListCellShim<>();
+        cell.setLockItemOnStartEdit(true);
+        return cell;
+    }
+
+    private static TreeCell<String> createTreeCell() {
+        TreeCellShim<String> cell = new TreeCellShim<>();
+        cell.setLockItemOnStartEdit(true);
+        return cell;
+    }
+
+    private static TableCell<String, String> createTableCell() {
+        TableCellShim<String, String> cell = new TableCellShim<>();
+        TableRow<String> tableRow = new TableRow<>();
+        CellShim.updateItem(tableRow, "TableRow", false);
+        cell.updateTableRow(tableRow);
+        cell.setLockItemOnStartEdit(true);
+        return cell;
+    }
+
+    private static TreeTableCell<String, String> createTreeTableCell() {
+        TreeTableCellShim<String, String> cell = new TreeTableCellShim<>();
+        TreeTableRow<String> tableRow = new TreeTableRow<>();
+        CellShim.updateItem(tableRow, "TableRow", false);
+        cell.updateTableRow(tableRow);
+        cell.setLockItemOnStartEdit(true);
+        return cell;
+    }
+
+    /* *********************************************************************
+     * Tests for the constructors                                          *
+     ***********************************************************************/
 
     @ParameterizedTest
-    @MethodSource("parameters")
-    public void cellsShouldBeNonFocusableByDefault(Class<?> c) {
-        setup(c);
+    @MethodSource("cells")
+    public void cellsShouldBeNonFocusableByDefault(Cell<String> cell) {
         // Cells are non-focusable because we manually position the focus from
         // the ListView / TableView / TreeView skin, rather than making them
         // focus traversable and having directional focus work etc. We must
@@ -127,16 +143,14 @@ public class CellTest {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
-    public void styleClassShouldDefaultTo_cell(Class<?> c) {
-        setup(c);
+    @MethodSource("cells")
+    public void styleClassShouldDefaultTo_cell(Cell<String> cell) {
         ControlTestUtils.assertStyleClassContains(cell, "cell");
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
-    public void pseudoClassStateShouldBe_empty_ByDefault(Class<?> c) {
-        setup(c);
+    @MethodSource("cells")
+    public void pseudoClassStateShouldBe_empty_ByDefault(Cell<String> cell) {
         ControlTestUtils.assertPseudoClassExists(cell, "empty");
         ControlTestUtils.assertPseudoClassDoesNotExist(cell, "filled");
         ControlTestUtils.assertPseudoClassDoesNotExist(cell, "selected");
@@ -144,10 +158,8 @@ public class CellTest {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
-    public void testFocusedPseudoClassIsSetWhenFocused(Class<?> c) {
-        setup(c);
-
+    @MethodSource("cells")
+    public void testFocusedPseudoClassIsSetWhenFocused(Cell<String> cell) {
         Button button = new Button();
         stageLoader = new StageLoader(new HBox(button, cell));
 
@@ -159,66 +171,67 @@ public class CellTest {
         ControlTestUtils.assertPseudoClassDoesNotExist(cell, "focused");
     }
 
-    /*********************************************************************
-     * Tests for updating the item, selection, editable                  *
-     ********************************************************************/
+    /* *********************************************************************
+     * Tests for updating the item, selection, editable                    *
+     ***********************************************************************/
 
     @ParameterizedTest
-    @MethodSource("parameters")
-    public void updatingItemAffectsBothItemAndEmpty(Class<?> c) {
-        setup(c);
+    @MethodSource("cells")
+    public void updatingItemAffectsBothItemAndEmpty(Cell<String> cell) {
         CellShim.updateItem(cell, "Apples", false);
         assertEquals("Apples", cell.getItem());
         assertFalse(cell.isEmpty());
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
-    public void updatingItemWithEmptyTrueAndItemNotNullIsWeirdButOK(Class<?> c) {
-        setup(c);
+    @MethodSource("cells")
+    public void updatingItemWithEmptyTrueAndItemNotNullIsWeirdButOK(Cell<String> cell) {
         CellShim.updateItem(cell, "Weird!", true);
         assertEquals("Weird!", cell.getItem());
         assertTrue(cell.isEmpty());
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
-    public void updatingItemWithEmptyFalseAndNullItemIsOK(Class<?> c) {
-        setup(c);
+    @MethodSource("cells")
+    public void updatingItemWithEmptyFalseAndNullItemIsOK(Cell<String> cell) {
         CellShim.updateItem(cell, null, false);
         assertNull(cell.getItem());
         assertFalse(cell.isEmpty());
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
-    public void selectingANonEmptyCellIsOK(Class<?> c) {
-        setup(c);
+    @MethodSource("cells")
+    public void selectingANonEmptyCellIsOK(Cell<String> cell) {
         CellShim.updateItem(cell, "Oranges", false);
         cell.updateSelected(true);
         assertTrue(cell.isSelected());
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
-    public void unSelectingANonEmptyCellIsOK(Class<?> c) {
-        setup(c);
+    @MethodSource("cells")
+    public void unSelectingANonEmptyCellIsOK(Cell<String> cell) {
         CellShim.updateItem(cell, "Oranges", false);
         cell.updateSelected(true);
         cell.updateSelected(false);
         assertFalse(cell.isSelected());
     }
 
-    public void selectingAnEmptyCellResultsInNoChange(Class<?> c) {
+    @ParameterizedTest
+    @MethodSource("cells")
+    public void selectingAnEmptyCellResultsInNoChange(Cell<String> cell) {
         CellShim.updateItem(cell, null, true);
         cell.updateSelected(true);
-        assertFalse(cell.isSelected());
+
+        if (isInsideARow(cell)) {
+            assertTrue(cell.isSelected());
+        } else {
+            assertFalse(cell.isSelected());
+        }
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
-    public void updatingASelectedCellToBeEmptyClearsSelection(Class<?> c) {
-        setup(c);
+    @MethodSource("cells")
+    public void updatingASelectedCellToBeEmptyClearsSelection(Cell<String> cell) {
         CellShim.updateItem(cell, "Oranges", false);
         cell.updateSelected(true);
         CellShim.updateItem(cell, null, true);
@@ -226,36 +239,32 @@ public class CellTest {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
-    public void updatingItemWithEmptyTrueResultsIn_empty_pseudoClassAndNot_filled(Class<?> c) {
-        setup(c);
+    @MethodSource("cells")
+    public void updatingItemWithEmptyTrueResultsIn_empty_pseudoClassAndNot_filled(Cell<String> cell) {
         CellShim.updateItem(cell, null, true);
         ControlTestUtils.assertPseudoClassExists(cell, "empty");
         ControlTestUtils.assertPseudoClassDoesNotExist(cell, "filled");
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
-    public void updatingItemWithEmptyFalseResultsIn_filled_pseudoClassAndNot_empty(Class<?> c) {
-        setup(c);
+    @MethodSource("cells")
+    public void updatingItemWithEmptyFalseResultsIn_filled_pseudoClassAndNot_empty(Cell<String> cell) {
         CellShim.updateItem(cell, null, false);
         ControlTestUtils.assertPseudoClassExists(cell, "filled");
         ControlTestUtils.assertPseudoClassDoesNotExist(cell, "empty");
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
-    public void updatingSelectedToTrueResultsIn_selected_pseudoClass(Class<?> c) {
-        setup(c);
+    @MethodSource("cells")
+    public void updatingSelectedToTrueResultsIn_selected_pseudoClass(Cell<String> cell) {
         CellShim.updateItem(cell, "Pears", false);
         cell.updateSelected(true);
         ControlTestUtils.assertPseudoClassExists(cell, "selected");
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
-    public void updatingSelectedToFalseResultsInNo_selected_pseudoClass(Class<?> c) {
-        setup(c);
+    @MethodSource("cells")
+    public void updatingSelectedToFalseResultsInNo_selected_pseudoClass(Cell<String> cell) {
         CellShim.updateItem(cell, "Pears", false);
         cell.updateSelected(true);
         cell.updateSelected(false);
@@ -263,42 +272,37 @@ public class CellTest {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
-    public void editableIsTrueByDefault(Class<?> c) {
-        setup(c);
+    @MethodSource("cells")
+    public void editableIsTrueByDefault(Cell<String> cell) {
         assertTrue(cell.isEditable());
         assertTrue(cell.editableProperty().get());
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
-    public void editableCanBeSet(Class<?> c) {
-        setup(c);
+    @MethodSource("cells")
+    public void editableCanBeSet(Cell<String> cell) {
         cell.setEditable(false);
         assertFalse(cell.isEditable());
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
-    public void editableSetToNonDefaultValueIsReflectedInModel(Class<?> c) {
-        setup(c);
+    @MethodSource("cells")
+    public void editableSetToNonDefaultValueIsReflectedInModel(Cell<String> cell) {
         cell.setEditable(false);
         assertFalse(cell.editableProperty().get());
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
-    public void editableCanBeCleared(Class<?> c) {
-        setup(c);
+    @MethodSource("cells")
+    public void editableCanBeCleared(Cell<String> cell) {
         cell.setEditable(false);
         cell.setEditable(true);
         assertTrue(cell.isEditable());
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
-    public void editableCanBeBound(Class<?> c) {
-        setup(c);
+    @MethodSource("cells")
+    public void editableCanBeBound(Cell<String> cell) {
         BooleanProperty other = new SimpleBooleanProperty(false);
         cell.editableProperty().bind(other);
         assertFalse(cell.isEditable());
@@ -307,9 +311,8 @@ public class CellTest {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
-    public void cannotSpecifyEditableViaCSS(Class<?> c) {
-        setup(c);
+    @MethodSource("cells")
+    public void cannotSpecifyEditableViaCSS(Cell<String> cell) {
         cell.setStyle("-fx-editable: false;");
         cell.applyCss();
         assertTrue(cell.isEditable());
@@ -322,22 +325,20 @@ public class CellTest {
         assertFalse(cell.isEditable());
     }
 
-    /*********************************************************************
-     * Tests for editing                                                 *
-     ********************************************************************/
+    /* *********************************************************************
+     * Tests for editing                                                   *
+     ***********************************************************************/
 
     @ParameterizedTest
-    @MethodSource("parameters")
-    public void editingAnEmptyCellResultsInNoChange(Class<?> c) {
-        setup(c);
+    @MethodSource("cells")
+    public void editingAnEmptyCellResultsInNoChange(Cell<String> cell) {
         cell.startEdit();
         assertFalse(cell.isEditing());
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
-    public void editingAnEmptyCellResultsInNoChange2(Class<?> c) {
-        setup(c);
+    @MethodSource("cells")
+    public void editingAnEmptyCellResultsInNoChange2(Cell<String> cell) {
         CellShim.updateItem(cell, null, false);
         CellShim.updateItem(cell, null, true);
         cell.startEdit();
@@ -345,9 +346,8 @@ public class CellTest {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
-    public void updatingACellBeingEditedDoesNotResultInACancelOfEdit(Class<?> c) {
-        setup(c);
+    @MethodSource("cells")
+    public void updatingACellBeingEditedDoesNotResultInACancelOfEdit(Cell<String> cell) {
         CellShim.updateItem(cell, "Apples", false);
         cell.startEdit();
         assertFalse(cell.isEmpty());
@@ -357,9 +357,8 @@ public class CellTest {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
-    public void updatingACellBeingEditedDoesNotResultInACancelOfEdit2(Class<?> c) {
-        setup(c);
+    @MethodSource("cells")
+    public void updatingACellBeingEditedDoesNotResultInACancelOfEdit2(Cell<String> cell) {
         CellShim.updateItem(cell, "Apples", false);
         cell.startEdit();
         assertFalse(cell.isEmpty());
@@ -369,18 +368,16 @@ public class CellTest {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
-    public void startEditWhenEditableIsTrue(Class<?> c) {
-        setup(c);
+    @MethodSource("cells")
+    public void startEditWhenEditableIsTrue(Cell<String> cell) {
         CellShim.updateItem(cell, "Apples", false);
         cell.startEdit();
         assertTrue(cell.isEditing());
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
-    public void startEditWhenEditableIsFalse(Class<?> c) {
-        setup(c);
+    @MethodSource("cells")
+    public void startEditWhenEditableIsFalse(Cell<String> cell) {
         CellShim.updateItem(cell, "Apples", false);
         cell.setEditable(false);
         cell.startEdit();
@@ -388,9 +385,8 @@ public class CellTest {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
-    public void startEditWhileAlreadyEditingIsIgnored(Class<?> c) {
-        setup(c);
+    @MethodSource("cells")
+    public void startEditWhileAlreadyEditingIsIgnored(Cell<String> cell) {
         CellShim.updateItem(cell, "Apples", false);
         cell.startEdit();
         cell.startEdit();
@@ -398,9 +394,8 @@ public class CellTest {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
-    public void cancelEditWhenEditableIsTrue(Class<?> c) {
-        setup(c);
+    @MethodSource("cells")
+    public void cancelEditWhenEditableIsTrue(Cell<String> cell) {
         CellShim.updateItem(cell, "Apples", false);
         cell.startEdit();
         cell.cancelEdit();
@@ -408,10 +403,9 @@ public class CellTest {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
-    public void cancelEditWhenEditableIsFalse(Class<?> c) {
-        setup(c);
-       CellShim.updateItem(cell, "Apples", false);
+    @MethodSource("cells")
+    public void cancelEditWhenEditableIsFalse(Cell<String> cell) {
+        CellShim.updateItem(cell, "Apples", false);
         cell.setEditable(false);
         cell.startEdit();
         cell.cancelEdit();
@@ -419,9 +413,8 @@ public class CellTest {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
-    public void commitEditWhenEditableIsTrue(Class<?> c) {
-        setup(c);
+    @MethodSource("cells")
+    public void commitEditWhenEditableIsTrue(Cell<String> cell) {
         CellShim.updateItem(cell, "Apples", false);
         cell.startEdit();
         cell.commitEdit("Oranges");
@@ -429,9 +422,8 @@ public class CellTest {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
-    public void commitEditWhenEditableIsFalse(Class<?> c) {
-        setup(c);
+    @MethodSource("cells")
+    public void commitEditWhenEditableIsFalse(Cell<String> cell) {
         CellShim.updateItem(cell, "Apples", false);
         cell.setEditable(false);
         cell.startEdit();
@@ -440,79 +432,68 @@ public class CellTest {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
-    public void getBeanIsCorrectForItemProperty(Class<?> c) {
-        setup(c);
+    @MethodSource("cells")
+    public void getBeanIsCorrectForItemProperty(Cell<String> cell) {
         assertSame(cell, cell.itemProperty().getBean());
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
-    public void getNameIsCorrectForItemProperty(Class<?> c) {
-        setup(c);
+    @MethodSource("cells")
+    public void getNameIsCorrectForItemProperty(Cell<String> cell) {
         assertEquals("item", cell.itemProperty().getName());
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
-    public void getBeanIsCorrectForEmptyProperty(Class<?> c) {
-        setup(c);
+    @MethodSource("cells")
+    public void getBeanIsCorrectForEmptyProperty(Cell<String> cell) {
         assertSame(cell, cell.emptyProperty().getBean());
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
-    public void getNameIsCorrectForEmptyProperty(Class<?> c) {
-        setup(c);
+    @MethodSource("cells")
+    public void getNameIsCorrectForEmptyProperty(Cell<String> cell) {
         assertEquals("empty", cell.emptyProperty().getName());
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
-    public void getBeanIsCorrectForSelectedProperty(Class<?> c) {
-        setup(c);
+    @MethodSource("cells")
+    public void getBeanIsCorrectForSelectedProperty(Cell<String> cell) {
         assertSame(cell, cell.selectedProperty().getBean());
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
-    public void getNameIsCorrectForSelectedProperty(Class<?> c) {
-        setup(c);
+    @MethodSource("cells")
+    public void getNameIsCorrectForSelectedProperty(Cell<String> cell) {
         assertEquals("selected", cell.selectedProperty().getName());
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
-    public void getBeanIsCorrectForEditingProperty(Class<?> c) {
-        setup(c);
+    @MethodSource("cells")
+    public void getBeanIsCorrectForEditingProperty(Cell<String> cell) {
         assertSame(cell, cell.editingProperty().getBean());
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
-    public void getNameIsCorrectForEditingProperty(Class<?> c) {
-        setup(c);
+    @MethodSource("cells")
+    public void getNameIsCorrectForEditingProperty(Cell<String> cell) {
         assertEquals("editing", cell.editingProperty().getName());
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
-    public void getBeanIsCorrectForEditableProperty(Class<?> c) {
-        setup(c);
+    @MethodSource("cells")
+    public void getBeanIsCorrectForEditableProperty(Cell<String> cell) {
         assertSame(cell, cell.editableProperty().getBean());
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
-    public void getNameIsCorrectForEditableProperty(Class<?> c) {
-        setup(c);
+    @MethodSource("cells")
+    public void getNameIsCorrectForEditableProperty(Cell<String> cell) {
         assertEquals("editable", cell.editableProperty().getName());
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
-    public void loseFocusWhileEditing(Class<?> c) {
-        setup(c);
+    @MethodSource("cells")
+    public void loseFocusWhileEditing(Cell<String> cell) {
         Button other = new Button();
         Group root = new Group(other, cell);
         Scene scene = new Scene(root);
@@ -534,5 +515,29 @@ public class CellTest {
 
         assertFalse(cell.isEditing());
         stage.hide();
+    }
+
+    @ParameterizedTest
+    @MethodSource("cells")
+    public void settingAnIndexWithoutAViewEmptiesTheCell(Cell<String> cell) {
+        assumeTrue(cell instanceof IndexedCell<String>, "the plain Cell has no index");
+        CellShim.updateItem(cell, "Apples", false);
+
+        ((IndexedCell<String>) cell).updateIndex(0);
+
+        assertNull(cell.getItem());
+        assertTrue(cell.isEmpty());
+    }
+
+    @ParameterizedTest
+    @MethodSource("cells")
+    public void settingANegativeIndexWithoutAViewEmptiesTheCell(Cell<String> cell) {
+        assumeTrue(cell instanceof IndexedCell<String>, "the plain Cell has no index");
+        CellShim.updateItem(cell, "Apples", false);
+
+        ((IndexedCell<String>) cell).updateIndex(-1);
+
+        assertNull(cell.getItem());
+        assertTrue(cell.isEmpty());
     }
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/EventAnyTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/EventAnyTest.java
@@ -93,9 +93,10 @@ public class EventAnyTest {
 
     }
 
+    @SuppressWarnings("removal")
     private static Event listViewEditEvent() {
-        return new ListView.EditEvent<>(new ListView<String>(),
-                ListView.<String>editCommitEvent(), "", 1);
+        return new ListView.EditEvent<>(new ListView<>(),
+                ListView.<String>editCommitEvent(), "old", "new", 1);
     }
 
     private static Event scrollToEvent() {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListCellTest.java
@@ -780,6 +780,54 @@ public class ListCellTest {
     }
 
     @Test
+    public void testEditStartEventCarriesTheOldValue() {
+        list.setEditable(true);
+        cell.updateListView(list);
+        cell.updateIndex(1);
+        List<EditEvent<String>> events = new ArrayList<>();
+        list.setOnEditStart(events::add);
+
+        cell.startEdit();
+
+        assertEquals(1, events.size());
+        assertEquals("Oranges", events.get(0).getOldValue(), "old value of start event");
+        assertNull(events.get(0).getNewValue(), "new value of start event");
+    }
+
+    @Test
+    public void testEditCommitEventCarriesTheOldAndTheNewValue() {
+        list.setEditable(true);
+        cell.updateListView(list);
+        cell.updateIndex(1);
+        cell.startEdit();
+        List<EditEvent<String>> events = new ArrayList<>();
+        list.setOnEditCommit(events::add);
+
+        cell.commitEdit("Watermelon");
+
+        assertEquals(1, events.size());
+        assertEquals("Oranges", events.get(0).getOldValue(), "old value of commit event");
+        assertEquals("Watermelon", events.get(0).getNewValue(), "new value of commit event");
+    }
+
+    @Test
+    public void testEditCancelEventCarriesTheOldValue() {
+        list.setEditable(true);
+        cell.updateListView(list);
+        cell.updateIndex(1);
+        cell.startEdit();
+        List<EditEvent<String>> events = new ArrayList<>();
+        list.setOnEditCancel(events::add);
+
+        cell.cancelEdit();
+
+        assertEquals(1, events.size());
+        assertEquals("Oranges", events.get(0).getOldValue(), "old value of cancel event");
+        assertNull(events.get(0).getNewValue(), "new value of cancel event");
+    }
+
+    @Test
+    @SuppressWarnings("removal")
     public void testEditCancelEventAfterCancelOnCell() {
         list.setEditable(true);
         cell.updateListView(list);
@@ -794,6 +842,7 @@ public class ListCellTest {
     }
 
     @Test
+    @SuppressWarnings("removal")
     public void testEditCancelEventAfterCancelOnList() {
         list.setEditable(true);
         cell.updateListView(list);
@@ -808,6 +857,7 @@ public class ListCellTest {
     }
 
     @Test
+    @SuppressWarnings("removal")
     public void testEditCancelEventAfterChangeEditingIndexOnList() {
         list.setEditable(true);
         cell.updateListView(list);
@@ -822,6 +872,7 @@ public class ListCellTest {
     }
 
     @Test
+    @SuppressWarnings("removal")
     public void testEditCancelEventAfterCellReuse() {
         list.setEditable(true);
         cell.updateListView(list);
@@ -836,6 +887,7 @@ public class ListCellTest {
     }
 
     @Test
+    @SuppressWarnings("removal")
     public void testEditCancelEventAfterModifyItems() {
         list.setEditable(true);
         stageLoader = new StageLoader(list);
@@ -850,6 +902,7 @@ public class ListCellTest {
     }
 
     @Test
+    @SuppressWarnings("removal")
     public void testEditCancelEventAfterRemoveEditingItem() {
         list.setEditable(true);
         stageLoader = new StageLoader(list);
@@ -887,6 +940,7 @@ public class ListCellTest {
     }
 
     @Test
+    @SuppressWarnings("removal")
     public void testCommitEditMustNotFireCancel() {
         list.setEditable(true);
         // JDK-8187307: handler that resets control's editing state

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListViewTest.java
@@ -2247,6 +2247,7 @@ public class ListViewTest {
         }
     }
 
+    @SuppressWarnings("removal")
     @Test public void testListEditStartOnCellStandalone_JDK8187432() {
         ListView<String> control = new ListView<>(FXCollections
                 .observableArrayList("Item1", "Item2", "Item3", "Item4"));

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableCellTest.java
@@ -978,6 +978,44 @@ public class TableCellTest {
         assertTrue(isItemChangedCalled.get());
     }
 
+    @Test
+    public void testNullItemUpdateIndexNegative() {
+        setupNullValueColumn();
+        cell.updateIndex(0);
+        assertInRangeNullItemState(0);
+        cell.updateIndex(-1);
+        assertOffRangeState(-1);
+    }
+
+    @Test
+    public void testNullItemUpdateIndexOffRange() {
+        setupNullValueColumn();
+        cell.updateIndex(0);
+        assertInRangeNullItemState(0);
+        cell.updateIndex(model.size());
+        assertOffRangeState(model.size());
+    }
+
+    private void setupNullValueColumn() {
+        TableColumn<String, String> column = new TableColumn<>("TEST");
+        column.setCellValueFactory(cd -> null);
+        table.getColumns().add(column);
+        cell.updateTableColumn(column);
+        cell.updateTableView(table);
+    }
+
+    private void assertInRangeNullItemState(int index) {
+        assertEquals(index, cell.getIndex(), "in range index");
+        assertNull(cell.getItem(), "in range cell item must be null");
+        assertFalse(cell.isEmpty(), "in range cell with null item must not be empty");
+    }
+
+    private void assertOffRangeState(int index) {
+        assertEquals(index, cell.getIndex(), "off range index");
+        assertNull(cell.getItem(), "off range cell item must be null");
+        assertTrue(cell.isEmpty(), "off range cell must be empty");
+    }
+
     public static class MisbehavingOnCancelTableCell<S, T> extends TableCell<S, T> {
 
         @Override

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewRowTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewRowTest.java
@@ -26,11 +26,16 @@ package test.javafx.scene.control;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
 import javafx.scene.control.SelectionMode;
 import javafx.scene.control.TableCell;
 import javafx.scene.control.TableColumn;
@@ -232,5 +237,231 @@ public class TableViewRowTest {
         for (TableCell<String, String> cell : cells) {
             assertEquals(1, cell.getIndex());
         }
+    }
+
+    @Test
+    public void testEditOnTableViewStartsEditingInRow() {
+        TableView<String> table = createEditableTableView();
+        TableRow<String> row = createRow(table, 1);
+
+        table.edit(1, null);
+
+        assertTrue(row.isEditing());
+    }
+
+    @Test
+    public void testEditOnTableViewWithAnotherIndexDoesNotStartEditingInRow() {
+        TableView<String> table = createEditableTableView();
+        TableRow<String> row = createRow(table, 1);
+
+        table.edit(0, null);
+
+        assertFalse(row.isEditing());
+    }
+
+    @Test
+    public void testStartEditOnNonEditableTableViewDoesNothing() {
+        TableView<String> table = createEditableTableView();
+        table.setEditable(false);
+        TableRow<String> row = createRow(table, 1);
+
+        row.startEdit();
+
+        assertFalse(row.isEditing());
+        assertNull(table.getEditingCell());
+    }
+
+    @Test
+    public void testStartEditOnNonEditableRowDoesNothing() {
+        TableView<String> table = createEditableTableView();
+        TableRow<String> row = createRow(table, 1);
+        row.setEditable(false);
+
+        row.startEdit();
+
+        assertFalse(row.isEditing());
+    }
+
+    @Test
+    public void testStartEditWithoutTableViewDoesNotThrow() {
+        TableRow<String> row = new TableRow<>();
+        row.updateIndex(1);
+
+        row.startEdit();
+    }
+
+    @Test
+    public void testStartEditFiresEditStartEvent() {
+        TableView<String> table = createEditableTableView();
+        TableRow<String> row = createRow(table, 1);
+
+        AtomicInteger counter = new AtomicInteger();
+        table.addEventHandler(TableView.editStartEvent(), event -> counter.incrementAndGet());
+
+        row.startEdit();
+
+        assertTrue(row.isEditing());
+        assertEquals(1, counter.get());
+    }
+
+    @Test
+    public void testCommitEditFiresEditCommitEventWithOldAndNewValue() {
+        TableView<String> table = createEditableTableView();
+        TableRow<String> row = createRow(table, 1);
+        row.startEdit();
+
+        List<TableView.EditEvent<String>> events = new ArrayList<>();
+        table.addEventHandler(TableView.<String>editCommitEvent(), events::add);
+
+        row.commitEdit("Watermelon");
+
+        assertEquals(1, events.size());
+        assertEquals("Oranges", events.get(0).getOldValue());
+        assertEquals("Watermelon", events.get(0).getNewValue());
+        assertSame(table, events.get(0).getSource());
+    }
+
+    @Test
+    public void testCommitEditUpdatesTheRowAndStopsEditing() {
+        TableView<String> table = createEditableTableView();
+        TableRow<String> row = createRow(table, 1);
+        row.startEdit();
+
+        row.commitEdit("Watermelon");
+
+        assertEquals("Watermelon", row.getItem());
+        assertFalse(row.isEditing());
+        assertNull(table.getEditingCell());
+    }
+
+    @Test
+    public void testCommitEditWithoutEditingDoesNothing() {
+        TableView<String> table = createEditableTableView();
+        TableRow<String> row = createRow(table, 1);
+
+        AtomicInteger counter = new AtomicInteger();
+        table.addEventHandler(TableView.editCommitEvent(), event -> counter.incrementAndGet());
+
+        row.commitEdit("Watermelon");
+
+        assertEquals("Oranges", row.getItem());
+        assertEquals(0, counter.get());
+    }
+
+    @Test
+    public void testCancelEditFiresEditCancelEventAndStopsEditing() {
+        TableView<String> table = createEditableTableView();
+        TableRow<String> row = createRow(table, 1);
+        row.startEdit();
+
+        AtomicInteger counter = new AtomicInteger();
+        table.addEventHandler(TableView.editCancelEvent(), event -> counter.incrementAndGet());
+
+        row.cancelEdit();
+
+        assertEquals(1, counter.get());
+        assertFalse(row.isEditing());
+        assertNull(table.getEditingCell());
+        assertEquals("Oranges", row.getItem());
+    }
+
+    @Test
+    public void testCancelEditWithoutEditingDoesNothing() {
+        TableView<String> table = createEditableTableView();
+        TableRow<String> row = createRow(table, 1);
+
+        AtomicInteger counter = new AtomicInteger();
+        table.addEventHandler(TableView.editCancelEvent(), event -> counter.incrementAndGet());
+
+        row.cancelEdit();
+
+        assertEquals(0, counter.get());
+    }
+
+    @Test
+    public void testEditEventsAreSubTypesOfEditAnyEvent() {
+        TableView<String> table = createEditableTableView();
+        TableRow<String> row = createRow(table, 1);
+
+        AtomicInteger counter = new AtomicInteger();
+        table.addEventHandler(TableView.editAnyEvent(), event -> counter.incrementAndGet());
+
+        row.startEdit();
+        row.commitEdit("Watermelon");
+
+        assertEquals(2, counter.get());
+    }
+
+    @Test
+    public void testStartEditOnEmptyRowDoesNotFireEditStartEvent() {
+        TableView<String> table = createEditableTableView();
+        // an index past the items, so that the row is empty
+        TableRow<String> row = createRow(table, table.getItems().size());
+
+        AtomicInteger counter = new AtomicInteger();
+        table.addEventHandler(TableView.editStartEvent(), event -> counter.incrementAndGet());
+
+        row.startEdit();
+
+        assertTrue(row.isEmpty());
+        assertFalse(row.isEditing());
+        assertEquals(0, counter.get());
+    }
+
+    private static TableView<String> createEditableTableView() {
+        TableView<String> table =
+                new TableView<>(FXCollections.observableArrayList("Apples", "Oranges", "Pears"));
+        table.getColumns().add(new TableColumn<>("C0"));
+        table.setEditable(true);
+        return table;
+    }
+
+    private static TableRow<String> createRow(TableView<String> table, int index) {
+        TableRow<String> row = new TableRow<>();
+        row.updateTableView(table);
+        row.updateIndex(index);
+        return row;
+    }
+
+    /**
+     * A row with a null item at a valid index is not empty, so it must be cleaned up when its index is moved off-range.
+     */
+    @Test
+    public void testNullItemUpdateIndexNegative() {
+        TableRow<String> row = setupNullItemRow();
+        row.updateIndex(0);
+        assertInRangeNullItemState(row, 0);
+        row.updateIndex(-1);
+        assertOffRangeState(row, -1);
+    }
+
+    @Test
+    public void testNullItemUpdateIndexOffRange() {
+        TableRow<String> row = setupNullItemRow();
+        row.updateIndex(0);
+        assertInRangeNullItemState(row, 0);
+        row.updateIndex(nullItemModel.size());
+        assertOffRangeState(row, nullItemModel.size());
+    }
+
+    private ObservableList<String> nullItemModel;
+
+    private TableRow<String> setupNullItemRow() {
+        nullItemModel = FXCollections.observableArrayList(null, "Oranges", "Pears");
+        TableRow<String> row = new TableRow<>();
+        row.updateTableView(new TableView<>(nullItemModel));
+        return row;
+    }
+
+    private void assertInRangeNullItemState(TableRow<String> row, int index) {
+        assertEquals(index, row.getIndex(), "in range index");
+        assertNull(row.getItem(), "in range row item must be null");
+        assertFalse(row.isEmpty(), "in range row with null item must not be empty");
+    }
+
+    private void assertOffRangeState(TableRow<String> row, int index) {
+        assertEquals(index, row.getIndex(), "off range index");
+        assertNull(row.getItem(), "off range row item must be null");
+        assertTrue(row.isEmpty(), "off range row must be empty");
     }
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeCellTest.java
@@ -1114,4 +1114,40 @@ public class TreeCellTest {
 
         assertTrue(isItemChangedCalled.get());
     }
+
+    @Test
+    public void testNullItemUpdateIndexNegative() {
+        setupNullValueItem();
+        cell.updateIndex(1);
+        assertInRangeNullItemState(1);
+        cell.updateIndex(-1);
+        assertOffRangeState(-1);
+    }
+
+    @Test
+    public void testNullItemUpdateIndexOffRange() {
+        setupNullValueItem();
+        cell.updateIndex(1);
+        assertInRangeNullItemState(1);
+        int offRange = tree.getExpandedItemCount();
+        cell.updateIndex(offRange);
+        assertOffRangeState(offRange);
+    }
+
+    private void setupNullValueItem() {
+        apples.setValue(null);
+        cell.updateTreeView(tree);
+    }
+
+    private void assertInRangeNullItemState(int index) {
+        assertEquals(index, cell.getIndex(), "in range index");
+        assertNull(cell.getItem(), "in range cell item must be null");
+        assertFalse(cell.isEmpty(), "in range cell with null item must not be empty");
+    }
+
+    private void assertOffRangeState(int index) {
+        assertEquals(index, cell.getIndex(), "off range index");
+        assertNull(cell.getItem(), "off range cell item must be null");
+        assertTrue(cell.isEmpty(), "off range cell must be empty");
+    }
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableCellTest.java
@@ -1290,6 +1290,45 @@ public class TreeTableCellTest {
         assertTrue(isItemChangedCalled.get());
     }
 
+    @Test
+    public void testNullItemUpdateIndexNegative() {
+        setupNullValueColumn();
+        cell.updateIndex(1);
+        assertInRangeNullItemState(1);
+        cell.updateIndex(-1);
+        assertOffRangeState(-1);
+    }
+
+    @Test
+    public void testNullItemUpdateIndexOffRange() {
+        setupNullValueColumn();
+        cell.updateIndex(1);
+        assertInRangeNullItemState(1);
+        int offRange = tree.getExpandedItemCount();
+        cell.updateIndex(offRange);
+        assertOffRangeState(offRange);
+    }
+
+    private void setupNullValueColumn() {
+        TreeTableColumn<String, String> column = new TreeTableColumn<>("TEST");
+        column.setCellValueFactory(cd -> null);
+        tree.getColumns().add(column);
+        cell.updateTableColumn(column);
+        cell.updateTreeTableView(tree);
+    }
+
+    private void assertInRangeNullItemState(int index) {
+        assertEquals(index, cell.getIndex(), "in range index");
+        assertNull(cell.getItem(), "in range cell item must be null");
+        assertFalse(cell.isEmpty(), "in range cell with null item must not be empty");
+    }
+
+    private void assertOffRangeState(int index) {
+        assertEquals(index, cell.getIndex(), "off range index");
+        assertNull(cell.getItem(), "off range cell item must be null");
+        assertTrue(cell.isEmpty(), "off range cell must be empty");
+    }
+
     public static class MisbehavingOnCancelTreeTableCell<S, T> extends TreeTableCell<S, T> {
 
         @Override

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableRowTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableRowTest.java
@@ -624,6 +624,22 @@ public class TreeTableRowTest {
 //        assertTrue(called[0]);
 //    }
 
+    @Test public void editCellOnEmptyRowDoesNotFireEditStartEvent() {
+        tree.setEditable(true);
+        cell.updateTreeTableView(tree);
+        // an index past the expanded items, so that the row is empty
+        cell.updateIndex(tree.getExpandedItemCount());
+
+        AtomicInteger counter = new AtomicInteger();
+        tree.addEventHandler(TreeTableView.editStartEvent(), event -> counter.incrementAndGet());
+
+        cell.startEdit();
+
+        assertTrue(cell.isEmpty());
+        assertFalse(cell.isEditing());
+        assertEquals(0, counter.get());
+    }
+
     // commitEdit()
     @Test public void commitWhenTreeIsNullIsOK() {
         cell.updateIndex(1);
@@ -1017,5 +1033,44 @@ public class TreeTableRowTest {
         for (TreeTableCell<String, String> cell : cells) {
             assertEquals(1, cell.getIndex());
         }
+    }
+
+    /**
+     * A row with a null item at a valid index is not empty, so it must be cleaned up when its index is moved off-range.
+     */
+    @Test
+    public void testNullItemUpdateIndexNegative() {
+        setupNullValueItem();
+        cell.updateIndex(1);
+        assertInRangeNullItemState(1);
+        cell.updateIndex(-1);
+        assertOffRangeState(-1);
+    }
+
+    @Test
+    public void testNullItemUpdateIndexOffRange() {
+        setupNullValueItem();
+        cell.updateIndex(1);
+        assertInRangeNullItemState(1);
+        int offRange = tree.getExpandedItemCount();
+        cell.updateIndex(offRange);
+        assertOffRangeState(offRange);
+    }
+
+    private void setupNullValueItem() {
+        apples.setValue(null);
+        cell.updateTreeTableView(tree);
+    }
+
+    private void assertInRangeNullItemState(int index) {
+        assertEquals(index, cell.getIndex(), "in range index");
+        assertNull(cell.getItem(), "in range row item must be null");
+        assertFalse(cell.isEmpty(), "in range row with null item must not be empty");
+    }
+
+    private void assertOffRangeState(int index) {
+        assertEquals(index, cell.getIndex(), "off range index");
+        assertNull(cell.getItem(), "off range row item must be null");
+        assertTrue(cell.isEmpty(), "off range row must be empty");
     }
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/cell/ChoiceBoxListCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/cell/ChoiceBoxListCellTest.java
@@ -298,11 +298,11 @@ public class ChoiceBoxListCellTest {
     }
 
     @Test public void test_startEdit_listViewEditableIsTrue_isNotEmpty() {
-        ListView listView = new ListView();
+        ListView listView = new ListView(FXCollections.observableArrayList("TEST"));
         listView.setEditable(true);
         ChoiceBoxListCell<Object> cell = new ChoiceBoxListCell<>();
         cell.updateListView(listView);
-        cell.updateItem("TEST", false);
+        cell.updateIndex(0);
 
         cell.startEdit();
         assertTrue(cell.isEditing());
@@ -310,12 +310,12 @@ public class ChoiceBoxListCellTest {
     }
 
     @Test public void test_startEdit_listViewEditableIsTrue_cellEditableIsTrue_isNotEmpty() {
-        ListView listView = new ListView();
+        ListView listView = new ListView(FXCollections.observableArrayList("TEST"));
         listView.setEditable(true);
         ChoiceBoxListCell<Object> cell = new ChoiceBoxListCell<>();
         cell.setEditable(true);
         cell.updateListView(listView);
-        cell.updateItem("TEST", false);
+        cell.updateIndex(0);
 
         cell.startEdit();
         assertTrue(cell.isEditing());
@@ -324,11 +324,11 @@ public class ChoiceBoxListCellTest {
 
     // --- cancel edit
     @Test public void test_cancelEdit() {
-        ListView listView = new ListView();
+        ListView listView = new ListView(FXCollections.observableArrayList("TEST"));
         listView.setEditable(true);
         ChoiceBoxListCell<Object> cell = new ChoiceBoxListCell<>();
         cell.updateListView(listView);
-        cell.updateItem("TEST", false);
+        cell.updateIndex(0);
 
         cell.startEdit();
         assertTrue(cell.isEditing());
@@ -340,11 +340,11 @@ public class ChoiceBoxListCellTest {
     }
 
     @Test public void test_rt_29320() {
-        ListView listView = new ListView();
+        ListView listView = new ListView(FXCollections.observableArrayList("TEST"));
         listView.setEditable(true);
         ChoiceBoxListCell<Object> cell = new ChoiceBoxListCell<>();
         cell.updateListView(listView);
-        cell.updateItem("TEST", false);
+        cell.updateIndex(0);
         cell.setEditable(true);
 
         cell.startEdit();

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/cell/ComboBoxListCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/cell/ComboBoxListCellTest.java
@@ -292,11 +292,11 @@ public class ComboBoxListCellTest {
     }
 
     @Test public void test_startEdit_listViewEditableIsTrue_isNotEmpty() {
-        ListView listView = new ListView();
+        ListView listView = new ListView(FXCollections.observableArrayList("TEST"));
         listView.setEditable(true);
         ComboBoxListCell<Object> cell = new ComboBoxListCell<>();
         cell.updateListView(listView);
-        cell.updateItem("TEST", false);
+        cell.updateIndex(0);
 
         cell.startEdit();
         assertTrue(cell.isEditing());
@@ -304,12 +304,12 @@ public class ComboBoxListCellTest {
     }
 
     @Test public void test_startEdit_listViewEditableIsTrue_cellEditableIsTrue_isNotEmpty() {
-        ListView listView = new ListView();
+        ListView listView = new ListView(FXCollections.observableArrayList("TEST"));
         listView.setEditable(true);
         ComboBoxListCell<Object> cell = new ComboBoxListCell<>();
         cell.setEditable(true);
         cell.updateListView(listView);
-        cell.updateItem("TEST", false);
+        cell.updateIndex(0);
 
         cell.startEdit();
         assertTrue(cell.isEditing());
@@ -318,11 +318,11 @@ public class ComboBoxListCellTest {
 
     // --- cancel edit
     @Test public void test_cancelEdit() {
-        ListView listView = new ListView();
+        ListView listView = new ListView(FXCollections.observableArrayList("TEST"));
         listView.setEditable(true);
         ComboBoxListCell<Object> cell = new ComboBoxListCell<>();
         cell.updateListView(listView);
-        cell.updateItem("TEST", false);
+        cell.updateIndex(0);
 
         cell.startEdit();
         assertTrue(cell.isEditing());
@@ -334,11 +334,11 @@ public class ComboBoxListCellTest {
     }
 
     @Test public void test_rt_29320() {
-        ListView listView = new ListView();
+        ListView listView = new ListView(FXCollections.observableArrayList("TEST"));
         listView.setEditable(true);
         ComboBoxListCell<Object> cell = new ComboBoxListCell<>();
         cell.updateListView(listView);
-        cell.updateItem("TEST", false);
+        cell.updateIndex(0);
         cell.setEditable(true);
 
         cell.startEdit();

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/cell/TextFieldListCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/cell/TextFieldListCellTest.java
@@ -30,6 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import javafx.collections.FXCollections;
 import javafx.scene.control.ListCell;
 import javafx.scene.control.ListView;
 import javafx.scene.control.cell.TextFieldListCell;
@@ -284,11 +285,11 @@ public class TextFieldListCellTest {
     }
 
     @Test public void test_startEdit_listViewEditableIsTrue_isNotEmpty() {
-        ListView listView = new ListView();
+        ListView listView = new ListView(FXCollections.observableArrayList("TEST"));
         listView.setEditable(true);
         TextFieldListCell<Object> cell = new TextFieldListCell<>();
         cell.updateListView(listView);
-        cell.updateItem("TEST", false);
+        cell.updateIndex(0);
 
         cell.startEdit();
         assertTrue(cell.isEditing());
@@ -296,12 +297,12 @@ public class TextFieldListCellTest {
     }
 
     @Test public void test_startEdit_listViewEditableIsTrue_cellEditableIsTrue_isNotEmpty() {
-        ListView listView = new ListView();
+        ListView listView = new ListView(FXCollections.observableArrayList("TEST"));
         listView.setEditable(true);
         TextFieldListCell<Object> cell = new TextFieldListCell<>();
         cell.setEditable(true);
         cell.updateListView(listView);
-        cell.updateItem("TEST", false);
+        cell.updateIndex(0);
 
         cell.startEdit();
         assertTrue(cell.isEditing());
@@ -310,11 +311,11 @@ public class TextFieldListCellTest {
 
     // --- cancel edit
     @Test public void test_cancelEdit() {
-        ListView listView = new ListView();
+        ListView listView = new ListView(FXCollections.observableArrayList("TEST"));
         listView.setEditable(true);
         TextFieldListCell<Object> cell = new TextFieldListCell<>();
         cell.updateListView(listView);
-        cell.updateItem("TEST", false);
+        cell.updateIndex(0);
 
         cell.startEdit();
         assertTrue(cell.isEditing());


### PR DESCRIPTION
@andy-goryachev-oracle, as discussed in https://github.com/openjdk/jfx/pull/1935 where we saw some code in cells that is vastly different from other cells.

This PR tries to unify the cell logic. The code really is all over the place, each cell has at least some special logic or some fixes were only applied to some cells, ...

Three major things:
- Some cells did not update correctly when the value is null
- `ListView.EditEvent` had no old value
- `TableView` had no `EditEvent` at all, while they are actually very useful for some kind of on-commit handling. I can't explain how every virtualized container got that but they forgot the `TableView` ...

So naturally, this PR got a bit bigger. I might manage to split that. Also improved the `CellTest`.

For now, I would like to get your opinion first and if you think this the right way forward.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[ \] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2295/head:pull/2295` \
`$ git checkout pull/2295`

Update a local copy of the PR: \
`$ git checkout pull/2295` \
`$ git pull https://git.openjdk.org/jfx.git pull/2295/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2295`

View PR using the GUI difftool: \
`$ git pr show -t 2295`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2295.diff">https://git.openjdk.org/jfx/pull/2295.diff</a>

</details>
