### PR TITLE
8392013: CSS transition can not be deserialized

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/css/InterpolatorConverter.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/css/InterpolatorConverter.java
@@ -32,7 +32,6 @@ import javafx.css.StyleConverter;
 import javafx.geometry.Point2D;
 import javafx.scene.text.Font;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -46,8 +45,8 @@ import java.util.Map;
  * </ol>
  * <p>
  * If the value is a {@code ParsedValue} array, the first element represents the name of the function
- * ({@code linear}, {@code cubic-bezier}, or {@code steps}), and the second element contains a list of
- * arguments.
+ * ({@code linear}, {@code cubic-bezier}, or {@code steps}), and the remaining values contain the
+ * function arguments.
  */
 public class InterpolatorConverter extends StyleConverter<Object, Interpolator> {
 
@@ -100,14 +99,14 @@ public class InterpolatorConverter extends StyleConverter<Object, Interpolator> 
         if (value.getValue() instanceof ParsedValue<?, ?>[] pv && pv[0].getValue() instanceof String funcName) {
             return switch (funcName) {
                 case "cubic-bezier(" -> CACHE.computeIfAbsent(value, key -> {
-                    List<Double> args = arguments(key);
-                    return Interpolator.ofSpline(args.get(0), args.get(1), args.get(2), args.get(3));
+                    return Interpolator.ofSpline(
+                        numberArg(pv, 1), numberArg(pv, 2),
+                        numberArg(pv, 3), numberArg(pv, 4));
                 });
 
                 case "steps(" -> CACHE.computeIfAbsent(value, key -> {
-                    List<Object> args = arguments(key);
-                    String position = args.get(1) != null ? (String)args.get(1) : "end";
-                    return Interpolator.ofSteps((int)args.get(0), switch (position) {
+                    String position = pv[2] != null ? (String)pv[2].getValue() : "end";
+                    return Interpolator.ofSteps(((Number)pv[1].getValue()).intValue(), switch (position) {
                         case "jump-start", "start" -> StepPosition.START;
                         case "jump-both" -> StepPosition.BOTH;
                         case "jump-none" -> StepPosition.NONE;
@@ -116,8 +115,7 @@ public class InterpolatorConverter extends StyleConverter<Object, Interpolator> 
                 });
 
                 case "linear(" -> CACHE.computeIfAbsent(value, key -> {
-                    List<Point2D> args = arguments(key);
-                    return Interpolator.ofLinear(args.toArray(Point2D[]::new));
+                    return Interpolator.ofLinear(pointArg(pv));
                 });
 
                 default -> throw new AssertionError();
@@ -127,10 +125,19 @@ public class InterpolatorConverter extends StyleConverter<Object, Interpolator> 
         throw new AssertionError();
     }
 
-    @SuppressWarnings("unchecked")
-    private <T> List<T> arguments(ParsedValue<?, ?> value) {
-        ParsedValue<?, ?>[] values = (ParsedValue<?, ?>[])value.getValue();
-        return (List<T>)values[1].getValue();
+    private double numberArg(ParsedValue<?, ?>[] values, int index) {
+        return ((Number)values[index].getValue()).doubleValue();
+    }
+
+    private Point2D[] pointArg(ParsedValue<?, ?>[] values) {
+        Point2D[] arguments = new Point2D[(values.length - 1) / 2];
+        for (int i = 1; i < values.length; i += 2) {
+            Number x = (Number)values[i].getValue();
+            Number y = (Number)values[i + 1].getValue();
+            arguments[i / 2] = new Point2D(x.doubleValue(), y.doubleValue());
+        }
+
+        return arguments;
     }
 
     /**

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/css/InterpolatorConverter.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/css/InterpolatorConverter.java
@@ -98,13 +98,13 @@ public class InterpolatorConverter extends StyleConverter<Object, Interpolator> 
 
         if (value.getValue() instanceof ParsedValue<?, ?>[] pv && pv[0].getValue() instanceof String funcName) {
             return switch (funcName) {
-                case "cubic-bezier(" -> CACHE.computeIfAbsent(value, key -> {
+                case "cubic-bezier(" -> CACHE.computeIfAbsent(value, _ -> {
                     return Interpolator.ofSpline(
                         numberArg(pv, 1), numberArg(pv, 2),
                         numberArg(pv, 3), numberArg(pv, 4));
                 });
 
-                case "steps(" -> CACHE.computeIfAbsent(value, key -> {
+                case "steps(" -> CACHE.computeIfAbsent(value, _ -> {
                     String position = pv[2] != null ? (String)pv[2].getValue() : "end";
                     return Interpolator.ofSteps(((Number)pv[1].getValue()).intValue(), switch (position) {
                         case "jump-start", "start" -> StepPosition.START;
@@ -114,7 +114,7 @@ public class InterpolatorConverter extends StyleConverter<Object, Interpolator> 
                     });
                 });
 
-                case "linear(" -> CACHE.computeIfAbsent(value, key -> {
+                case "linear(" -> CACHE.computeIfAbsent(value, _ -> {
                     return Interpolator.ofLinear(pointArg(pv));
                 });
 

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/css/ParsedValueImpl.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/css/ParsedValueImpl.java
@@ -706,9 +706,7 @@ public class ParsedValueImpl<V, T> extends ParsedValue<V,T> {
 
     private enum NumberType {
         INT(0, (stream, number) -> stream.writeInt(number.intValue()), stream -> stream.readInt()),
-        LONG(1, (stream, number) -> stream.writeLong(number.longValue()), stream -> stream.readLong()),
-        FLOAT(2, (stream, number) -> stream.writeFloat(number.floatValue()), stream -> stream.readFloat()),
-        DOUBLE(3, (stream, number) -> stream.writeDouble(number.doubleValue()), stream -> stream.readDouble());
+        DOUBLE(1, (stream, number) -> stream.writeDouble(number.doubleValue()), stream -> stream.readDouble());
 
         NumberType(int typeCode, Serializer serializer, Deserializer deserializer) {
             this.typeCode = typeCode;
@@ -723,8 +721,6 @@ public class ParsedValueImpl<V, T> extends ParsedValue<V,T> {
         static void writeBinary(DataOutputStream stream, Number number) throws IOException {
             NumberType typeCode = switch (number) {
                 case Integer _ -> INT;
-                case Long _ -> LONG;
-                case Float _ -> FLOAT;
                 case Double _ -> DOUBLE;
                 default -> throw new AssertionError();
             };
@@ -736,9 +732,7 @@ public class ParsedValueImpl<V, T> extends ParsedValue<V,T> {
         static Number readBinary(DataInputStream stream) throws IOException {
             NumberType typeCode = switch (stream.readUnsignedByte()) {
                 case 0 -> INT;
-                case 1 -> LONG;
-                case 2 -> FLOAT;
-                case 3 -> DOUBLE;
+                case 1 -> DOUBLE;
                 default -> throw new IOException("Unknown number type");
             };
 

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/css/ParsedValueImpl.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/css/ParsedValueImpl.java
@@ -705,12 +705,10 @@ public class ParsedValueImpl<V, T> extends ParsedValue<V,T> {
     }
 
     private enum NumberType {
-        BYTE(0, (stream, number) -> stream.writeByte(number.byteValue()), stream -> stream.readByte()),
-        SHORT(1, (stream, number) -> stream.writeShort(number.shortValue()), stream -> stream.readShort()),
-        INT(2, (stream, number) -> stream.writeInt(number.intValue()), stream -> stream.readInt()),
-        LONG(3, (stream, number) -> stream.writeLong(number.longValue()), stream -> stream.readLong()),
-        FLOAT(4, (stream, number) -> stream.writeFloat(number.floatValue()), stream -> stream.readFloat()),
-        DOUBLE(5, (stream, number) -> stream.writeDouble(number.doubleValue()), stream -> stream.readDouble());
+        INT(0, (stream, number) -> stream.writeInt(number.intValue()), stream -> stream.readInt()),
+        LONG(1, (stream, number) -> stream.writeLong(number.longValue()), stream -> stream.readLong()),
+        FLOAT(2, (stream, number) -> stream.writeFloat(number.floatValue()), stream -> stream.readFloat()),
+        DOUBLE(3, (stream, number) -> stream.writeDouble(number.doubleValue()), stream -> stream.readDouble());
 
         NumberType(int typeCode, Serializer serializer, Deserializer deserializer) {
             this.typeCode = typeCode;
@@ -724,8 +722,6 @@ public class ParsedValueImpl<V, T> extends ParsedValue<V,T> {
 
         static void writeBinary(DataOutputStream stream, Number number) throws IOException {
             NumberType typeCode = switch (number) {
-                case Byte _ -> BYTE;
-                case Short _ -> SHORT;
                 case Integer _ -> INT;
                 case Long _ -> LONG;
                 case Float _ -> FLOAT;
@@ -739,12 +735,10 @@ public class ParsedValueImpl<V, T> extends ParsedValue<V,T> {
 
         static Number readBinary(DataInputStream stream) throws IOException {
             NumberType typeCode = switch (stream.readUnsignedByte()) {
-                case 0 -> BYTE;
-                case 1 -> SHORT;
-                case 2 -> INT;
-                case 3 -> LONG;
-                case 4 -> FLOAT;
-                case 5 -> DOUBLE;
+                case 0 -> INT;
+                case 1 -> LONG;
+                case 2 -> FLOAT;
+                case 3 -> DOUBLE;
                 default -> throw new IOException("Unknown number type");
             };
 

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/css/ParsedValueImpl.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/css/ParsedValueImpl.java
@@ -33,6 +33,7 @@ import javafx.css.StyleConverter.StringStore;
 import javafx.scene.paint.Color;
 import javafx.scene.text.Font;
 
+import java.io.DataInput;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
@@ -705,8 +706,8 @@ public class ParsedValueImpl<V, T> extends ParsedValue<V,T> {
     }
 
     private enum NumberType {
-        INT(0, (stream, number) -> stream.writeInt(number.intValue()), stream -> stream.readInt()),
-        DOUBLE(1, (stream, number) -> stream.writeDouble(number.doubleValue()), stream -> stream.readDouble());
+        INT(0, (stream, number) -> stream.writeInt(number.intValue()), DataInputStream::readInt),
+        DOUBLE(1, (stream, number) -> stream.writeDouble(number.doubleValue()), DataInputStream::readDouble);
 
         NumberType(int typeCode, Serializer serializer, Deserializer deserializer) {
             this.typeCode = typeCode;
@@ -722,7 +723,7 @@ public class ParsedValueImpl<V, T> extends ParsedValue<V,T> {
             NumberType typeCode = switch (number) {
                 case Integer _ -> INT;
                 case Double _ -> DOUBLE;
-                default -> throw new AssertionError();
+                default -> throw new InternalError();
             };
 
             stream.writeByte(typeCode.typeCode);

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/css/ParsedValueImpl.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/css/ParsedValueImpl.java
@@ -428,7 +428,7 @@ public class ParsedValueImpl<V, T> extends ParsedValue<V,T> {
     final static private byte BOOLEAN = 7;
     final static private byte URL = 8;
     final static private byte SIZE = 9;
-
+    final static private byte NUMBER = 10;
 
     public final void writeBinary(DataOutputStream os, StringStore stringStore)
         throws IOException {
@@ -541,6 +541,10 @@ public class ParsedValueImpl<V, T> extends ParsedValue<V,T> {
 
             final int index = stringStore.addString(size.getUnits().name());
             os.writeShort(index);
+
+        } else if (value instanceof Number n) {
+            os.writeByte(NUMBER);
+            NumberType.writeBinary(os, n);
 
         } else if (value instanceof String) {
             os.writeByte(STRING);
@@ -676,6 +680,9 @@ public class ParsedValueImpl<V, T> extends ParsedValue<V,T> {
             }
             return new ParsedValueImpl<Size,Size>(new Size(val,units), converter, lookup);
 
+        } else if (valType == NUMBER) {
+            return new ParsedValueImpl(NumberType.readBinary(is), converter, lookup);
+
         } else if (valType == STRING) {
             String str = strings[is.readShort()];
             return new ParsedValueImpl(str, converter, lookup);
@@ -694,6 +701,62 @@ public class ParsedValueImpl<V, T> extends ParsedValue<V,T> {
 
         } else {
             throw new InternalError("unknown type: " + valType);
+        }
+    }
+
+    private enum NumberType {
+        BYTE(0, (stream, number) -> stream.writeByte(number.byteValue()), stream -> stream.readByte()),
+        SHORT(1, (stream, number) -> stream.writeShort(number.shortValue()), stream -> stream.readShort()),
+        INT(2, (stream, number) -> stream.writeInt(number.intValue()), stream -> stream.readInt()),
+        LONG(3, (stream, number) -> stream.writeLong(number.longValue()), stream -> stream.readLong()),
+        FLOAT(4, (stream, number) -> stream.writeFloat(number.floatValue()), stream -> stream.readFloat()),
+        DOUBLE(5, (stream, number) -> stream.writeDouble(number.doubleValue()), stream -> stream.readDouble());
+
+        NumberType(int typeCode, Serializer serializer, Deserializer deserializer) {
+            this.typeCode = typeCode;
+            this.serializer = serializer;
+            this.deserializer = deserializer;
+        }
+
+        final int typeCode;
+        final Serializer serializer;
+        final Deserializer deserializer;
+
+        static void writeBinary(DataOutputStream stream, Number number) throws IOException {
+            NumberType typeCode = switch (number) {
+                case Byte _ -> BYTE;
+                case Short _ -> SHORT;
+                case Integer _ -> INT;
+                case Long _ -> LONG;
+                case Float _ -> FLOAT;
+                case Double _ -> DOUBLE;
+                default -> throw new AssertionError();
+            };
+
+            stream.writeByte(typeCode.typeCode);
+            typeCode.serializer.serialize(stream, number);
+        }
+
+        static Number readBinary(DataInputStream stream) throws IOException {
+            NumberType typeCode = switch (stream.readUnsignedByte()) {
+                case 0 -> BYTE;
+                case 1 -> SHORT;
+                case 2 -> INT;
+                case 3 -> LONG;
+                case 4 -> FLOAT;
+                case 5 -> DOUBLE;
+                default -> throw new IOException("Unknown number type");
+            };
+
+            return typeCode.deserializer.deserialize(stream);
+        }
+
+        interface Serializer {
+            void serialize(DataOutputStream stream, Number number) throws IOException;
+        }
+
+        interface Deserializer {
+            Number deserialize(DataInputStream stream) throws IOException;
         }
     }
 }

--- a/modules/javafx.graphics/src/main/java/javafx/css/CssParser.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/CssParser.java
@@ -114,7 +114,6 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -4132,10 +4131,7 @@ final public class CssParser {
                     }
                 }
 
-                yield new ParsedValueImpl<>(new ParsedValueImpl[] {
-                        new ParsedValueImpl(term.token.getText(), null),
-                        new ParsedValueImpl(Arrays.asList(args), null)
-                    }, InterpolatorConverter.getInstance());
+                yield createEasingFunction(term.token.getText(), args);
             }
 
             case "steps(" -> {
@@ -4156,10 +4152,7 @@ final public class CssParser {
                     }
                 }
 
-                yield new ParsedValueImpl<>(new ParsedValueImpl[] {
-                        new ParsedValueImpl(term.token.getText(), null),
-                        new ParsedValueImpl(Arrays.asList(args), null)
-                    }, InterpolatorConverter.getInstance());
+                yield createEasingFunction(term.token.getText(), args);
             }
 
             case "linear(" -> {
@@ -4193,10 +4186,15 @@ final public class CssParser {
                     }
                 }
 
-                yield new ParsedValueImpl<>(new ParsedValueImpl[] {
-                        new ParsedValueImpl(term.token.getText(), null),
-                        new ParsedValueImpl(args, null)
-                    }, InterpolatorConverter.getInstance());
+                Object[] values = new Object[args.size() * 2];
+
+                for (int i = 0; i < args.size(); ++i) {
+                    Point2D point = args.get(i);
+                    values[i * 2] = point.getX();
+                    values[i * 2 + 1] = point.getY();
+                }
+
+                yield createEasingFunction(term.token.getText(), values);
             }
 
             default -> {
@@ -4205,6 +4203,17 @@ final public class CssParser {
                     InterpolatorConverter.getInstance());
             }
         };
+    }
+
+    private ParsedValueImpl<?, Interpolator> createEasingFunction(String name, Object[] arguments) {
+        ParsedValueImpl[] values = new ParsedValueImpl[arguments.length + 1];
+        values[0] = new ParsedValueImpl(name, null);
+
+        for (int i = 0; i < arguments.length; ++i) {
+            values[i + 1] = arguments[i] != null ? new ParsedValueImpl(arguments[i], null) : null;
+        }
+
+        return new ParsedValueImpl<>(values, InterpolatorConverter.getInstance());
     }
 
     // https://www.w3.org/TR/css-easing-2/#easing-functions

--- a/modules/javafx.graphics/src/main/java/javafx/css/StyleConverter.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/StyleConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -367,6 +367,12 @@ public class StyleConverter<F, T> {
         case "javafx.css.converter.CursorConverter" :
             styleConverter = javafx.css.converter.CursorConverter.getInstance();
             break;
+        case "javafx.css.converter.DurationConverter" :
+            styleConverter = DurationConverter.getInstance();
+            break;
+        case "javafx.css.converter.DurationConverter$SequenceConverter" :
+            styleConverter = DurationConverter.SequenceConverter.getInstance();
+            break;
         case "javafx.css.converter.EffectConverter" :
             styleConverter = javafx.css.converter.EffectConverter.getInstance();
             break;
@@ -430,6 +436,19 @@ public class StyleConverter<F, T> {
             break;
         case "javafx.css.converter.URLConverter$SequenceConverter" :
             styleConverter = javafx.css.converter.URLConverter.SequenceConverter.getInstance();
+            break;
+
+        case "com.sun.javafx.css.InterpolatorConverter" :
+            styleConverter = com.sun.javafx.css.InterpolatorConverter.getInstance();
+            break;
+        case "com.sun.javafx.css.InterpolatorConverter$SequenceConverter" :
+            styleConverter = com.sun.javafx.css.InterpolatorConverter.SequenceConverter.getInstance();
+            break;
+        case "com.sun.javafx.css.TransitionDefinitionConverter" :
+            styleConverter = com.sun.javafx.css.TransitionDefinitionConverter.getInstance();
+            break;
+        case "com.sun.javafx.css.TransitionDefinitionConverter$SequenceConverter" :
+            styleConverter = com.sun.javafx.css.TransitionDefinitionConverter.SequenceConverter.getInstance();
             break;
 
         // Region stuff  - including 2.x class names

--- a/modules/javafx.graphics/src/main/java/javafx/css/Stylesheet.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/Stylesheet.java
@@ -70,8 +70,9 @@ public class Stylesheet {
      * Version 7: user-preference media queries
      * Version 8: viewport characteristics media queries
      * Version 9: conditional stylesheet imports
+     * Version 10: direct serialization of Number types
      */
-    final static int BINARY_CSS_VERSION = 9;
+    final static int BINARY_CSS_VERSION = 10;
 
     private final String url;
     /**

--- a/modules/javafx.graphics/src/test/java/test/com/sun/javafx/css/converters/InterpolatorConverterTest.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/javafx/css/converters/InterpolatorConverterTest.java
@@ -31,7 +31,6 @@ import javafx.animation.Interpolator;
 import javafx.animation.Interpolator.StepPosition;
 import javafx.css.ParsedValue;
 import javafx.geometry.Point2D;
-import java.util.List;
 import java.util.Locale;
 import org.junit.jupiter.api.Test;
 
@@ -53,7 +52,9 @@ public class InterpolatorConverterTest {
     public void testConvertLinearInterpolatorWithControlPoints() {
         var value = new ParsedValueImpl<Object, Interpolator>(new ParsedValue[] {
             new ParsedValueImpl<>("linear(", null),
-            new ParsedValueImpl<>(List.of(new Point2D(0, 0), new Point2D(0.5, 0.25), new Point2D(1, 1)), null) },
+            new ParsedValueImpl<>(0.0, null), new ParsedValueImpl<>(0.0, null),
+            new ParsedValueImpl<>(0.5, null), new ParsedValueImpl<>(0.25, null),
+            new ParsedValueImpl<>(1.0, null), new ParsedValueImpl<>(1.0, null) },
             null);
         var result = InterpolatorConverter.getInstance().convert(value, null);
         assertInterpolatorEquals(ofLinear(new Point2D(0, 0), new Point2D(0.5, 0.25), new Point2D(1, 1)), result);
@@ -112,7 +113,8 @@ public class InterpolatorConverterTest {
     public void testConvertCubicBezierInterpolator() {
         var value = new ParsedValueImpl<Object, Interpolator>(new ParsedValue[] {
             new ParsedValueImpl<>("cubic-bezier(", null),
-            new ParsedValueImpl<>(List.of(0.1, 0.2, 0.3, 0.4), null) },
+            new ParsedValueImpl<>(0.1, null), new ParsedValueImpl<>(0.2, null),
+            new ParsedValueImpl<>(0.3, null), new ParsedValueImpl<>(0.4, null) },
             null);
         var result = InterpolatorConverter.getInstance().convert(value, null);
         assertInterpolatorEquals(ofSpline(0.1, 0.2, 0.3, 0.4), result);
@@ -138,7 +140,7 @@ public class InterpolatorConverterTest {
             var cssName = "jump-" + stepPosition.toString().toLowerCase(Locale.ROOT).replace('_', '-');
             var value = new ParsedValueImpl<Object, Interpolator>(new ParsedValue[] {
                 new ParsedValueImpl<>("steps(", null),
-                new ParsedValueImpl<>(List.of(3, cssName), null) },
+                new ParsedValueImpl<>(3, null), new ParsedValueImpl<>(cssName, null) },
                 null);
             var result = InterpolatorConverter.getInstance().convert(value, null);
             assertInterpolatorEquals(ofSteps(3, stepPosition), result);
@@ -150,12 +152,14 @@ public class InterpolatorConverterTest {
         var result1 = InterpolatorConverter.getInstance().convert(
             new ParsedValueImpl<>(new ParsedValueImpl[] {
                 new ParsedValueImpl<>("cubic-bezier(", null),
-                new ParsedValueImpl<>(List.of(0.1, 0.2, 0.3, 0.4), null) }, null),
+                new ParsedValueImpl<>(0.1, null), new ParsedValueImpl<>(0.2, null),
+                new ParsedValueImpl<>(0.3, null), new ParsedValueImpl<>(0.4, null) }, null),
             null);
         var result2 = InterpolatorConverter.getInstance().convert(
             new ParsedValueImpl<>(new ParsedValueImpl[] {
                 new ParsedValueImpl<>("cubic-bezier(", null),
-                new ParsedValueImpl<>(List.of(0.1, 0.2, 0.3, 0.4), null) }, null),
+                new ParsedValueImpl<>(0.1, null), new ParsedValueImpl<>(0.2, null),
+                new ParsedValueImpl<>(0.3, null), new ParsedValueImpl<>(0.4, null) }, null),
             null);
         assertSame(result1, result2);
     }

--- a/modules/javafx.graphics/src/test/java/test/javafx/css/ParsedValueTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/css/ParsedValueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -502,6 +502,23 @@ public class ParsedValueTest {
         }
 
     }
+
+    @Test
+    public void testWriteAndReadBinaryNumbers() {
+        Number[] numbers = {
+            Byte.MIN_VALUE,
+            Short.MIN_VALUE,
+            0x12345678,
+            0x0123456789ABCDEFL,
+            -123.75F,
+            Math.PI
+        };
+
+        for (Number number : numbers) {
+            writeAndReadBinary(new ParsedValueImpl<>(number, null));
+        }
+    }
+
     /**
      * Test of readBinary method, of class ParsedValueImpl.
      */

--- a/modules/javafx.graphics/src/test/java/test/javafx/css/ParsedValueTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/css/ParsedValueTest.java
@@ -507,7 +507,11 @@ public class ParsedValueTest {
     @Test
     public void testWriteAndReadBinaryNumbers() {
         Number[] numbers = {
+            Integer.MIN_VALUE,
+            Integer.MAX_VALUE,
             12345678,
+            Double.NaN,
+            -0.0,
             -123.5
         };
 

--- a/modules/javafx.graphics/src/test/java/test/javafx/css/ParsedValueTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/css/ParsedValueTest.java
@@ -44,6 +44,7 @@ import javafx.css.SizeUnits;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -506,14 +507,29 @@ public class ParsedValueTest {
     @Test
     public void testWriteAndReadBinaryNumbers() {
         Number[] numbers = {
-            0x12345678,
-            0x0123456789ABCDEFL,
-            -123.75F,
-            Math.PI
+            12345678,
+            -123.5
         };
 
         for (Number number : numbers) {
             writeAndReadBinary(new ParsedValueImpl<>(number, null));
+        }
+    }
+
+    @Test
+    public void testWriteBinaryFailsForUnsupportedNumberTypes() {
+        Number[] numbers = {
+            Byte.MIN_VALUE,
+            Short.MIN_VALUE,
+            0x0123456789ABCDEFL,
+            -123.75F
+        };
+
+        for (Number number : numbers) {
+            assertThrows(AssertionError.class, () ->
+                new ParsedValueImpl<>(number, null).writeBinary(
+                    new DataOutputStream(new ByteArrayOutputStream()), new StringStore()),
+                number.getClass().getName());
         }
     }
 

--- a/modules/javafx.graphics/src/test/java/test/javafx/css/ParsedValueTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/css/ParsedValueTest.java
@@ -506,8 +506,6 @@ public class ParsedValueTest {
     @Test
     public void testWriteAndReadBinaryNumbers() {
         Number[] numbers = {
-            Byte.MIN_VALUE,
-            Short.MIN_VALUE,
             0x12345678,
             0x0123456789ABCDEFL,
             -123.75F,

--- a/modules/javafx.graphics/src/test/java/test/javafx/css/ParsedValueTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/css/ParsedValueTest.java
@@ -530,7 +530,7 @@ public class ParsedValueTest {
         };
 
         for (Number number : numbers) {
-            assertThrows(AssertionError.class, () ->
+            assertThrows(InternalError.class, () ->
                 new ParsedValueImpl<>(number, null).writeBinary(
                     new DataOutputStream(new ByteArrayOutputStream()), new StringStore()),
                 number.getClass().getName());

--- a/modules/javafx.graphics/src/test/java/test/javafx/css/StylesheetTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/css/StylesheetTest.java
@@ -811,13 +811,19 @@ public class StylesheetTest {
         String css = """
             .control {
                 transition: -fx-background-color 120ms ease-out,
-                            -fx-opacity 0.2s 30ms linear;
+                            -fx-opacity 0.2s 30ms linear,
+                            -fx-scale-x 160ms cubic-bezier(0.1, 0.2, 0.3, 0.4),
+                            -fx-scale-y 0.2s steps(3, jump-both),
+                            -fx-rotate 180ms linear(0 0%, 0.25 50%, 1 100%);
             }
             .longhand {
                 transition-property: -fx-scale-x, -fx-scale-y;
                 transition-duration: 160ms, 0.2s;
                 transition-delay: 0s, -20ms;
-                transition-timing-function: ease-out, linear;
+                transition-timing-function: ease-out, linear,
+                                            cubic-bezier(0.5, 2, 0.5, -1),
+                                            step-start, step-end, steps(3),
+                                            linear(0 0%, 0.25 25% 75%, 1 100%);
             }
             @media (prefers-reduced-motion: reduce) {
                 .control { transition: all 0s; }

--- a/modules/javafx.graphics/src/test/java/test/javafx/css/StylesheetTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/css/StylesheetTest.java
@@ -25,6 +25,7 @@
 
 package test.javafx.css;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -803,6 +804,42 @@ public class StylesheetTest {
 
         root.applyCss();
         assertEquals(Background.fill(Color.RED), root.getBackground());
+    }
+
+    @Test
+    void serializeStylesheetWithTransitions() throws IOException {
+        String css = """
+            .control {
+                transition: -fx-background-color 120ms ease-out,
+                            -fx-opacity 0.2s 30ms linear;
+            }
+            .longhand {
+                transition-property: -fx-scale-x, -fx-scale-y;
+                transition-duration: 160ms, 0.2s;
+                transition-delay: 0s, -20ms;
+                transition-timing-function: ease-out, linear;
+            }
+            @media (prefers-reduced-motion: reduce) {
+                .control { transition: all 0s; }
+            }
+            """;
+
+        var source = new CssParser().parse(css);
+        var restored = Stylesheet.loadBinary(new ByteArrayInputStream(convertCssTextToBinary(css)));
+        assertEquals(source.getRules().size(), restored.getRules().size());
+
+        for (int rule = 0; rule < source.getRules().size(); rule++) {
+            var original = source.getRules().get(rule).getDeclarations();
+            var loaded = restored.getRules().get(rule).getDeclarations();
+            assertEquals(original.size(), loaded.size());
+
+            for (int declaration = 0; declaration < original.size(); declaration++) {
+                assertArrayEquals(
+                    (Object[])original.get(declaration).getParsedValue().convert(null),
+                    (Object[])loaded.get(declaration).getParsedValue().convert(null),
+                    original.get(declaration).getProperty());
+            }
+        }
     }
 
     @Test

--- a/modules/javafx.graphics/src/test/java/test/javafx/css/StylesheetTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/css/StylesheetTest.java
@@ -822,7 +822,11 @@ public class StylesheetTest {
                 transition-delay: 0s, -20ms;
                 transition-timing-function: ease-out, linear,
                                             cubic-bezier(0.5, 2, 0.5, -1),
-                                            step-start, step-end, steps(3),
+                                            step-start, step-end,
+                                            steps(3), steps(3, start), steps(3, end),
+                                            steps(3, jump-start), steps(3, jump-end),
+                                            steps(3, jump-none), steps(3, jump-both),
+                                            linear(0, 0.3, 1),
                                             linear(0 0%, 0.25 25% 75%, 1 100%);
             }
             @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
When a binary stylesheet contains CSS transitions, deserialization fails with errors similar to:
```
SEVERE: could not deserialize com.sun.javafx.css.TransitionDefinitionConverter
```

The reason is that the `StyleConverter.getInstance(String)` factory used to deserialize converters doesn't include the converters that were added to support CSS transitions.

Additionally, easing functions are not serialized at all. Since those functions can contain numbers (instead of `Size`), we need to extend the BSS format to support direct serialization of numbers.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))
- \[x\] Change requires CSR request [JDK-8392197](https://bugs.openjdk.org/browse/JDK-8392197) to be approved

### Issues
 * [JDK-8392013](https://bugs.openjdk.org/browse/JDK-8392013): CSS transition can not be deserialized (**Bug** - P4)
 * [JDK-8392197](https://bugs.openjdk.org/browse/JDK-8392197): CSS transition can not be deserialized (**CSR**)


### Reviewers
 * [Marius Hanl](https://openjdk.org/census#mhanl) (@Maran23 - **Reviewer**)
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2303/head:pull/2303` \
`$ git checkout pull/2303`

Update a local copy of the PR: \
`$ git checkout pull/2303` \
`$ git pull https://git.openjdk.org/jfx.git pull/2303/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2303`

View PR using the GUI difftool: \
`$ git pr show -t 2303`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2303.diff">https://git.openjdk.org/jfx/pull/2303.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2303#issuecomment-5594483234)
</details>
