### PR TITLE
8392117: VirtualFlow may end up creating 1-2 unnecessary cells

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
@@ -1702,10 +1702,13 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
 
             // Add any necessary leading cells
             if (firstCell != null) {
-                // NOTE: The index might be -1, but the call to addLeadingCells() is still required.
-                int previousIndex = getCellIndex(firstCell) - 1;
-                double prevIndexSize = getCellLength(previousIndex);
-                addLeadingCells(previousIndex, getCellPosition(firstCell) - prevIndexSize);
+                double firstCellPosition = getCellPosition(firstCell);
+                if (firstCellPosition > 0) {
+                    // NOTE: The index might be -1, but the call to addLeadingCells() is still required.
+                    int previousIndex = getCellIndex(firstCell) - 1;
+                    double prevIndexSize = getCellLength(previousIndex);
+                    addLeadingCells(previousIndex, firstCellPosition - prevIndexSize);
+                }
             } else {
                 int currentIndex = computeCurrentIndex();
 
@@ -2848,11 +2851,10 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
             T cell = pile.get(i);
             wasFocusOwner = wasFocusOwner || doesCellContainFocus(cell);
             cell.setVisible(false);
-        }
 
-        // Remove all cells that are in the pile and therefore not relevant anymore.
-        if (sheetChildren.size() != cells.size()) {
-            sheetChildren.removeAll(pile);
+            if (cell.getParent() != null) {
+                sheetChildren.remove(cell);
+            }
         }
 
         // Fix for JDK-8095710: Rather than have the cells do weird things with

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
@@ -2847,14 +2847,23 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
     private void cleanPile() {
         boolean wasFocusOwner = false;
 
+        List<T> removedCells = null;
         for (int i = 0, max = pile.size(); i < max; i++) {
             T cell = pile.get(i);
             wasFocusOwner = wasFocusOwner || doesCellContainFocus(cell);
             cell.setVisible(false);
 
+            // Everything that ended up in the pile should not be inside the sheet.
             if (cell.getParent() != null) {
-                sheetChildren.remove(cell);
+                if (removedCells == null) {
+                    removedCells = new ArrayList<>();
+                }
+                removedCells.add(cell);
             }
+        }
+
+        if (removedCells != null) {
+            sheetChildren.removeAll(removedCells);
         }
 
         // Fix for JDK-8095710: Rather than have the cells do weird things with

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,6 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicIntegerArray;
 import java.util.function.DoubleSupplier;
 import java.util.function.Supplier;
 import javafx.beans.InvalidationListener;

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
@@ -38,6 +38,8 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicIntegerArray;
 import java.util.function.DoubleSupplier;
 import java.util.function.Supplier;
 import javafx.beans.InvalidationListener;
@@ -2118,6 +2120,49 @@ assertEquals(0, firstCell.getIndex());
         assertEquals(flow.cells, flow.sheetChildren);
     }
 
+    @Test
+    public void testScrollingDoesNotCreateMoreCellsThanFitInViewport() {
+        int cellSize = 25;
+        int viewportLength = 300;
+        int maxVisibleCells = viewportLength / cellSize + 1;
+
+        AtomicInteger createdCells = new AtomicInteger(0);
+        flow = new VirtualFlowShim<>();
+        flow.setFixedCellSize(cellSize);
+        flow.setCellCount(100);
+        flow.resize(300, viewportLength);
+        flow.setCellFactory(f -> {
+            createdCells.addAndGet(1);
+            return new CellStub(flow);
+        });
+        pulse();
+
+        for (int i = 0; i < 100; i++) {
+            flow.scrollPixels(10);
+            pulse();
+            assertMaxCellCount(maxVisibleCells, createdCells.get());
+        }
+        for (int i = 0; i < 120; i++) {
+            flow.scrollPixels(-10);
+            pulse();
+            assertMaxCellCount(maxVisibleCells, createdCells.get());
+        }
+
+        flow.scrollPixels(Integer.MAX_VALUE);
+        pulse();
+        assertMaxCellCount(maxVisibleCells, createdCells.get());
+
+        for (int i = 0; i < 20; i++) {
+            flow.scrollPixels(i % 2 == 0 ? -7 : 7);
+            pulse();
+            assertMaxCellCount(maxVisibleCells, createdCells.get());
+        }
+    }
+
+    private void assertMaxCellCount(int maxVisibleCells, int createdCells) {
+        assertTrue(flow.sheetChildren.size() <= maxVisibleCells, "Too many cells in the sheet");
+        assertTrue(createdCells <= maxVisibleCells, "Too many cells were created");
+    }
 }
 
 class GraphicalCellStub extends IndexedCellShim<Node> {


### PR DESCRIPTION
Something I found out while experimenting in https://github.com/openjdk/jfx/pull/2051.
It was on my list to do since then.

The `VirtualFlow` can end up creating 1-2 unnecessary cells, which then are never used. They just sit in the pile.
This happens because we may end up calling `addLeadingCells` although our first cell is already on position `0`, so at the top - there is no cell above us.

In this scenario, we do not need to call `addLeadingCells`.

Also added the optimization I found in the PR mentioned above.
When we have 10 visible cells, size 25px and scroll 10px, we will have 11 cells visible. 
If we scroll to the top again, we will have 10 cells visible again -- and in this case we will remove it from the `sheet`. 
But the pile could contain even more piled cells (e.g. when the application size got smaller, we have less cells to render, all remaining cells went into the pile). 
So the removal is a bit faster with that method, instead of always calling `removeAll`. Same functionality.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8392117](https://bugs.openjdk.org/browse/JDK-8392117): VirtualFlow may end up creating 1-2 unnecessary cells (**Bug** - P4)


### Reviewers
 * [Michael Strauß](https://openjdk.org/census#mstrauss) (@mstr2 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2308/head:pull/2308` \
`$ git checkout pull/2308`

Update a local copy of the PR: \
`$ git checkout pull/2308` \
`$ git pull https://git.openjdk.org/jfx.git pull/2308/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2308`

View PR using the GUI difftool: \
`$ git pr show -t 2308`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2308.diff">https://git.openjdk.org/jfx/pull/2308.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2308#issuecomment-5610214755)
</details>
