### PR TITLE
8268374: MenuItem's accelerator gets fired even when ContextMenu is set to null

### DIFF
--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/ControlAcceleratorSupport.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/ControlAcceleratorSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -255,8 +255,7 @@ public class ControlAcceleratorSupport {
         TabPane tabPane = anchor.getTabPane();
         if (tabPane == null) return;
 
-        Scene scene = tabPane.getScene();
-        removeAcceleratorsFromScene(items, scene);
+        removeAcceleratorsFromScene(items, tabPane);
     }
 
     public static void removeAcceleratorsFromScene(ObservableList<? extends MenuItem> items, TableColumnBase<?,?> anchor) {
@@ -266,8 +265,7 @@ public class ControlAcceleratorSupport {
         Control control = controlProperty.get();
         if (control == null) return;
 
-        Scene scene = control.getScene();
-        removeAcceleratorsFromScene(items, scene);
+        removeAcceleratorsFromScene(items, control);
     }
 
     public static void removeAcceleratorsFromScene(ObservableList<? extends MenuItem> items, Node anchor) {
@@ -393,7 +391,5 @@ public class ControlAcceleratorSupport {
             IdentityWrapperListChangeListener that = (IdentityWrapperListChangeListener) o;
             return innerList == that.innerList;
         }
-    };
+    }
 }
-
-

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/AcceleratorParameterizedTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/AcceleratorParameterizedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.fail;
 import static test.com.sun.javafx.scene.control.infrastructure.ControlTestUtils.getListenerCount;
 import java.util.List;
-import java.util.stream.Stream;
 import javafx.beans.property.ObjectProperty;
 import javafx.scene.Group;
 import javafx.scene.Scene;
@@ -47,12 +46,7 @@ import javafx.scene.control.TreeTableView;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyCombination;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import test.com.sun.javafx.scene.control.infrastructure.KeyEventFirer;
 import test.com.sun.javafx.scene.control.infrastructure.KeyModifier;
@@ -378,7 +372,6 @@ public class AcceleratorParameterizedTest {
         assertEquals(2, eventCounter);
     }
 
-    @Disabled("JDK-8268374")
     @ParameterizedTest
     @MethodSource("parameters")
     public void testAcceleratorShouldNotGetFiredWhenControlsIsRemovedFromSceneThenContextMenuIsSetToNullAndControlIsAddedBackToScene(Class testClass) {


### PR DESCRIPTION
This fixes a asymmetry in `ControlAcceleratorSupport` that causes a bug and also a test to fail (an existing `Disabled` test).

All `addAcceleratorsIntoScene` will register a listener on the `anchor.sceneProperty()`.
The anchor is:
- The `Node`
- The `TabPane` for a `Tab`
- The `Tree/TableView` for a `TableColumnBase`

Until this PR, the `removeAcceleratorsFromScene` sequence was sometimes inconsistent:
- For `Node`: 
  - Unregister the `sceneProperty` on `Node`
    - Then remove the accelerators from `Scene`
- For `Tab` -> Get `TabPane`
  - Then remove the accelerators from `Scene`
- For `TableColumnBase` -> Get `Tree/TableView`
  - Then remove the accelerators from `Scene`

Note how the "Unregister the `sceneProperty` on `Node`" step is completely missing for `Tab` and `TableColumnBase`, explaining the bug and failing test for only those two cases.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8268374](https://bugs.openjdk.org/browse/JDK-8268374): MenuItem's accelerator gets fired even when ContextMenu is set to null (**Bug** - P3)


### Reviewers
 * [Ajit Ghaisas](https://openjdk.org/census#aghaisas) (@aghaisas - **Reviewer**)
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2306/head:pull/2306` \
`$ git checkout pull/2306`

Update a local copy of the PR: \
`$ git checkout pull/2306` \
`$ git pull https://git.openjdk.org/jfx.git pull/2306/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2306`

View PR using the GUI difftool: \
`$ git pr show -t 2306`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2306.diff">https://git.openjdk.org/jfx/pull/2306.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2306#issuecomment-5602156202)
</details>
