### PR TITLE
8389363: [testbug] InitializeJavaFXLaunchBase should use a 15-second timeout 

### DIFF
--- a/tests/system/src/test/java/test/com/sun/javafx/application/InitializeJavaFXLaunchBase.java
+++ b/tests/system/src/test/java/test/com/sun/javafx/application/InitializeJavaFXLaunchBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,6 +45,6 @@ public class InitializeJavaFXLaunchBase extends InitializeJavaFXBase {
         new Thread(() -> {
             Application.launch(InitializeApp.class);
         }).start();
-        assertTrue(appLatch.await(5, TimeUnit.SECONDS));
+        assertTrue(appLatch.await(15, TimeUnit.SECONDS));
     }
 }

--- a/tests/system/src/test/java/test/com/sun/javafx/application/InitializeJavaFXLaunchBase.java
+++ b/tests/system/src/test/java/test/com/sun/javafx/application/InitializeJavaFXLaunchBase.java
@@ -31,6 +31,8 @@ import java.util.concurrent.TimeUnit;
 import javafx.application.Application;
 import javafx.stage.Stage;
 
+import test.util.Util;
+
 public class InitializeJavaFXLaunchBase extends InitializeJavaFXBase {
     public static final CountDownLatch appLatch = new CountDownLatch(1);
 
@@ -45,6 +47,6 @@ public class InitializeJavaFXLaunchBase extends InitializeJavaFXBase {
         new Thread(() -> {
             Application.launch(InitializeApp.class);
         }).start();
-        assertTrue(appLatch.await(15, TimeUnit.SECONDS));
+        assertTrue(appLatch.await(Util.STARTUP_TIMEOUT, TimeUnit.SECONDS));
     }
 }


### PR DESCRIPTION
When running tests in DebugNative I caught this testbug, `InitializeJavaFX` tests used a 5-second startup timeout while in all other tests we assume a 15 second timeout.

This change fixes this discrepancy by using `test.util.Util.STARTUP_TIMEOUT` constant instead of a magic number in `InitializeJavaFXLaunchBase`. This lines up the startup timeout for these tests with all other tests we have.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8389363](https://bugs.openjdk.org/browse/JDK-8389363): [testbug] InitializeJavaFXLaunchBase should use a 15-second timeout (**Bug** - P4)


### Reviewers
 * [Marius Hanl](https://openjdk.org/census#mhanl) (@Maran23 - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2300/head:pull/2300` \
`$ git checkout pull/2300`

Update a local copy of the PR: \
`$ git checkout pull/2300` \
`$ git pull https://git.openjdk.org/jfx.git pull/2300/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2300`

View PR using the GUI difftool: \
`$ git pr show -t 2300`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2300.diff">https://git.openjdk.org/jfx/pull/2300.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2300#issuecomment-5584966639)
</details>
