### PR TITLE
8156779: GTK3: warning when running SwingNode applications

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/gtk/GlassApplication.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/GlassApplication.cpp
@@ -53,6 +53,12 @@ PlatformSupport* platformSupport = NULL;
 
 extern gboolean disableGrab;
 
+// Silently consume X errors for the lifetime of the GTK main loop.
+static int glass_x_error_handler(Display*, XErrorEvent*)
+{
+    return 0;
+}
+
 void checkGtkVersion(JNIEnv* env, jint reqMajor) {
     // Major version is checked before loading
     // GTK_3_MIN_MINOR_VERSION and GTK_3_MIN_MICRO_VERSION comes from the build system
@@ -226,7 +232,7 @@ JNIEXPORT void JNICALL Java_com_sun_glass_ui_gtk_GtkApplication__1runLoop
     // Disable X error handling
 #ifndef VERBOSE
     if (!noErrorTrap) {
-        gdk_error_trap_push();
+        XSetErrorHandler(glass_x_error_handler);
     }
 #endif
 
@@ -242,7 +248,7 @@ JNIEXPORT void JNICALL Java_com_sun_glass_ui_gtk_GtkApplication__1runLoop
     // Restore X error handling
     // #ifndef VERBOSE
     //     if (!noErrorTrap) {
-    //         gdk_error_trap_pop();
+    //         XSetErrorHandler(NULL);
     //     }
     // #endif
 


### PR DESCRIPTION
This PR fixes a Warning I always get when JavaFX and Swing are both mixed together in an application.
The error: `XSetErrorHandler() called with a GDK error trap pushed. Don't do that.`

The problem is that we call `gdk_error_trap_push`, which will result in this warning when there was already an `XSetErrorHandler` set previously, in this case Swing.

See also:
- https://gitlab.gnome.org/GNOME/gtk/-/blob/gtk-3-24/gdk/x11/gdkmain-x11.c#L313

Checking the Swing code, we just call `XSetErrorHandler` and not `gdk_error_trap_push`. See also:

- [XlibWrapper](https://github.com/openjdk/jdk/blob/master/src/java.desktop/unix/native/libawt_xawt/xawt/XlibWrapper.c#L1328)
- [gtk3_interface](https://github.com/openjdk/jdk/blob/master/src/java.desktop/unix/native/libawt_xawt/awt/gtk3_interface.c#L679)

`gdk_error_trap_push` will call `XSetErrorHandler`, so we might as well do that directly.
I checked the code in `gdk_error_trap_push` I do not see any problems with this new approach.

cc @tsayao, a review is appreciated.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8156779](https://bugs.openjdk.org/browse/JDK-8156779): GTK3: warning when running SwingNode applications (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2296/head:pull/2296` \
`$ git checkout pull/2296`

Update a local copy of the PR: \
`$ git checkout pull/2296` \
`$ git pull https://git.openjdk.org/jfx.git pull/2296/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2296`

View PR using the GUI difftool: \
`$ git pr show -t 2296`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2296.diff">https://git.openjdk.org/jfx/pull/2296.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2296#issuecomment-5551605078)
</details>
