### PR TITLE
8392158: GridPane: hgap/vgap ignored for percentage rows/columns and when shrinking spanned rows/columns

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/GridPane.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/GridPane.java
@@ -1848,10 +1848,9 @@ public class GridPane extends Pane {
 
     private double adjustRowHeights(final CompositeSize heights, double height) {
         assert(height != -1);
-        final double snapvgap = snapSpaceY(getVgap());
         final double top = snapSpaceY(getInsets().getTop());
         final double bottom = snapSpaceY(getInsets().getBottom());
-        final double vgaps = snapvgap * (getNumberOfRows() - 1);
+        final double vgaps = heights.computeGaps(0, heights.getLength());
         final double contentHeight = height - top - bottom;
 
         // if there are percentage rows, give them their percentages first
@@ -2089,10 +2088,9 @@ public class GridPane extends Pane {
 
     private double adjustColumnWidths(final CompositeSize widths, double width) {
         assert(width != -1);
-        final double snaphgap = snapSpaceX(getHgap());
         final double left = snapSpaceX(getInsets().getLeft());
         final double right = snapSpaceX(getInsets().getRight());
-        final double hgaps = snaphgap * (getNumberOfColumns() - 1);
+        final double hgaps = widths.computeGaps(0, widths.getLength());
         final double contentWidth = width - left - right;
 
         // if there are percentage rows, give them their percentages first
@@ -2653,7 +2651,7 @@ public class GridPane extends Pane {
             if (!isPreset(position) && multiSizes != null) {
                 for (Interval i : multiSizes.keySet()) {
                     if (i.contains(position)) {
-                        double segment = multiSizes.get(i) / i.size();
+                        double segment = (multiSizes.get(i) - computeGaps(i.begin, i.end)) / i.size();
                         double propSize = segment;
                         for (int j = i.begin; j < i.end; ++j) {
                             if (j != position) {
@@ -2686,6 +2684,14 @@ public class GridPane extends Pane {
 
         private double computeTotal() {
             return computeTotal(0, singleSizes.length);
+        }
+
+        private double computeGaps(final int from, final int to) {
+            double total = 0;
+            for (int i = from + 1; i < to; ++i) {
+                total += gapBefore[i] ? gap : 0;
+            }
+            return total;
         }
 
         private boolean allPreset(int begin, int end) {

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/GridPaneTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/GridPaneTest.java
@@ -3248,4 +3248,87 @@ public class GridPaneTest {
         assertEquals(100, fixedArea.getWidth());
         fixedArea.assertSize();
     }
+
+    @Test
+    public void testPercentageGrowthReservesVgaps() {
+        gridpane.setVgap(10);
+        RowConstraints half1 = new RowConstraints();
+        half1.setPercentHeight(50);
+        RowConstraints half2 = new RowConstraints();
+        half2.setPercentHeight(50);
+        gridpane.getRowConstraints().addAll(half1, new RowConstraints(), half2);
+        MockResizable top = new MockResizable(10, 10);
+        MockResizable bottom = new MockResizable(10, 10);
+        gridpane.add(top, 0, 0);
+        gridpane.add(bottom, 0, 2);
+
+        gridpane.resize(100, 200);
+        gridpane.layout();
+
+        // row 1 is empty, so only one vgap is rendered and the percent rows must share the rest
+        assertEquals(95, top.getHeight(), 1e-100);
+        assertEquals(105, bottom.getLayoutY(), 1e-100);
+        assertEquals(95, bottom.getHeight(), 1e-100);
+    }
+
+    @Test
+    public void testPercentageGrowthReservesHgaps() {
+        gridpane.setHgap(10);
+        ColumnConstraints half1 = new ColumnConstraints();
+        half1.setPercentWidth(50);
+        ColumnConstraints half2 = new ColumnConstraints();
+        half2.setPercentWidth(50);
+        gridpane.getColumnConstraints().addAll(half1, new ColumnConstraints(), half2);
+        MockResizable left = new MockResizable(10, 10);
+        MockResizable right = new MockResizable(10, 10);
+        gridpane.add(left, 0, 0);
+        gridpane.add(right, 2, 0);
+
+        gridpane.resize(200, 100);
+        gridpane.layout();
+
+        assertEquals(95, left.getWidth(), 1e-100);
+        assertEquals(105, right.getLayoutX(), 1e-100);
+        assertEquals(95, right.getWidth(), 1e-100);
+    }
+
+    @Test
+    public void testCheckShrinkingRowsAccountsVgap() {
+        gridpane.setVgap(10);
+        MockResizable spanning = new MockResizable(100, 100, 100, 100, 5000, 5000);
+        MockResizable row0 = new MockResizable(0, 0, 100, 200, 5000, 5000);
+        MockResizable row1 = new MockResizable(0, 0, 100, 200, 5000, 5000);
+        gridpane.add(spanning, 0, 0, 1, 2);
+        gridpane.add(row0, 1, 0);
+        gridpane.add(row1, 1, 1);
+
+        assertEquals(100, gridpane.minHeight(-1), 1e-100);
+
+        gridpane.resize(200, 100);
+        gridpane.layout();
+
+        assertEquals(100, spanning.getHeight(), 1e-100);
+        assertEquals(45, row0.getHeight(), 1e-100);
+        assertEquals(45, row1.getHeight(), 1e-100);
+    }
+
+    @Test
+    public void testCheckShrinkingColumnsAccountsHgap() {
+        gridpane.setHgap(10);
+        MockResizable spanning = new MockResizable(100, 100, 100, 100, 5000, 5000);
+        MockResizable col0 = new MockResizable(0, 0, 200, 100, 5000, 5000);
+        MockResizable col1 = new MockResizable(0, 0, 200, 100, 5000, 5000);
+        gridpane.add(spanning, 0, 0, 2, 1);
+        gridpane.add(col0, 0, 1);
+        gridpane.add(col1, 1, 1);
+
+        assertEquals(100, gridpane.minWidth(-1), 1e-100);
+
+        gridpane.resize(100, 200);
+        gridpane.layout();
+
+        assertEquals(100, spanning.getWidth(), 1e-100);
+        assertEquals(45, col0.getWidth(), 1e-100);
+        assertEquals(45, col1.getWidth(), 1e-100);
+    }
 }


### PR DESCRIPTION
Follow-up to JDK-8092379: since then a gap is only rendered before a row/column in which a child starts, but two places still assumed a gap between every row/column.

adjustRowHeights / adjustColumnWidths reserved a gap before every row/column before distributing the percentages. They now reserve only the rendered gaps.

CompositeSize.getProportionalMinOrMaxSize divided the size of a spanning child by the number of rows/columns without subtracting the gaps inside the span. It now subtracts them.

Each fix is covered by tests that fail before and pass after the change.
A test application can be found in the ticket.


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8392158](https://bugs.openjdk.org/browse/JDK-8392158): GridPane: hgap/vgap ignored for percentage rows/columns and when shrinking spanned rows/columns (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2312/head:pull/2312` \
`$ git checkout pull/2312`

Update a local copy of the PR: \
`$ git checkout pull/2312` \
`$ git pull https://git.openjdk.org/jfx.git pull/2312/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2312`

View PR using the GUI difftool: \
`$ git pr show -t 2312`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2312.diff">https://git.openjdk.org/jfx/pull/2312.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/2312#issuecomment-5619737847)
</details>
