### PR TITLE
8391883: Headless Tests may throw Exception when matching a KeyCharacterCombination

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/headless/HeadlessApplication.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/headless/HeadlessApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Gluon. All rights reserved.
+ * Copyright (c) 2025, 2026, Gluon. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -240,7 +240,60 @@ public class HeadlessApplication extends Application {
 
     @Override
     protected int _getKeyCodeForChar(char c, int hint) {
-        throw new UnsupportedOperationException("Not supported yet.");
+        c = Character.toUpperCase(c);
+        c = characterWithoutShift(c);
+        if (c >= 'A' && c <= 'Z') {
+            return (c - 'A') + KeyEvent.VK_A;
+        } else if (c >= '0' && c <= '9') {
+            return (c - '0') + KeyEvent.VK_0;
+        }
+        return switch (c) {
+            case '`' -> KeyEvent.VK_BACK_QUOTE;
+            case '-' -> KeyEvent.VK_MINUS;
+            case '=' -> KeyEvent.VK_EQUALS;
+            case '[' -> KeyEvent.VK_BRACELEFT;
+            case ']' -> KeyEvent.VK_BRACERIGHT;
+            case '\\' -> KeyEvent.VK_BACK_SLASH;
+            case ';' -> KeyEvent.VK_SEMICOLON;
+            case '\'' -> KeyEvent.VK_QUOTE;
+            case ',' -> KeyEvent.VK_COMMA;
+            case '.' -> KeyEvent.VK_PERIOD;
+            case '/' -> KeyEvent.VK_SLASH;
+            default -> KeyEvent.VK_UNDEFINED;
+        };
+    }
+
+    /**
+     * Removes the shift modification (US keyboard layout), if needed.
+     *
+     * @param c the character
+     * @return the eventually modified character
+     */
+    private static char characterWithoutShift(char c) {
+        return switch (c) {
+            case '!' -> '1';
+            case '@' -> '2';
+            case '#' -> '3';
+            case '$' -> '4';
+            case '%' -> '5';
+            case '^' -> '6';
+            case '&' -> '7';
+            case '*' -> '8';
+            case '(' -> '9';
+            case ')' -> '0';
+            case '~' -> '`';
+            case '_' -> '-';
+            case '+' -> '=';
+            case '{' -> '[';
+            case '}' -> ']';
+            case '|' -> '\\';
+            case ':' -> ';';
+            case '\"' -> '\'';
+            case '<' -> ',';
+            case '>' -> '.';
+            case '?' -> '/';
+            default -> c;
+        };
     }
 
 }

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/headless/HeadlessApplication.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/headless/HeadlessApplication.java
@@ -240,6 +240,9 @@ public class HeadlessApplication extends Application {
 
     @Override
     protected int _getKeyCodeForChar(char c, int hint) {
+        if (charForNumpadKeyCode(hint) == c) {
+            return hint;
+        }
         c = Character.toUpperCase(c);
         c = characterWithoutShift(c);
         if (c >= 'A' && c <= 'Z') {
@@ -248,6 +251,7 @@ public class HeadlessApplication extends Application {
             return (c - '0') + KeyEvent.VK_0;
         }
         return switch (c) {
+            case ' ' -> KeyEvent.VK_SPACE;
             case '`' -> KeyEvent.VK_BACK_QUOTE;
             case '-' -> KeyEvent.VK_MINUS;
             case '=' -> KeyEvent.VK_EQUALS;
@@ -264,7 +268,35 @@ public class HeadlessApplication extends Application {
     }
 
     /**
-     * Removes the shift modification (US keyboard layout), if needed.
+     * Returns the character produced by the given numpad key code (US keyboard layout),
+     * or {@code '\0'} if there is no character for the numpad key code.
+     *
+     * @param keyCode the key code
+     * @return the produced character, or {@code '\0'}
+     */
+    private static char charForNumpadKeyCode(int keyCode) {
+        return switch (keyCode) {
+            case KeyEvent.VK_NUMPAD0 -> '0';
+            case KeyEvent.VK_NUMPAD1 -> '1';
+            case KeyEvent.VK_NUMPAD2 -> '2';
+            case KeyEvent.VK_NUMPAD3 -> '3';
+            case KeyEvent.VK_NUMPAD4 -> '4';
+            case KeyEvent.VK_NUMPAD5 -> '5';
+            case KeyEvent.VK_NUMPAD6 -> '6';
+            case KeyEvent.VK_NUMPAD7 -> '7';
+            case KeyEvent.VK_NUMPAD8 -> '8';
+            case KeyEvent.VK_NUMPAD9 -> '9';
+            case KeyEvent.VK_DIVIDE -> '/';
+            case KeyEvent.VK_MULTIPLY -> '*';
+            case KeyEvent.VK_SUBTRACT -> '-';
+            case KeyEvent.VK_ADD -> '+';
+            case KeyEvent.VK_DECIMAL -> '.';
+            default -> '\0';
+        };
+    }
+
+    /**
+     * Removes the shift modification (US keyboard layout), and returns the new character, if needed.
      *
      * @param c the character
      * @return the eventually modified character

--- a/tests/system/src/test/java/test/com/sun/glass/ui/headless/HeadlessApplicationKeyCombinationTest.java
+++ b/tests/system/src/test/java/test/com/sun/glass/ui/headless/HeadlessApplicationKeyCombinationTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package test.com.sun.glass.ui.headless;
+
+import javafx.application.Platform;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyCombination;
+import javafx.scene.input.KeyEvent;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class HeadlessApplicationKeyCombinationTest {
+
+    @BeforeAll
+    public static void setup() throws Exception {
+        System.setProperty("glass.platform", "Headless");
+        System.setProperty("prism.order", "sw");
+
+        AtomicBoolean fail = new AtomicBoolean();
+
+        CountDownLatch waitLatch = new CountDownLatch(1);
+        Platform.startup(waitLatch::countDown);
+        try {
+            if (!waitLatch.await(1, TimeUnit.SECONDS)) {
+                fail.set(true);
+            }
+        } catch (InterruptedException e) {
+            fail.set(true);
+        }
+        assertFalse(fail.get());
+    }
+
+    @Test
+    public void testKeyCharacterCombinationMatching() {
+        KeyCombination combination = KeyCombination.valueOf("shortcut+,");
+
+        KeyEvent event = new KeyEvent(KeyEvent.KEY_PRESSED, "s", "S", KeyCode.S, false, true, false, false);
+        boolean match = combination.match(event);
+
+        assertFalse(match);
+
+        event = new KeyEvent(KeyEvent.KEY_PRESSED, ",", ",", KeyCode.COMMA, false, true, false, false);
+        match = combination.match(event);
+
+        assertTrue(match);
+    }
+
+}

--- a/tests/system/src/test/java/test/com/sun/glass/ui/headless/HeadlessApplicationKeyCombinationTest.java
+++ b/tests/system/src/test/java/test/com/sun/glass/ui/headless/HeadlessApplicationKeyCombinationTest.java
@@ -72,6 +72,19 @@ public class HeadlessApplicationKeyCombinationTest {
     }
 
     @Test
+    public void testShiftedCharacterMatchesUnshiftedKey() {
+        KeyCombination combination = KeyCombination.valueOf("'+'");
+        assertTrue(combination.match(keyPressed("=", KeyCode.EQUALS)));
+        assertTrue(combination.match(keyPressed("+", KeyCode.ADD)));
+
+        combination = KeyCombination.valueOf("'?'");
+        assertTrue(combination.match(keyPressed("/", KeyCode.SLASH)));
+
+        combination = KeyCombination.valueOf("':'");
+        assertTrue(combination.match(keyPressed(";", KeyCode.SEMICOLON)));
+    }
+
+    @Test
     public void testNumpadKeyMatchesCharacterOfNumpadKey() {
         KeyCombination combination = KeyCombination.valueOf("'*'");
         assertTrue(combination.match(keyPressed("*", KeyCode.MULTIPLY)));

--- a/tests/system/src/test/java/test/com/sun/glass/ui/headless/HeadlessApplicationKeyCombinationTest.java
+++ b/tests/system/src/test/java/test/com/sun/glass/ui/headless/HeadlessApplicationKeyCombinationTest.java
@@ -69,9 +69,12 @@ public class HeadlessApplicationKeyCombinationTest {
         assertFalse(match);
 
         event = new KeyEvent(KeyEvent.KEY_PRESSED, ",", ",", KeyCode.COMMA, false, true, false, false);
-        match = combination.match(event);
+        boolean otherOSMatch = combination.match(event);
 
-        assertTrue(match);
+        event = new KeyEvent(KeyEvent.KEY_PRESSED, ",", ",", KeyCode.COMMA, false, false, false, true);
+        boolean macOSMatch = combination.match(event);
+
+        assertTrue(otherOSMatch ^ macOSMatch);
     }
 
 }

--- a/tests/system/src/test/java/test/com/sun/glass/ui/headless/HeadlessApplicationKeyCombinationTest.java
+++ b/tests/system/src/test/java/test/com/sun/glass/ui/headless/HeadlessApplicationKeyCombinationTest.java
@@ -60,21 +60,50 @@ public class HeadlessApplicationKeyCombinationTest {
     }
 
     @Test
-    public void testKeyCharacterCombinationMatching() {
+    public void testKeyCharacterCombinationShortcutMatching() {
         KeyCombination combination = KeyCombination.valueOf("shortcut+,");
 
-        KeyEvent event = new KeyEvent(KeyEvent.KEY_PRESSED, "s", "S", KeyCode.S, false, true, false, false);
-        boolean match = combination.match(event);
+        assertFalse(combination.match(keyPressed(",", KeyCode.COMMA, false, false)));
 
-        assertFalse(match);
-
-        event = new KeyEvent(KeyEvent.KEY_PRESSED, ",", ",", KeyCode.COMMA, false, true, false, false);
-        boolean otherOSMatch = combination.match(event);
-
-        event = new KeyEvent(KeyEvent.KEY_PRESSED, ",", ",", KeyCode.COMMA, false, false, false, true);
-        boolean macOSMatch = combination.match(event);
+        boolean otherOSMatch = combination.match(keyPressed(",", KeyCode.COMMA, true, false));
+        boolean macOSMatch = combination.match(keyPressed(",", KeyCode.COMMA, false, true));
 
         assertTrue(otherOSMatch ^ macOSMatch);
     }
 
+    @Test
+    public void testNumpadKeyMatchesCharacterOfNumpadKey() {
+        KeyCombination combination = KeyCombination.valueOf("'*'");
+        assertTrue(combination.match(keyPressed("*", KeyCode.MULTIPLY)));
+
+        combination = KeyCombination.valueOf("'8'");
+        assertTrue(combination.match(keyPressed("8", KeyCode.NUMPAD8)));
+        assertTrue(combination.match(keyPressed("8", KeyCode.DIGIT8)));
+
+        combination = KeyCombination.valueOf("'.'");
+        assertTrue(combination.match(keyPressed(".", KeyCode.DECIMAL)));
+        assertTrue(combination.match(keyPressed(".", KeyCode.PERIOD)));
+    }
+
+    @Test
+    public void testNumpadKeyDoesNotMatchCharacterOfOtherNumpadKey() {
+        KeyCombination combination = KeyCombination.valueOf("'*'");
+        assertFalse(combination.match(keyPressed("*", KeyCode.NUMPAD8)));
+        assertFalse(combination.match(keyPressed("*", KeyCode.ADD)));
+    }
+
+    @Test
+    public void testSpaceMatchesSpaceKey() {
+        KeyCombination combination = KeyCombination.valueOf("' '");
+        assertTrue(combination.match(keyPressed(" ", KeyCode.SPACE)));
+        assertFalse(combination.match(keyPressed(" ", KeyCode.ENTER)));
+    }
+
+    private static KeyEvent keyPressed(String character, KeyCode code) {
+        return keyPressed(character, code, false, false);
+    }
+
+    private static KeyEvent keyPressed(String character, KeyCode code, boolean controlDown, boolean metaDown) {
+        return new KeyEvent(KeyEvent.KEY_PRESSED, character, character, code, false, controlDown, false, metaDown);
+    }
 }


### PR DESCRIPTION
Issue only exists in the Headless platform. Consider this test code:

```java
KeyCombination combination = KeyCombination.valueOf("shortcut+,");

KeyEvent event = new KeyEvent(KeyEvent.KEY_PRESSED, "s", "S", KeyCode.S, false, true, false, false);
boolean match = combination.match(event);
```

What happens is that the KeyCombination is an instance of `KeyCharacterCombination`.

`KeyCharacterCombination` is special, because in its `match` function, it will call: 
`Toolkit.getToolkit().getKeyCodeForChar(getCharacter(), code));`
which will be delegated to the `HeadlessApplication`, which will throw an `UnsupportedOperationException`.

Most of the time, the `KeyCombination` is not an instance of `KeyCharacterCombination`, so this exception can only be reproduced with more special combinations like in the example with the comma.

I used the implementation we also use in `Monocle`. Rechecked with the US keyboard layout on a mac.

---

Trivia: JabRef found this issue when changing their tests from Monocle to Headless: [GHA run](https://github.com/JabRef/jabref/actions/runs/34032443925/job/101484543433?pr=16850)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8391883](https://bugs.openjdk.org/browse/JDK-8391883): Headless Tests may throw Exception when matching a KeyCharacterCombination (**Bug** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Martin Fox](https://openjdk.org/census#mfox) (@beldenfox - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2297/head:pull/2297` \
`$ git checkout pull/2297`

Update a local copy of the PR: \
`$ git checkout pull/2297` \
`$ git pull https://git.openjdk.org/jfx.git pull/2297/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2297`

View PR using the GUI difftool: \
`$ git pr show -t 2297`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2297.diff">https://git.openjdk.org/jfx/pull/2297.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2297#issuecomment-5560243287)
</details>
