### PR TITLE
8392106: Add @SuppressWarnings("sync-override") to WinTimer

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinTimer.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinTimer.java
@@ -69,6 +69,7 @@ final class WinTimer extends Timer {
      * _stop() completes, so pause() cannot acquire the monitor; _stop() will not
      * complete until the callback returns.
      */
+    @SuppressWarnings("sync-override")
     @Override
     public void pause() {
     }
@@ -81,6 +82,7 @@ final class WinTimer extends Timer {
      * _stop() completes, so resume() cannot acquire the monitor; _stop() will not
      * complete until the callback returns.
      */
+    @SuppressWarnings("sync-override")
     @Override
     public void resume() {
     }


### PR DESCRIPTION
My mistake - I missed that the fix for [JDK-8389783](https://bugs.openjdk.org/browse/JDK-8389783) created a warning in Eclipse:

|Description |Resource |Type |Path |Location
|------------|---------|-----|-----|---
|The method WinTimer.pause() is overriding a synchronized method without being synchronized |WinTimer.java |Java Problem |/graphics/src/main/java/com/sun/glass/ui/win |line 73
|The method WinTimer.resume() is overriding a synchronized method without being synchronized |WinTimer.java |Java Problem |/graphics/src/main/java/com/sun/glass/ui/win |line 85

These two methods need `@SuppressWarnings("sync-override")` added to suppress the warning (it's a useful warning to have enabled).

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8392106](https://bugs.openjdk.org/browse/JDK-8392106): Add @<!---->SuppressWarnings("sync-override") to WinTimer (**Bug** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [John Hendrikx](https://openjdk.org/census#jhendrikx) (@hjohn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2307/head:pull/2307` \
`$ git checkout pull/2307`

Update a local copy of the PR: \
`$ git checkout pull/2307` \
`$ git pull https://git.openjdk.org/jfx.git pull/2307/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2307`

View PR using the GUI difftool: \
`$ git pr show -t 2307`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2307.diff">https://git.openjdk.org/jfx/pull/2307.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2307#issuecomment-5606926538)
</details>
