### PR TITLE
8392118: Replace use of terminally-deprecated snapSpace in LayoutDemo

### DIFF
--- a/apps/toys/LayoutDemo/src/layout/CustomHBox.java
+++ b/apps/toys/LayoutDemo/src/layout/CustomHBox.java
@@ -82,7 +82,7 @@ public class CustomHBox extends HBox {
         // height could be -1
         double[][] temp = getTempArray(managed.size());
         final double insideHeight = height == -1? -1 : height -
-                                     snapSpace(getInsets().getTop()) - snapSpace(getInsets().getBottom());
+                                     snapSpaceY(getInsets().getTop()) - snapSpaceY(getInsets().getBottom());
         final boolean shouldFillHeight = true;
         for (int i = 0, size = managed.size(); i < size; i++) {
             Node child = managed.get(i);
@@ -107,12 +107,12 @@ public class CustomHBox extends HBox {
 
     private double adjustAreaWidths(List<Node>managed, double areaWidths[][], double width, double height) {
         Insets insets = getInsets();
-        double top = snapSpace(insets.getTop());
-        double bottom = snapSpace(insets.getBottom());
+        double top = snapSpaceY(insets.getTop());
+        double bottom = snapSpaceY(insets.getBottom());
 
-        double contentWidth = sum(areaWidths[0], managed.size()) + (managed.size()-1)*snapSpace(getSpacing());
+        double contentWidth = sum(areaWidths[0], managed.size()) + (managed.size()-1)*snapSpaceX(getSpacing());
         double extraWidth = width -
-                snapSpace(insets.getLeft()) - snapSpace(insets.getRight()) - contentWidth;
+                snapSpaceX(insets.getLeft()) - snapSpaceX(insets.getRight()) - contentWidth;
 
 //        if (extraWidth != 0) {
 //            final double refHeight = shouldFillHeight() && height != -1? height - top - bottom : -1;
@@ -132,11 +132,11 @@ public class CustomHBox extends HBox {
         VPos alignVpos = align.getVpos();
         double width = getWidth();
         double height = getHeight();
-        double top = snapSpace(insets.getTop());
-        double left = snapSpace(insets.getLeft());
-        double bottom = snapSpace(insets.getBottom());
-        double right = snapSpace(insets.getRight());
-        double space = snapSpace(getSpacing());
+        double top = snapSpaceY(insets.getTop());
+        double left = snapSpaceX(insets.getLeft());
+        double bottom = snapSpaceY(insets.getBottom());
+        double right = snapSpaceX(insets.getRight());
+        double space = snapSpaceX(getSpacing());
         boolean shouldFillHeight = true;
 
         final double[][] actualAreaWidths = getAreaWidths(managed, height, false);

--- a/apps/toys/LayoutDemo/src/layout/CustomTilePane.java
+++ b/apps/toys/LayoutDemo/src/layout/CustomTilePane.java
@@ -118,25 +118,25 @@ public class CustomTilePane extends TilePane {
     }
 
     private int computeColumns(double width, double tilewidth) {
-        return Math.max(1, (int) ((width + snapSpace(getHgap())) / (tilewidth + snapSpace(getHgap()))));
+        return Math.max(1, (int) ((width + snapSpaceX(getHgap())) / (tilewidth + snapSpaceX(getHgap()))));
     }
 
     private int computeRows(double height, double tileheight) {
-        return Math.max(1, (int) ((height + snapSpace(getVgap())) / (tileheight + snapSpace(getVgap()))));
+        return Math.max(1, (int) ((height + snapSpaceY(getVgap())) / (tileheight + snapSpaceY(getVgap()))));
     }
 
     private double computeContentWidth(int columns, double tilewidth) {
         if (columns == 0) {
             return 0;
         }
-        return columns * tilewidth + (columns - 1) * snapSpace(getHgap());
+        return columns * tilewidth + (columns - 1) * snapSpaceX(getHgap());
     }
 
     private double computeContentHeight(int rows, double tileheight) {
         if (rows == 0) {
             return 0;
         }
-        return rows * tileheight + (rows - 1) * snapSpace(getVgap());
+        return rows * tileheight + (rows - 1) * snapSpaceY(getVgap());
     }
 
     static double computeXOffset(double width, double contentWidth, HPos hpos) {
@@ -177,12 +177,12 @@ public class CustomTilePane extends TilePane {
         VPos vpos = getAlignmentInternal().getVpos();
         double width = getWidth();
         double height = getHeight();
-        double top = snapSpace(getInsets().getTop());
-        double left = snapSpace(getInsets().getLeft());
-        double bottom = snapSpace(getInsets().getBottom());
-        double right = snapSpace(getInsets().getRight());
-        double vgap = snapSpace(getVgap());
-        double hgap = snapSpace(getHgap());
+        double top = snapSpaceY(getInsets().getTop());
+        double left = snapSpaceX(getInsets().getLeft());
+        double bottom = snapSpaceY(getInsets().getBottom());
+        double right = snapSpaceX(getInsets().getRight());
+        double vgap = snapSpaceY(getVgap());
+        double hgap = snapSpaceX(getHgap());
         double insideWidth = width - left - right;
         double insideHeight = height - top - bottom;
 


### PR DESCRIPTION
Two classes in `apps` were still using the deprecated (now for removal) `snap` methods.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8392118](https://bugs.openjdk.org/browse/JDK-8392118): Replace use of terminally-deprecated snapSpace in LayoutDemo (**Bug** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2310/head:pull/2310` \
`$ git checkout pull/2310`

Update a local copy of the PR: \
`$ git checkout pull/2310` \
`$ git pull https://git.openjdk.org/jfx.git pull/2310/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2310`

View PR using the GUI difftool: \
`$ git pr show -t 2310`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2310.diff">https://git.openjdk.org/jfx/pull/2310.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2310#issuecomment-5617598162)
</details>
