### PR TITLE
8392169: GridPane - content-biased child is shrunk below its min size and overlaps neighbours

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/GridPane.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/GridPane.java
@@ -1734,12 +1734,12 @@ public class GridPane extends Pane {
                 widths = (CompositeSize) computePrefWidths(null).clone();
                 columnTotal = adjustColumnWidths(widths, width);
                 heights = computePrefHeights(widths);
-                rowTotal = adjustRowHeights(heights, height);
+                rowTotal = adjustRowHeights(heights, height, widths);
             } else {
                 heights = (CompositeSize) computePrefHeights(null).clone();
                 rowTotal = adjustRowHeights(heights, height);
                 widths = computePrefWidths(heights);
-                columnTotal = adjustColumnWidths(widths, width);
+                columnTotal = adjustColumnWidths(widths, width, heights);
             }
 
             final double x = left + computeXOffset(contentWidth, columnTotal, getAlignmentInternal().getHpos());
@@ -1847,6 +1847,10 @@ public class GridPane extends Pane {
     }
 
     private double adjustRowHeights(final CompositeSize heights, double height) {
+        return adjustRowHeights(heights, height, null);
+    }
+
+    private double adjustRowHeights(final CompositeSize heights, double height, CompositeSize widths) {
         assert(height != -1);
         final double snapvgap = snapSpaceY(getVgap());
         final double top = snapSpaceY(getInsets().getTop());
@@ -1880,8 +1884,8 @@ public class GridPane extends Pane {
             if (heightAvailable != 0) {
                 // maybe grow or shrink row heights
                 double remaining = growToMultiSpanPreferredHeights(heights, heightAvailable);
-                remaining = growOrShrinkRowHeights(heights, Priority.ALWAYS, remaining);
-                remaining = growOrShrinkRowHeights(heights, Priority.SOMETIMES, remaining);
+                remaining = growOrShrinkRowHeights(heights, Priority.ALWAYS, remaining, widths);
+                remaining = growOrShrinkRowHeights(heights, Priority.SOMETIMES, remaining, widths);
                 rowTotal += (heightAvailable - remaining);
             }
         }
@@ -2023,7 +2027,7 @@ public class GridPane extends Pane {
         return remaining;
     }
 
-    private double growOrShrinkRowHeights(CompositeSize heights, Priority priority, double extraHeight) {
+    private double growOrShrinkRowHeights(CompositeSize heights, Priority priority, double extraHeight, CompositeSize widths) {
         final boolean shrinking = extraHeight < 0;
         List<Integer> adjusting = new ArrayList<>();
 
@@ -2043,7 +2047,7 @@ public class GridPane extends Pane {
         final boolean wasPositive = available >= 0.0;
         boolean isPositive = wasPositive;
 
-        CompositeSize limitSize = shrinking? computeMinHeights(null) :
+        CompositeSize limitSize = shrinking? computeMinHeights(widths) :
                             computeMaxHeights();
         while (available != 0 && wasPositive == isPositive && adjusting.size() > 0) {
             if (!handleRemainder) {
@@ -2088,6 +2092,10 @@ public class GridPane extends Pane {
     }
 
     private double adjustColumnWidths(final CompositeSize widths, double width) {
+        return adjustColumnWidths(widths, width, null);
+    }
+
+    private double adjustColumnWidths(final CompositeSize widths, double width, CompositeSize heights) {
         assert(width != -1);
         final double snaphgap = snapSpaceX(getHgap());
         final double left = snapSpaceX(getInsets().getLeft());
@@ -2122,8 +2130,8 @@ public class GridPane extends Pane {
             if (widthAvailable != 0) {
                 // maybe grow or shrink row heights
                 double remaining = growToMultiSpanPreferredWidths(widths, widthAvailable);
-                remaining = growOrShrinkColumnWidths(widths, Priority.ALWAYS, remaining);
-                remaining = growOrShrinkColumnWidths(widths, Priority.SOMETIMES, remaining);
+                remaining = growOrShrinkColumnWidths(widths, Priority.ALWAYS, remaining, heights);
+                remaining = growOrShrinkColumnWidths(widths, Priority.SOMETIMES, remaining, heights);
                 columnTotal += (widthAvailable - remaining);
             }
         }
@@ -2264,7 +2272,7 @@ public class GridPane extends Pane {
         return remaining;
     }
 
-    private double growOrShrinkColumnWidths(CompositeSize widths, Priority priority, double extraWidth) {
+    private double growOrShrinkColumnWidths(CompositeSize widths, Priority priority, double extraWidth, CompositeSize heights) {
         if (extraWidth == 0) {
             return 0;
         }
@@ -2287,7 +2295,7 @@ public class GridPane extends Pane {
         final boolean wasPositive = available >= 0.0;
         boolean isPositive = wasPositive;
 
-        CompositeSize limitSize = shrinking? computeMinWidths(null) :
+        CompositeSize limitSize = shrinking? computeMinWidths(heights) :
                             computeMaxWidths();
         while (available != 0 && wasPositive == isPositive && adjusting.size() > 0) {
             if (!handleRemainder) {

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/GridPaneTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/GridPaneTest.java
@@ -2511,6 +2511,37 @@ public class GridPaneTest {
         assertEquals(400, child1_1.getLayoutBounds().getHeight(), 1e-100);
     }
 
+    @Test
+    public void testShrinkingRowsUsesWidths() {
+        MockBiased biased = new MockBiased(Orientation.HORIZONTAL, 100, 100);
+        MockResizable below = new MockResizable(0, 0, 50, 100, 5000, 5000);
+        gridpane.add(biased, 0, 0);
+        gridpane.add(below, 0, 1);
+
+        gridpane.resize(50, 250);
+        gridpane.layout();
+
+        // at width 50 the biased child needs (and reports as min) 200 height, so row 0 must not shrink
+        assertEquals(200, biased.getHeight(), 1e-100);
+        assertEquals(200, below.getLayoutY(), 1e-100);
+        assertEquals(50, below.getHeight(), 1e-100);
+    }
+
+    @Test
+    public void testShrinkingColumnsUsesHeights() {
+        MockBiased biased = new MockBiased(Orientation.VERTICAL, 100, 100);
+        MockResizable right = new MockResizable(0, 0, 100, 50, 5000, 5000);
+        gridpane.add(biased, 0, 0);
+        gridpane.add(right, 1, 0);
+
+        gridpane.resize(250, 50);
+        gridpane.layout();
+
+        assertEquals(200, biased.getWidth(), 1e-100);
+        assertEquals(200, right.getLayoutX(), 1e-100);
+        assertEquals(50, right.getWidth(), 1e-100);
+    }
+
     @Test public void test_RT18518_sizeIsNotUpdatedAfterRemovingChild() {
         MockResizable child0_0 = new MockResizable(100,200);
         GridPane.setConstraints(child0_0, 0, 0);


### PR DESCRIPTION
growOrShrinkRowHeights and growOrShrinkColumnWidths need the other dimension to compute the min-limits correctly.
Adding them leads to some follow-up changes in adjustColumnWidths and adjustRowHeights.

The fix is covered by two tests that fail before and pass after the change.
A test application can be found in the ticket.


---------
- \[x\] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Error
&nbsp;⚠️ Pull request body is missing required line: `- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).`

### Issue
 * [JDK-8392169](https://bugs.openjdk.org/browse/JDK-8392169): GridPane - content-biased child is shrunk below its min size and overlaps neighbours (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/2313/head:pull/2313` \
`$ git checkout pull/2313`

Update a local copy of the PR: \
`$ git checkout pull/2313` \
`$ git pull https://git.openjdk.org/jfx.git pull/2313/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2313`

View PR using the GUI difftool: \
`$ git pr show -t 2313`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/2313.diff">https://git.openjdk.org/jfx/pull/2313.diff</a>

</details>
