### PR TITLE
8377370: GHA: Update macOS / aarch64 build to use macos-15 runner

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -321,7 +321,7 @@ jobs:
   macos_aarch64_build:
     name: macOS aarch64
     needs: validation
-    runs-on: "macos-14"
+    runs-on: "macos-15"
 
     env:
       # FIXME: read this information from a property file
@@ -383,7 +383,8 @@ jobs:
           java -version
           which ant
           ant -version
-          sudo xcode-select --switch /Applications/Xcode_15.4.app/Contents/Developer
+          # Production builds use Xcode 15.4, but 16.0 is the lowest that the GHA macOS 15 runner supports
+          sudo xcode-select --switch /Applications/Xcode_16.0.app/Contents/Developer
           xcodebuild -version
 
       - name: Build JavaFX artifacts


### PR DESCRIPTION
Update the macOS 14 arm64 runner to macOS 15.

As announced here: https://github.com/actions/runner-images/issues/13518 , the macOS 14 arm64 images are already deprecated and will be retired soon.
Deprecation: July 6th, 2026
Retirement: November 2nd, 2026


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8377370](https://bugs.openjdk.org/browse/JDK-8377370): GHA: Update macOS / aarch64 build to use macos-15 runner (**Bug** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2298/head:pull/2298` \
`$ git checkout pull/2298`

Update a local copy of the PR: \
`$ git checkout pull/2298` \
`$ git pull https://git.openjdk.org/jfx.git pull/2298/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2298`

View PR using the GUI difftool: \
`$ git pr show -t 2298`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2298.diff">https://git.openjdk.org/jfx/pull/2298.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2298#issuecomment-5596139817)
</details>
