### PR TITLE
Clarify that Javadoc indent is 4 spaces

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -224,7 +224,7 @@ The following formatting rules are enforced for source code files by
 
 Please also follow these formatting guidelines:
 
-* Java indent is 4 spaces
+* Java and Javadoc indent is 4 spaces
 * Line width is no more than 120 characters
 * The rest is left to Java coding standards
 * Avoid making changes that are unrelated to the bug you are fixing. This includes fixing minor errors such as warnings, spacing / indentation, spelling errors, etc, in code that you aren't otherwise modifying as part of your fix.


### PR DESCRIPTION
This issue has now come up repeatedly, and I don't think it's a good investment of time to discuss it again and again.

The style guide says that Java indent is 4 spaces. Make it clear that this also applies to Javadoc documentation, because it is an inseparable part of Java code and not a personal expression of creativity.

If you have a list or a table in your Javadoc, then indent its elements with the default Java indentation. That is all.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[ \] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2301/head:pull/2301` \
`$ git checkout pull/2301`

Update a local copy of the PR: \
`$ git checkout pull/2301` \
`$ git pull https://git.openjdk.org/jfx.git pull/2301/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2301`

View PR using the GUI difftool: \
`$ git pr show -t 2301`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2301.diff">https://git.openjdk.org/jfx/pull/2301.diff</a>

</details>
