### PR TITLE
8391968: [TestBug] Re-enable and Fix ControlTooltipTest

### DIFF
--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ControlTooltipTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ControlTooltipTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,80 +25,70 @@
 
 package test.javafx.scene.control;
 
+import javafx.scene.Node;
 import javafx.scene.control.Tooltip;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.Arguments;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertNotSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertTimeout;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import org.junit.jupiter.api.Assumptions;
 
 /**
- *
+ * Tests setting Tooltip on a Control
  */
-@Disabled
 public class ControlTooltipTest {
     private ControlStub c;
-    private SkinStub<ControlStub> s;
     private Tooltip t;
 
     @BeforeEach
     public void setUp() {
         c = new ControlStub();
-        s = new SkinStub<>(c);
-        c.setSkin(s);
         t = new Tooltip();
     }
 
-    @Test public void controlsWithNoTooltipHaveNoTooltipAsAChild() {
-        // only the skin's node should be a child
-        assertEquals(1, c.getChildrenUnmodifiable().size());
-        assertSame(s.getNode(), c.getChildrenUnmodifiable().get(0));
+    @Test public void controlHasNoTooltipByDefault() {
+        assertNull(c.getTooltip());
     }
 
-    @Test public void settingTooltipOnControlResultsInTooltipBeingFirstChild() {
+    @Test public void testAddingRemovingTooltipOnControl() {
         c.setTooltip(t);
-        assertEquals(2, c.getChildrenUnmodifiable().size());
-        assertSame(t, c.getChildrenUnmodifiable().get(0));
-        assertSame(s.getNode(), c.getChildrenUnmodifiable().get(1));
-    }
+        assertSame(t, c.getTooltip());
 
-    @Test public void settingTooltipToNullRemovesTheTooltipFromChildren() {
-        c.setTooltip(t);
         c.setTooltip(null);
-        assertEquals(1, c.getChildrenUnmodifiable().size());
-        assertSame(s.getNode(), c.getChildrenUnmodifiable().get(0));
+        assertNull(c.getTooltip());
     }
 
-    @Test public void settingTooltipTwiceIgnoresTheSecondAdd() {
+    @Test public void testAddingASecondTooltipOnControl() {
         c.setTooltip(t);
-        c.setTooltip(t);
-        assertEquals(2, c.getChildrenUnmodifiable().size());
-        assertSame(t, c.getChildrenUnmodifiable().get(0));
-        assertSame(s.getNode(), c.getChildrenUnmodifiable().get(1));
+        assertSame(t, c.getTooltip());
+
+        Tooltip t1 = new Tooltip();
+        c.setTooltip(t1);
+        assertSame(t1, c.getTooltip());
     }
 
-    @Test public void swappingTheTooltipForAnotherResultsInTheNewTooltipBeingAChildAndTheOldOneRemoved() {
-        c.setTooltip(t);
-        Tooltip t2 = new Tooltip();
-//        t2.setSkin(new SkinStub<Tooltip>(t2));
-        c.setTooltip(t2);
-        assertEquals(2, c.getChildrenUnmodifiable().size());
-        assertSame(t2, c.getChildrenUnmodifiable().get(0));
-        assertSame(s.getNode(), c.getChildrenUnmodifiable().get(1));
+    @Test public void testTooltipInstallAndUninstallOnControl() {
+        // Test Tooltip install
+        Tooltip.install(c, t);
+        Node n = (Node) c;
+        Tooltip temp = (Tooltip) n.getProperties().get("javafx.scene.control.Tooltip");
+        assertSame(t, temp);
+
+        // Test Tooltip uninstall
+        Tooltip.uninstall(c, t);
+        temp = (Tooltip) n.getProperties().get("javafx.scene.control.Tooltip");
+        assertNull(temp);
+    }
+
+    @Test public void testTooltipInstallTwiceOnControl() {
+        Tooltip.install(c, t);
+        Node n = (Node) c;
+        Tooltip temp = (Tooltip) n.getProperties().get("javafx.scene.control.Tooltip");
+        assertSame(t, temp);
+
+        Tooltip t1 = new Tooltip();
+        Tooltip.install(c, t1);
+
+        temp = (Tooltip) n.getProperties().get("javafx.scene.control.Tooltip");
+        assertSame(t1, temp);
     }
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ControlTooltipTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ControlTooltipTest.java
@@ -44,11 +44,13 @@ public class ControlTooltipTest {
         tooltip = new Tooltip();
     }
 
-    @Test public void controlHasNoTooltipByDefault() {
+    @Test
+    public void controlHasNoTooltipByDefault() {
         assertNull(control.getTooltip());
     }
 
-    @Test public void testAddingRemovingTooltipOnControl() {
+    @Test
+    public void testAddingRemovingTooltipOnControl() {
         control.setTooltip(tooltip);
         assertSame(tooltip, control.getTooltip());
 
@@ -56,7 +58,8 @@ public class ControlTooltipTest {
         assertNull(control.getTooltip());
     }
 
-    @Test public void testAddingASecondTooltipOnControl() {
+    @Test
+    public void testAddingASecondTooltipOnControl() {
         control.setTooltip(tooltip);
         assertSame(tooltip, control.getTooltip());
 
@@ -65,7 +68,8 @@ public class ControlTooltipTest {
         assertSame(tooltip1, control.getTooltip());
     }
 
-    @Test public void testTooltipInstallAndUninstallOnControl() {
+    @Test
+    public void testTooltipInstallAndUninstallOnControl() {
         // Test Tooltip install
         Tooltip.install(control, tooltip);
         Tooltip temp = (Tooltip) control.getProperties().get("javafx.scene.control.Tooltip");
@@ -77,7 +81,8 @@ public class ControlTooltipTest {
         assertNull(temp);
     }
 
-    @Test public void testTooltipInstallTwiceOnControl() {
+    @Test
+    public void testTooltipInstallTwiceOnControl() {
         Tooltip.install(control, tooltip);
         Tooltip temp = (Tooltip) control.getProperties().get("javafx.scene.control.Tooltip");
         assertSame(tooltip, temp);

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ControlTooltipTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ControlTooltipTest.java
@@ -25,7 +25,6 @@
 
 package test.javafx.scene.control;
 
-import javafx.scene.Node;
 import javafx.scene.control.Tooltip;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -69,26 +68,24 @@ public class ControlTooltipTest {
     @Test public void testTooltipInstallAndUninstallOnControl() {
         // Test Tooltip install
         Tooltip.install(control, tooltip);
-        Node node = (Node) control;
-        Tooltip temp = (Tooltip) node.getProperties().get("javafx.scene.control.Tooltip");
+        Tooltip temp = (Tooltip) control.getProperties().get("javafx.scene.control.Tooltip");
         assertSame(tooltip, temp);
 
         // Test Tooltip uninstall
         Tooltip.uninstall(control, tooltip);
-        temp = (Tooltip) node.getProperties().get("javafx.scene.control.Tooltip");
+        temp = (Tooltip) control.getProperties().get("javafx.scene.control.Tooltip");
         assertNull(temp);
     }
 
     @Test public void testTooltipInstallTwiceOnControl() {
         Tooltip.install(control, tooltip);
-        Node node = (Node) control;
-        Tooltip temp = (Tooltip) node.getProperties().get("javafx.scene.control.Tooltip");
+        Tooltip temp = (Tooltip) control.getProperties().get("javafx.scene.control.Tooltip");
         assertSame(tooltip, temp);
 
         Tooltip tooltip1 = new Tooltip();
         Tooltip.install(control, tooltip1);
 
-        temp = (Tooltip) node.getProperties().get("javafx.scene.control.Tooltip");
+        temp = (Tooltip) control.getProperties().get("javafx.scene.control.Tooltip");
         assertSame(tooltip1, temp);
     }
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ControlTooltipTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ControlTooltipTest.java
@@ -36,59 +36,59 @@ import static org.junit.jupiter.api.Assertions.assertSame;
  * Tests setting Tooltip on a Control
  */
 public class ControlTooltipTest {
-    private ControlStub c;
-    private Tooltip t;
+    private ControlStub control;
+    private Tooltip tooltip;
 
     @BeforeEach
     public void setUp() {
-        c = new ControlStub();
-        t = new Tooltip();
+        control = new ControlStub();
+        tooltip = new Tooltip();
     }
 
     @Test public void controlHasNoTooltipByDefault() {
-        assertNull(c.getTooltip());
+        assertNull(control.getTooltip());
     }
 
     @Test public void testAddingRemovingTooltipOnControl() {
-        c.setTooltip(t);
-        assertSame(t, c.getTooltip());
+        control.setTooltip(tooltip);
+        assertSame(tooltip, control.getTooltip());
 
-        c.setTooltip(null);
-        assertNull(c.getTooltip());
+        control.setTooltip(null);
+        assertNull(control.getTooltip());
     }
 
     @Test public void testAddingASecondTooltipOnControl() {
-        c.setTooltip(t);
-        assertSame(t, c.getTooltip());
+        control.setTooltip(tooltip);
+        assertSame(tooltip, control.getTooltip());
 
-        Tooltip t1 = new Tooltip();
-        c.setTooltip(t1);
-        assertSame(t1, c.getTooltip());
+        Tooltip tooltip1 = new Tooltip();
+        control.setTooltip(tooltip1);
+        assertSame(tooltip1, control.getTooltip());
     }
 
     @Test public void testTooltipInstallAndUninstallOnControl() {
         // Test Tooltip install
-        Tooltip.install(c, t);
-        Node n = (Node) c;
-        Tooltip temp = (Tooltip) n.getProperties().get("javafx.scene.control.Tooltip");
-        assertSame(t, temp);
+        Tooltip.install(control, tooltip);
+        Node node = (Node) control;
+        Tooltip temp = (Tooltip) node.getProperties().get("javafx.scene.control.Tooltip");
+        assertSame(tooltip, temp);
 
         // Test Tooltip uninstall
-        Tooltip.uninstall(c, t);
-        temp = (Tooltip) n.getProperties().get("javafx.scene.control.Tooltip");
+        Tooltip.uninstall(control, tooltip);
+        temp = (Tooltip) node.getProperties().get("javafx.scene.control.Tooltip");
         assertNull(temp);
     }
 
     @Test public void testTooltipInstallTwiceOnControl() {
-        Tooltip.install(c, t);
-        Node n = (Node) c;
-        Tooltip temp = (Tooltip) n.getProperties().get("javafx.scene.control.Tooltip");
-        assertSame(t, temp);
+        Tooltip.install(control, tooltip);
+        Node node = (Node) control;
+        Tooltip temp = (Tooltip) node.getProperties().get("javafx.scene.control.Tooltip");
+        assertSame(tooltip, temp);
 
-        Tooltip t1 = new Tooltip();
-        Tooltip.install(c, t1);
+        Tooltip tooltip1 = new Tooltip();
+        Tooltip.install(control, tooltip1);
 
-        temp = (Tooltip) n.getProperties().get("javafx.scene.control.Tooltip");
-        assertSame(t1, temp);
+        temp = (Tooltip) node.getProperties().get("javafx.scene.control.Tooltip");
+        assertSame(tooltip1, temp);
     }
 }


### PR DESCRIPTION
This is a minor test cleanup fix.
Note : All tests in `ControlTooltipTest` were disabled/ignored since beginning.

Fix :
The test cases used to make an incorrect assumption that adding a `Tooltip` to a `Control` adds it to `Control`'s children list. The old test cases are discarded and new unit tests are added to test setting a `Tooltip` on a `Control`.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8391968](https://bugs.openjdk.org/browse/JDK-8391968): [TestBug] Re-enable and Fix ControlTooltipTest (**Bug** - P4)


### Reviewers
 * [Marius Hanl](https://openjdk.org/census#mhanl) (@Maran23 - **Reviewer**)
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2304/head:pull/2304` \
`$ git checkout pull/2304`

Update a local copy of the PR: \
`$ git checkout pull/2304` \
`$ git pull https://git.openjdk.org/jfx.git pull/2304/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2304`

View PR using the GUI difftool: \
`$ git pr show -t 2304`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2304.diff">https://git.openjdk.org/jfx/pull/2304.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2304#issuecomment-5597549730)
</details>
